### PR TITLE
net/tcp:Use a temporary variable to store dev to prevent conn from being released after tcp_conn_list_unlock.

### DIFF
--- a/net/tcp/tcp_timer.c
+++ b/net/tcp/tcp_timer.c
@@ -152,11 +152,12 @@ static void tcp_timer_expiry(FAR void *arg)
     {
       if (conn == arg)
         {
-          tcp_conn_list_unlock();
+          FAR struct net_driver_s *dev = conn->dev;
           conn->timeout = true;
-          netdev_lock(conn->dev);
-          netdev_txnotify_dev(conn->dev, TCP_POLL);
-          netdev_unlock(conn->dev);
+          tcp_conn_list_unlock();
+          netdev_lock(dev);
+          netdev_txnotify_dev(dev, TCP_POLL);
+          netdev_unlock(dev);
           return;
         }
     }


### PR DESCRIPTION
## Summary

After `tcp_conn_list_unlock`, `conn` might be released, so `conn->timeout = true` is moved to the lock protection scope. At the same time, a temporary variable is used to store `dev` to prevent `conn` from being released.

## Impact
Severity: High
Type: Race condition / Use-After-Free
Affected scenario: High-concurrency TCP connection timeout handling, especially on multi-core systems where the timing window between unlock and access can be exploited by other CPU cores

## Testing
none