### PR TITLE
libc/stream,lzf: add lzf decompress stream and fix lzf-stream header/seek/read issues

### DIFF
--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -125,7 +125,7 @@ struct lib_sistream_s
   off_t                  nget;    /* Total number of characters gotten.  Written
                                    * by get method, readable by user */
   lib_sigetc_t           getc;    /* Get one character from the instream */
-  lib_gets_t             gets;    /* Get the string from the instream */
+  lib_sigets_t           gets;    /* Get the string from the instream */
   lib_siseek_t           seek;    /* Seek to a position in the instream */
 };
 

--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -286,6 +286,18 @@ struct lib_syslograwstream_s
 /* LZF compressed stream pipeline */
 
 #ifdef CONFIG_LIBC_LZF
+
+struct lib_lzfsistream_s
+{
+  struct lib_sistream_s      common;
+  FAR struct lib_sistream_s *backend;
+  off_t                      offset;
+  off_t                      blkoff;
+  off_t                      blkcoff;
+  char                       out[LZF_STREAM_BLOCKSIZE];
+  char                       in[LZF_MAX_HDR_SIZE + LZF_STREAM_BLOCKSIZE];
+};
+
 struct lib_lzfoutstream_s
 {
   struct lib_outstream_s      common;
@@ -627,6 +639,27 @@ void lib_syslograwstream_open(FAR struct lib_syslograwstream_s *stream);
 void lib_syslograwstream_close(FAR struct lib_syslograwstream_s *stream);
 #else
 #  define lib_syslograwstream_close(s)
+#endif
+
+/****************************************************************************
+ * Name: lib_lzfsistream
+ *
+ * Description:
+ *  LZF decompressed pipeline stream
+ *
+ * Input Parameters:
+ *   stream  - User allocated, uninitialized instance of struct
+ *                lib_lzfsistream_s to be initialized.
+ *   backend - Stream backend port.
+ *
+ * Returned Value:
+ *   None (User allocated instance initialized).
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_LIBC_LZF
+void lib_lzfsistream(FAR struct lib_lzfsistream_s *sistream,
+                     FAR struct lib_sistream_s *backend);
 #endif
 
 /****************************************************************************

--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -211,9 +211,10 @@ struct lib_rawoutstream_s
   int                    fd;
 };
 
-struct lib_fileinstream_s
+#ifndef CONFIG_DISABLE_MOUNTPOINT
+struct lib_filesistream_s
 {
-  struct lib_instream_s  common;
+  struct lib_sistream_s  common;
   struct file            file;
 };
 
@@ -406,7 +407,7 @@ void lib_stdsostream(FAR struct lib_stdsostream_s *stream,
                      FAR FILE *handle);
 
 /****************************************************************************
- * Name: lib_fileinstream_open, lib_fileinstream_close,
+ * Name: lib_filesistream_open, lib_filesistream_close,
  *       lib_fileoutstream_open, lib_fileoutstream_close
  *
  * Description:
@@ -428,9 +429,10 @@ void lib_stdsostream(FAR struct lib_stdsostream_s *stream,
  *
  ****************************************************************************/
 
-int lib_fileinstream_open(FAR struct lib_fileinstream_s *stream,
+#ifndef CONFIG_DISABLE_MOUNTPOINT
+int lib_filesistream_open(FAR struct lib_filesistream_s *stream,
                           FAR const char *path, int oflag, mode_t mode);
-void lib_fileinstream_close(FAR struct lib_fileinstream_s *stream);
+void lib_filesistream_close(FAR struct lib_filesistream_s *stream);
 int lib_fileoutstream_open(FAR struct lib_fileoutstream_s *stream,
                            FAR const char *path, int oflag, mode_t mode);
 void lib_fileoutstream_close(FAR struct lib_fileoutstream_s *stream);

--- a/include/nuttx/streams.h
+++ b/include/nuttx/streams.h
@@ -135,8 +135,8 @@ struct lib_sostream_s
                                    * by put method, readable by user */
   lib_soputc_t           putc;    /* Put one character to the outstream */
   lib_soputs_t           puts;    /* Writes the string to the outstream */
-  lib_soflush_t          flush;   /* Flush any buffered characters in the outstream */
   lib_soseek_t           seek;    /* Seek a position in the output stream */
+  lib_soflush_t          flush;   /* Flush any buffered characters in the outstream */
 };
 
 /* These are streams that operate on a fixed-sized block of memory */

--- a/libs/libc/stream/CMakeLists.txt
+++ b/libs/libc/stream/CMakeLists.txt
@@ -43,7 +43,7 @@ list(
   lib_bufferedoutstream.c
   lib_hexdumpstream.c
   lib_base64outstream.c
-  lib_fileinstream.c
+  lib_filesistream.c
   lib_fileoutstream.c
   lib_libbsprintf.c
   lib_libvscanf.c

--- a/libs/libc/stream/CMakeLists.txt
+++ b/libs/libc/stream/CMakeLists.txt
@@ -60,7 +60,7 @@ if(CONFIG_FILE_STREAM)
 endif()
 
 if(CONFIG_LIBC_LZF)
-  list(APPEND SRCS lib_lzfcompress.c)
+  list(APPEND SRCS lib_lzfcompress.c lib_lzfdecompress.c)
 endif()
 
 if(NOT CONFIG_DISABLE_MOUNTPOINT)

--- a/libs/libc/stream/Make.defs
+++ b/libs/libc/stream/Make.defs
@@ -45,7 +45,7 @@ CSRCS += lib_stdsostream.c
 endif
 
 ifeq ($(CONFIG_LIBC_LZF),y)
-CSRCS += lib_lzfcompress.c
+CSRCS += lib_lzfcompress.c lib_lzfdecompress.c
 endif
 
 ifeq ($(CONFIG_DISABLE_MOUNTPOINT),)

--- a/libs/libc/stream/Make.defs
+++ b/libs/libc/stream/Make.defs
@@ -30,7 +30,7 @@ CSRCS += lib_zeroinstream.c lib_nullinstream.c lib_nulloutstream.c
 CSRCS += lib_mtdoutstream.c lib_libnoflush.c lib_libsnoflush.c
 CSRCS += lib_syslogstream.c lib_syslograwstream.c lib_bufferedoutstream.c
 CSRCS += lib_hexdumpstream.c lib_base64outstream.c lib_mtdsostream.c
-CSRCS += lib_fileinstream.c lib_fileoutstream.c lib_libbsprintf.c
+CSRCS += lib_filesistream.c lib_fileoutstream.c lib_libosprintf.c
 CSRCS += lib_libvscanf.c lib_libvsprintf.c lib_ultoa_invert.c
 
 ifeq ($(CONFIG_LIBC_FLOATINGPOINT),y)

--- a/libs/libc/stream/lib_filesistream.c
+++ b/libs/libc/stream/lib_filesistream.c
@@ -45,20 +45,27 @@ static ssize_t filesistream_gets(FAR struct lib_sistream_s *self,
 {
   FAR struct lib_filesistream_s *stream =
                                 (FAR struct lib_filesistream_s *)self;
-  ssize_t nread;
+  size_t left = len;
+  ssize_t ret = 0;
 
-  do
+  while (left >= 0)
     {
-      nread = file_read(&stream->file, buf, len);
-    }
-  while (nread == -EINTR);
+      ret = file_read(&stream->file, buf, left);
+      if (ret == -EINTR)
+        {
+          continue;
+        }
+      else if (ret <= 0)
+        {
+          break;
+        }
 
-  if (nread >= 0)
-    {
-      self->nget += nread;
+      self->nget += ret;
+      buf += ret;
+      left -= ret;
     }
 
-  return nread;
+  return left == len ? ret : len - left;
 }
 
 /****************************************************************************

--- a/libs/libc/stream/lib_filesistream.c
+++ b/libs/libc/stream/lib_filesistream.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * libs/libc/stream/lib_fileinstream.c
+ * libs/libc/stream/lib_filesistream.c
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -37,14 +37,14 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: fileinstream_gets
+ * Name: filesistream_gets
  ****************************************************************************/
 
-static ssize_t fileinstream_gets(FAR struct lib_instream_s *self,
+static ssize_t filesistream_gets(FAR struct lib_sistream_s *self,
                                  FAR void *buf, size_t len)
 {
-  FAR struct lib_fileinstream_s *stream =
-                                (FAR struct lib_fileinstream_s *)self;
+  FAR struct lib_filesistream_s *stream =
+                                (FAR struct lib_filesistream_s *)self;
   ssize_t nread;
 
   do
@@ -62,13 +62,26 @@ static ssize_t fileinstream_gets(FAR struct lib_instream_s *self,
 }
 
 /****************************************************************************
- * Name: fileinstream_getc
+ * Name: filesistream_getc
  ****************************************************************************/
 
-static int fileinstream_getc(FAR struct lib_instream_s *self)
+static int filesistream_getc(FAR struct lib_sistream_s *self)
 {
   unsigned char ch;
-  return fileinstream_gets(self, &ch, 1) == 1 ? ch : EOF;
+  return filesistream_gets(self, &ch, 1) == 1 ? ch : EOF;
+}
+
+/****************************************************************************
+ * Name: filesistream_getc
+ ****************************************************************************/
+
+static off_t filesistream_seek(FAR struct lib_sistream_s *self, off_t offset,
+                               int whence)
+{
+  FAR struct lib_filesistream_s *stream =
+                                (FAR struct lib_filesistream_s *)self;
+
+  return file_seek(&stream->file, offset, whence);
 }
 
 /****************************************************************************
@@ -76,21 +89,21 @@ static int fileinstream_getc(FAR struct lib_instream_s *self)
  ****************************************************************************/
 
 /****************************************************************************
- * Name: lib_fileinstream_open
+ * Name: lib_filesistream_open
  *
  * Description:
  *   Initializes a stream for use with a file descriptor.
  *
  * Input Parameters:
  *   stream   - User allocated, uninitialized instance of struct
- *              lib_fileinstream_s to be initialized.
+ *              lib_filesistream_s to be initialized.
  *
  * Returned Value:
  *   None (User allocated instance initialized).
  *
  ****************************************************************************/
 
-int lib_fileinstream_open(FAR struct lib_fileinstream_s *stream,
+int lib_filesistream_open(FAR struct lib_filesistream_s *stream,
                           FAR const char *path, int oflag, mode_t mode)
 {
   int ret;
@@ -101,29 +114,30 @@ int lib_fileinstream_open(FAR struct lib_fileinstream_s *stream,
       return ret;
     }
 
-  stream->common.getc = fileinstream_getc;
-  stream->common.gets = fileinstream_gets;
+  stream->common.getc = filesistream_getc;
+  stream->common.gets = filesistream_gets;
+  stream->common.seek = filesistream_seek;
   stream->common.nget = 0;
 
   return 0;
 }
 
 /****************************************************************************
- * Name: lib_fileinstream_close
+ * Name: lib_filesistream_close
  *
  * Description:
  *  Close the file associated with the stream.
  *
  * Input Parameters:
  *   stream   - User allocated, uninitialized instance of struct
- *              lib_fileinstream_s to be initialized.
+ *              lib_filesistream_s to be initialized.
  *
  * Returned Value:
  *   None (User allocated instance initialized).
  *
  ****************************************************************************/
 
-void lib_fileinstream_close(FAR struct lib_fileinstream_s *stream)
+void lib_filesistream_close(FAR struct lib_filesistream_s *stream)
 {
   if (stream != NULL)
     {

--- a/libs/libc/stream/lib_lzfdecompress.c
+++ b/libs/libc/stream/lib_lzfdecompress.c
@@ -1,0 +1,250 @@
+/****************************************************************************
+ * libs/libc/stream/lib_lzfdecompress.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <assert.h>
+#include <errno.h>
+#include <sys/endian.h>
+#include <sys/param.h>
+#include <nuttx/streams.h>
+
+#include "libc.h"
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+typedef CODE int (*lzf_foreach_cb)(FAR struct lib_lzfsistream_s *stream,
+                                   size_t blklen, size_t blkclen,
+                                   off_t offset, FAR void *arg);
+
+struct lzf_uncompress_s
+{
+  FAR uint8_t *buffer;
+  size_t size;
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: lzf_header_foreach
+ ****************************************************************************/
+
+static int lzf_header_foreach(FAR struct lib_lzfsistream_s *lzfstream,
+                              lzf_foreach_cb cb, FAR void *arg)
+{
+  FAR struct lib_sistream_s *stream = lzfstream->backend;
+  struct lzf_type1_header_s hdr;
+  size_t blkclen;
+  size_t blklen;
+  int ret;
+
+  for (; ; )
+    {
+      ret = lib_stream_seek(stream, lzfstream->blkcoff, SEEK_SET);
+      if (ret < 0)
+        {
+          return ret;
+        }
+
+      ret = lib_stream_gets(stream, &hdr, sizeof(hdr));
+      if (ret < sizeof(hdr))
+        {
+          return ret < 0 ? ret : -EINVAL;
+        }
+
+      if (hdr.lzf_magic[0] != 'Z' || hdr.lzf_magic[1] != 'V')
+        {
+          return -EINVAL;
+        }
+
+      blkclen = be16toh(*(uint16_t *)hdr.lzf_clen);
+      blklen = be16toh(*(uint16_t *)hdr.lzf_ulen);
+      ret = cb(lzfstream, blklen, blkclen, lzfstream->blkoff, arg);
+      if (ret <= 0)
+        {
+          break;
+        }
+
+      lzfstream->blkcoff += blkclen + LZF_MAX_HDR_SIZE;
+      lzfstream->blkoff += blklen;
+    }
+
+  return ret;
+}
+
+/****************************************************************************
+ * Name: lzf_uncompress
+ ****************************************************************************/
+
+static int lzf_uncompress(FAR struct lib_lzfsistream_s *lzfstream,
+                          size_t blklen, size_t blkclen,
+                          off_t offset, FAR void *arg)
+{
+  /* Implementation of memory copy from stream based on header information */
+
+  FAR struct lzf_uncompress_s *uncompress =
+                              (FAR struct lzf_uncompress_s *)arg;
+  FAR struct lib_sistream_s *stream = lzfstream->backend;
+  size_t ncopy;
+  int ret;
+
+  if (uncompress->size == 0 ||
+      lzfstream->offset < offset || lzfstream->offset >= offset + blklen)
+    {
+      return uncompress->size;
+    }
+
+  ret = lib_stream_gets(stream, lzfstream->in, blkclen);
+  if (ret < blkclen)
+    {
+      return ret < 0 ? ret : -EIO;
+    }
+
+  if (lzf_decompress(lzfstream->in, blkclen,
+                     lzfstream->out, LZF_STREAM_BLOCKSIZE) != blklen)
+    {
+      return -EINVAL;
+    }
+
+  offset = lzfstream->offset - offset;
+  blklen -= offset;
+  ncopy = MIN(uncompress->size, blklen);
+
+  memcpy(uncompress->buffer, lzfstream->out + offset, ncopy);
+
+  lzfstream->offset += ncopy;
+  uncompress->buffer += ncopy;
+  uncompress->size -= ncopy;
+
+  return uncompress->size;
+}
+
+/****************************************************************************
+ * Name: lzfsistream_gets
+ ****************************************************************************/
+
+static ssize_t lzfsistream_gets(FAR struct lib_sistream_s *self,
+                                FAR void *buffer, size_t len)
+{
+  FAR struct lib_lzfsistream_s *stream =
+                               (FAR struct lib_lzfsistream_s *)self;
+  struct lzf_uncompress_s uncompress =
+    {
+      .buffer = buffer,
+      .size = len
+    };
+
+  int ret = lzf_header_foreach(stream, lzf_uncompress, &uncompress);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  return len - uncompress.size;
+}
+
+/****************************************************************************
+ * Name: lzfsistream_getc
+ ****************************************************************************/
+
+static int lzfsistream_getc(FAR struct lib_sistream_s *self)
+{
+  char c;
+  return lzfsistream_gets(self, &c, 1) == 1 ? c : EOF;
+}
+
+/****************************************************************************
+ * Name: lzfsistream_seek
+ ****************************************************************************/
+
+static off_t lzfsistream_seek(FAR struct lib_sistream_s *self, off_t offset,
+                              int whence)
+{
+  FAR struct lib_lzfsistream_s *stream =
+                               (FAR struct lib_lzfsistream_s *)self;
+
+  DEBUGASSERT(self);
+
+  switch (whence)
+    {
+      case SEEK_CUR:
+        offset += stream->offset;
+      case SEEK_SET:
+        if (offset >= 0)
+          {
+            break;
+          }
+
+      case SEEK_END:
+      default:
+        return -EINVAL;
+    }
+
+  stream->offset = offset;
+  if (offset < stream->blkoff)
+    {
+      stream->blkcoff = 0;
+      stream->blkoff = 0;
+    }
+
+  /* Return the new position */
+
+  return stream->offset;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: lib_lzfsistream
+ *
+ * Description:
+ *   Initializes a stream for use with a fixed-size memory buffer.
+ *
+ * Input Parameters:
+ *   instream    - User allocated, uninitialized instance of struct
+ *                 lib_lzfsistream_s to be initialized.
+ *   bufstart    - Address of the beginning of the fixed-size memory buffer
+ *   buflen      - Size of the fixed-sized memory buffer in bytes
+ *
+ * Returned Value:
+ *   None (instream initialized).
+ *
+ ****************************************************************************/
+
+void lib_lzfsistream(FAR struct lib_lzfsistream_s *sistream,
+                     FAR struct lib_sistream_s *backend)
+{
+  memset(sistream, 0, sizeof(*sistream));
+
+  sistream->common.getc = lzfsistream_getc;
+  sistream->common.gets = lzfsistream_gets;
+  sistream->common.seek = lzfsistream_seek;
+  sistream->backend = backend;
+}

--- a/libs/libc/stream/lib_memsistream.c
+++ b/libs/libc/stream/lib_memsistream.c
@@ -61,7 +61,7 @@ static int memsistream_getc(FAR struct lib_sistream_s *self)
  * Name: meminstream_gets
  ****************************************************************************/
 
-static ssize_t memsistream_gets(FAR struct lib_instream_s *self,
+static ssize_t memsistream_gets(FAR struct lib_sistream_s *self,
                                 FAR void *buffer, size_t len)
 {
   FAR struct lib_memsistream_s *stream =

--- a/libs/libc/stream/lib_rawsistream.c
+++ b/libs/libc/stream/lib_rawsistream.c
@@ -69,7 +69,7 @@ static int rawsistream_getc(FAR struct lib_sistream_s *self)
  * Name: rawsistream_gets
  ****************************************************************************/
 
-static ssize_t rawsistream_gets(FAR struct lib_instream_s *self,
+static ssize_t rawsistream_gets(FAR struct lib_sistream_s *self,
                                 FAR void *buffer, size_t len)
 {
   FAR struct lib_rawsistream_s *stream =

--- a/libs/libc/stream/lib_stdsistream.c
+++ b/libs/libc/stream/lib_stdsistream.c
@@ -63,7 +63,7 @@ static int stdsistream_getc(FAR struct lib_sistream_s *self)
  * Name: stdsistream_gets
  ****************************************************************************/
 
-static ssize_t stdsistream_gets(FAR struct lib_instream_s *self,
+static ssize_t stdsistream_gets(FAR struct lib_sistream_s *self,
                                 FAR void *buffer, size_t len)
 {
   FAR struct lib_stdsistream_s *stream =


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Added lib_lzfinstream (LZF decompression input stream), supporting seek operations on "decompressed data": backward processing is possible, while forward scanning reconstructs the state from the beginning.

Aligned sistream/sostream structures to allow them to reuse the same lib_stream_seek macros/interfaces, avoiding type inconsistency issues.

Fixed errors in the loop read offset/buffer handling of file(s)istream, preventing read errors when there is no buffer offset.

Fixed the handling of lzf-stream in both "compression successful" and "compression failed" header scenarios: preventing decompression errors caused by parsing according to the compressed block format when compression fails, and reducing the risk of potential compression failure/decompression errors.

## Impact

Provides stream-based LZF decompression capabilities, facilitating on-demand reading in file/storage scenarios and supporting location-based reading of uncompressed views.

Improves stream system consistency (sistream/sostream alignment) and stability (type errors, read offset errors, LZF header branch handling).

The changes primarily focus on libc/stream and LZF-related implementations and are not expected to affect modules that do not use these streams/algorithms.

## Testing

ci test
