### PR TITLE
drivers/note: Fix data address alignment trap cause by sched_note_add.

### DIFF
--- a/drivers/note/note_driver.c
+++ b/drivers/note/note_driver.c
@@ -611,8 +611,12 @@ void sched_note_add(FAR const void *data, size_t len)
           note_add(*driver, note, notelen);
         }
 
-      data = (FAR void *)((uintptr_t)data + notelen);
-      len -= notelen;
+      /* The note data from note rpmsg is aligned. When parsing
+       * the data, it is necessary to align the notelen.
+       */
+
+      data = (FAR void *)((uintptr_t)data + NOTE_ALIGN(notelen));
+      len -= NOTE_ALIGN(notelen);
     }
 }
 #endif

--- a/drivers/note/noterpmsg_driver.c
+++ b/drivers/note/noterpmsg_driver.c
@@ -202,7 +202,7 @@ static void noterpmsg_add(FAR struct note_driver_s *driver,
   flags = spin_lock_irqsave_notrace(&drv->lock);
 
   space = CONFIG_DRIVERS_NOTERPMSG_BUFSIZE - noterpmsg_length(drv);
-  if (space < notelen)
+  if (space < NOTE_ALIGN(notelen))
     {
       if (!up_interrupt_context() && !sched_idletask())
         {
@@ -218,7 +218,7 @@ static void noterpmsg_add(FAR struct note_driver_s *driver,
               space = CONFIG_DRIVERS_NOTERPMSG_BUFSIZE -
                       noterpmsg_length(drv);
             }
-          while (space < notelen);
+          while (space < NOTE_ALIGN(notelen));
         }
     }
 
@@ -228,7 +228,7 @@ static void noterpmsg_add(FAR struct note_driver_s *driver,
   memcpy(drv->buffer + drv->head, note, space);
   memcpy(drv->buffer, note + space, notelen - space);
 
-  drv->head = noterpmsg_next(drv, drv->head, notelen);
+  drv->head = noterpmsg_next(drv, drv->head, NOTE_ALIGN(notelen));
 
   if (work_available(&drv->work))
     {


### PR DESCRIPTION
Solve the problem of address misalignment exception triggered when sched_note_add parses note data.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This PR fixes a data address alignment issue in the NuttX note driver subsystem.
Previously, the sched_note_add and noterpmsg_add functions used the raw note length (notelen) for pointer arithmetic and buffer management.
On platforms with strict alignment requirements, this could cause misaligned memory accesses and trigger exceptions.

The patch updates all relevant pointer and buffer operations to use NOTE_ALIGN(notelen) instead of notelen, ensuring that all note data is properly aligned during parsing and storage.

## Impact

- Prevents address misalignment exceptions when handling note data.
- Improves compatibility and stability on architectures with strict alignment requirements.
- No impact on platforms that do not enforce alignment.

## Testing

- Verified on hardware platforms with strict alignment requirements.
- No misalignment exceptions observed after applying the patch.
- Note data is correctly parsed and stored in all tested scenarios.

