### PR TITLE
tls_getinfo.c: tls_get_info needs to be compiled in most cases.

### DIFF
--- a/libs/libc/tls/tls_getinfo.c
+++ b/libs/libc/tls/tls_getinfo.c
@@ -32,7 +32,7 @@
 #include <nuttx/tls.h>
 #include <nuttx/sched.h>
 
-#if !defined(up_tls_info) && (defined(__KERNEL__) || !defined(CONFIG_TLS_ALIGNED))
+#ifndef up_tls_info
 
 /****************************************************************************
  * Public Functions
@@ -55,6 +55,7 @@
  *
  ****************************************************************************/
 
+#undef tls_get_info
 FAR struct tls_info_s *tls_get_info(void)
 {
   FAR struct tls_info_s *info = NULL;


### PR DESCRIPTION
Improve tls_get_info function availability in different build configurations

Simplify the conditional compilation logic for the tls_get_info() function in
libs/libc/tls/tls_getinfo.c. The function is essential for TLS management and
should be available in most build configurations. By removing the restrictive
CONFIG_TLS_ALIGNED dependency and implementing an explicit undef directive,
the implementation ensures broader availability while maintaining proper control
over macro definitions.

###Summary

- Modify conditional compilation from complex multi-condition check to simpler up_tls_info check
- Add explicit undef directive for tls_get_info to prevent macro definition conflicts
- Ensure tls_get_info function is compiled and available in most configurations instead of being limited to kernel or non-aligned TLS builds

#TEST

In FlatBuild, if we use the CONFIG_TLS_ALIGNED=y and also utilize poll, the following compilation error will occur.

for example:
make distclean -j20; ./tools/configure.sh -l fvp-armv8r:nsh;make -j25;

```
LD: nuttx
aarch64-none-elf-ld: /home/hujun5/downloads/vela_sim/nuttx/staging/libfs.a(fs_poll.o): in function `poll':
/home/hujun5/downloads/vela_sim/nuttx/fs/vfs/fs_poll.c:470:(.text.poll+0x114): undefined reference to `tls_get_info'
aarch64-none-elf-ld: /home/hujun5/downloads/vela_sim/nuttx/fs/vfs/fs_poll.c:521:(.text.poll+0x14c): undefined reference to `tls_get_info'
Memory region         Used Size  Region Size  %age Used
           ksram:        288 KB       128 MB      0.22%
```