### PR TITLE
syscall: add coredump to syscall

### DIFF
--- a/include/sys/syscall_lookup.h
+++ b/include/sys/syscall_lookup.h
@@ -403,3 +403,7 @@ SYSCALL_LOOKUP(signal,                     2)
   SYSCALL_LOOKUP(sched_note_vprintf_ip,    5)
   SYSCALL_LOOKUP(sched_note_event_ip,      5)
 #endif
+
+#ifdef CONFIG_COREDUMP
+  SYSCALL_LOOKUP(coredump,                 3)
+#endif

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -18,6 +18,7 @@
 "clock_settime","time.h","","int","clockid_t","const struct timespec*"
 "close","unistd.h","","int","int"
 "connect","sys/socket.h","defined(CONFIG_NET)","int","int","FAR const struct sockaddr *","socklen_t"
+"coredump","nuttx/coredump.h","defined(CONFIG_COREDUMP)","int","FAR const struct memory_region_s *","FAR struct lib_outstream_s *","pid_t"
 "dup","unistd.h","","int","int"
 "dup2","unistd.h","","int","int","int"
 "epoll_close","sys/epoll.h","","void","int"


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

syscall: add coredump to syscall

## Impact

none

## Testing

none