### PR TITLE
arch/arm64: Delete the default save for SCTLR and fix the issue of including incorrect order

### DIFF
--- a/arch/arm64/include/irq.h
+++ b/arch/arm64/include/irq.h
@@ -40,13 +40,13 @@
 #  include <nuttx/macro.h>
 #endif
 
-/* Include NuttX-specific IRQ definitions */
-
-#include <nuttx/irq.h>
-
 /* Include chip-specific IRQ definitions (including IRQ numbers) */
 
 #include <arch/chip/irq.h>
+
+/* Include NuttX-specific IRQ definitions */
+
+#include <nuttx/irq.h>
 
 /****************************************************************************
  * Pre-processor Prototypes

--- a/arch/arm64/src/common/arm64_fork.c
+++ b/arch/arm64/src/common/arm64_fork.c
@@ -225,9 +225,8 @@ pid_t arm64_fork(const struct fork_s *context)
 
   child->xcp.regs[REG_ELR]    = (uint64_t)context->lr;
 
-  child->xcp.regs[REG_SCTLR_EL1]  = read_sysreg(sctlr_el1);
 #ifdef CONFIG_ARM64_MTE
-  child->xcp.regs[REG_SCTLR_EL1] |= SCTLR_TCF1_BIT;
+  child->xcp.regs[REG_SCTLR_EL1] = read_sysreg(sctlr_el1) | SCTLR_TCF1_BIT;
 #endif
 
   child->xcp.regs[REG_EXE_DEPTH] = 0;

--- a/arch/arm64/src/common/arm64_initialstate.c
+++ b/arch/arm64/src/common/arm64_initialstate.c
@@ -85,9 +85,8 @@ void arm64_new_task(struct tcb_s * tcb)
   xcp->regs[REG_SPSR]      = SPSR_MODE_EL1H;
 #endif
 
-  xcp->regs[REG_SCTLR_EL1] = read_sysreg(sctlr_el1);
 #ifdef CONFIG_ARM64_MTE
-  xcp->regs[REG_SCTLR_EL1] |= SCTLR_TCF1_BIT;
+  xcp->regs[REG_SCTLR_EL1] = read_sysreg(sctlr_el1) | SCTLR_TCF1_BIT;
 #endif
 
 #ifndef CONFIG_ARM64_DECODEFIQ

--- a/arch/arm64/src/common/arm64_registerdump.c
+++ b/arch/arm64/src/common/arm64_registerdump.c
@@ -94,5 +94,8 @@ void up_dump_register(void *dumpregs)
   _alert("SP_EL0:    0x%-16"PRIx64"\n", regs[REG_SP_EL0]);
   _alert("SP_ELX:    0x%-16"PRIx64"\n", regs[REG_SP_ELX]);
   _alert("EXE_DEPTH: 0x%-16"PRIx64"\n", regs[REG_EXE_DEPTH]);
+
+#ifdef CONFIG_ARM64_MTE
   _alert("SCTLR_EL1: 0x%-16"PRIx64"\n", regs[REG_SCTLR_EL1]);
+#endif
 }

--- a/arch/arm64/src/common/arm64_schedulesigaction.c
+++ b/arch/arm64/src/common/arm64_schedulesigaction.c
@@ -66,9 +66,8 @@ static void arm64_init_signal_process(struct tcb_s *tcb, uint64_t *regs)
   tcb->xcp.regs[REG_SPSR]   = SPSR_MODE_EL1H | DAIF_FIQ_BIT | DAIF_IRQ_BIT;
 #endif
 
-  tcb->xcp.regs[REG_SCTLR_EL1] = read_sysreg(sctlr_el1);
 #ifdef CONFIG_ARM64_MTE
-  tcb->xcp.regs[REG_SCTLR_EL1] |= SCTLR_TCF1_BIT;
+  tcb->xcp.regs[REG_SCTLR_EL1] = read_sysreg(sctlr_el1) | SCTLR_TCF1_BIT;
 #endif
 
 #ifdef CONFIG_ARCH_KERNEL_STACK

--- a/arch/arm64/src/common/arm64_vector_table.S
+++ b/arch/arm64/src/common/arm64_vector_table.S
@@ -269,8 +269,10 @@ SECTION_FUNC(text, arm64_exit_exception)
     msr    spsr_el1,  x1
 #endif
 
+#ifdef CONFIG_ARM64_MTE
     ldr    x0,   [sp, #8 * REG_SCTLR_EL1]
     msr    sctlr_el1, x0
+#endif
 
     ldp    x0, x1,   [sp, #8 * REG_SP_EL0]
     msr    sp_el0,   x0

--- a/arch/arm64/src/common/arm64_vectors.S
+++ b/arch/arm64/src/common/arm64_vectors.S
@@ -84,8 +84,10 @@ SECTION_FUNC(text, up_saveusercontext)
 #endif
     stp    x4,  x5,  [x0, #8 * REG_ELR]
 
+#ifdef CONFIG_ARM64_MTE
     mrs    x4,  sctlr_el1
     str    x4,  [x0, #8 * REG_SCTLR_EL1]
+#endif
 
     ret
 
@@ -119,8 +121,12 @@ SECTION_FUNC(text, arm64_jump_to_user)
     and x0,  x0, #~SPSR_MODE_MASK
     #orr x0, x0, #SPSR_MODE_EL0T # EL0T=0x00, out of range for orr
     str x0,  [sp, #8 * REG_SPSR]
+
+#ifdef CONFIG_ARM64_MTE
     mrs x0,  sctlr_el1
     str x0,  [sp, #8 * REG_SCTLR_EL1]
+#endif
+
     b arm64_exit_exception
 #endif
 


### PR DESCRIPTION
Currently, the SCTLR register is only used to switch the thread MTE state and has no other uses. Because saving this register is special, it will take a long time after testing, so the default saving behavior is deleted.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

1. Currently, the SCTLR register is only used to switch the thread MTE state and has no other uses. Because saving this register is special, it will take a long time after testing, so the default saving behavior is deleted.
2. arm64/irq.h: Fix the issue of including incorrect order:
<nuttx/irq.h> will use the macros defined in <arch/chip/irq.h>, so the include order should be after it
## Impact

none

## Testing

citest
