### PR TITLE
arch/arm64: support armv8r hwdebug

### DIFF
--- a/arch/arm64/src/common/arm64_hwdebug.c
+++ b/arch/arm64/src/common/arm64_hwdebug.c
@@ -342,6 +342,10 @@ int arm64_enable_dbgmonitor(void)
   mdscr |= ARM64_MDSCR_EL1_MDE | ARM64_MDSCR_EL1_KDE;
   write_sysreg(mdscr, mdscr_el1);
 
+  write_sysreg(0, osdlr_el1);
+  write_sysreg(0, oslar_el1);
+  UP_ISB();
+
   arm64_register_debug_hook(DBG_ESR_EVT_HWBP, arm64_breakpoint_match);
   arm64_register_debug_hook(DBG_ESR_EVT_HWWP, arm64_watchpoint_match);
   return OK;


### PR DESCRIPTION
These two registers need to be cleared before arm64-r hwdebug can be used.The arm64-a does not have such stringent requirements.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

arm64/hwdebug: support armv8r hwdebug:These two registers need to be cleared before arm64-r hwdebug can be used.The arm64-a does not have such stringent requirements.

## Impact

none

## Testing

build armv8-r config and use up_debugpoint_add api to test