### PR TITLE
arch/x86_64: use pause to reduce power consumption in spin wait loops

### DIFF
--- a/arch/x86_64/include/arch.h
+++ b/arch/x86_64/include/arch.h
@@ -41,6 +41,8 @@
 
 /* Include architecture-specific definitions */
 
+#include <arch/barriers.h>
+
 #ifdef CONFIG_ARCH_INTEL64
 #  include <arch/intel64/arch.h>
 #endif

--- a/arch/x86_64/include/barriers.h
+++ b/arch/x86_64/include/barriers.h
@@ -29,5 +29,6 @@
 #define UP_DMB() __asm__ __volatile__ ("mfence" ::: "memory")
 #define UP_RMB() __asm__ __volatile__ ("lfence" ::: "memory")
 #define UP_WMB() __asm__ __volatile__ ("sfence" ::: "memory")
+#define UP_WFE() __asm__ __volatile__ ("pause")
 
 #endif /* __ARCH_X86_64_INCLUDE_BARRIERS_H */


### PR DESCRIPTION
## Summary

This PR optimizes contended spinlock acquisition in the x86_64 kernel by defining the UP_WFE() macro as the pause instruction. Using the pause instruction in spin wait loops is standard and recommended on intel platforms. This is because it can reduce power consumption and improve responsiveness by providing a hint to the processor to de-pipeline the spin wait loop and avoid memory ordering violations (which could cause machine clears) in busy load-compare-branch loops.

Intel 64 and IA-32 Architectures Software Developer's Manual, Volume 3, 10.10.2 -

```
The PAUSE instruction can improves the performance of processors supporting Intel Hyper-Threading Technology
when executing “spin-wait loops” and other routines where one thread is accessing a shared lock or semaphore in
a tight polling loop. When executing a spin-wait loop, the processor can suffer a severe performance penalty when
exiting the loop because it detects a possible memory order violation and flushes the core processor’s pipeline. The
PAUSE instruction provides a hint to the processor that the code sequence is a spin-wait loop. The processor uses 
this hint to avoid the memory order violation and prevent the pipeline flush. In addition, the PAUSE instruction de-
pipelines the spin-wait loop to prevent it from consuming execution resources excessively and consume power
needlessly. (See Section 10.10.6.1, “Use the PAUSE Instruction in Spin-Wait Loops,” for more information about
using the PAUSE instruction with IA-32 processors supporting Intel Hyper-Threading Technology.)
```

## Impact

- Reduced power consumption during contended spinlock acquisition 

## Testing

- Host: Linux x86_64
- Board: qemu-intel64:nsh
- ostest passed

