### PR TITLE
libc/tls: update preprocessor condition comment to match implementation

### DIFF
--- a/libs/libc/tls/tls_getinfo.c
+++ b/libs/libc/tls/tls_getinfo.c
@@ -75,4 +75,4 @@ FAR struct tls_info_s *tls_get_info(void)
   return info;
 }
 
-#endif /* !defined(up_tls_info) && (defined(__KERNEL__) || !defined(CONFIG_TLS_ALIGNED)) */
+#endif /* !defined(up_tls_info) */


### PR DESCRIPTION
Fix documentation inconsistency in the tls_getinfo.c file where the closing
preprocessor conditional comment does not match the actual compilation guard
condition. This minor cleanup ensures that code comments remain accurate and
helpful for future maintenance, reducing confusion about the actual scope of
the conditional block.

### Summary
- Update closing preprocessor comment to accurately reflect the current conditional guard

### TEST
NONE