### PR TITLE
net/rpmsg: Modify error handling to rpmsg socket

### DIFF
--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -778,6 +778,10 @@ static int rpmsg_socket_connect_internal(FAR struct socket *psock)
 
       ret = net_sem_timedwait(&conn->sendsem,
                               _SO_TIMEOUT(conn->sconn.s_sndtimeo));
+      if (!conn->ept.rdev || conn->unbind)
+        {
+          ret = -ECONNRESET;
+        }
 
       if (ret < 0)
         {


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This PR made the following two changes.
1.  Added POLLHUP notification on rpmsg_socket_ns_unbind to ensure poll-based users detect disconnects correctly.
2.  Added error checking in rpmsg_socket_connect to handle cases where the peer is already disconnected.

## Impact

Error handling， No impact on functionality

## Testing

Build Verification
```
# Build sim:rpserver/rpproxy configuration
```
Test Environment
```
Host: Linux x86_64
Configuration: sim:rpserver/rpproxy
```
Test Results
```
server> rpsock_server stream block hello proxy &
rpsock_server [9:100]
server> server: create socket SOCK_STREAM nonblock 0
server: bind cpu proxy, name hello ...
server: listen ...
server: try accept ...

server> 
server> cu

NuttShell (NSH) NuttX-12.12.0
proxy> 
proxy> 
proxy> rpsock
  rpsock_client
  rpsock_server
proxy> rpsock_client stream block hello server &
rpsock_client [6:100]
proxy> client: create socket SOCK_STREAM nonblock 0
client: Connecting to server,hello...
server: Connection accepted -- 4
server: try accept ...
client: Connected
client send data, cnt 0, total len 64, BUFHEAD process0006, msg0000, name:hello
...
client recv done, total 4096000, endflags, send total 4096000
server recv data normal exit
server Complete ret 0, errno 0
client: Terminating
```


