### PR TITLE
arch/xtensa: fix `INT32_C` macro to match `int32_t` type

### DIFF
--- a/arch/xtensa/include/inttypes.h
+++ b/arch/xtensa/include/inttypes.h
@@ -110,7 +110,7 @@
 
 #define INT8_C(x)   x
 #define INT16_C(x)  x
-#define INT32_C(x)  x ## ll
+#define INT32_C(x)  x ## l
 #define INT64_C(x)  x ## ll
 
 #define UINT8_C(x)  x


### PR DESCRIPTION
`INT32_C(x)` is currently defined as `x ## ll` on Xtensa, which produces a `long long int` constant. However, `int32_t` is defined as `long int` on this architecture.

This mismatch breaks C++ template overload resolution and causes build failures in downstream projects such as PX4.

Fixes #17992 