### PR TITLE
[BUG FIX] rpmsg_virtio/rptun: support fallback cpuname when VIRTIO_RPMSG_F_CPUNAME not set

### DIFF
--- a/include/nuttx/rpmsg/rpmsg_virtio.h
+++ b/include/nuttx/rpmsg/rpmsg_virtio.h
@@ -51,6 +51,8 @@ extern "C"
  * Public Function Prototypes
  ****************************************************************************/
 
+int rpmsg_virtio_probe_cpuname(FAR struct virtio_device *vdev,
+                               FAR const char *cpuname);
 int rpmsg_virtio_probe(FAR struct virtio_device *vdev);
 void rpmsg_virtio_remove(FAR struct virtio_device *vdev);
 


### PR DESCRIPTION
## Summary

Closes #18346

And adds support for a fallback cpuname mechanism in rpmsg_virtio driver when the `VIRTIO_RPMSG_F_CPUNAME` feature is not negotiated with the remote side.

### Background

Currently, when the `VIRTIO_RPMSG_F_CPUNAME` feature is not available (i.e., the remote side doesn't support it), the rpmsg_virtio driver would crash due to `DEBUGASSERT`. This is problematic in heterogeneous systems where different cores may run different firmware versions with varying feature support.

### Changes

1. **New API `rpmsg_virtio_probe_cpuname()`**: Added a new probe function that accepts an optional `cpuname` parameter to be used as fallback when `VIRTIO_RPMSG_F_CPUNAME` is not negotiated.

2. **Graceful feature handling**: Instead of asserting when `VIRTIO_RPMSG_F_CPUNAME` is missing, the driver now checks the feature flag and falls back to the provided cpuname parameter.

3. **rptun integration**: Modified rptun driver to pass the cpuname from `rptun_dev_s` config to `rpmsg_virtio_probe_cpuname()`, enabling the fallback mechanism.

4. **Code reorganization**: Refactored `rptun_register_device()` and `rptun_unregister_device()` to prioritize RPMSG device handling before other virtio device types for cleaner code flow.

## Impact

- **No breaking changes**: Systems that already negotiate `VIRTIO_RPMSG_F_CPUNAME` will continue to work as before.
- **Improved robustness**: Systems with mixed firmware versions can now communicate without crashes.

## Testing

### Build Verification

```bash
# Build for qemu-armv8a with rptun configuration
cmake -B build -DBOARD_CONFIG=qemu-armv8a:rpserver -GNinja
cmake --build build

cmake -B build -DBOARD_CONFIG=qemu-armv8a:rpproxy -GNinja
cmake --build build
```

### Test Environment

- **Host**: Ubuntu 22.04 x86_64
- **Target**: QEMU ARM64 (qemu-armv8a)
- **Configuration**: rpserver + rpproxy dual-core setup with ivshmem

### Test Procedure
Test with local disable the VIRTIO_RPMSG_F_CPUNAME in drivers/rptun/rptun_ivshmem.c

rpserver to rpproxy test log
```c
❯ qemu-system-aarch64 -cpu cortex-a53 -nographic \
-machine virt,virtualization=on,gic-version=3 \
-chardev stdio,id=con,mux=on -serial chardev:con \
-object memory-backend-file,discard-data=on,id=shmmem-shmem0,mem-path=/dev/shm/my_shmem0,size=4194304,share=yes \
-device ivshmem-plain,id=shmem0,memdev=shmmem-shmem0,addr=0xb \
-device virtio-serial-device,bus=virtio-mmio-bus.0 \
-chardev socket,path=/tmp/rpmsg_port_uart_socket,server=on,wait=off,id=foo \
-device virtconsole,chardev=foo \
-mon chardev=con,mode=readline -kernel ./cmake_out/v8a_server/nuttx \
-gdb tcp::7775
[    0.000000] [ 0] [  INFO] [server] pci_register_rptun_ivshmem_driver: Register ivshmem driver, id=0, cpuname=proxy, master=1
[    0.000000] [ 3] [  INFO] [server] pci_scan_bus: pci_scan_bus for bus 0
[    0.000000] [ 3] [  INFO] [server] pci_scan_bus: class = 00000600, hdr_type = 00000000
[    0.000000] [ 3] [  INFO] [server] pci_scan_bus: 00:00 [1b36:0008]
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar0 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar1 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar2 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar3 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar4 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar5 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_scan_bus: class = 00000200, hdr_type = 00000000
[    0.000000] [ 3] [  INFO] [server] pci_scan_bus: 00:08 [1af4:1000]
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar0: mask64=fffffffe 32bytes
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar1: mask64=fffffff0 4096bytes
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar2 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar3 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar4: mask64=fffffffffffffff0 16384bytes
[    0.000000] [ 3] [  INFO] [server] pci_scan_bus: class = 00000500, hdr_type = 00000000
[    0.000000] [ 3] [  INFO] [server] pci_scan_bus: 00:58 [1af4:1110]
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar0: mask64=fffffff0 256bytes
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar1 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar2: mask64=fffffffffffffff0 4194304bytes
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar4 set bad mask
[    0.000000] [ 3] [  INFO] [server] pci_setup_device: pbar5 set bad mask
[    0.000000] [ 3] [  INFO] [server] ivshmem_probe: shmem addr=0x8000400000 size=4194304 reg=0x10001000
[    0.000000] [ 3] [  INFO] [server] rptun_ivshmem_probe: shmem addr=0x8000400000 size=4194304

NuttShell (NSH) NuttX-12.12.0
server> [    0.000000] [ 0] [  INFO] [proxy] pci_register_rptun_ivshmem_driver: Register ivshmem driver, id=0, cpuname=server, master=0
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: pci_scan_bus for bus 0
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: class = 00000600, hdr_type = 00000000
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: 00:00 [1b36:0008]
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar0 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar1 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar2 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar3 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar4 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar5 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: class = 00000200, hdr_type = 00000000
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: 00:08 [1af4:1000]
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar0: mask64=fffffffe 32bytes
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar1: mask64=fffffff0 4096bytes
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar2 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar3 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar4: mask64=fffffffffffffff0 16384bytes
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: class = 00000500, hdr_type = 00000000
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: 00:58 [1af4:1110]
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar0: mask64=fffffff0 256bytes
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar1 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar2: mask64=fffffffffffffff0 4194304bytes
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar4 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar5 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] ivshmem_probe: shmem addr=0x8000400000 size=4194304 reg=0x10001000
[    0.000000] [ 3] [  INFO] [proxy] rptun_ivshmem_probe: shmem addr=0x8000400000 size=4194304
[    0.000000] [ 3] [  INFO] [proxy] rptun_ivshmem_probe: Start the wdog

server> 
server> 
server> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK    USED FILLED COMMAND
    0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0008144 0001792  22.0%  Idle_Task
    1     0     0 192 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0008080 0001328  16.4%  hpwork 0x4047bc60 0x4047bce0
    2     0     0 100 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0008080 0001328  16.4%  lpwork 0x4047bd10 0x4047bd90
    5     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0008080 0002368  29.3%  rpmsg-uart-rx proxy2 0x404b1048
    6     0     0 224 FIFO     Kthread   - Waiting  Event     0000000000000000 0008080 0001968  24.3%  rpmsg-uart-tx proxy2 0x404b1048
    7     7     0 100 FIFO     Task      - Running            0000000000000000 0008112 0004176  51.4%  nsh_main
    8     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0008080 0002256  27.9%  rpmsg-virtio proxy 0x40495b10
server> rpmsg ping all 1 1 1 1
[    0.000000] [ 7] [ EMERG] [server] ping times: 1
[    0.000000] [ 7] [ EMERG] [server] buffer_len: 1520, send_len: 17
[    0.000000] [ 7] [ EMERG] [server] avg: 0 s, 80862768 ns
[    0.000000] [ 7] [ EMERG] [server] min: 0 s, 80862768 ns
[    0.000000] [ 7] [ EMERG] [server] max: 0 s, 80862768 ns
[    0.000000] [ 7] [ EMERG] [server] rate: 0.001681 Mbits/sec
[    0.000000] [ 7] [ EMERG] [server] ping times: 1
[    0.000000] [ 7] [ EMERG] [server] buffer_len: 2008, send_len: 17
[    0.000000] [ 7] [ EMERG] [server] avg: 0 s, 87159024 ns
[    0.000000] [ 7] [ EMERG] [server] min: 0 s, 87159024 ns
[    0.000000] [ 7] [ EMERG] [server] max: 0 s, 87159024 ns
[    0.000000] [ 7] [ EMERG] [server] rate: 0.001560 Mbits/sec
server> uname -a
NuttX server 12.12.0 37e3e8f7e6f-dirty Feb  4 2026 20:51:13 arm64 qemu-armv8a
server> rpmsg dump all
[    0.000000] [ 7] [ EMERG] [server] Local:  Remote: proxy Headrx 8
[    0.000000] [ 7] [ EMERG] [server] Dump rpmsg info between cpu (master: yes) <==> proxy:
[    0.000000] [ 7] [ EMERG] [server] rpmsg vq RX:
[    0.000000] [ 7] [ EMERG] [server] VQ: rx_vq - size=8; free=0; queued=0; desc_head_idx=32768; available_idx=0; avail.idx=16; used_cons_idx=8; used.idx=8; avail.flags=0x0; used.flags=0x1
[    0.000000] [ 7] [ EMERG] [server] rpmsg vq TX:
[    0.000000] [ 7] [ EMERG] [server] VQ: tx_vq - size=8; free=6; queued=0; desc_head_idx=2; available_idx=0; avail.idx=6; used_cons_idx=4; used.idx=6; avail.flags=0x1; used.flags=0x0
[    0.000000] [ 7] [ EMERG] [server]   rpmsg ept list:
[    0.000000] [ 7] [ EMERG] [server]     ept NS
[    0.000000] [ 7] [ EMERG] [server]     ept rpmsg-sensor
[    0.000000] [ 7] [ EMERG] [server]     ept rpmsg-ping
[    0.000000] [ 7] [ EMERG] [server]     ept rpmsg-syslog
[    0.000000] [ 7] [ EMERG] [server]   rpmsg buffer list:
[    0.000000] [ 7] [ EMERG] [server]     RX buffer, total 8, pending 0
[    0.000000] [ 7] [ EMERG] [server]     TX buffer, total 8, pending 0
[    0.000000] [ 7] [ EMERG] [server] Remote: proxy2 state: 1
[    0.000000] [ 7] [ EMERG] [server] ept NS
[    0.000000] [ 7] [ EMERG] [server] ept rpmsg-sensor
[    0.000000] [ 7] [ EMERG] [server] ept rpmsg-ping
[    0.000000] [ 7] [ EMERG] [server] rpmsg_port queue RX: {used: 0, avail: 8}
[    0.000000] [ 7] [ EMERG] [server] rpmsg buffer list:
[    0.000000] [ 7] [ EMERG] [server] rpmsg_port queue TX: {used: 0, avail: 8}
[    0.000000] [ 7] [ EMERG] [server] rpmsg buffer list:
[    0.000000] [ 7] [ ALERT] [server] sched_dumpstack: backtrace| 5: 0x00000000402a8788 0x00000000402aa43c 0x000000004029c068 0x000000004028caf4 0x00000000402e4028 0x00000000402e40d8 0x00000000402bcd98 0x00000000402bd220
[    0.000000] [ 7] [ ALERT] [server] sched_dumpstack: backtrace| 5: 0x00000000402ad0f4
[    0.000000] [ 7] [ ALERT] [server] sched_dumpstack: backtrace| 6: 0x00000000402a8ba8 0x00000000402f6178 0x00000000402bc16c 0x00000000402bd308 0x00000000402ad0f4
server> 
server> 
server>
```

rpproxy to linux test log
```c
❯ qemu-system-aarch64 -cpu cortex-a53 -nographic \
-machine virt,virtualization=on,gic-version=3 \
-chardev stdio,id=con,mux=on -serial chardev:con \
-object memory-backend-file,discard-data=on,id=shmmem-shmem0,mem-path=/dev/shm/my_shmem0,size=4194304,share=yes \
-device ivshmem-plain,id=shmem0,memdev=shmmem-shmem0,addr=0xb \
-mon chardev=con,mode=readline -kernel ./cmake_out/v8a_proxy/nuttx \
-gdb tcp::7776
- Ready to Boot Primary CPU
- Boot from EL2
- Boot from EL1
- Boot to C runtime for OS Initialize
[    0.000000] [ 0] [  INFO] [proxy] pci_register_rptun_ivshmem_driver: Register ivshmem driver, id=0, cpuname=server, master=0
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: pci_scan_bus for bus 0
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: class = 00000600, hdr_type = 00000000
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: 00:00 [1b36:0008]
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar0 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar1 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar2 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar3 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar4 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar5 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: class = 00000200, hdr_type = 00000000
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: 00:08 [1af4:1000]
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar0: mask64=fffffffe 32bytes
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar1: mask64=fffffff0 4096bytes
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar2 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar3 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar4: mask64=fffffffffffffff0 16384bytes
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: class = 00000500, hdr_type = 00000000
[    0.000000] [ 3] [  INFO] [proxy] pci_scan_bus: 00:58 [1af4:1110]
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar0: mask64=fffffff0 256bytes
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar1 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar2: mask64=fffffffffffffff0 4194304bytes
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar4 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] pci_setup_device: pbar5 set bad mask
[    0.000000] [ 3] [  INFO] [proxy] ivshmem_probe: shmem addr=0x8000400000 size=4194304 reg=0x10001000
[    0.000000] [ 3] [  INFO] [proxy] rptun_ivshmem_probe: shmem addr=0x8000400000 size=4194304
[    0.000000] [ 3] [  INFO] [proxy] rptun_ivshmem_probe: Start the wdog
[    0.000000] [ 3] [ ERROR] [proxy] rpmsg_port_uart_initialize: Open uart device failed, ret=-2
[    0.000000] [ 3] [ ERROR] [proxy] ERROR: Failed to initialize rpmsg port uart: -2
[    0.000000] [ 3] [ ERROR] [proxy] ERROR: Failed to initialize rpmsg port uart: -2

NuttShell (NSH) NuttX-12.12.0
proxy> 
proxy> 
proxy> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK    USED FILLED COMMAND
    0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0008144 0001792  22.0%  Idle_Task
    1     0     0 192 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0008080 0001488  18.4%  hpwork 0x4047ecc0 0x4047ed40
    2     0     0 100 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0008080 0001328  16.4%  lpwork 0x4047ed70 0x4047edf0
    5     5     0 100 FIFO     Task      - Running            0000000000000000 0008112 0004176  51.4%  nsh_main
    6     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0008080 0002000  24.7%  rpmsg-virtio server 0x40499b18
proxy> 
proxy> 
proxy> rpmsg ping all 1 1 1 1
[    0.000000] [ 5] [ EMERG] [proxy] ping times: 1
[    0.000000] [ 5] [ EMERG] [proxy] buffer_len: 1520, send_len: 17
[    0.000000] [ 5] [ EMERG] [proxy] avg: 0 s, 90760640 ns
[    0.000000] [ 5] [ EMERG] [proxy] min: 0 s, 90760640 ns
[    0.000000] [ 5] [ EMERG] [proxy] max: 0 s, 90760640 ns
[    0.000000] [ 5] [ EMERG] [proxy] rate: 0.001498 Mbits/sec
proxy> 
proxy> 
proxy> uname -a
NuttX proxy 12.12.0 37e3e8f7e6f-dirty Feb  4 2026 23:13:48 arm64 qemu-armv8a
```