### PR TITLE
boards/boardctl: BOARDIOC_SPINLOCK missing some Conditional branch

### DIFF
--- a/Documentation/applications/examples/boardioc_spinlock/index.rst
+++ b/Documentation/applications/examples/boardioc_spinlock/index.rst
@@ -1,0 +1,116 @@
+==================================
+BOARDIOC_SPINLOCK Spinlock Example
+==================================
+
+Overview
+========
+
+This example demonstrates the usage of the BOARDIOC_SPINLOCK board control
+interface for managing hardware spinlock operations in NuttX. The BOARDIOC_SPINLOCK
+interface provides a low-level mechanism to synchronize access to shared resources
+across multiple threads or CPUs using spinlock primitives.
+
+What is BOARDIOC_SPINLOCK?
+==========================
+
+BOARDIOC_SPINLOCK is a board control request that allows applications to perform
+atomic spinlock operations through the boardctl() interface.
+
+The BOARDIOC_SPINLOCK interface supports three primary operations:
+
+* **BOARDIOC_SPINLOCK_LOCK** - Acquire a spinlock (blocks until available)
+* **BOARDIOC_SPINLOCK_TRYLOCK** - Try to acquire a spinlock (non-blocking)
+* **BOARDIOC_SPINLOCK_UNLOCK** - Release a spinlock
+
+Prerequisites
+=============
+
+The following configuration options must be enabled:
+
+.. code-block:: bash
+
+    # Enable board spinlock support
+    CONFIG_BOARDCTL_SPINLOCK=y
+
+
+Basic Usage
+===========
+
+Header Files
+------------
+
+Include the following headers in your application:
+
+.. code-block:: c
+
+    #include <sys/boardctl.h>        /* For boardctl() interface */
+    #include <nuttx/spinlock.h>      /* For spinlock types */
+
+Data Structures
+---------------
+
+The BOARDIOC_SPINLOCK interface uses the following structure:
+
+.. code-block:: c
+
+    struct boardioc_spinlock_s
+    {
+        int action;                   /* Operation: LOCK, TRYLOCK, or UNLOCK */
+        spinlock_t *lock;             /* Pointer to the spinlock variable */
+        void *flags;                  /* Optional flags (reserved, set to NULL) */
+    };
+
+Actions
+-------
+
+The following action values are supported:
+
+.. code-block:: c
+
+    BOARDIOC_SPINLOCK_LOCK        /* Acquire lock (blocks if unavailable) */
+    BOARDIOC_SPINLOCK_TRYLOCK     /* Try to acquire (non-blocking) */
+    BOARDIOC_SPINLOCK_UNLOCK      /* Release lock */
+
+Return Values
+^^^^^^^^^^^^^
+
+* **0** - Success
+* **Negative value** - Error code (converted to errno)
+
+Simple Lock Example
+-------------------
+
+Here's a basic example of acquiring and releasing a spinlock:
+
+.. code-block:: c
+
+    spinlock_t my_lock;
+    struct boardioc_spinlock_s spinlock_op;
+    int ret;
+
+    /* Initialize the spinlock */
+    spin_lock_init(&my_lock);
+
+    /* Acquire the spinlock */
+    spinlock_op.action = BOARDIOC_SPINLOCK_LOCK;
+    spinlock_op.lock = &my_lock;
+    spinlock_op.flags = NULL;
+    
+    ret = boardctl(BOARDIOC_SPINLOCK, (uintptr_t)&spinlock_op);
+    if (ret == 0) {
+        printf("Spinlock acquired successfully\n");
+    } else {
+        printf("Failed to acquire spinlock: %d\n", ret);
+    }
+
+    printf("Inside spinlock\n");
+
+    /* Release the spinlock */
+    spinlock_op.action = BOARDIOC_SPINLOCK_UNLOCK;
+    ret = boardctl(BOARDIOC_SPINLOCK, (uintptr_t)&spinlock_op);
+    if (ret == 0) {
+        printf("Spinlock released successfully\n");
+    }
+
+
+

--- a/boards/boardctl.c
+++ b/boards/boardctl.c
@@ -819,6 +819,10 @@ int boardctl(unsigned int cmd, uintptr_t arg)
                       spin_lock(lock);
                     }
                 }
+              else
+                {
+                  *flags = up_irq_save();
+                }
             }
           else if (spinlock->action == BOARDIOC_SPINLOCK_TRYLOCK)
             {
@@ -849,6 +853,10 @@ int boardctl(unsigned int cmd, uintptr_t arg)
                     {
                       spin_unlock(lock);
                     }
+                }
+              else
+                {
+                  up_irq_restore(*flags);
                 }
             }
           else


### PR DESCRIPTION
The current code only handles spinlock operations when
a spinlock is successfully obtained, but fails to provide fallback IRQ handling
for scenarios where spinlock retrieval fails or spinlock support is unavailable.

This PR adds the missing else branches to ensure proper IRQ state management
in edge cases, restoring the intended behavior prior to a recent refactoring
that inadvertently removed this safety path.

### Summary

- Add missing else branch in BOARDIOC_SPINLOCK lock operation to call up_irq_save() when spinlock retrieval fails
- Add missing else branch in BOARDIOC_SPINLOCK unlock operation to call up_irq_restore() when spinlock retrieval fails


### TEST

```
nsh>
nsh>
nsh> uname -a
NuttX 12.12.0 bcdb84b6004-dirty Jan 30 2026 18:34:21 xtensa esp32s3-devkit
nsh> ostest
stdio_test: write fd=1
stdio_test: Standard I/O Check: printf
stdio_test: write fd=2
stdio_test: Standard I/O Check: fprintf to stderr
ostest_main: putenv(Variable1=BadValue3)
ostest_main: setenv(Variable1, GoodValue1, TRUE)
ostest_main: setenv(Variable2, BadValue1, FALSE)
ostest_main: setenv(Variable2, GoodValue2, TRUE)
ostest_main: setenv(Variable3, GoodValue3, FALSE)
ostest_main: setenv(Variable3, BadValue2, FALSE)
show_variable: Variable=Variable1 has value=GoodValue1
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3
ostest_main: Started user_main at PID=76

user_main: Begin argument test
user_main: Started with argc=5
user_main: argv[0]="ostest"
user_main: argv[1]="Arg1"
user_main: argv[2]="Arg2"
user_main: argv[3]="Arg3"
user_main: argv[4]="Arg4"

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 2 2
mxordblk 57178 57178
uordblks 46d0 46d0
fordblks 59210 59210

user_main: getopt() test
getopt(): Simple test
getopt(): Invalid argument
getopt(): Missing optional argument
getopt_long(): Simple test
getopt_long(): No short options NOR | Minicom 2.9 | VT102 | 脱机 | ttyUSB0 getopt_long(): Argument for --option=argument
getopt_long(): Invalid long option
getopt_long(): Mixed long and short options
getopt_long(): Invalid short option
getopt_long(): Missing optional arguments
getopt_long_only(): Mixed long and short options
getopt_long_only(): Single hyphen long options

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 2 2
mxordblk 57178 57178
uordblks 46d0 46d0
fordblks 59210 59210

user_main: libc tests

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 2 2
mxordblk 57178 57178
uordblks 46d0 46d0
fordblks 59210 59210
show_variable: Variable=Variable1 has value=GoodValue1
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3
show_variable: Variable=Variable1 has no value
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 2 3
mxordblk 57178 57178
uordblks 46d0 46b0
fordblks 59210 59230
show_variable: Variable=Variable1 has no value
show_variable: Variable=Variable2 has no value
show_variable: Variable=Variable3 has no value

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 3 4
mxordblk 57178 57178
uordblks 46b0 4630
fordblks 59230 592b0

user_main: setvbuf test
setvbuf_test: Test NO buffering
setvbuf_test: Using NO buffering
setvbuf_test: Test default FULL buffering
setvbuf_test: Using default FULL buffering
setvbuf_test: Test FULL buffering, buffer size 64
setvbuf_test: Using FULL buffering, buffer size 64
setvbuf_test: Test FULL buffering, pre-allocated buffer
setvbuf_test: Using FULL buffering, pre-allocated buffer
setvbuf_test: Test LINE buffering, buffer size 64
setvbuf_test: Using LINE buffering, buffer size 64
setvbuf_test: Test FULL buffering, pre-allocated buffer
setvbuf_test: Using FULL buffering, pre-allocated buffer

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 4 4
mxordblk 57178 57178
uordblks 4630 4630
fordblks 592b0 592b0

user_main: /dev/null test
dev_null: Read 0 bytes from /dev/null
dev_null: Wrote 1024 bytes to /dev/null

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 4 4
mxordblk 57178 57178
uordblks 4630 4630
fordblks 592b0 592b0

user_main: FPU test
Starting task FPU#1
fpu_test: Started task FPU#1 at PID=77
FPU#1: pass 1
Starting task FPU#2
fpu_test: Started task FPU#2 at PID=78
FPU#2: pass 1
FPU#1: pass 2
FPU#2: pass 2
FPU#1: pass 3
FPU#2: pass 3
FPU#1: pass 4
FPU#2: pass 4
FPU#1: pass 5
FPU#2: pass 5
FPU#1: pass 6
FPU#2: pass 6
FPU#1: pass 7
FPU#2: pass 7
FPU#1: pass 8
FPU#2: pass 8
FPU#1: pass 9
FPU#2: pass 9
FPU#1: pass 10
FPU#2: pass 10
FPU#1: pass 11
FPU#2: pass 11
FPU#1: pass 12
FPU#2: pass 12
FPU#1: pass 13
FPU#2: pass 13
FPU#1: pass 14
FPU#2: pass 14
FPU#1: pass 15
FPU#2: pass 15
FPU#1: pass 16
FPU#2: pass 16
FPU#1: Succeeded
FPU#2: Succeeded
fpu_test: Returning

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 4 6
mxordblk 57178 57178
uordblks 4630 57d0
fordblks 592b0 58110

user_main: task_restart test

Test task_restart()
restart_main: setenv(VarName, VarValue, TRUE)
restart_main: Started restart_main at PID=79
restart_main: Started with argc=4
restart_main: argv[0]="ostest"
restart_main: argv[1]="This is argument 1"
restart_main: argv[2]="Argument 2 here"
restart_main: argv[3]="Lastly, the 3rd argument"
restart_main: Variable=VarName has value=VarValue
restart_main: I am still here
restart_main: I am still here
restart_main: Started restart_main at PID=79
restart_main: Started with argc=4
restart_main: argv[0]="ostest"
restart_main: argv[1]="This is argument 1"
restart_main: argv[2]="Argument 2 here"
restart_main: argv[3]="Lastly, the 3rd argument"
restart_main: Variable=VarName has value=VarValue
restart_main: Started with argc=4
restart_main: argv[0]="ostest"
restart_main: argv[1]="This is argument 1"
restart_main: argv[2]="Argument 2 here"
restart_main: argv[3]="Lastly, the 3rd argument"
restart_main: Variable=VarName has value=VarValue
restart_main: Exiting

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 6 3
mxordblk 57178 55170
uordblks 57d0 6740
fordblks 58110 571a0

user_main: waitpid test

Test waitpid()
waitpid_start_child: Started waitpid_main at PID=82
waitpid_start_child: Started waitpid_main at PID=83
waitpid_start_child: Started waitpid_main at PID=84
waitpid_test: Waiting for PID=82 with waitpid()
waitpid_main: PID 82 Started
waitpid_main: PID 83 Started
waitpid_main: PID 84 Started
waitpid_main: PID 82 exitting with result=14
waitpid_main: PID 83 exitting with result=14
waitpid_main: PID 84 exitting with result=14
waitpid_test: PID 82 waitpid succeeded with stat_loc=0e00
waitpid_last: Waiting for PID=84 with waitpid()
waitpid_last: PASS: PID 84 waitpid failed with ECHILD. That may be
acceptable because child status is disabled on this thread.

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 3 5
mxordblk 55170 51160
uordblks 6740 a8e0
fordblks 571a0 53000

user_main: mutex test
Initializing mutex
Starting thread 1
Starting thread 2
Thread1 Thread2
Loops 32 32
Errors 0 0

Testing moved mutex
Starting moved mutex thread 1
Starting moved mutex thread 2
Thread1 Thread2
Moved Loops 32 32
Moved Errors 0 0

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 5 3
mxordblk 51160 57178
uordblks a8e0 5820
fordblks 53000 580c0

user_main: timed mutex test
mutex_test: Initializing mutex
mutex_test: Starting thread
pthread: Started
pthread: Waiting for lock or timeout
mutex_test: Unlocking
pthread: Got the lock
pthread: Waiting for lock or timeout
pthread: Got the timeout. Terminating
mutex_test: PASSED

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 3 3
mxordblk 57178 57178
uordblks 5820 4f48
fordblks 580c0 58998

user_main: cancel test
cancel_test: Test 1a: Normal Cancellation
cancel_test: Starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sem_waiter: Taking mutex
sem_waiter: Starting wait for condition
cancel_test: Canceling thread
cancel_test: Joining
cancel_test: waiter exited with result=0xffffffff
cancel_test: PASS thread terminated with PTHREAD_CANCELED
cancel_test: Test 2: Asynchronous Cancellation
... Skipped
cancel_test: Test 3: Cancellation of detached thread
cancel_test: Re-starting thread
restart_thread: Destroying cond
restart_thread: Destroying mutex
restart_thread: Re-starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sem_waiter: Taking mutex
sem_waiter: Starting wait for condition
cancel_test: Canceling thread
cancel_test: Joining
cancel_test: PASS pthread_join failed with status=ESRCH
cancel_test: Test 5: Non-cancelable threads
cancel_test: Re-starting thread (non-cancelable)
restart_thread: Destroying cond
restart_thread: Destroying mutex
restart_thread: Re-starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sem_waiter: Taking mutex
sem_waiter: Starting wait for condition
sem_waiter: Setting non-cancelable
cancel_test: Canceling thread
cancel_test: Joining
sem_waiter: Releasing mutex
sem_waiter: Setting cancelable
cancel_test: waiter exited with result=0xffffffff
cancel_test: PASS thread terminated with PTHREAD_CANCELED
cancel_test: Test 6: Cancel message queue wait
cancel_test: Starting thread (cancelable)
Skipped
cancel_test: Test 7: Cancel signal wait
cancel_test: Starting thread (cancelable)
Skipped

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 3 3
mxordblk 57178 55170
uordblks 4f48 6748
fordblks 58998 57198

user_main: robust test
robust_test: Initializing mutex
robust_test: Starting thread
robust_waiter: Taking mutex
robust_waiter: Exiting with mutex
robust_test: Take the lock again
robust_test: Make the mutex consistent again.
robust_test: Take the lock again
robust_test: Joining
robust_test: waiter exited with result=0
robust_test: Test complete with nerrors=0

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 3 3
mxordblk 55170 55170
uordblks 6748 6748
fordblks 57198 57198

user_main: semaphore test
sem_test: Initializing semaphore to 0
sem_test: Starting waiter thread 1
sem_test: Set thread 1 priority to 191
waiter_func: Thread 1 Started
waiter_func: Thread 1 initial semaphore value = 0
waiter_func: Thread 1 waiting on semaphore
sem_test: Starting waiter thread 2
sem_test: Set thread 2 priority to 128
waiter_func: Thread 2 Started
waiter_func: Thread 2 initial semaphore value = -1
waiter_func: Thread 2 waiting on semaphore
sem_test: Starting poster thread 3
sem_test: Set thread 3 priority to 64
poster_func: Thread 3 started
poster_func: Thread 3 semaphore value = -2
poster_func: Thread 3 posting semaphore
waiter_func: Thread 1 awakened
waiter_func: Thread 1 new semaphore value = -1
waiter_func: Thread 1 done
poster_func: Thread 3 new semaphore value = -1
poster_func: Thread 3 semaphore value = -1
poster_func: Thread 3 posting semaphore
waiter_func: Thread 2 awakened
waiter_func: Thread 2 new semaphore value = 0
waiter_func: Thread 2 done
poster_func: Thread 3 new semaphore value = 0
poster_func: Thread 3 done

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 3 3
mxordblk 55170 57178
uordblks 6748 60f8
fordblks 57198 577e8

user_main: timed semaphore test
semtimed_test: Initializing semaphore to 0
semtimed_test: Waiting for two second timeout
semtimed_test: PASS: first test returned timeout
BEFORE: (1323129866 sec, 410000000 nsec)
AFTER: (1323129868 sec, 410000000 nsec)
semtimed_test: Starting poster thread
semtimed_test: Set thread 1 priority to 191
semtimed_test: Starting poster thread 3
semtimed_test: Set thread 3 priority to 64
semtimed_test: Waiting for two second timeout
poster_func: Waiting for 1 second
poster_func: Posting
semtimed_test: PASS: sem_timedwait succeeded
BEFORE: (1323129868 sec, 420000000 nsec)
AFTER: (1323129869 sec, 440000000 nsec)

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 3 3
mxordblk 57178 57178
uordblks 60f8 4f48
fordblks 577e8 58998

user_main: condition variable test
cond_test: Initializing mutex
cond_test: Initializing cond
cond_test: Starting waiter
cond_test: Set thread 1 priority to 128
waiter_thread: Started
cond_test: Starting signaler
cond_test: Set thread 2 priority to 64
thread_signaler: Started
thread_signaler: Terminating
cond_test: signaler terminated, now cancel the waiter
cond_test: Waiter Signaler
cond_test: Loops 64 64
cond_test: Errors 0 0
cond_test:
cond_test: 0 times, waiter did not have to wait for data
cond_test: 0 times, data was already available when the signaler run
cond_test: 0 times, the waiter was in an unexpected state when the signaler ran

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 3 4
mxordblk 57178 57178
uordblks 4f48 4f48
fordblks 58998 58998

user_main: pthread_exit() test
pthread_exit_test: Started pthread_exit_main at PID=104
pthread_exit_main 104: Starting pthread_exit_thread
pthread_exit_main 104: Sleeping for 5 seconds
pthread_exit_thread 105: Sleeping for 10 second
pthread_exit_main 104: Calling pthread_exit()
pthread_exit_thread 105: Still running...

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 4 3
mxordblk 57178 55170
uordblks 4f48 7020
fordblks 58998 568c0

user_main: pthread_rwlock test
pthread_rwlock: Initializing rwlock
pthread_exit_thread 105: Exiting

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 3 4
mxordblk 55170 57178
uordblks 7020 4f58
fordblks 568c0 58988

user_main: pthread_rwlock_cancel test
pthread_rwlock_cancel: Starting test

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 4 3
mxordblk 57178 57178
uordblks 4f58 4680
fordblks 58988 59260

user_main: timed wait test
thread_waiter: Initializing mutex
timedwait_test: Initializing cond
timedwait_test: Starting waiter
timedwait_test: Set thread 2 priority to 177
thread_waiter: Taking mutex
thread_waiter: Starting 5 second wait for condition
timedwait_test: Joining
thread_waiter: pthread_cond_timedwait timed out
thread_waiter: Releasing mutex
thread_waiter: Exit with status 0x12345678
timedwait_test: waiter exited with result=0x12345678

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 3 3
mxordblk 57178 57178
uordblks 4680 4f58
fordblks 59260 58988

user_main: timed message queue test
timedmqueue_test: Starting sender
timedmqueue_test: Waiting for sender to complete
sender_thread: Starting
sender_thread: mq_timedsend succeeded on msg 0
sender_thread: mq_timedsend succeeded on msg 1
sender_thread: mq_timedsend succeeded on msg 2
sender_thread: mq_timedsend succeeded on msg 3
sender_thread: mq_timedsend succeeded on msg 4
sender_thread: mq_timedsend succeeded on msg 5
sender_thread: mq_timedsend succeeded on msg 6
sender_thread: mq_timedsend succeeded on msg 7
sender_thread: mq_timedsend succeeded on msg 8
sender_thread: mq_timedsend 9 timed out as expected
sender_thread: returning nerrors=0
timedmqueue_test: Starting receiver
timedmqueue_test: Waiting for receiver to complete
receiver_thread: Starting
receiver_thread: mq_timedreceive succeed on msg 0
receiver_thread: mq_timedreceive succeed on msg 1
receiver_thread: mq_timedreceive succeed on msg 2
receiver_thread: mq_timedreceive succeed on msg 3
receiver_thread: mq_timedreceive succeed on msg 4
receiver_thread: mq_timedreceive succeed on msg 5
receiver_thread: mq_timedreceive succeed on msg 6
receiver_thread: mq_timedreceive succeed on msg 7
receiver_thread: mq_timedreceive succeed on msg 8
receiver_thread: Receive 9 timed out as expected
receiver_thread: returning nerrors=0
timedmqueue_test: Test complete

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 3 3
mxordblk 57178 55170
uordblks 4f58 6758
fordblks 58988 57188

user_main: sigprocmask test
sigprocmask_test: SUCCESS

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 3 3
mxordblk 55170 55170
uordblks 6758 6758
fordblks 57188 57188

user_main: message queue test
mqueue_test: Starting receiver
mqueue_test: Set receiver priority to 128
receiver_thread: Starting
mqueue_test: Starting sender
mqueue_test: Set sender thread priority to 64
mqueue_test: Waiting for sender to complete
sender_thread: Starting
receiver_thread: mq_receive succeeded on msg 0
sender_thread: mq_send succeeded on msg 0
receiver_thread: mq_receive succeeded on msg 1
sender_thread: mq_send succeeded on msg 1
receiver_thread: mq_receive succeeded on msg 2
sender_thread: mq_send succeeded on msg 2
receiver_thread: mq_receive succeeded on msg 3
sender_thread: mq_send succeeded on msg 3
receiver_thread: mq_receive succeeded on msg 4
sender_thread: mq_send succeeded on msg 4
receiver_thread: mq_receive succeeded on msg 5
sender_thread: mq_send succeeded on msg 5
receiver_thread: mq_receive succeeded on msg 6
sender_thread: mq_send succeeded on msg 6
receiver_thread: mq_receive succeeded on msg 7
sender_thread: mq_send succeeded on msg 7
receiver_thread: mq_receive succeeded on msg 8
sender_thread: mq_send succeeded on msg 8
receiver_thread: mq_receive succeeded on msg 9
sender_thread: mq_send succeeded on msg 9
sender_thread: returning nerrors=0
mqueue_test: Killing receiver
receiver_thread: mq_receive interrupted!
receiver_thread: returning nerrors=0
mqueue_test: Canceling receiver
mqueue_test: receiver has already terminated

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 3 4
mxordblk 55170 53168
uordblks 6758 8830
fordblks 57188 550b0

user_main: signal handler test
sighand_test: Initializing semaphore to 0
sighand_test: Starting waiter task
sighand_test: Started waiter_main pid=121
waiter_main: Waiter started
waiter_main: Unmasking signal 32
waiter_main: Registering signal handler
waiter_main: oact.sigaction=0 oact.sa_flags=0 oact.sa_mask=0000000000000000
waiter_main: Waiting on semaphore
sighand_test: Signaling pid=121 with signo=32 sigvalue=42
waiter_main: sem_wait() successfully interrupted by signal
waiter_main: done
sighand_test: done

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 4 3
mxordblk 53168 55170
uordblks 8830 6768
fordblks 550b0 57178

user_main: nested signal handler test
signest_test: Starting signal waiter task at priority 101
waiter_main: Waiter started
waiter_main: Setting signal mask
waiter_main: Registering signal handler
waiter_main: Waiting on semaphore
signest_test: Started waiter_main pid=122
signest_test: Starting interfering task at priority 102
interfere_main: Waiting on semaphore
signest_test: Started interfere_main pid=125
signest_test: Simple case:
Total signalled 1240 Odd=620 Even=620
Total handled 1240 Odd=620 Even=620
Total nested 0 Odd=0 Even=0
signest_test: With task locking
Total signalled 2480 Odd=1240 Even=1240
Total handled 2480 Odd=1240 Even=1240
Total nested 0 Odd=0 Even=0
signest_test: With intefering thread
Total signalled 3720 Odd=1860 Even=1860
Total handled 3720 Odd=1860 Even=1860
Total nested 0 Odd=0 Even=0
signest_test: done

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 3 7
mxordblk 55170 53168
uordblks 6768 67c8
fordblks 57178 57118

user_main: POSIX timer test
timer_test: Initializing semaphore to 0
timer_test: Unmasking signal 32
timer_test: Registering signal handler
timer_test: oact.sigaction=0 oact.sa_flags=0 oact.sa_mask=0000000000000000
timer_test: Creating timer
timer_test: Starting timer
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=6
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=7
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=8
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=9
timer_test: Waiting on semaphore
timer_expiration: Received signal 32
timer_expiration: sival_int=42
timer_expiration: si_code=2 (SI_TIMER)
timer_expiration: ucontext=0
timer_test: sem_wait() successfully interrupted by signal
timer_test: g_nsigreceived=10
timer_test: Deleting timer
timer_test: done

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 7 7
mxordblk 53168 53168
uordblks 67c8 67c8
fordblks 57118 57118

user_main: wdog test
wdog_test start...
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wd_start with maximum delay, cancel OK, rest 1073741821
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 1073741821
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 1073741821
wdtest_recursive 1000000ns
wd_start with maximum delay, cancel OK, rest 1073741820
wdtest_recursive 1000000ns
recursive wdog triggered 6 times, elapsed tick 12
wdtest_recursive 10000000ns
recursive wdog triggered 6 times, elapsed tick 12
wdtest_recursive 10000000ns
recursive wdog triggered 6 times, elapsed tick 12
wdtest_recursive 10000000ns
recursive wdog triggered 6 times, elapsed tick 12
wdtest_recursive 10000000ns
recursive wdog triggered 6 times, elapsed tick 12
recursive wdog triggered 6 times, elapsed tick 12
recursive wdog triggered 6 times, elapsed tick 12
recursive wdog triggered 6 times, elapsed tick 12
wdog_test end...

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 7 9
mxordblk 53168 56168
uordblks 67c8 58a0
fordblks 57118 58040

user_main: round-robin scheduler test
rr_test: Set thread priority to 1
rr_test: Set thread policy to SCHED_RR
rr_test: Starting first get_primes_thread
First get_primes_thread: 132
rr_test: Starting second get_primes_thread
Second get_primes_thread: 133
rr_test: Waiting for threads to complete -- this should take awhile
If RR scheduling is working, they should start and complete at
about the same time
get_primes_thread id=1 started, looking for primes < 30000, doing 10 run(s)
get_primes_thread id=2 started, looking for primes < 30000, doing 10 run(s)
get_primes_thread id=1 finished, found 3246 primes, last one was 29989
get_primes_thread id=2 finished, found 3246 primes, last one was 29989
rr_test: Done

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 9 6
mxordblk 56168 57178
uordblks 58a0 58a0
fordblks 58040 58040

user_main: barrier test
barrier_test: Initializing barrier
barrier_test: Thread 0 created
barrier_test: Thread 1 created
barrier_test: Thread 2 created
barrier_test: Thread 3 created
barrier_test: Thread 4 created
barrier_test: Thread 5 created
barrier_test: Thread 6 created
barrier_test: Thread 7 created
barrier_func: Thread 0 started
barrier_func: Thread 1 started
barrier_func: Thread 2 started
barrier_func: Thread 3 started
barrier_func: Thread 4 started
barrier_func: Thread 5 started
barrier_func: Thread 6 started
barrier_func: Thread 7 started
barrier_func: Thread 0 calling pthread_barrier_wait()
barrier_func: Thread 1 calling pthread_barrier_wait()
barrier_func: Thread 2 calling pthread_barrier_wait()
barrier_func: Thread 3 calling pthread_barrier_wait()
barrier_func: Thread 4 calling pthread_barrier_wait()
barrier_func: Thread 5 calling pthread_barrier_wait()
barrier_func: Thread 6 calling pthread_barrier_wait()
barrier_func: Thread 7 calling pthread_barrier_wait()
barrier_func: Thread 7, back with status=PTHREAD_BARRIER_SERIAL_THREAD (I AM SPECIAL)
barrier_func: Thread 0, back with status=0 (I am not special)
barrier_func: Thread 1, back with status=0 (I am not special)
barrier_func: Thread 2, back with status=0 (I am not special)
barrier_func: Thread 3, back with status=0 (I am not special)
barrier_func: Thread 4, back with status=0 (I am not special)
barrier_func: Thread 5, back with status=0 (I am not special)
barrier_func: Thread 6, back with status=0 (I am not special)
barrier_func: Thread 7 done
barrier_func: Thread 0 done
barrier_test: Thread 0 completed with result=0
barrier_func: Thread 1 done
barrier_func: Thread 2 done
barrier_test: Thread 1 completed with result=0
barrier_test: Thread 2 completed with result=0
barrier_func: Thread 3 done
barrier_func: Thread 4 done
barrier_test: Thread 3 completed with result=0
barrier_test: Thread 4 completed with result=0
barrier_func: Thread 5 done
barrier_func: Thread 6 done
barrier_test: Thread 5 completed with result=0
barrier_test: Thread 6 completed with result=0
barrier_test: Thread 7 completed with result=0

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 6 8
mxordblk 57178 54950
uordblks 58a0 4fc8
fordblks 58040 58918

user_main: scheduler lock test
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Finished

End of test memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 8 7
mxordblk 54950 57178
uordblks 4fc8 4fc8
fordblks 58918 58918

Final memory usage:
VARIABLE BEFORE AFTER
======== ======== ========
arena 5d8e0 5d8e0
ordblks 2 7
mxordblk 57178 57178
uordblks 46d0 4fc8
fordblks 59210 58918
user_main: Exiting
ostest_main: Exiting with status 0
nsh>
```