### PR TITLE
arm64: Add kmalloc header for arch timer

### DIFF
--- a/arch/arm64/src/common/arm64_arch_timer.c
+++ b/arch/arm64/src/common/arm64_arch_timer.c
@@ -32,6 +32,7 @@
 #include <nuttx/arch.h>
 #include <arch/irq.h>
 #include <arch/chip/chip.h>
+#include <nuttx/kmalloc.h>
 #include <nuttx/spinlock.h>
 #include <nuttx/timers/arch_alarm.h>
 


### PR DESCRIPTION
# Summary

Add missing kmalloc.h header include to ARM64 architecture timer implementation.

**Why:**
The `arch/arm64/src/common/arm64_arch_timer.c` file uses kernel memory allocation functions but was missing the `nuttx/kmalloc.h` header include, causing compilation failures or implicit function declaration warnings in certain build configurations.

**What changed:**
- Added `#include <nuttx/kmalloc.h>` to `arch/arm64/src/common/arm64_arch_timer.c`
- Ensures proper declaration of memory allocation functions used by the timer subsystem

# Impact

**Scope:**
- **ARM64 architecture**: Fixed header dependency in timer subsystem
- **Compilation**: Eliminates implicit function declaration warnings

**Affected files:**
- `arch/arm64/src/common/arm64_arch_timer.c` - Architecture timer implementation

**Breaking changes:** None

**Backward compatibility:** Fully maintained - this is a build fix with no functional changes

# Testing

**Build testing:**
```bash
# ARM64 configuration with arch timer
./tools/configure.sh qemu-armv8a:nsh_smp
make clean && make
# Build successful with no warnings