### PR TITLE
drivers/virtio: fix the minor code style in virtio.c

### DIFF
--- a/drivers/virtio/virtio.c
+++ b/drivers/virtio/virtio.c
@@ -51,6 +51,7 @@ struct virtio_bus_s
   struct list_node device;     /* Wait match virtio device list */
   struct list_node driver;     /* Virtio driver list */
 };
+
 struct virtio_device_item_s
 {
   struct list_node      node;    /* list node */


### PR DESCRIPTION
## Summary

This PR fixes a minor code style issue in `drivers/virtio/virtio.c` by adding a missing empty line between struct definitions.

## Impact

- **Stability**: No functional changes
- **Compatibility**: No API changes
- **Code Quality**: Improves code style compliance

## Testing

### Build Verification

```bash
cmake -B cmake_out/v8a_netnsh -DBOARD_CONFIG=qemu-armv8a:netnsh -GNinja
cmake --build cmake_out/v8a_netnsh
```

Build passes without errors.