### PR TITLE
sched/spawn: Fix MISRA C Rule 10.4 violations

### DIFF
--- a/include/spawn.h
+++ b/include/spawn.h
@@ -48,13 +48,13 @@
  * posix_spawnattr_t object using the posix_spawnattr_setflags() function:"
  */
 
-#define POSIX_SPAWN_RESETIDS      (1 << 0)  /* 1: Reset effective user ID */
-#define POSIX_SPAWN_SETPGROUP     (1 << 1)  /* 1: Set process group */
-#define POSIX_SPAWN_SETSCHEDPARAM (1 << 2)  /* 1: Set task's priority */
-#define POSIX_SPAWN_SETSCHEDULER  (1 << 3)  /* 1: Set task's scheduler policy */
-#define POSIX_SPAWN_SETSIGDEF     (1 << 4)  /* 1: Set default signal actions */
-#define POSIX_SPAWN_SETSIGMASK    (1 << 5)  /* 1: Set sigmask */
-#define POSIX_SPAWN_SETSID        (1 << 7)  /* 1: Create the new session(glibc specific) */
+#define POSIX_SPAWN_RESETIDS      (1u << 0)  /* 1: Reset effective user ID */
+#define POSIX_SPAWN_SETPGROUP     (1u << 1)  /* 1: Set process group */
+#define POSIX_SPAWN_SETSCHEDPARAM (1u << 2)  /* 1: Set task's priority */
+#define POSIX_SPAWN_SETSCHEDULER  (1u << 3)  /* 1: Set task's scheduler policy */
+#define POSIX_SPAWN_SETSIGDEF     (1u << 4)  /* 1: Set default signal actions */
+#define POSIX_SPAWN_SETSIGMASK    (1u << 5)  /* 1: Set sigmask */
+#define POSIX_SPAWN_SETSID        (1u << 7)  /* 1: Create the new session(glibc specific) */
 
 /* NOTE: NuttX provides only one implementation:  If
  * CONFIG_LIBC_ENVPATH is defined, then only posix_spawnp() behavior

--- a/sched/task/task_spawnparms.c
+++ b/sched/task/task_spawnparms.c
@@ -158,7 +158,7 @@ int spawn_execattrs(pid_t pid, FAR const posix_spawnattr_t *attr)
   /* Firstly, set the signal mask if requested to do so */
 
 #ifndef CONFIG_DISABLE_ALL_SIGNALS
-  if ((attr->flags & POSIX_SPAWN_SETSIGMASK) != 0)
+  if ((attr->flags & POSIX_SPAWN_SETSIGMASK) != 0u)
     {
       FAR struct tcb_s *tcb = nxsched_get_tcb(pid);
       if (tcb)
@@ -172,7 +172,7 @@ int spawn_execattrs(pid_t pid, FAR const posix_spawnattr_t *attr)
    * to set the priority of the of the new task.
    */
 
-  if ((attr->flags & POSIX_SPAWN_SETSCHEDPARAM) != 0)
+  if ((attr->flags & POSIX_SPAWN_SETSCHEDPARAM) != 0u)
     {
 #ifdef CONFIG_SCHED_SPORADIC
       /* Get the current sporadic scheduling parameters.  Those will not be
@@ -192,7 +192,7 @@ int spawn_execattrs(pid_t pid, FAR const posix_spawnattr_t *attr)
            * then we will call nxsched_set_scheduler() below.
            */
 
-          if ((attr->flags & POSIX_SPAWN_SETSCHEDULER) == 0)
+          if ((attr->flags & POSIX_SPAWN_SETSCHEDULER) == 0u)
             {
               sinfo("Setting priority=%d for pid=%d\n",
                     param.sched_priority, pid);
@@ -207,7 +207,7 @@ int spawn_execattrs(pid_t pid, FAR const posix_spawnattr_t *attr)
    * preparation for the nxsched_set_scheduler() call below.
    */
 
-  else if ((attr->flags & POSIX_SPAWN_SETSCHEDULER) != 0)
+  else if ((attr->flags & POSIX_SPAWN_SETSCHEDULER) != 0u)
     {
       ret = nxsched_get_param(0, &param);
     }
@@ -216,7 +216,7 @@ int spawn_execattrs(pid_t pid, FAR const posix_spawnattr_t *attr)
    * setting determined above.
    */
 
-  if (ret == OK && (attr->flags & POSIX_SPAWN_SETSCHEDULER) != 0)
+  if (ret == OK && (attr->flags & POSIX_SPAWN_SETSCHEDULER) != 0u)
     {
       sinfo("Setting policy=%d priority=%d for pid=%d\n",
             attr->policy, param.sched_priority, pid);


### PR DESCRIPTION
## Summary

This PR fixes MISRA C:2012 Rule 10.4 violations in posix_spawn attribute handling code by ensuring consistent use of unsigned operands in bitwise operations.

### Changes Made

Modified all `POSIX_SPAWN_*` flag macro definitions and their usage sites to use unsigned literals:

**Macro definitions** (`include/spawn.h`):
- `POSIX_SPAWN_RESETIDS`: Changed from `(1 << 0)` to `(1u << 0)`
- `POSIX_SPAWN_SETPGROUP`: Changed from `(1 << 1)` to `(1u << 1)`
- `POSIX_SPAWN_SETSCHEDPARAM`: Changed from `(1 << 2)` to `(1u << 2)`
- `POSIX_SPAWN_SETSCHEDULER`: Changed from `(1 << 3)` to `(1u << 3)`
- `POSIX_SPAWN_SETSIGDEF`: Changed from `(1 << 4)` to `(1u << 4)`
- `POSIX_SPAWN_SETSIGMASK`: Changed from `(1 << 5)` to `(1u << 5)`
- `POSIX_SPAWN_SETSID`: Changed from `(1 << 7)` to `(1u << 7)`

**Usage sites** (`sched/task/task_spawnparms.c`):
- Updated 5 flag checking comparisons in `spawn_execattrs()` to compare against `0u` instead of `0`

### Why This Change is Needed

MISRA C:2012 Rule 10.4 prohibits mixing signed and unsigned operands in arithmetic operations. The original code violated this rule by:
1. Using signed integer literals (`1`) in bit shift operations for flag definitions
2. Comparing bitwise results against signed zero (`0`)

This could lead to:
- Undefined behavior in edge cases
- Compiler warnings in strict compliance mode
- Potential portability issues across different platforms

## Impact

**Stability**: No impact - purely type-safety improvements  
**Compatibility**: No breaking changes - all modifications preserve existing POSIX spawn behavior  
**Code Quality**: Positive - eliminates 12 MISRA C:2012 Rule 10.4 violations

## Testing

### Test Environment
- **Host**: Ubuntu 22.04 x86_64
- **Toolchain**: GCC 13.1.0
- **Target**: sim:nsh configuration
- **Build**: CMake + Ninja

### Test Steps

1. **Build verification**:
```bash
cd nuttx
cmake -B build -DBOARD_CONFIG=sim:nsh -GNinja
cmake --build build -j
```
2. **Results**:
- MISRA/Coverity: PASS (no new issues introduced; targeted findings addressed)
- sim:nsh (CMake): PASS (build + NSH smoke)
