### PR TITLE
audio: upper half enhancement

### DIFF
--- a/audio/audio.c
+++ b/audio/audio.c
@@ -477,6 +477,7 @@ static int audio_configure(FAR struct file *filep,
       /* INPUT/OUTPUT configure success here */
 
       audio_setstate(upper, AUDIO_STATE_PREPARED);
+      upper->info.type = caps->ac_type;
       upper->info.format = caps->ac_subtype;
       upper->info.channels = caps->ac_channels;
       upper->info.subformat = caps->ac_format.b[0];
@@ -1423,6 +1424,12 @@ static inline void audio_dequeuebuffer(FAR struct audio_upperhalf_s *upper,
   irqstate_t flags;
 
   audinfo("Entry\n");
+
+  if (upper->info.type == AUDIO_TYPE_OUTPUT)
+    {
+      apb->nbytes = 0;
+      memset(apb->samp, 0, apb->nmaxbytes);
+    }
 
   flags = spin_lock_irqsave_nopreempt(&upper->spinlock);
   upper->status->tail++;

--- a/include/nuttx/audio/audio.h
+++ b/include/nuttx/audio/audio.h
@@ -732,16 +732,12 @@ struct audio_caps_desc_s
 
 struct audio_info_s
 {
-  uint32_t samplerate;   /* Sample Rate of the audio data */
-  uint8_t  channels;     /* Number of channels (1, 2, 5, 7) */
-  uint8_t  format;       /* Audio data format */
-  uint8_t  subformat;    /* Audio subformat
-                          * (maybe should be combined with format?)
-                          */
-
-  /* Codec extra params */
-
-  struct audio_codec_s codec;
+  uint32_t              samplerate; /* Sample Rate of the audio data */
+  uint8_t               channels;   /* Number of channels (1, 2, 5, 7) */
+  uint8_t               format;     /* Audio data format */
+  uint8_t               subformat;  /* Audio subformat */
+  uint8_t               type;       /* device type */
+  struct audio_codec_s  codec;      /* Codec extra params */
 };
 
 /* This structure describes the preferred number and size of


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

We have enhanced the capabilities of the upper driver, mainly including the following features:
1. Support for multiple applications simultaneously using the upper driver for playback/recording;
2. Support for maintaining a ringbuffer in the upper driver for simultaneous access by multiple applications;
3. Lower driver state management and retrieval;
4. Support for poll/mmap;
5. More comprehensive information retrieval via ioctl interfaces.

## Impact

Affects: audio upper-half driver (playback/recording path).
Behavior: supports concurrent apps, upper ringbuffer, extra ioctls, state management, poll/mmap. Playback now supports multiple instances; recorder behavior remains unchanged.
Compatibility: no breaking API changes expected; existing apps should continue to work.

## Testing

Simulator (NSH, audio_sim). Verified that existing playback/recording flows still work.

Steps:
1. mount hostfs and run `nxrecorder` to record raw audio
2. run `nxplayer` to play raw audio

Logs (excerpt):
```
audio_register: Registering /dev/audio/pcm0p
audio_register: Registering /dev/audio/pcm0c
audio_register: Registering /dev/audio/pcm1p
audio_register: Registering /dev/audio/pcm1c
audio_register: Registering /dev/audio/mixer

NuttShell (NSH) NuttX-3.6.1
nsh> mount -t hostfs -o fs=/home/mi/music /music
nsh> nxrecorder
...
nxrecorder> recordraw /tmp/d_1ch_32bit_44100.pcm 1 16 16000
...
nxrecorder_recordthread: Recording...
...
nxrecorder_recordthread: Record complete.  outstanding=0
...
nsh> nxplayer
...
nxplayer> playraw /music/part_stereo.pcm 2 16 44100
...
nxplayer_playthread: Playing...
...
nxplayer_playthread: Play complete.  outstanding=0
```

Result: PASS (recording + playback unchanged).

Additional platform coverage:
- Simulator – Playback/Recording, plus multi-instance playback verified via ALSA-lib port on NuttX.
- BES Platform – Playback/Recording, plus multi-instance playback verified via ALSA-lib port on NuttX.
- Allwinner Platform – Playback/Recording, plus multi-instance playback verified via ALSA-lib port on NuttX.
