### PR TITLE
Fix SPI DMA bug with null txbuffer on ESP32S3

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_spi.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_spi.c
@@ -893,6 +893,7 @@ static void esp32s3_spi_dma_exchange(struct esp32s3_spi_priv_s *priv,
   if (tp == NULL)
     {
       tp = rp;
+      memset(tp, 0, bytes);
     }
 
   esp32s3_spi_set_regbits(SPI_DMA_INT_CLR_REG(priv->config->id),


### PR DESCRIPTION
## Summary

This PR fixes an issue where SPI transmits incorrect bytes when DMA is enabled and the `txbuffer` argument of `esp32s3_spi_dma_exchange()` is NULL. This can sometimes cause the SPI device to enter an invalid or unexpected state.

For example:  

When using SPI to communicate with an SD card, executing 
 
```
mount -t vfat /dev/mmcsd0 /fs/microsd
```  

returns an `ENODEV` error.

Logs are shown below:  

<details>
<summary>Logs</summary>

```
ESP-ROM:esp32s3-20210327
Build:Mar 27 2021
rst:0x1 (POWERON),boot:0xb (SPI_FAST_FLASH_BOOT)
SPIWP:0xee
mode:DIO, clock div:2
load:0x3fc951b0,len:0x2478
load:0x40374000,len:0x90b0
load:0x50000000,len:0x20
SHA-256 comparison failed:
Calculated: 02cd780b717c2c9af9e1a1f2535ba505ab891fc59afa8aded5c2572dd1ad41af
Expected: 00000000704a0000000000000000000000000000000000000000000000000000
Attempting to boot anyway...
entry 0x40374a38
*** Booting NuttX ***
I (71) boot: chip revision: v0.2
I (71) boot: efuse block revision: v1.3
I (71) boot.esp32s3: Boot SPI Speed : 40MHz
I (72) boot.esp32s3: SPI Mode       : DIO
I (76) boot.esp32s3: SPI Flash Size : 4MB
I (79) boot: Enabling RNG early entropy source...
dram: lma 0x00000020 vma 0x3fc951b0 len 0x2478   (9336)
iram: lma 0x000024a0 vma 0x40374000 len 0x90b0   (37040)
rtc: lma 0x0000b558 vma 0x50000000 len 0x20     (32)
padd: lma 0x0000b588 vma 0x00000000 len 0x4a70   (19056)
imap: lma 0x00010000 vma 0x42010000 len 0x157e70 (1408624)
padd: lma 0x00167e78 vma 0x00000000 len 0x8180   (33152)
dmap: lma 0x00170000 vma 0x3c180000 len 0x65f3c  (417596)
total segments stored 7
ABI (799) app_init: Application information:
I (799) app_init: Compile time:     Jan 30 2026 12:15:36
I (804) app_init: ELF file SHA256:  000000000...
I (804) app_init: ESP-IDF:          
I (806) sleep_gpio: Configure to isolate all GPIO pins in sleep state
I (812) sleep_gpio: Enable automatic switching of GPIO sleep configuration
nx_romfsetc: Mounting ROMFS filesystem at target=/etc with source=/dev/ram0
find_blockdriver: pathname="/dev/ram0"
find_blockdriver: ERROR: Failed to find /dev/ram0
find_mtddriver: ERROR: Failed to find /dev/ram0
nx_mount: found cromfs
cromfs_bind: blkdriver: 0 data: 0 handle: 0x3fc9510c
nx_mount: found procfs
nx_mount: found binfs
binfs_bind: Entry
esp32s3_spiflash_alloc_mtdpart: ESP32-S3 SPI Flash information:
esp32s3_spiflash_alloc_mtdpart: 	ID = 0x5e4016
esp32s3_spiflash_alloc_mtdpart: 	Status mask = 0xffff
esp32s3_spiflash_alloc_mtdpart: 	Chip size = 4096 KB
esp32s3_spiflash_alloc_mtdpart: 	Page size = 256 B
esp32s3_spiflash_alloc_mtdpart: 	Sector size = 4 KB
esp32s3_spiflash_alloc_mtdpart: 	Block size = 64 KB
esp32s3_spiflash_alloc_mtdpart: 	MTD offset = 0x340000
esp32s3_spiflash_alloc_mtdpart: 	MTD size = 0x10000
esp32s3_ioctl: cmd: 1537
esp32s3_ioctl: blocksize: 256 erasesize: 4096 neraseblocks: 1024
esp32s3_ioctl: return 0
esp32s3_dma_request: periph=0 tx_prio=1 rx_prio=1
esp32s3_dma_request: Allocated channel=0
esp32s3_spi_setfrequency: frequency=400000, actual=400000
esp32s3_spi_setbits: nbits=8
esp32s3_spi_setmode: mode=0
esp32s3_dma_request: periph=1 tx_prio=1 rx_prio=1
esp32s3_dma_request: Allocated channel=1
esp32s3_spi_setfrequency: frequency=400000, actual=400000
esp32s3_spi_setbits: nbits=8
esp32s3_spi_setmode: mode=0
esp32s3_spi_setmode: mode=0
esp32s3_spi_setbits: nbits=8
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
mmcsd_mediainitialize: Send CMD0
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x40 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x95 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x1
mmcsd_sendcmd: CMD0[00000000] R1=01
mmcsd_mediainitialize: Card is in IDLE state
mmcsd_mediainitialize: Send CMD8
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x48 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x1 and recv=0xff
esp32s3_spi_poll_send: send=0xaa and recv=0xff
esp32s3_spi_poll_send: send=0x87 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x1
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x1
esp32s3_spi_poll_send: send=0xff and recv=0xaa
mmcsd_sendcmd: CMD8[000001aa] R1=01 R7=000001aa
mmcsd_mediainitialize: 0. Send CMD55/ACMD41
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x77 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x1
mmcsd_sendcmd: CMD55[00000000] R1=01
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x69 and recv=0xff
esp32s3_spi_poll_send: send=0x40 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x1
mmcsd_sendcmd: CMD41[40000000] R1=01
mmcsd_mediainitialize: 69. Send CMD55/ACMD41
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x77 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x1
mmcsd_sendcmd: CMD55[00000000] R1=01
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x69 and recv=0xff
esp32s3_spi_poll_send: send=0x40 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x0
mmcsd_sendcmd: CMD41[40000000] R1=00
mmcsd_mediainitialize: Send CMD58
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x7a and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0xc0
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x80
esp32s3_spi_poll_send: send=0xff and recv=0x0
mmcsd_sendcmd: CMD58[00000000] R1=00 OCR=c0ff8000
mmcsd_mediainitialize: OCR: c0ff8000
mmcsd_mediainitialize: Identified SD ver2 card/with block access
mmcsd_mediainitialize: Get CSD
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x49 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x0
mmcsd_sendcmd: CMD9[00000000] R1=00
esp32s3_spi_poll_send: send=0xff and recv=0xff
mmcsd_getcardinfo: 0. SPI send returned ff
esp32s3_spi_poll_send: send=0xff and recv=0xfe
mmcsd_getcardinfo: 1. SPI send returned fe
esp32s3_spi_poll_send: send=0xff and recv=0x40
esp32s3_spi_poll_send: send=0xff and recv=0xe
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x32
esp32s3_spi_poll_send: send=0xff and recv=0x5b
esp32s3_spi_poll_send: send=0xff and recv=0x59
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x74
esp32s3_spi_poll_send: send=0xff and recv=0x7b
esp32s3_spi_poll_send: send=0xff and recv=0x7f
esp32s3_spi_poll_send: send=0xff and recv=0x80
esp32s3_spi_poll_send: send=0xff and recv=0xa
esp32s3_spi_poll_send: send=0xff and recv=0x40
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x9d
esp32s3_spi_poll_send: send=0xff and recv=0xa6
esp32s3_spi_poll_send: send=0xff and recv=0x66
mmcsd_dmpcsd: CSD
mmcsd_dmpcsd:   CSD_STRUCTURE:           1.1
mmcsd_dmpcsd:   TAAC:
mmcsd_dmpcsd:     TIME_VALUE:            0x01
mmcsd_dmpcsd:     TIME_UNIT:             0x06
mmcsd_dmpcsd:   NSAC:                    0x00
mmcsd_dmpcsd:   TRAN_SPEED:
mmcsd_dmpcsd:     TIME_VALUE:            0x06
mmcsd_dmpcsd:     RATE_UNIT:             0x02
mmcsd_dmpcsd:   CCC:                     0x5b5
mmcsd_dmpcsd:   READ_BL_LEN:             9
mmcsd_dmpcsd:   READ_BL_PARTIAL:         0
mmcsd_dmpcsd:   WRITE_BLK_MISALIGN:      0
mmcsd_dmpcsd:   READ_BLK_MISALIGN:       0
mmcsd_dmpcsd:   DSR_IMP:                 0
mmcsd_dmpcsd:   C_SIZE:                  29819 
mmcsd_dmpcsd:   VDD_R_CURR_MIN:          7
mmcsd_dmpcsd:   VDD_R_CURR_MAX:          6
mmcsd_dmpcsd:   VDD_W_CURR_MIN:          7
mmcsd_dmpcsd:   VDD_W_CURR_MAX:          6
mmcsd_dmpcsd:   C_SIZE_MULT:             8
mmcsd_dmpcsd:   SD ER_BLK_EN:            1
mmcsd_dmpcsd:   SD SECTOR_SIZE:          127
mmcsd_dmpcsd:   SD WP_GRP_SIZE:          0
mmcsd_dmpcsd:   WP_GRP_EN:               0
mmcsd_dmpcsd:   R2W_FACTOR:              2
mmcsd_dmpcsd:   WRITE_BL_LEN:            9
mmcsd_dmpcsd:   WRITE_BL_PARTIAL:        0
mmcsd_dmpcsd:   FILE_FORMAT_GROUP:       0
mmcsd_dmpcsd:   COPY:                    0
mmcsd_dmpcsd:   PERM_WRITE_PROTECT:      0
mmcsd_dmpcsd:   TMP_WRITE_PROTECT:       0
mmcsd_dmpcsd:   FILE_FORMAT:             0
mmcsd_dmpcsd:   CRC:                     4e
esp32s3_spi_setfrequency: frequency=20000000, actual=20000000
mmcsd_decodecsd: SPI Frequency
mmcsd_decodecsd:   Maximum:         25000000 Hz
mmcsd_decodecsd:   Actual:          20000000 Hz
mmcsd_decodecsd: Read access time:  101 ticks
mmcsd_decodecsd: Write access time: 251 ticks
mmcsd_decodecsd: Sector size:       512
mmcsd_decodecsd: Number of sectors: 30535680
esp32s3_spi_poll_send: send=0xff and recv=0xff
mmcsd_spislotinitialize: mmcsd_mediainitialize returned OK
cromfs_open: Open: init.d/rc.sysinit
cromfs_find_node: relpath: init.d/rc.sysinit
cromfs_compare_node: Compare . to init.d/rc.sysinit[0-6]
cromfs_compare_node: Compare extras to init.d/rc.sysinit[0-6]
cromfs_compare_node: Compare init.d to init.d/rc.sysinit[0-6]
cromfs_compare_node: Compare . to rc.sysinit[0-10]
cromfs_compare_node: Compare .. to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.board_sensors to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.autostart to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.vehicle_setup to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.autostart.post to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.filepaths to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.mc_apps to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.logging to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.balloon_defaults to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.sensors to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.board_defaults to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.board_mavlink to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.serial to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.sysinit to rc.sysinit[0-10]
cromfs_ioctl: cmd: 257 arg: 3c1f19e0
cromfs_read: Read 1 bytes from offset 0
cromfs_ioctl: cmd: 257 arg: 3c1f19e0
cromfs_close: Closing
cromfs_open: Open: init.d/rcS
cromfs_find_node: relpath: init.d/rcS
cromfs_compare_node: Compare . to init.d/rcS[0-6]
cromfs_compare_node: Compare extras to init.d/rcS[0-6]
cromfs_compare_node: Compare init.d to init.d/rcS[0-6]
cromfs_compare_node: Compare . to rcS[0-3]
cromfs_compare_node: Compare .. to rcS[0-3]
cromfs_compare_node: Compare rc.board_sensors to rcS[0-3]
cromfs_compare_node: Compare rc.autostart to rcS[0-3]
cromfs_compare_node: Compare rc.vehicle_setup to rcS[0-3]
cromfs_compare_node: Compare rc.autostart.post to rcS[0-3]
cromfs_compare_node: Compare rc.filepaths to rcS[0-3]
cromfs_compare_node: Compare rc.mc_apps to rcS[0-3]
cromfs_compare_node: Compare rc.logging to rcS[0-3]
cromfs_compare_node: Compare rc.balloon_defaults to rcS[0-3]
cromfs_compare_node: Compare rc.sensors to rcS[0-3]
cromfs_compare_node: Compare rc.board_defaults to rcS[0-3]
cromfs_compare_node: Compare rc.board_mavlink to rcS[0-3]
cromfs_compare_node: Compare rc.serial to rcS[0-3]
cromfs_compare_node: Compare rc.sysinit to rcS[0-3]
cromfs_compare_node: Compare rc.autostart_ext to rcS[0-3]
cromfs_compare_node: Compare rc.mc_defaults to rcS[0-3]
cromfs_compare_node: Compare airframes to rcS[0-3]
cromfs_compare_node: Compare rcS to rcS[0-3]
cromfs_ioctl: cmd: 257 arg: 3c1f19e0
cromfs_read: Read 1 bytes from offset 0
cromfs_ioctl: cmd: 257 arg: 3c1f19e0
cromfs_close: Closing

NuttShell (NSH) NuttX-11.0.0
nsh> mount -t vfat /dev/mmcsd0 /fs/microsd
find_blockdriver: pathname="/dev/mmcsd0"
mmcsd_open: Entry
esp32s3_spi_setmode: mode=0
esp32s3_spi_setbits: nbits=8
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_setmode: mode=0
esp32s3_spi_setbits: nbits=8
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x49 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x0
mmcsd_sendcmd: CMD9[00000000] R1=00
esp32s3_spi_poll_send: send=0xff and recv=0xff
mmcsd_getcardinfo: 0. SPI send returned ff
esp32s3_spi_poll_send: send=0xff and recv=0xfe
mmcsd_getcardinfo: 1. SPI send returned fe
esp32s3_spi_poll_send: send=0xff and recv=0x40
esp32s3_spi_poll_send: send=0xff and recv=0xe
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x32
esp32s3_spi_poll_send: send=0xff and recv=0x5b
esp32s3_spi_poll_send: send=0xff and recv=0x59
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x74
esp32s3_spi_poll_send: send=0xff and recv=0x7b
esp32s3_spi_poll_send: send=0xff and recv=0x7f
esp32s3_spi_poll_send: send=0xff and recv=0x80
esp32s3_spi_poll_send: send=0xff and recv=0xa
esp32s3_spi_poll_send: send=0xff and recv=0x40
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x9d
esp32s3_spi_poll_send: send=0xff and recv=0xa6
esp32s3_spi_poll_send: send=0xff and recv=0x66
esp32s3_spi_poll_send: send=0xff and recv=0xff
mmcsd_geometry: geo_available:     1
mmcsd_geometry: geo_mediachanged:  1
mmcsd_geometry: geo_writeenabled:  1
mmcsd_geometry: geo_nsectors:      30535680
mmcsd_geometry: geo_sectorsize:    512
mmcsd_read: start_sector=0 nsectors=1
mmcsd_read: nbytes=512 sector offset=0
esp32s3_spi_setmode: mode=0
esp32s3_spi_setbits: nbits=8
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x51 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x0
mmcsd_sendcmd: CMD17[00000000] R1=00
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xfe
esp32s3_spi_dma_exchange: nwords=512
esp32s3_spi_poll_send: send=0xff and recv=0x2d
esp32s3_spi_poll_send: send=0xff and recv=0xca
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
mmcsd_read: Read 512 bytes:
mmcsd_read: start_sector=1 nsectors=1
mmcsd_read: nbytes=512 sector offset=1
esp32s3_spi_setmode: mode=0
esp32s3_spi_setbits: nbits=8
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x51 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x1 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x0
mmcsd_sendcmd: CMD17[00000001] R1=00
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xfe
esp32s3_spi_dma_exchange: nwords=512
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
mmcsd_read: Read 512 bytes:
nx_mount: ERROR: Bind method failed: -19
nsh: mount: mount failed: 19
nsh> 
```

</details>

### Root Cause

The problem occurs during the SD card mounting process, specifically when performing repeated SPI reads after opening the device. When mounting the SD card, the system first opens the device, then performs multiple reads. Each read triggers a call to `esp32s3_spi_dma_exchange()`. In these calls, the `txbuffer` is NULL while the `rxbuffer` points to the same memory region. As a result, during the second (and subsequent) read operations, stale data from the previous transaction is transmitted to the SD card. This confuses the card and may leave it in a bad state.

### Solution

My solution is to reset `tp` to zero when `txbuffer` is NULL. A NULL `txbuffer` implies that we are only receiving data from the SPI device. Therefore, resetting `tp`—even if it shares the same address as `rxbuffer` in this case—should be safe and necessary to avoid sending unintended data.

## Impact

- esp32s3 spi

## Testing

The issue can be reproduced on any board that has an SD card slot connected via SPI, and when the SD card is formatted with a FAT32 filesystem.

To test the fix:

1. Use a custom board (or ESP32-S3 DevKit as a reference).
2. Connect an SD card via SPI.
3. Build and flash the firmware with the modified code.
4. Run the following command:
   ```
   mount -t vfat /dev/mmcsd0 /fs/microsd
   ```
5. Confirm that the mount succeeds without returning `-ENODEV`.

Below are the logs after applying the fix:  

<details>
<summary>Logs after applying the fix</summary>

```
ESP-ROM:esp32s3-20210327
Build:Mar 27 2021
rst:0x1 (POWERON),boot:0xb (SPI_FAST_FLASH_BOOT)
SPIWP:0xee
mode:DIO, clock div:2
load:0x3fc951b0,len:0x2478
load:0x40374000,len:0x90b0
load:0x50000000,len:0x20
SHA-256 comparison failed:
Calculated: aba9d127ce14ed5734224eecd99d6c470a02dc3ddd29f5288095fa598ac52a3e
Expected: 00000000704a0000000000000000000000000000000000000000000000000000
Attempting to boot anyway...
entry 0x40374a38
*** Booting NuttX ***
I (71) boot: chip revision: v0.2
I (71) boot: efuse block revision: v1.3
I (71) boot.esp32s3: Boot SPI Speed : 40MHz
I (72) boot.esp32s3: SPI Mode       : DIO
I (76) boot.esp32s3: SPI Flash Size : 4MB
I (79) boot: Enabling RNG early entropy source...
dram: lma 0x00000020 vma 0x3fc951b0 len 0x2478   (9336)
iram: lma 0x000024a0 vma 0x40374000 len 0x90b0   (37040)
rtc: lma 0x0000b558 vma 0x50000000 len 0x20     (32)
padd: lma 0x0000b588 vma 0x00000000 len 0x4a70   (19056)
imap: lma 0x00010000 vma 0x42010000 len 0x157e7c (1408636)
padd: lma 0x00167e84 vma 0x00000000 len 0x8174   (33140)
dmap: lma 0x00170000 vma 0x3c180000 len 0x65f3c  (417596)
total segments stored 7
ABI (799) app_init: Application information:
I (799) app_init: Compile time:     Jan 30 2026 12:36:36
I (804) app_init: ELF file SHA256:  000000000...
I (804) app_init: ESP-IDF:          
I (806) sleep_gpio: Configure to isolate all GPIO pins in sleep state
I (812) sleep_gpio: Enable automatic switching of GPIO sleep configuration
nx_romfsetc: Mounting ROMFS filesystem at target=/etc with source=/dev/ram0
find_blockdriver: pathname="/dev/ram0"
find_blockdriver: ERROR: Failed to find /dev/ram0
find_mtddriver: ERROR: Failed to find /dev/ram0
nx_mount: found cromfs
cromfs_bind: blkdriver: 0 data: 0 handle: 0x3fc9510c
nx_mount: found procfs
nx_mount: found binfs
binfs_bind: Entry
esp32s3_spiflash_alloc_mtdpart: ESP32-S3 SPI Flash information:
esp32s3_spiflash_alloc_mtdpart: 	ID = 0x5e4016
esp32s3_spiflash_alloc_mtdpart: 	Status mask = 0xffff
esp32s3_spiflash_alloc_mtdpart: 	Chip size = 4096 KB
esp32s3_spiflash_alloc_mtdpart: 	Page size = 256 B
esp32s3_spiflash_alloc_mtdpart: 	Sector size = 4 KB
esp32s3_spiflash_alloc_mtdpart: 	Block size = 64 KB
esp32s3_spiflash_alloc_mtdpart: 	MTD offset = 0x340000
esp32s3_spiflash_alloc_mtdpart: 	MTD size = 0x10000
esp32s3_ioctl: cmd: 1537
esp32s3_ioctl: blocksize: 256 erasesize: 4096 neraseblocks: 1024
esp32s3_ioctl: return 0
esp32s3_dma_request: periph=0 tx_prio=1 rx_prio=1
esp32s3_dma_request: Allocated channel=0
esp32s3_spi_setfrequency: frequency=400000, actual=400000
esp32s3_spi_setbits: nbits=8
esp32s3_spi_setmode: mode=0
esp32s3_dma_request: periph=1 tx_prio=1 rx_prio=1
esp32s3_dma_request: Allocated channel=1
esp32s3_spi_setfrequency: frequency=400000, actual=400000
esp32s3_spi_setbits: nbits=8
esp32s3_spi_setmode: mode=0
esp32s3_spi_setmode: mode=0
esp32s3_spi_setbits: nbits=8
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
mmcsd_mediainitialize: Send CMD0
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x40 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x95 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x1
mmcsd_sendcmd: CMD0[00000000] R1=01
mmcsd_mediainitialize: Card is in IDLE state
mmcsd_mediainitialize: Send CMD8
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x48 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x1 and recv=0xff
esp32s3_spi_poll_send: send=0xaa and recv=0xff
esp32s3_spi_poll_send: send=0x87 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x1
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x1
esp32s3_spi_poll_send: send=0xff and recv=0xaa
mmcsd_sendcmd: CMD8[000001aa] R1=01 R7=000001aa
mmcsd_mediainitialize: 0. Send CMD55/ACMD41
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x77 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x1
mmcsd_sendcmd: CMD55[00000000] R1=01
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x69 and recv=0xff
esp32s3_spi_poll_send: send=0x40 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x1
mmcsd_sendcmd: CMD41[40000000] R1=01
mmcsd_mediainitialize: 71. Send CMD55/ACMD41
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x77 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x1
mmcsd_sendcmd: CMD55[00000000] R1=01
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x69 and recv=0xff
esp32s3_spi_poll_send: send=0x40 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x0
mmcsd_sendcmd: CMD41[40000000] R1=00
mmcsd_mediainitialize: Send CMD58
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x7a and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0xc0
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x80
esp32s3_spi_poll_send: send=0xff and recv=0x0
mmcsd_sendcmd: CMD58[00000000] R1=00 OCR=c0ff8000
mmcsd_mediainitialize: OCR: c0ff8000
mmcsd_mediainitialize: Identified SD ver2 card/with block access
mmcsd_mediainitialize: Get CSD
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x49 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x0
mmcsd_sendcmd: CMD9[00000000] R1=00
esp32s3_spi_poll_send: send=0xff and recv=0xff
mmcsd_getcardinfo: 0. SPI send returned ff
esp32s3_spi_poll_send: send=0xff and recv=0xfe
mmcsd_getcardinfo: 1. SPI send returned fe
esp32s3_spi_poll_send: send=0xff and recv=0x40
esp32s3_spi_poll_send: send=0xff and recv=0xe
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x32
esp32s3_spi_poll_send: send=0xff and recv=0x5b
esp32s3_spi_poll_send: send=0xff and recv=0x59
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x74
esp32s3_spi_poll_send: send=0xff and recv=0x7b
esp32s3_spi_poll_send: send=0xff and recv=0x7f
esp32s3_spi_poll_send: send=0xff and recv=0x80
esp32s3_spi_poll_send: send=0xff and recv=0xa
esp32s3_spi_poll_send: send=0xff and recv=0x40
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x9d
esp32s3_spi_poll_send: send=0xff and recv=0xa6
esp32s3_spi_poll_send: send=0xff and recv=0x66
mmcsd_dmpcsd: CSD
mmcsd_dmpcsd:   CSD_STRUCTURE:           1.1
mmcsd_dmpcsd:   TAAC:
mmcsd_dmpcsd:     TIME_VALUE:            0x01
mmcsd_dmpcsd:     TIME_UNIT:             0x06
mmcsd_dmpcsd:   NSAC:                    0x00
mmcsd_dmpcsd:   TRAN_SPEED:
mmcsd_dmpcsd:     TIME_VALUE:            0x06
mmcsd_dmpcsd:     RATE_UNIT:             0x02
mmcsd_dmpcsd:   CCC:                     0x5b5
mmcsd_dmpcsd:   READ_BL_LEN:             9
mmcsd_dmpcsd:   READ_BL_PARTIAL:         0
mmcsd_dmpcsd:   WRITE_BLK_MISALIGN:      0
mmcsd_dmpcsd:   READ_BLK_MISALIGN:       0
mmcsd_dmpcsd:   DSR_IMP:                 0
mmcsd_dmpcsd:   C_SIZE:                  29819 
mmcsd_dmpcsd:   VDD_R_CURR_MIN:          7
mmcsd_dmpcsd:   VDD_R_CURR_MAX:          6
mmcsd_dmpcsd:   VDD_W_CURR_MIN:          7
mmcsd_dmpcsd:   VDD_W_CURR_MAX:          6
mmcsd_dmpcsd:   C_SIZE_MULT:             8
mmcsd_dmpcsd:   SD ER_BLK_EN:            1
mmcsd_dmpcsd:   SD SECTOR_SIZE:          127
mmcsd_dmpcsd:   SD WP_GRP_SIZE:          0
mmcsd_dmpcsd:   WP_GRP_EN:               0
mmcsd_dmpcsd:   R2W_FACTOR:              2
mmcsd_dmpcsd:   WRITE_BL_LEN:            9
mmcsd_dmpcsd:   WRITE_BL_PARTIAL:        0
mmcsd_dmpcsd:   FILE_FORMAT_GROUP:       0
mmcsd_dmpcsd:   COPY:                    0
mmcsd_dmpcsd:   PERM_WRITE_PROTECT:      0
mmcsd_dmpcsd:   TMP_WRITE_PROTECT:       0
mmcsd_dmpcsd:   FILE_FORMAT:             0
mmcsd_dmpcsd:   CRC:                     4e
esp32s3_spi_setfrequency: frequency=20000000, actual=20000000
mmcsd_decodecsd: SPI Frequency
mmcsd_decodecsd:   Maximum:         25000000 Hz
mmcsd_decodecsd:   Actual:          20000000 Hz
mmcsd_decodecsd: Read access time:  101 ticks
mmcsd_decodecsd: Write access time: 251 ticks
mmcsd_decodecsd: Sector size:       512
mmcsd_decodecsd: Number of sectors: 30535680
esp32s3_spi_poll_send: send=0xff and recv=0xff
mmcsd_spislotinitialize: mmcsd_mediainitialize returned OK
cromfs_open: Open: init.d/rc.sysinit
cromfs_find_node: relpath: init.d/rc.sysinit
cromfs_compare_node: Compare . to init.d/rc.sysinit[0-6]
cromfs_compare_node: Compare extras to init.d/rc.sysinit[0-6]
cromfs_compare_node: Compare init.d to init.d/rc.sysinit[0-6]
cromfs_compare_node: Compare . to rc.sysinit[0-10]
cromfs_compare_node: Compare .. to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.board_sensors to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.autostart to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.vehicle_setup to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.autostart.post to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.filepaths to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.mc_apps to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.logging to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.balloon_defaults to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.sensors to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.board_defaults to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.board_mavlink to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.serial to rc.sysinit[0-10]
cromfs_compare_node: Compare rc.sysinit to rc.sysinit[0-10]
cromfs_ioctl: cmd: 257 arg: 3c1f19e0
cromfs_read: Read 1 bytes from offset 0
cromfs_ioctl: cmd: 257 arg: 3c1f19e0
cromfs_close: Closing
cromfs_open: Open: init.d/rcS
cromfs_find_node: relpath: init.d/rcS
cromfs_compare_node: Compare . to init.d/rcS[0-6]
cromfs_compare_node: Compare extras to init.d/rcS[0-6]
cromfs_compare_node: Compare init.d to init.d/rcS[0-6]
cromfs_compare_node: Compare . to rcS[0-3]
cromfs_compare_node: Compare .. to rcS[0-3]
cromfs_compare_node: Compare rc.board_sensors to rcS[0-3]
cromfs_compare_node: Compare rc.autostart to rcS[0-3]
cromfs_compare_node: Compare rc.vehicle_setup to rcS[0-3]
cromfs_compare_node: Compare rc.autostart.post to rcS[0-3]
cromfs_compare_node: Compare rc.filepaths to rcS[0-3]
cromfs_compare_node: Compare rc.mc_apps to rcS[0-3]
cromfs_compare_node: Compare rc.logging to rcS[0-3]
cromfs_compare_node: Compare rc.balloon_defaults to rcS[0-3]
cromfs_compare_node: Compare rc.sensors to rcS[0-3]
cromfs_compare_node: Compare rc.board_defaults to rcS[0-3]
cromfs_compare_node: Compare rc.board_mavlink to rcS[0-3]
cromfs_compare_node: Compare rc.serial to rcS[0-3]
cromfs_compare_node: Compare rc.sysinit to rcS[0-3]
cromfs_compare_node: Compare rc.autostart_ext to rcS[0-3]
cromfs_compare_node: Compare rc.mc_defaults to rcS[0-3]
cromfs_compare_node: Compare airframes to rcS[0-3]
cromfs_compare_node: Compare rcS to rcS[0-3]
cromfs_ioctl: cmd: 257 arg: 3c1f19e0
cromfs_read: Read 1 bytes from offset 0
cromfs_ioctl: cmd: 257 arg: 3c1f19e0
cromfs_close: Closing

NuttShell (NSH) NuttX-11.0.0
nsh> mount -t vfat /dev/mmcsd0 /fs/microsd
find_blockdriver: pathname="/dev/mmcsd0"
mmcsd_open: Entry
esp32s3_spi_setmode: mode=0
esp32s3_spi_setbits: nbits=8
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_setmode: mode=0
esp32s3_spi_setbits: nbits=8
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x49 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x0
mmcsd_sendcmd: CMD9[00000000] R1=00
esp32s3_spi_poll_send: send=0xff and recv=0xff
mmcsd_getcardinfo: 0. SPI send returned ff
esp32s3_spi_poll_send: send=0xff and recv=0xfe
mmcsd_getcardinfo: 1. SPI send returned fe
esp32s3_spi_poll_send: send=0xff and recv=0x40
esp32s3_spi_poll_send: send=0xff and recv=0xe
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x32
esp32s3_spi_poll_send: send=0xff and recv=0x5b
esp32s3_spi_poll_send: send=0xff and recv=0x59
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x74
esp32s3_spi_poll_send: send=0xff and recv=0x7b
esp32s3_spi_poll_send: send=0xff and recv=0x7f
esp32s3_spi_poll_send: send=0xff and recv=0x80
esp32s3_spi_poll_send: send=0xff and recv=0xa
esp32s3_spi_poll_send: send=0xff and recv=0x40
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x9d
esp32s3_spi_poll_send: send=0xff and recv=0xa6
esp32s3_spi_poll_send: send=0xff and recv=0x66
esp32s3_spi_poll_send: send=0xff and recv=0xff
mmcsd_geometry: geo_available:     1
mmcsd_geometry: geo_mediachanged:  1
mmcsd_geometry: geo_writeenabled:  1
mmcsd_geometry: geo_nsectors:      30535680
mmcsd_geometry: geo_sectorsize:    512
mmcsd_read: start_sector=0 nsectors=1
mmcsd_read: nbytes=512 sector offset=0
esp32s3_spi_setmode: mode=0
esp32s3_spi_setbits: nbits=8
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x51 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x0
mmcsd_sendcmd: CMD17[00000000] R1=00
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xfe
esp32s3_spi_dma_exchange: nwords=512
esp32s3_spi_poll_send: send=0xff and recv=0x2d
esp32s3_spi_poll_send: send=0xff and recv=0xca
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
mmcsd_read: Read 512 bytes:
mmcsd_read: start_sector=1 nsectors=1
mmcsd_read: nbytes=512 sector offset=1
esp32s3_spi_setmode: mode=0
esp32s3_spi_setbits: nbits=8
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x51 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x1 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x0
mmcsd_sendcmd: CMD17[00000001] R1=00
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xfe
esp32s3_spi_dma_exchange: nwords=512
esp32s3_spi_poll_send: send=0xff and recv=0x43
esp32s3_spi_poll_send: send=0xff and recv=0xc5
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
mmcsd_read: Read 512 bytes:
fat_mount: FAT32:
fat_mount: 	HW  sector size:     512
fat_mount: 	    sectors:         30535680
fat_mount: 	FAT reserved:        32
fat_mount: 	    sectors:         30535680
fat_mount: 	    start sector:    32
fat_mount: 	    root sector:     2
fat_mount: 	    root entries:    0
fat_mount: 	    data sector:     14936
fat_mount: 	    FSINFO sector:   1
fat_mount: 	    Num FATs:        2
fat_mount: 	    FAT sectors:     7452
fat_mount: 	    sectors/cluster: 32
fat_mount: 	    max clusters:    953773
fat_mount: 	FSI free count       953771
fat_mount: 	    next free        4
nsh> ls /fs
/fs:
 microsd/
 mtd_caldata
nsh> ls /fs/microsd
esp32s3_spi_setmode: mode=0
esp32s3_spi_setbits: nbits=8
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x49 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x0
mmcsd_sendcmd: CMD9[00000000] R1=00
esp32s3_spi_poll_send: send=0xff and recv=0xff
mmcsd_getcardinfo: 0. SPI send returned ff
esp32s3_spi_poll_send: send=0xff and recv=0xfe
mmcsd_getcardinfo: 1. SPI send returned fe
esp32s3_spi_poll_send: send=0xff and recv=0x40
esp32s3_spi_poll_send: send=0xff and recv=0xe
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x32
esp32s3_spi_poll_send: send=0xff and recv=0x5b
esp32s3_spi_poll_send: send=0xff and recv=0x59
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x74
esp32s3_spi_poll_send: send=0xff and recv=0x7b
esp32s3_spi_poll_send: send=0xff and recv=0x7f
esp32s3_spi_poll_send: send=0xff and recv=0x80
esp32s3_spi_poll_send: send=0xff and recv=0xa
esp32s3_spi_poll_send: send=0xff and recv=0x40
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x9d
esp32s3_spi_poll_send: send=0xff and recv=0xa6
esp32s3_spi_poll_send: send=0xff and recv=0x66
esp32s3_spi_poll_send: send=0xff and recv=0xff
mmcsd_geometry: geo_available:     1
mmcsd_geometry: geo_mediachanged:  0
mmcsd_geometry: geo_writeenabled:  1
mmcsd_geometry: geo_nsectors:      30535680
mmcsd_geometry: geo_sectorsize:    512
/fs/microsd:
esp32s3_spi_setmode: mode=0
esp32s3_spi_setbits: nbits=8
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x49 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x0
mmcsd_sendcmd: CMD9[00000000] R1=00
esp32s3_spi_poll_send: send=0xff and recv=0xff
mmcsd_getcardinfo: 0. SPI send returned ff
esp32s3_spi_poll_send: send=0xff and recv=0xfe
mmcsd_getcardinfo: 1. SPI send returned fe
esp32s3_spi_poll_send: send=0xff and recv=0x40
esp32s3_spi_poll_send: send=0xff and recv=0xe
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x32
esp32s3_spi_poll_send: send=0xff and recv=0x5b
esp32s3_spi_poll_send: send=0xff and recv=0x59
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x74
esp32s3_spi_poll_send: send=0xff and recv=0x7b
esp32s3_spi_poll_send: send=0xff and recv=0x7f
esp32s3_spi_poll_send: send=0xff and recv=0x80
esp32s3_spi_poll_send: send=0xff and recv=0xa
esp32s3_spi_poll_send: send=0xff and recv=0x40
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x9d
esp32s3_spi_poll_send: send=0xff and recv=0xa6
esp32s3_spi_poll_send: send=0xff and recv=0x66
esp32s3_spi_poll_send: send=0xff and recv=0xff
mmcsd_geometry: geo_available:     1
mmcsd_geometry: geo_mediachanged:  0
mmcsd_geometry: geo_writeenabled:  1
mmcsd_geometry: geo_nsectors:      30535680
mmcsd_geometry: geo_sectorsize:    512
esp32s3_spi_setmode: mode=0
esp32s3_spi_setbits: nbits=8
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x49 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x0
mmcsd_sendcmd: CMD9[00000000] R1=00
esp32s3_spi_poll_send: send=0xff and recv=0xff
mmcsd_getcardinfo: 0. SPI send returned ff
esp32s3_spi_poll_send: send=0xff and recv=0xfe
mmcsd_getcardinfo: 1. SPI send returned fe
esp32s3_spi_poll_send: send=0xff and recv=0x40
esp32s3_spi_poll_send: send=0xff and recv=0xe
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x32
esp32s3_spi_poll_send: send=0xff and recv=0x5b
esp32s3_spi_poll_send: send=0xff and recv=0x59
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x74
esp32s3_spi_poll_send: send=0xff and recv=0x7b
esp32s3_spi_poll_send: send=0xff and recv=0x7f
esp32s3_spi_poll_send: send=0xff and recv=0x80
esp32s3_spi_poll_send: send=0xff and recv=0xa
esp32s3_spi_poll_send: send=0xff and recv=0x40
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x9d
esp32s3_spi_poll_send: send=0xff and recv=0xa6
esp32s3_spi_poll_send: send=0xff and recv=0x66
esp32s3_spi_poll_send: send=0xff and recv=0xff
mmcsd_geometry: geo_available:     1
mmcsd_geometry: geo_mediachanged:  0
mmcsd_geometry: geo_writeenabled:  1
mmcsd_geometry: geo_nsectors:      30535680
mmcsd_geometry: geo_sectorsize:    512
mmcsd_read: start_sector=14936 nsectors=1
mmcsd_read: nbytes=512 sector offset=14936
esp32s3_spi_setmode: mode=0
esp32s3_spi_setbits: nbits=8
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x51 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x3a and recv=0xff
esp32s3_spi_poll_send: send=0x58 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x0
mmcsd_sendcmd: CMD17[00003a58] R1=00
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xfe
esp32s3_spi_dma_exchange: nwords=512
esp32s3_spi_poll_send: send=0xff and recv=0x52
esp32s3_spi_poll_send: send=0xff and recv=0x7f
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
mmcsd_read: Read 512 bytes:
 System Volume Information/
esp32s3_spi_setmode: mode=0
esp32s3_spi_setbits: nbits=8
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0x49 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0x0 and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0xff
esp32s3_spi_poll_send: send=0xff and recv=0x0
mmcsd_sendcmd: CMD9[00000000] R1=00
esp32s3_spi_poll_send: send=0xff and recv=0xff
mmcsd_getcardinfo: 0. SPI send returned ff
esp32s3_spi_poll_send: send=0xff and recv=0xfe
mmcsd_getcardinfo: 1. SPI send returned fe
esp32s3_spi_poll_send: send=0xff and recv=0x40
esp32s3_spi_poll_send: send=0xff and recv=0xe
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x32
esp32s3_spi_poll_send: send=0xff and recv=0x5b
esp32s3_spi_poll_send: send=0xff and recv=0x59
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x74
esp32s3_spi_poll_send: send=0xff and recv=0x7b
esp32s3_spi_poll_send: send=0xff and recv=0x7f
esp32s3_spi_poll_send: send=0xff and recv=0x80
esp32s3_spi_poll_send: send=0xff and recv=0xa
esp32s3_spi_poll_send: send=0xff and recv=0x40
esp32s3_spi_poll_send: send=0xff and recv=0x0
esp32s3_spi_poll_send: send=0xff and recv=0x9d
esp32s3_spi_poll_send: send=0xff and recv=0xa6
esp32s3_spi_poll_send: send=0xff and recv=0x66
esp32s3_spi_poll_send: send=0xff and recv=0xff
mmcsd_geometry: geo_available:     1
mmcsd_geometry: geo_mediachanged:  0
mmcsd_geometry: geo_writeenabled:  1
mmcsd_geometry: geo_nsectors:      30535680
mmcsd_geometry: geo_sectorsize:    512
nsh> 
```

</details>

The corresponding defconfig file is shown below:  

<details>

<summary>defconfig</summary>

```
#
# This file is autogenerated: PLEASE DO NOT EDIT IT.
#
# You can use "make menuconfig" to make any modifications to the installed .config file.
# You can then do "make savedefconfig" to generate a new defconfig file that includes your
# modifications.
#
# CONFIG_MMCSD_HAVE_CARDDETECT is not set
# CONFIG_MMCSD_HAVE_WRITEPROTECT is not set
# CONFIG_MMCSD_MMCSUPPORT is not set
# CONFIG_NSH_DISABLE_DATE is not set
# CONFIG_SPI_CALLBACK is not set
CONFIG_ALLOW_BSD_COMPONENTS=y
CONFIG_ARCH="xtensa"
CONFIG_ARCH_BOARD_COMMON=y
CONFIG_ARCH_BOARD_CUSTOM=y
CONFIG_ARCH_BOARD_CUSTOM_DIR="../../../../boards/espressif/esp32s3/nuttx-config"
CONFIG_ARCH_BOARD_CUSTOM_DIR_RELPATH=y
CONFIG_ARCH_BOARD_CUSTOM_NAME=""
CONFIG_ARCH_CHIP="esp32s3"
CONFIG_ARCH_CHIP_ESP32S3=y
CONFIG_ARCH_CHIP_ESP32S3WROOM1N4=y
CONFIG_ARCH_INTERRUPTSTACK=2048
CONFIG_ARCH_STACKDUMP=y
CONFIG_ARCH_XTENSA=y
CONFIG_BOARDCTL_MKRD=y
CONFIG_BOARDCTL_RESET=y
CONFIG_BOARD_LOOPSPERMSEC=16717
CONFIG_BUILTIN=y
CONFIG_CDCACM=y
CONFIG_DEBUG_ASSERTIONS=y
CONFIG_DEBUG_ASSERTIONS_EXPRESSION=y
CONFIG_DEBUG_DMA=y
CONFIG_DEBUG_DMA_ERROR=y
CONFIG_DEBUG_DMA_INFO=y
CONFIG_DEBUG_DMA_WARN=y
CONFIG_DEBUG_FEATURES=y
CONFIG_DEBUG_FS=y
CONFIG_DEBUG_FS_ERROR=y
CONFIG_DEBUG_FS_INFO=y
CONFIG_DEBUG_FS_WARN=y
CONFIG_DEBUG_SPI=y
CONFIG_DEBUG_SPI_INFO=y
CONFIG_DEFAULT_TASK_STACKSIZE=3072
CONFIG_DEV_FIFO_SIZE=0
CONFIG_DEV_PIPE_MAXSIZE=1024
CONFIG_DEV_PIPE_SIZE=70
CONFIG_DEV_URANDOM=y
CONFIG_DRIVERS_IEEE80211=y
CONFIG_DRIVERS_WIRELESS=y
CONFIG_ELF=y
CONFIG_ESP32S3_GPIO_IRQ=y
CONFIG_ESP32S3_I2C0=y
CONFIG_ESP32S3_I2C1=y
CONFIG_ESP32S3_I2CTIMEOSEC=1
CONFIG_ESP32S3_OTG=y
CONFIG_ESP32S3_RT_TIMER=y
CONFIG_ESP32S3_SPI2=y
CONFIG_ESP32S3_SPI2_CLKPIN=7
CONFIG_ESP32S3_SPI2_CSPIN=6
CONFIG_ESP32S3_SPI2_MISOPIN=16
CONFIG_ESP32S3_SPI2_MOSIPIN=15
CONFIG_ESP32S3_SPI3=y
CONFIG_ESP32S3_SPI3_CLKPIN=40
CONFIG_ESP32S3_SPI3_CSPIN=38
CONFIG_ESP32S3_SPI3_MISOPIN=41
CONFIG_ESP32S3_SPI3_MOSIPIN=39
CONFIG_ESP32S3_SPIFLASH=y
CONFIG_ESP32S3_SPIRAM=y
CONFIG_ESP32S3_SPIRAM_MODE_OCT=y
CONFIG_ESP32S3_SPI_DMA=y
CONFIG_ESP32S3_SPI_SWCS=y
CONFIG_ESP32S3_SPI_UDCS=y
CONFIG_ESP32S3_UART0=y
CONFIG_ESP32S3_UART1=y
CONFIG_ESP32S3_UART1_RXPIN=42
CONFIG_ESP32S3_UART1_TXPIN=45
CONFIG_ESP32S3_UART2=y
CONFIG_ESP32S3_UART2_RXPIN=3
CONFIG_ESP32S3_UART2_TXPIN=8
CONFIG_ETC_CROMFS=y
CONFIG_ETC_ROMFS=y
CONFIG_EXAMPLES_CALIB_UDELAY=y
CONFIG_FAT_DMAMEMORY=y
CONFIG_FAT_LCNAMES=y
CONFIG_FAT_LFN=y
CONFIG_FAT_LFN_ALIAS_HASH=y
CONFIG_FAT_LFN_UTF8=y
CONFIG_FS_BINFS=y
CONFIG_FS_CROMFS=y
CONFIG_FS_FAT=y
CONFIG_FS_FATTIME=y
CONFIG_FS_PROCFS=y
CONFIG_FS_PROCFS_REGISTER=y
CONFIG_FS_ROMFS=y
CONFIG_FS_SPIFFS=y
CONFIG_GRAN=y
CONFIG_GRAN_INTR=y
CONFIG_HAVE_CXX=y
CONFIG_HAVE_CXXINITIALIZE=y
CONFIG_I2C_DRIVER=y
CONFIG_I2C_RESET=y
CONFIG_IDLETHREAD_STACKSIZE=3072
CONFIG_INIT_ENTRYPOINT="nsh_main"
CONFIG_INIT_STACKSIZE=6144
CONFIG_INTELHEX_BINARY=y
CONFIG_IOB_NBUFFERS=36
CONFIG_IOB_NCHAINS=36
CONFIG_LIBC_MAX_EXITFUNS=1
CONFIG_MMCSD=y
CONFIG_MM_IOB=y
CONFIG_MM_REGIONS=2
CONFIG_MTD_RAMTRON=y
CONFIG_NAME_MAX=48
CONFIG_NDEBUG=y
CONFIG_NSH_ARCHINIT=y
CONFIG_NSH_BUILTIN_APPS=y
CONFIG_NSH_DISABLE_BASENAME=y
CONFIG_NSH_DISABLE_CMP=y
CONFIG_NSH_DISABLE_DIRNAME=y
CONFIG_NSH_DISABLE_HEXDUMP=y
CONFIG_NSH_DISABLE_LOSETUP=y
CONFIG_NSH_DISABLE_MKFIFO=y
CONFIG_NSH_DISABLE_MKRD=y
CONFIG_NSH_DISABLE_PRINTF=y
CONFIG_NSH_DISABLE_PUT=y
CONFIG_NSH_DISABLE_TRUNCATE=y
CONFIG_NSH_DISABLE_UNAME=y
CONFIG_NSH_DISABLE_WGET=y
CONFIG_NSH_DISABLE_XD=y
CONFIG_NSH_FILEIOSIZE=512
CONFIG_NSH_MAXARGUMENTS=15
CONFIG_NSH_NESTDEPTH=8
CONFIG_NSH_READLINE=y
CONFIG_NSH_VARS=y
CONFIG_PIPES=y
CONFIG_PREALLOC_TIMERS=50
CONFIG_PRIORITY_INHERITANCE=y
CONFIG_PTHREAD_MUTEX_TYPES=y
CONFIG_PTHREAD_STACK_MIN=512
CONFIG_PWM=y
CONFIG_RAMTRON_EMULATE_PAGE_SHIFT=10
CONFIG_RAMTRON_EMULATE_SECTOR_SHIFT=10
CONFIG_RAMTRON_SETSPEED=y
CONFIG_RAM_SIZE=114688
CONFIG_RAM_START=0x20000000
CONFIG_RAW_BINARY=y
CONFIG_READLINE_CMD_HISTORY=y
CONFIG_READLINE_CMD_HISTORY_LEN=4
CONFIG_READLINE_CMD_HISTORY_LINELEN=64
CONFIG_READLINE_TABCOMPLETION=y
CONFIG_SCHED_BACKTRACE=y
CONFIG_SCHED_HPWORK=y
CONFIG_SCHED_HPWORKPRIORITY=249
CONFIG_SCHED_INSTRUMENTATION=y
CONFIG_SCHED_INSTRUMENTATION_SWITCH=y
CONFIG_SCHED_LPWORK=y
CONFIG_SCHED_LPWORKPRIOMAX=178
CONFIG_SCHED_LPWORKSTACKSIZE=2048
CONFIG_SCHED_WAITPID=y
CONFIG_SEM_PREALLOCHOLDERS=32
CONFIG_SERIAL_TERMIOS=y
CONFIG_SIG_DEFAULT=y
CONFIG_SIG_SIGALRM_ACTION=y
CONFIG_SIG_SIGUSR1_ACTION=y
CONFIG_SIG_SIGUSR2_ACTION=y
CONFIG_SPIFFS_NAME_MAX=48
CONFIG_SPINLOCK=y
CONFIG_SPI_DRIVER=y
CONFIG_STACK_COLORATION=y
CONFIG_START_DAY=30
CONFIG_START_MONTH=11
CONFIG_STDIO_BUFFER_SIZE=32
CONFIG_SYSTEM_CDCACM=y
CONFIG_SYSTEM_NSH=y
CONFIG_SYSTEM_NSH_STACKSIZE=2000
CONFIG_TASK_NAME_SIZE=24
CONFIG_TLS_TASK_NELEM=4
CONFIG_UART0_SERIAL_CONSOLE=y
CONFIG_USEC_PER_TICK=1000
CONFIG_WQUEUE_NOTIFIER=y

```

</details>

If any additional information is needed, I’m happy to provide it.
