### PR TITLE
libc/machine/arm64: Use .d rather than .2d for element mov instructions

### DIFF
--- a/libs/libc/machine/arm64/arch_memchr.S
+++ b/libs/libc/machine/arm64/arch_memchr.S
@@ -114,7 +114,7 @@ def_fn ARCH_LIBCFUN(memchr)
 	and	vhas_chr2.16b, vhas_chr2.16b, vrepmask.16b
 	addp	vend.16b, vhas_chr1.16b, vhas_chr2.16b		/* 256->128 */
 	addp	vend.16b, vend.16b, vend.16b			/* 128->64 */
-	mov	synd, vend.2d[0]
+	mov	synd, vend.d[0]
 	/* Clear the soff*2 lower bits */
 	lsl	tmp, soff, #1
 	lsr	synd, synd, tmp
@@ -134,7 +134,7 @@ def_fn ARCH_LIBCFUN(memchr)
 	/* Use a fast check for the termination condition */
 	orr	vend.16b, vhas_chr1.16b, vhas_chr2.16b
 	addp	vend.2d, vend.2d, vend.2d
-	mov	synd, vend.2d[0]
+	mov	synd, vend.d[0]
 	/* We're not out of data, loop if we haven't found the character */
 	cbz	synd, .Lloop
 
@@ -144,7 +144,7 @@ def_fn ARCH_LIBCFUN(memchr)
 	and	vhas_chr2.16b, vhas_chr2.16b, vrepmask.16b
 	addp	vend.16b, vhas_chr1.16b, vhas_chr2.16b		/* 256->128 */
 	addp	vend.16b, vend.16b, vend.16b			/* 128->64 */
-	mov	synd, vend.2d[0]
+	mov	synd, vend.d[0]
 	/* Only do the clear for the last possible block */
 	b.hi	.Ltail
 

--- a/libs/libc/machine/arm64/arch_strchr.S
+++ b/libs/libc/machine/arm64/arch_strchr.S
@@ -121,7 +121,7 @@ def_fn ARCH_LIBCFUN(strchr)
 	addp	vend1.16b, vend1.16b, vend2.16b		// 128->64
 	lsr	tmp1, tmp3, tmp1
 
-	mov	tmp3, vend1.2d[0]
+	mov	tmp3, vend1.d[0]
 	bic	tmp1, tmp3, tmp1	// Mask padding bits.
 	cbnz	tmp1, .Ltail
 
@@ -136,7 +136,7 @@ def_fn ARCH_LIBCFUN(strchr)
 	orr	vend2.16b, vhas_nul2.16b, vhas_chr2.16b
 	orr	vend1.16b, vend1.16b, vend2.16b
 	addp	vend1.2d, vend1.2d, vend1.2d
-	mov	tmp1, vend1.2d[0]
+	mov	tmp1, vend1.d[0]
 	cbz	tmp1, .Lloop
 
 	/* Termination condition found.  Now need to establish exactly why
@@ -150,7 +150,7 @@ def_fn ARCH_LIBCFUN(strchr)
 	addp	vend1.16b, vend1.16b, vend2.16b		// 256->128
 	addp	vend1.16b, vend1.16b, vend2.16b		// 128->64
 
-	mov	tmp1, vend1.2d[0]
+	mov	tmp1, vend1.d[0]
 .Ltail:
 	/* Count the trailing zeros, by bit reversing...  */
 	rbit	tmp1, tmp1

--- a/libs/libc/machine/arm64/arch_strchrnul.S
+++ b/libs/libc/machine/arm64/arch_strchrnul.S
@@ -113,7 +113,7 @@ def_fn ARCH_LIBCFUN(strchrnul)
 	addp	vend1.16b, vend1.16b, vend1.16b		// 128->64
 	lsr	tmp1, tmp3, tmp1
 
-	mov	tmp3, vend1.2d[0]
+	mov	tmp3, vend1.d[0]
 	bic	tmp1, tmp3, tmp1	// Mask padding bits.
 	cbnz	tmp1, .Ltail
 
@@ -128,7 +128,7 @@ def_fn ARCH_LIBCFUN(strchrnul)
 	orr	vhas_chr2.16b, vhas_nul2.16b, vhas_chr2.16b
 	orr	vend1.16b, vhas_chr1.16b, vhas_chr2.16b
 	addp	vend1.2d, vend1.2d, vend1.2d
-	mov	tmp1, vend1.2d[0]
+	mov	tmp1, vend1.d[0]
 	cbz	tmp1, .Lloop
 
 	/* Termination condition found.  Now need to establish exactly why
@@ -138,7 +138,7 @@ def_fn ARCH_LIBCFUN(strchrnul)
 	addp	vend1.16b, vhas_chr1.16b, vhas_chr2.16b		// 256->128
 	addp	vend1.16b, vend1.16b, vend1.16b		// 128->64
 
-	mov	tmp1, vend1.2d[0]
+	mov	tmp1, vend1.d[0]
 .Ltail:
 	/* Count the trailing zeros, by bit reversing...  */
 	rbit	tmp1, tmp1

--- a/libs/libc/machine/arm64/arch_strrchr.S
+++ b/libs/libc/machine/arm64/arch_strrchr.S
@@ -124,10 +124,10 @@ def_fn ARCH_LIBCFUN(strrchr)
 	addp	vhas_chr1.16b, vhas_chr1.16b, vhas_chr2.16b	// 256->128
 	addp	vhas_nul1.16b, vhas_nul1.16b, vhas_nul1.16b	// 128->64
 	addp	vhas_chr1.16b, vhas_chr1.16b, vhas_chr1.16b	// 128->64
-	mov	nul_match, vhas_nul1.2d[0]
+	mov	nul_match, vhas_nul1.d[0]
 	lsl	tmp1, tmp1, #1
 	mov	const_m1, #~0
-	mov	chr_match, vhas_chr1.2d[0]
+	mov	chr_match, vhas_chr1.d[0]
 	lsr	tmp3, const_m1, tmp1
 
 	bic	nul_match, nul_match, tmp3	// Mask padding bits.


### PR DESCRIPTION

## Summary

Use .d rather than .2d for element mov instructions in string routines
so the assembly compiles with clang too.The same changes are also found in github arm-software: https://github.com/ARM-software/optimized-routines/commit/4f4e530b2fda475a37e583bc113ad2fd3e83dc7f

## Impact

no impact

## Testing

1. ci
2. use memchr,strchr,strrchr in function 
