### PR TITLE
wireless: Replace nxsem_get_value with NXSEM_COUNT

### DIFF
--- a/wireless/ieee802154/mac802154.c
+++ b/wireless/ieee802154/mac802154.c
@@ -2050,9 +2050,8 @@ static void mac802154_rxbeaconframe(FAR struct ieee802154_privmac_s *priv,
                     }
                   else if (priv->curr_op == MAC802154_OP_NONE)
                     {
-                      int sval;
-                      DEBUGASSERT(nxsem_get_value(&priv->opsem, &sval) == 0
-                                  && sval == 1);
+                      DEBUGASSERT(atomic_read(NXSEM_COUNT(&priv->opsem))
+                                  == 1);
                       nxsem_wait_uninterruptible(&priv->opsem);
                       priv->curr_op = MAC802154_OP_AUTOEXTRACT;
                       priv->curr_cmd = IEEE802154_CMD_DATA_REQ;


### PR DESCRIPTION
## Summary

Using the atomic operation `atomic_read` provides safer access to shared resources. At the same time, the interface is more unified.

## Impact

None

## Testing
1. Build the tree and verify there are no compilation errors:

```bash
./tools/configure.sh -l armv7a:smp
make -j$(nproc)
```

ostest 

```
NuttShell (NSH) NuttX-12.12.0
nsh> ostest
stdio_test: write fd=1
stdio_test: Standard I/O Check: printf
stdio_test: write fd=2
stdio_test: Standard I/O Check: fprintf to stderr
ostest_main: putenv(Variable1=BadValue3)
ostest_main: setenv(Variable1, GoodValue1, TRUE)
ostest_main: setenv(Variable2, BadValue1, FALSE)
ostest_main: setenv(Variable2, GoodValue2, TRUE)
ostest_main: setenv(Variable3, GoodValue3, FALSE)
ostest_main: setenv(Variable3, BadValue2, FALSE)
show_variable: Variable=Variable1 has value=GoodValue1
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3
ostest_main: Started user_main at PID=7

user_main: Begin argument test
user_main: Started with argc=5
user_main: argv[0]="ostest"
user_main: argv[1]="Arg1"
user_main: argv[2]="Arg2"
user_main: argv[3]="Arg3"
user_main: argv[4]="Arg4"

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 4 4
mxordblk 79d7878 79d7878
uordblks 636c 636c
fordblks 79da510 79da510

user_main: getopt() test
getopt(): Simple test
getopt(): Invalid argument
getopt(): Missing optional argument
getopt_long(): Simple test
getopt_long(): No short options
getopt_long(): Argument for --option=argument
getopt_long(): Invalid long option
getopt_long(): Mixed long and short options
getopt_long(): Invalid short option
getopt_long(): Missing optional arguments
getopt_long_only(): Mixed long and short options
getopt_long_only(): Single hyphen long options

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 4 4
mxordblk 79d7878 79d7878
uordblks 636c 636c
fordblks 79da510 79da510

user_main: libc tests

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 4 4
mxordblk 79d7878 79d7878
uordblks 636c 636c
fordblks 79da510 79da510
show_variable: Variable=Variable1 has value=GoodValue1
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3
show_variable: Variable=Variable1 has no value
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 4 5
mxordblk 79d7878 79d7878
uordblks 636c 634c
fordblks 79da510 79da530
show_variable: Variable=Variable1 has no value
show_variable: Variable=Variable2 has no value
show_variable: Variable=Variable3 has no value

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 5 4
mxordblk 79d7878 79d7878
uordblks 634c 62d4
fordblks 79da530 79da5a8

user_main: setvbuf test
setvbuf_test: Test NO buffering
setvbuf_test: Using NO buffering
setvbuf_test: Test default FULL buffering
setvbuf_test: Using default FULL buffering
setvbuf_test: Test FULL buffering, buffer size 64
setvbuf_test: Using FULL buffering, buffer size 64
setvbuf_test: Test FULL buffering, pre-allocated buffer
setvbuf_test: Using FULL buffering, pre-allocated buffer
setvbuf_test: Test LINE buffering, buffer size 64
setvbuf_test: Using LINE buffering, buffer size 64
setvbuf_test: Test FULL buffering, pre-allocated buffer
setvbuf_test: Using FULL buffering, pre-allocated buffer

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 4 4
mxordblk 79d7878 79d7878
uordblks 62d4 62d4
fordblks 79da5a8 79da5a8

user_main: /dev/null test
dev_null: Read 0 bytes from /dev/null
dev_null: Wrote 1024 bytes to /dev/null

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 4 4
mxordblk 79d7878 79d7878
uordblks 62d4 62d4
fordblks 79da5a8 79da5a8

user_main: FPU test
Starting task FPU#1
fpu_test: Started task FPU#1 at PID=8
FPU#1: pass 1
Starting task FPU#2
FPU#2: pass 1
fpu_test: Started task FPU#2 at PID=9
FPU#1: pass 2
FPU#2: pass 2
FPU#1: pass 3
FPU#2: pass 3
FPU#1: pass 4
FPU#2: pass 4
FPU#1: pass 5
FPU#2: pass 5
FPU#1: pass 6
FPU#2: pass 6
FPU#1: pass 7
FPU#2: pass 7
FPU#1: pass 8
FPU#2: pass 8
FPU#1: pass 9
FPU#2: pass 9
FPU#1: pass 10
FPU#2: pass 10
FPU#1: pass 11
FPU#2: pass 11
FPU#1: pass 12
FPU#2: pass 12
FPU#1: pass 13
FPU#2: pass 13
FPU#1: pass 14
FPU#2: pass 14
FPU#1: pass 15
FPU#2: pass 15
FPU#1: pass 16
FPU#2: pass 16
FPU#1: Succeeded
FPU#2: Succeeded
fpu_test: Returning

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 4 7
mxordblk 79d7878 79d2878
uordblks 62d4 8484
fordblks 79da5a8 79d83f8

user_main: task_restart test

Test task_restart()
restart_main: setenv(VarName, VarValue, TRUE)
restart_main: Started restart_main at PID=10
restart_main: Started with argc=4
restart_main: argv[0]="ostest"
restart_main: argv[1]="This is argument 1"
restart_main: argv[2]="Argument 2 here"
restart_main: argv[3]="Lastly, the 3rd argument"
restart_main: Variable=VarName has value=VarValue
restart_main: I am still here
restart_main: I am still here
restart_main: Started restart_main at PID=10
restart_main: Started with argc=4
restart_main: argv[0]="ostest"
restart_main: argv[1]="This is argument 1"
restart_main: argv[2]="Argument 2 here"
restart_main: argv[3]="Lastly, the 3rd argument"
restart_main: Variable=VarName has value=VarValue
restart_main: Started with argc=4
restart_main: argv[0]="ostest"
restart_main: argv[1]="This is argument 1"
restart_main: argv[2]="Argument 2 here"
restart_main: argv[3]="Lastly, the 3rd argument"
restart_main: Variable=VarName has value=VarValue
restart_main: Exiting

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 7 7
mxordblk 79d2878 79cf878
uordblks 8484 94bc
fordblks 79d83f8 79d73c0

user_main: waitpid test

Test waitpid()
waitpid_main: PID 11 Started
waitpid_start_child: Started waitpid_main at PID=11
waitpid_start_child: Started waitpid_main at PID=12
waitpid_main: PID 12 Started
waitpid_start_child: Started waitpid_main at PID=13
waitpid_main: PID 13 Started
waitpid_test: Waiting for PID=11 with waitpid()
waitpid_main: PID 11 exitting with result=14
waitpid_test: PID 11 waitpid succeeded with stat_loc=0e00
waitpid_last: Waiting for PID=13 with waitpid()
waitpid_main: PID 12 exitting with result=14
waitpid_main: PID 13 exitting with result=14
waitpid_last: PASS: PID 13 waitpid succeeded with stat_loc=0e00

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 7 11
mxordblk 79cf878 79c7878
uordblks 94bc d66c
fordblks 79d73c0 79d3210

user_main: wqueue test
wqueue_test: HPWORK
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: HPWORK done
wqueue_test: test 1
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: test 1 done
wqueue_test: test 2
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: call = 100, expect = 100
wqueue_test: test 2 done
End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 11 12
mxordblk 79c7878 https://github.com/apache/nuttx/commit/79c40a82de810dc49f0b60cb689ca95b47acaca3
uordblks d66c e08c
fordblks 79d3210 79d27f0

user_main: mutex test
Initializing mutex
Starting thread 1
Starting thread 2
Thread1 Thread2
Loops 32 32
Errors 0 0

Testing moved mutex
Starting moved mutex thread 1
Starting moved mutex thread 2
Thread1 Thread2
Moved Loops 32 32
Moved Errors 0 0

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 12 14
mxordblk https://github.com/apache/nuttx/commit/79c40a82de810dc49f0b60cb689ca95b47acaca3 79c2878
uordblks e08c f1a4
fordblks 79d27f0 79d16d8

user_main: timed mutex test
mutex_test: Initializing mutex
mutex_test: Starting thread
pthread: Started
pthread: Waiting for lock or timeout
mutex_test: Unlocking
pthread: Got the lock
pthread: Waiting for lock or timeout
pthread: Got the timeout. Terminating
mutex_test: PASSED

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 14 13
mxordblk 79c2878 79c4878
uordblks f1a4 e0c4
fordblks 79d16d8 79d27b8

user_main: cancel test
cancel_test: Test 1a: Normal Cancellation
cancel_test: Starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sem_waiter: Taking mutex
sem_waiter: Starting wait for condition
cancel_test: Canceling thread
cancel_test: Joining
cancel_test: waiter exited with result=0xffffffff
cancel_test: PASS thread terminated with PTHREAD_CANCELED
cancel_test: Test 2: Asynchronous Cancellation
... Skipped
cancel_test: Test 3: Cancellation of detached thread
cancel_test: Re-starting thread
restart_thread: Destroying cond
restart_thread: Destroying mutex
restart_thread: Re-starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sem_waiter: Taking mutex
sem_waiter: Starting wait for condition
cancel_test: Canceling thread
cancel_test: Joining
cancel_test: PASS pthread_join failed with status=ESRCH
cancel_test: Test 5: Non-cancelable threads
cancel_test: Re-starting thread (non-cancelable)
restart_thread: Destroying cond
restart_thread: Destroying mutex
restart_thread: Re-starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sem_waiter: Taking mutex
sem_waiter: Starting wait for condition
sem_waiter: Setting non-cancelable
cancel_test: Canceling thread
cancel_test: Joining
sem_waiter: Releasing mutex
sem_waiter: Setting cancelable
cancel_test: waiter exited with result=0xffffffff
cancel_test: PASS thread terminated with PTHREAD_CANCELED
cancel_test: Test 6: Cancel message queue wait
cancel_test: Starting thread (cancelable)
Skipped
cancel_test: Test 7: Cancel signal wait
cancel_test: Starting thread (cancelable)
Skipped

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 13 6
mxordblk 79c4878 79cd878
uordblks e0c4 94cc
fordblks 79d27b8 79d73b0

user_main: robust test
robust_test: Initializing mutex
robust_test: Starting thread
robust_waiter: Taking mutex
robust_waiter: Exiting with mutex
robust_test: Take the lock again
robust_test: Make the mutex consistent again.
robust_test: Take the lock again
robust_test: Joining
robust_test: waiter exited with result=0
robust_test: Test complete with nerrors=0

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 6 6
mxordblk 79cd878 79cd878
uordblks 94cc 94cc
fordblks 79d73b0 79d73b0

user_main: semaphore test
sem_test: Initializing semaphore to 0
sem_test: Starting waiter thread 1
sem_test: Set thread 1 priority to 191
sem_test: Starting waiter thread 2
waiter_func: Thread 1 Started
sem_test: Set thread 2 priority to 128
waiter_func: Thread 1 initial semaphore value = 0
waiter_func: Thread 2 Started
waiter_func: Thread 1 waiting on semaphore
waiter_func: Thread 2 initial semaphore value = 0
waiter_func: Thread 2 waiting on semaphore
sem_test: Starting poster thread 3
sem_test: Set thread 3 priority to 64
poster_func: Thread 3 started
poster_func: Thread 3 semaphore value = -2
poster_func: Thread 3 posting semaphore
poster_func: Thread 3 new semaphore value = -1
waiter_func: Thread 1 awakened
poster_func: Thread 3 semaphore value = -1
waiter_func: Thread 1 new semaphore value = -1
poster_func: Thread 3 posting semaphore
waiter_func: Thread 1 done
waiter_func: Thread 2 awakened
poster_func: Thread 3 new semaphore value = 0
waiter_func: Thread 2 new semaphore value = 0
poster_func: Thread 3 done
waiter_func: Thread 2 done

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 6 8
mxordblk 79cd878 79cc878
uordblks 94cc 95ac
fordblks 79d73b0 79d72d0

user_main: timed semaphore test
semtimed_test: Initializing semaphore to 0
semtimed_test: Waiting for two second timeout
semtimed_test: PASS: first test returned timeout
BEFORE: (1682380868 sec, 171469312 nsec)
AFTER: (1682380870 sec, 172362256 nsec)
semtimed_test: Starting poster thread
semtimed_test: Set thread 1 priority to 191
semtimed_test: Starting poster thread 3
semtimed_test: Set thread 3 priority to 64
semtimed_test: Waiting for two second timeout
poster_func: Waiting for 1 second
poster_func: Posting
semtimed_test: PASS: sem_timedwait succeeded
BEFORE: (1682380870 sec, 175388544 nsec)
AFTER: (1682380871 sec, 177835792 nsec)

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 8 7
mxordblk 79cc878 79ce878
uordblks 95ac 95ac
fordblks 79d72d0 79d72d0

user_main: condition variable test
cond_test: Initializing mutex
cond_test: Initializing cond
cond_test: Starting waiter
cond_test: Set thread 1 priority to 128
waiter_thread: Started
cond_test: Starting signaler
cond_test: Set thread 2 priority to 64
thread_signaler: Started
thread_signaler: Terminating
cond_test: signaler terminated, now cancel the waiter
cond_test: Waiter Signaler
cond_test: Loops 32 32
cond_test: Errors 0 0
cond_test:
cond_test: 0 times, waiter did not have to wait for data
cond_test: 0 times, data was already available when the signaler run
cond_test: 0 times, the waiter was in an unexpected state when the signaler ran

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 7 7
mxordblk 79ce878 79ce878
uordblks 95ac 84cc
fordblks 79d72d0 79d83b0

user_main: pthread_exit() test
pthread_exit_test: Started pthread_exit_main at PID=299
pthread_exit_main 299: Starting pthread_exit_thread
pthread_exit_main 299: Sleeping for 5 seconds
pthread_exit_thread 300: Sleeping for 10 second
pthread_exit_thread 300: Still running...
pthread_exit_main 299: Calling pthread_exit()

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 7 7
mxordblk 79ce878 79cb878
uordblks 84cc a5ac
fordblks 79d83b0 79d62d0

user_main: pthread_rwlock test
pthread_rwlock: Initializing rwlock
pthread_exit_thread 300: Exiting

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 7 7
mxordblk 79cb878 79d0878
uordblks a5ac 84dc
fordblks 79d62d0 79d83a0

user_main: pthread_rwlock_cancel test
pthread_rwlock_cancel: Starting test

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 7 6
mxordblk 79d0878 79d0878
uordblks 84dc 73fc
fordblks 79d83a0 79d9480

user_main: timed wait test
thread_waiter: Initializing mutex
timedwait_test: Initializing cond
timedwait_test: Starting waiter
timedwait_test: Set thread 2 priority to 177
timedwait_test: Joining
thread_waiter: Taking mutex
thread_waiter: Starting 5 second wait for condition
thread_waiter: pthread_cond_timedwait timed out
thread_waiter: Releasing mutex
thread_waiter: Exit with status 0x12345678
timedwait_test: waiter exited with result=0x12345678

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 6 7
mxordblk 79d0878 79d0878
uordblks 73fc 84dc
fordblks 79d9480 79d83a0

user_main: timed message queue test
timedmqueue_test: Starting sender
timedmqueue_test: Waiting for sender to complete
sender_thread: Starting
sender_thread: mq_timedsend succeeded on msg 0
sender_thread: mq_timedsend succeeded on msg 1
sender_thread: mq_timedsend succeeded on msg 2
sender_thread: mq_timedsend succeeded on msg 3
sender_thread: mq_timedsend succeeded on msg 4
sender_thread: mq_timedsend succeeded on msg 5
sender_thread: mq_timedsend succeeded on msg 6
sender_thread: mq_timedsend succeeded on msg 7
sender_thread: mq_timedsend succeeded on msg 8
sender_thread: mq_timedsend 9 timed out as expected
sender_thread: returning nerrors=0
timedmqueue_test: Starting receiver
timedmqueue_test: Waiting for receiver to complete
receiver_thread: Starting
receiver_thread: mq_timedreceive succeed on msg 0
receiver_thread: mq_timedreceive succeed on msg 1
receiver_thread: mq_timedreceive succeed on msg 2
receiver_thread: mq_timedreceive succeed on msg 3
receiver_thread: mq_timedreceive succeed on msg 4
receiver_thread: mq_timedreceive succeed on msg 5
receiver_thread: mq_timedreceive succeed on msg 6
receiver_thread: mq_timedreceive succeed on msg 7
receiver_thread: mq_timedreceive succeed on msg 8
receiver_thread: Receive 9 timed out as expected
receiver_thread: returning nerrors=0
timedmqueue_test: Test complete

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 7 8
mxordblk 79d0878 79cd878
uordblks 84dc 9544
fordblks 79d83a0 79d7338

user_main: sigprocmask test
sigprocmask_test: SUCCESS

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 8 8
mxordblk 79cd878 79cd878
uordblks 9544 9544
fordblks 79d7338 79d7338

user_main: message queue test
mqueue_test: Starting receiver
mqueue_test: Set receiver priority to 128
mqueue_test: Starting sender
receiver_thread: Starting
mqueue_test: Set sender thread priority to 64
mqueue_test: Waiting for sender to complete
sender_thread: Starting
sender_thread: mq_send succeeded on msg 0
receiver_thread: mq_receive succeeded on msg 0
sender_thread: mq_send succeeded on msg 1
receiver_thread: mq_receive succeeded on msg 1
sender_thread: mq_send succeeded on msg 2
receiver_thread: mq_receive succeeded on msg 2
sender_thread: mq_send succeeded on msg 3
receiver_thread: mq_receive succeeded on msg 3
sender_thread: mq_send succeeded on msg 4
receiver_thread: mq_receive succeeded on msg 4
sender_thread: mq_send succeeded on msg 5
receiver_thread: mq_receive succeeded on msg 5
sender_thread: mq_send succeeded on msg 6
receiver_thread: mq_receive succeeded on msg 6
sender_thread: mq_send succeeded on msg 7
receiver_thread: mq_receive succeeded on msg 7
sender_thread: mq_send succeeded on msg 8
receiver_thread: mq_receive succeeded on msg 8
sender_thread: mq_send succeeded on msg 9
receiver_thread: mq_receive succeeded on msg 9
sender_thread: returning nerrors=0
mqueue_test: Killing receiver
receiver_thread: mq_receive interrupted!
receiver_thread: returning nerrors=0
mqueue_test: Canceling receiver
mqueue_test: receiver has already terminated

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 8 8
mxordblk 79cd878 79cd878
uordblks 9544 9544
fordblks 79d7338 79d7338

user_main: signal handler test
sighand_test: Initializing semaphore to 0
sighand_test: Starting waiter task
sighand_test: Started waiter_main pid=328
waiter_main: Waiter started
waiter_main: Unmasking signal 32
waiter_main: Registering signal handler
waiter_main: oact.sigaction=0 oact.sa_flags=0 oact.sa_mask=0000000000000000
waiter_main: Waiting on semaphore
sighand_test: Signaling pid=328 with signo=32 sigvalue=42
waiter_main: sem_wait() successfully interrupted by signal
waiter_main: done
sighand_test: done

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 8 8
mxordblk 79cd878 79c9878
uordblks 9544 955c
fordblks 79d7338 79d7320

user_main: nested signal handler test
signest_test: Starting signal waiter task at priority 101
signest_test: Started waiter_main pid=329
waiter_main: Waiter started
signest_test: Starting interfering task at priority 102
waiter_main: Setting signal mask
interfere_main: Waiting on semaphore
waiter_main: Registering signal handler
signest_test: Started interfere_main pid=330
waiter_main: Waiting on semaphore
signest_test: Simple case:
Total signalled 1240 Odd=620 Even=620
Total handled 1240 Odd=620 Even=620
Total nested 0 Odd=0 Even=0
signest_test: With task locking
Total signalled 2480 Odd=1240 Even=1240
Total handled 2480 Odd=1240 Even=1240
Total nested 0 Odd=0 Even=0
signest_test: With intefering thread
Total signalled 3720 Odd=1860 Even=1860
Total handled 3720 Odd=1860 Even=1860
Total nested 0 Odd=0 Even=0
signest_test: done

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 8 12
mxordblk 79c9878 79c1878
uordblks 955c d77c
fordblks 79d7320 79d3100

user_main: POSIX timer test
timer_test: Initializing semaphore to 0
timer_test: Unmasking signal 32
timer_test: Registering signal handler
timer_test: oact.sigaction=0 oact.sa_flags=0 oact.sa_mask=0000000000000000
timer_test: Creating timer
timer_test: Starting timer
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=1
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=2
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=3
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=4
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=5
timer_test: Deleting timer
timer_test: done

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 12 12
mxordblk 79c1878 79c1878
uordblks d77c d77c
fordblks 79d3100 79d3100

user_main: spinlock test
Start Lock test:
Thread num: 1, Loop times: 10000000

Test type: spinlock
spinlock: Test Results:
spinlock: Final counter: 10000000
spinlock: Average throughput : 5759977 op/s
spinlock: Total execution time: 1736787008 ns

Test type: rspinlock
rspinlock: Test Results:
rspinlock: Final counter: 10000000
rspinlock: Average throughput : 3473520 op/s
rspinlock: Total execution time: 2879306752 ns

Test type: seqcount
seqcount: Test Results:
seqcount: Final counter: 10000000
seqcount: Average throughput : 6538887 op/s
seqcount: Total execution time: 1529736096 ns

Start Lock test:
Thread num: 2, Loop times: 10000000

Test type: spinlock
spinlock: Test Results:
spinlock: Final counter: 20000000
spinlock: Average throughput : 2510364 op/s
spinlock: Total execution time: 3984563536 ns

Test type: rspinlock
rspinlock: Test Results:
rspinlock: Final counter: 20000000
rspinlock: Average throughput : 1585761 op/s
rspinlock: Total execution time: 6318388720 ns

Test type: seqcount
spinlock: Test Results:
spinlock: Final counter: 20000000
spinlock: Average throughput : 2510364 op/s
spinlock: Total execution time: 3984563536 ns

Test type: rspinlock
rspinlock: Test Results:
rspinlock: Final counter: 20000000
rspinlock: Average throughput : 1585761 op/s
rspinlock: Total execution time: 6318388720 ns

Test type: seqcount
seqcount: Test Results:
seqcount: Final counter: 20000000
seqcount: Average throughput : 2566609 op/s
seqcount: Total execution time: 3909949040 ns

Start Lock test:
Thread num: 3, Loop times: 10000000

Test type: spinlock
spinlock: Test Results:
spinlock: Final counter: 30000000
spinlock: Average throughput : 1187199 op/s
spinlock: Total execution time: 8543580880 ns

Test type: rspinlock
rspinlock: Test Results:
rspinlock: Final counter: 30000000
rspinlock: Average throughput : 1004611 op/s
rspinlock: Total execution time: 10816184224 ns

Test type: seqcount
seqcount: Test Results:
seqcount: Final counter: 30000000
seqcount: Average throughput : 1455844 op/s
seqcount: Total execution time: 7069242096 ns

Start Lock test:
Thread num: 4, Loop times: 10000000

Test type: spinlock
spinlock: Test Results:
spinlock: Final counter: 40000000
spinlock: Average throughput : 779557 op/s
spinlock: Total execution time: 13309599952 ns

Test type: rspinlock
rspinlock: Test Results:
rspinlock: Final counter: 40000000
rspinlock: Average throughput : 643309 op/s
rspinlock: Total execution time: 16806949776 ns

Test type: seqcount
seqcount: Test Results:
seqcount: Final counter: 40000000
seqcount: Average throughput : 1042020 op/s
seqcount: Total execution time: 9982159344 ns

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 12 11
mxordblk 79c1878 79cc878
uordblks d77c a77c
fordblks 79d3100 79d6100

user_main: wdog test
wdog_test start...
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wd_start with maximum delay, cancel OK, rest 1073741820
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 1073741819
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 1073741818
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 1073741817
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 1073741815
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 1073741815
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 1073741814
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 1073741813
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 1073741812
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 1073741812
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 1073741811
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 1073741810
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 1073741809
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 1073741809
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 1073741808
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 1073741806
wdtest_recursive 1000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 51 times, elapsed tick 102
wdtest_recursive 10000000ns
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
recursive wdog triggered 9 times, elapsed tick 99
wdog_test end...

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 11 14
mxordblk 79cc878 79b6878
uordblks a77c b89c
fordblks 79d6100 79d4fe0

user_main: round-robin scheduler test
rr_test: Set thread priority to 1
rr_test: Set thread policy to SCHED_RR
rr_test: Starting first get_primes_thread
First get_primes_thread: 425
rr_test: Starting second get_primes_thread
Second get_primes_thread: 426
rr_test: Waiting for threads to complete -- this should take awhile
If RR scheduling is working, they should start and complete at
about the same time
get_primes_thread id=1 started, looking for primes < 30000, doing 10 run(s)
get_primes_thread id=2 started, looking for primes < 30000, doing 10 run(s)
get_primes_thread id=1 finished, found 3246 primes, last one was 29989
get_primes_thread id=2 finished, found 3246 primes, last one was 29989
rr_test: Done

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 14 12
mxordblk 79b6878 https://github.com/apache/nuttx/commit/79ca8783189d1c25f29c4907edae1e103a21c464
uordblks b89c b89c
fordblks 79d4fe0 79d4fe0

user_main: barrier test
barrier_test: Initializing barrier
barrier_test: Thread 0 created
barrier_test: Thread 1 created
barrier_test: Thread 2 created
barrier_test: Thread 3 created
barrier_test: Thread 4 created
barrier_test: Thread 5 created
barrier_test: Thread 6 created
barrier_test: Thread 7 created
barrier_func: Thread 0 started
barrier_func: Thread 1 started
barrier_func: Thread 2 started
barrier_func: Thread 3 started
barrier_func: Thread 4 started
barrier_func: Thread 5 started
barrier_func: Thread 6 started
barrier_func: Thread 7 started
barrier_func: Thread 0 calling pthread_barrier_wait()
barrier_func: Thread 1 calling pthread_barrier_wait()
barrier_func: Thread 2 calling pthread_barrier_wait()
barrier_func: Thread 3 calling pthread_barrier_wait()
barrier_func: Thread 4 calling pthread_barrier_wait()
barrier_func: Thread 5 calling pthread_barrier_wait()
barrier_func: Thread 6 calling pthread_barrier_wait()
barrier_func: Thread 7 calling pthread_barrier_wait()
barrier_func: Thread 7, back with status=PTHREAD_BARRIER_SERIAL_THREAD (I AM SPECIAL)
barrier_func: Thread 0, back with status=0 (I am not special)
barrier_func: Thread 1, back with status=0 (I am not special)
barrier_func: Thread 2, back with status=0 (I am not special)
barrier_func: Thread 3, back with status=0 (I am not special)
barrier_func: Thread 4, back with status=0 (I am not special)
barrier_func: Thread 5, back with status=0 (I am not special)
barrier_func: Thread 6, back with status=0 (I am not special)
barrier_func: Thread 7 done
barrier_func: Thread 0 done
barrier_test: Thread 0 completed with result=0
barrier_func: Thread 1 done
barrier_func: Thread 2 done
barrier_test: Thread 1 completed with result=0
barrier_test: Thread 2 completed with result=0
barrier_func: Thread 3 done
barrier_func: Thread 4 done
barrier_func: Thread 5 done
barrier_test: Thread 3 completed with result=0
barrier_test: Thread 4 completed with result=0
barrier_test: Thread 5 completed with result=0
barrier_func: Thread 6 done
barrier_test: Thread 6 completed with result=0
barrier_test: Thread 7 completed with result=0

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 12 14
mxordblk https://github.com/apache/nuttx/commit/79ca8783189d1c25f29c4907edae1e103a21c464 79c0878
uordblks b89c b89c
fordblks 79d4fe0 79d4fe0

user_main: scheduler lock test
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Finished

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 14 12
mxordblk 79c0878 https://github.com/apache/nuttx/commit/79ca8783189d1c25f29c4907edae1e103a21c464
uordblks b89c a7bc
fordblks 79d4fe0 79d60c0

user_main: vfork() test
vfork_test: Child 439 ran successfully

user_main: smp call test
smp_call_test: Test start
smp_call_test: Call cpu 0, nowait
smp_call_test: Call cpu 0, wait
smp_call_test: Call cpu 1, nowait
smp_call_test: Call cpu 1, wait
smp_call_test: Call cpu 2, nowait
smp_call_test: Call cpu 2, wait
smp_call_test: Call cpu 3, nowait
smp_call_test: Call cpu 3, wait
smp_call_test: Call multi cpu, nowait
smp_call_test: Call in interrupt, wait
smp_call_test: Call multi cpu, wait
smp_call_test: Test success

Final memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 79e087c 79e087c
ordblks 4 11
mxordblk 79d7878 79cb878
uordblks 636c b7bc
fordblks 79da510 79d50c0
user_main: Exiting
ostest_main: Exiting with status 0
```
