### PR TITLE
libc/mutex: fix when choose CONFIG_PTHREAD_MUTEX_ROBUST flag skipped

### DIFF
--- a/libs/libc/pthread/pthread_mutex_init.c
+++ b/libs/libc/pthread/pthread_mutex_init.c
@@ -85,8 +85,8 @@ int pthread_mutex_init(FAR pthread_mutex_t *mutex,
 #  ifdef CONFIG_PTHREAD_MUTEX_BOTH
   mutex->flags = attr && attr->robust == PTHREAD_MUTEX_ROBUST ?
                  _PTHREAD_MFLAGS_ROBUST : 0;
-#  else
-  mutex->flags = 0;
+#  else /* CONFIG_PTHREAD_MUTEX_ROBUST */
+  mutex->flags = _PTHREAD_MFLAGS_ROBUST;
 #  endif
 #endif
 


### PR DESCRIPTION
## Summary

If choose CONFIG_PTHREAD_MUTEX_ROBUST flags missing _PTHREAD_MFLAGS_ROBUST will make tls info did not add self.
Cause ostest break, hang on robust test.

The pthread_mutex_add & pthread_mutex_remove always check the _PTHREAD_MFLAGS_ROBUST flag. and we miss the flag when choose CONFIG_PTHREAD_MUTEX_ROBUST.
```C
static inline_function
void pthread_mutex_add(FAR struct pthread_mutex_s *mutex)
{
  FAR struct tls_info_s *tls;

  if ((mutex->flags & _PTHREAD_MFLAGS_ROBUST) != 0)
    {
      tls = tls_get_info();
      DEBUGASSERT(mutex->flink == NULL);

      /* Add the mutex to the list of mutexes held by this pthread */

      mutex->flink = tls->tl_mhead;
      tls->tl_mhead = mutex;
    }
}
```


## Impact
Before fix the ostest hang if PTHREAD_MUTEX_ROBUST choosed.
After fix will correct pass the ostest.

## Testing
ci-test, local sim/nsh.

menuconfig select the CONFIG_PTHREAD_MUTEX_ROBUST, did not select both.

```bash
# before fix
user_main: robust test
robust_test: Initializing mutex
robust_test: Starting thread
robust_waiter: Taking mutex
robust_waiter: Exiting with mutex
[1]    3523079 terminated  ./nuttx
# hang and have to kill outside.

# afterfix
ostest_main: Exiting with status 0
stdio_test: Standard I/O Check: fprintf to stderr
nsh> 
```
