### PR TITLE
rp23xx/rp23xx-rv: Fix GPIO interrupt handler for RP2350B variant.

### DIFF
--- a/arch/arm/src/rp23xx/rp23xx_gpio.c
+++ b/arch/arm/src/rp23xx/rp23xx_gpio.c
@@ -168,15 +168,23 @@ static int rp23xx_gpio_interrupt(int irq, void *context, void *arg)
 
   /* Scan all GPIO interrupt status registers */
 
-  for (i = 0; i < 6; i++)
+  for (i = 0; i < RP23XX_GPIO_NREGS; i++)
     {
       /* Get and clear pending GPIO interrupt status */
 
       stat = getreg32(RP23XX_IO_BANK0_PROC_INTS(i * 8, 0));
-      if (i == 3)
+
+#if (RP23XX_GPIO_NUM & 7) != 0
+      /* Mask reserved bits in the last register.
+       * RP2350A: 30 GPIOs, last register has 6 valid GPIOs (bits 0-23)
+       * RP2350B: 48 GPIOs, all registers fully used (no masking needed)
+       */
+
+      if (i == RP23XX_GPIO_NREGS - 1)
         {
-          stat &= 0x00ffffff;     /* Clear reserved bits */
+          stat &= (1u << ((RP23XX_GPIO_NUM & 7) * 4)) - 1;
         }
+#endif
 
       putreg32(stat, RP23XX_IO_BANK0_INTR(i * 8));
 
@@ -256,7 +264,11 @@ int rp23xx_gpio_get_function_pin(uint32_t func, uint32_t port)
         break;
 
       case RP23XX_GPIO_FUNC_PWM:
+#ifdef CONFIG_RP23XX_RP2350B
+        if (port >= 12)
+#else
         if (port >= 8)
+#endif
           {
             return -1;
           }

--- a/arch/arm/src/rp23xx/rp23xx_gpio.h
+++ b/arch/arm/src/rp23xx/rp23xx_gpio.h
@@ -48,6 +48,10 @@
 #define RP23XX_GPIO_NUM    30       /* Number of GPIO pins */
 #endif
 
+/* Number of GPIO interrupt status registers */
+
+#define RP23XX_GPIO_NREGS  ((RP23XX_GPIO_NUM + 7) / 8)
+
 /* GPIO function types ******************************************************/
 
 #define RP23XX_GPIO_FUNC_HSTX       RP23XX_IO_BANK0_GPIO_CTRL_FUNCSEL_HSTX

--- a/arch/risc-v/src/rp23xx-rv/rp23xx_gpio.h
+++ b/arch/risc-v/src/rp23xx-rv/rp23xx_gpio.h
@@ -48,6 +48,10 @@
 #define RP23XX_GPIO_NUM    30       /* Number of GPIO pins */
 #endif
 
+/* Number of GPIO interrupt status registers */
+
+#define RP23XX_GPIO_NREGS  ((RP23XX_GPIO_NUM + 7) / 8)
+
 /* GPIO function types ******************************************************/
 
 #define RP23XX_GPIO_FUNC_HSTX       RP23XX_IO_BANK0_GPIO_CTRL_FUNCSEL_HSTX


### PR DESCRIPTION
The GPIO interrupt handler had hardcoded values that only worked correctly for RP2350A (30 GPIOs). For RP2350B (48 GPIOs):

- Loop count was hardcoded to 6 registers but should be computed based on RP23XX_GPIO_NUM (4 for RP2350A, 6 for RP2350B)
- Reserved bits mask was always applied at register index 3, but for RP2350B register 3 contains valid GPIOs 24-31. This caused interrupts for GPIOs 30-31 to be incorrectly discarded
- PWM port validation rejected valid ports 8-11 on RP2350B which has 12 PWM slices instead of 8

Changes:
- Add RP23XX_GPIO_NREGS macro to compute number of interrupt registers
- Use conditional compilation to only mask reserved bits on RP2350A where the last register has 6 valid GPIOs (bits 0-23)
- Fix PWM port validation to allow 12 ports on RP2350B

## Summary                                                                                                                           
  - Fix GPIO interrupt handler to properly support RP2350B variant with 48 GPIOs                                                       
  - Fix PWM port validation to allow 12 PWM slices on RP2350B                                                                          
                                                                                                                                       
  ## Problem                                                                                                                           
  The GPIO interrupt handler had hardcoded values that only worked for RP2350A (30 GPIOs):                                             
  - Loop count hardcoded to 6 registers instead of being computed from GPIO count                                                      
  - Reserved bits mask always applied at register index 3, causing GPIOs 30-31 interrupts to be lost on RP2350B                        
  - PWM port validation rejected valid ports 8-11 on RP2350B                                                                           
                                                                                                                                       
  ## Changes                                                                                                                           
  - Add `RP23XX_GPIO_NREGS` macro to compute number of interrupt registers                                                             
  - Use conditional compilation to only mask reserved bits on RP2350A                                                                  
  - Fix PWM port validation for RP2350B (12 PWM slices vs 8)                                                                           
                                                                                                                                       
  ## Testing                                                                                                                           
  Tested on RP2350B hardware with GPIO interrupts on pins > 29.                                                                        
                                                                                                                                       
  ## Impact                                                                                                                            
  Both ARM (rp23xx) and RISC-V (rp23xx-rv) architectures are fixed.
