### PR TITLE
driver/virtio: Delete reset on initialization

### DIFF
--- a/drivers/virtio/virtio-mmio.c
+++ b/drivers/virtio/virtio-mmio.c
@@ -853,7 +853,6 @@ static int virtio_mmio_init_device(FAR struct virtio_mmio_device_s *vmdev,
 
   /* Reset the virtio device and set ACK */
 
-  virtio_mmio_set_status(vdev, VIRTIO_CONFIG_STATUS_RESET);
   virtio_mmio_set_status(vdev, VIRTIO_CONFIG_STATUS_ACK);
   return OK;
 }

--- a/drivers/virtio/virtio-pci.c
+++ b/drivers/virtio/virtio-pci.c
@@ -255,7 +255,6 @@ static int virtio_pci_probe(FAR struct pci_device_s *dev)
   vrtinfo("Polling mode\n");
 #endif
 
-  virtio_set_status(vdev, VIRTIO_CONFIG_STATUS_RESET);
   virtio_set_status(vdev, VIRTIO_CONFIG_STATUS_ACK);
 
   ret = virtio_register_device(&vpdev->vdev);


### PR DESCRIPTION
Resetting during initialization can cause qemu to lock up, for example, virtio-gpu. qemu does not need to reset virtio during initialization.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Resetting during initialization can cause qemu to lock up, for example, virtio-gpu. qemu does not need to reset virtio during initialization.

## Impact

none

## Testing

ci test