### PR TITLE
arch/x86_64: replaced loop construct with rep movsb

### DIFF
--- a/arch/x86_64/src/common/multiboot1.S
+++ b/arch/x86_64/src/common/multiboot1.S
@@ -54,15 +54,9 @@ _start:
     movl                $realmode_start, %esi
     movl                $0, %edi
 
-copy_loop:
-
     /* Copy by bytes, make sure the addresses are not overlapped */
-
-    movb                (%esi), %al
-    movb                %al, (%edi)
-    inc                 %esi
-    inc                 %edi
-    loop                copy_loop
+    cld
+    rep movsb
 
     /* Jump to bin_start + 0x30, skip the multiboot1 header */
 


### PR DESCRIPTION
## Summary

This PR replaces the manual byte-by-byte copy loop for the .realmode section with more efficient rep movsb string instruction.

## Impact

- Minor boot-time performance improvement
- Reduced code size

## Testing

- Host: Linux x86_64
- Board: qemu-intel64:nsh
- ostest passed
