### PR TITLE
mm/mm_gran: fix data truncation on 64-bit systems by using size_t for mask

### DIFF
--- a/mm/mm_gran/mm_graninit.c
+++ b/mm/mm_gran/mm_graninit.c
@@ -99,7 +99,7 @@ GRAN_HANDLE gran_initialize(FAR void *heapstart, size_t heapsize,
   FAR struct gran_s *priv;
   uintptr_t          heapend;
   uintptr_t          alignedstart;
-  unsigned int       mask;
+  size_t             mask;
   unsigned int       alignedsize;
   unsigned int       ngranules;
 


### PR DESCRIPTION
mm/mm_gran: fix data truncation on 64-bit systems by using size_t for mask

## Summary

Fix data truncation during gran initialization on 64-bit systems when the heapstart address exceeds 32 bits, causing the alignedstart address to be truncated to 32 bits.

## Impact

The gran allocator, when used with a heapstart address exceeding 32 bits.

## Testing

- **Host OS**: Ubuntu 20.04 LTS (x86_64)
- **Target Boards**: 
  - Physical hardware featuring the SiFive U74 core, with physical memory starting at `0x2000000000`

### Test log

#### Before fix

```
Breakpoint 2, gran_initialize (heapstart=0x2000400000, heapsize=2097152, log2gran=log2gran@entry=12 '\f', log2align=log2align@entry=12 '\f') at mm_gran/mm_graninit.c:118
118       alignedstart = ((uintptr_t)heapstart + mask) & ~mask;
(gdb) p/x mask
$1 = 0xfff
(gdb) n
125       ngranules    = alignedsize >> log2gran;
(gdb) p/x alignedstart
$2 = 0x400000
(gdb) p/x heapstart
$3 = 0x2000400000
```
NuttX crashes at boot time：
```
[   11.289184] riscv_exception: EXCEPTION: Store/AMO access fault. MCAUSE: 0000000000000007, EPC: 000000200020a026, MTVAL: 0000000000000000
[   11.301265] riscv_exception: PANIC!!! Exception = 0000000000000007
[   11.307432] dump_assert_info: Current Version: NuttX  0.0.0 0 Feb  6 2026 10:24:44 risc-v
[   11.315587] dump_assert_info: Assertion failed panic: at file: common/riscv_exception.c:134 task: AppBringUp process: Kernel 0x20002012f6
[   11.327912] up_dump_register: EPC: 000000200020a026
[   11.332773] up_dump_register: A0: 0000000000000000 A1: 0000000000000000 A2: 0000000000001000 A3: 0000000000000000
[   11.343015] up_dump_register: A4: 0000000000000000 A5: 0000000000000000 A6: 0000000000000000 A7: 0000000000000000
[   11.353258] up_dump_register: T0: 0000000000000000 T1: 000000000000003f T2: 0000000000000000 T3: 0000000000001000
[   11.363500] up_dump_register: T4: 0000000000001000 T5: 0000000000000000 T6: 0000000000000000
[   11.371919] up_dump_register: S0: 000000200030e890 S1: 0000000000400000 S2: 000000200030d520 S3: 0000000000080000
[   11.382162] up_dump_register: S4: 00000000000007d0 S5: 0000000000012378 S6: 0000000000000000 S7: 0000000000000000
[   11.392404] up_dump_register: S8: 0000000000000000 S9: 0000000000000001 S10: 0000000000000000 S11: 0000000000000000
[   11.402820] up_dump_register: SP: 000000200030e880 FP: 000000200030e890 TP: 0000000000000000 RA: 000000200020d11a
[   11.413068] dump_stackinfo: User Stack:
[   11.416881] dump_stackinfo:   base: 0x200030e040
[   11.421482] dump_stackinfo:   size: 00003008
[   11.425735] dump_stackinfo:     sp: 0x200030e880
[   11.430336] stack_dump: 0x200030e840: 000000200030e860 000000200020bc16 000000200030e890 000000200020bd96 0000000000012378 0000000000080000 000000200030d520 fffffffffffffff4
[   11.445786] stack_dump: 0x200030e880: 000000200030e8a0 000000200030e8a0 000000200030e8e0 000000200020d338 00000000000142f5 0000000000000000 0000000000012378 000000200030e950
[   11.461236] stack_dump: 0x200030e8c0: 000000200030d520 fffffffffffffff4 000000200030e930 000000200021daae 000000200030e950 00000000000007d0 000000200030e930 000000200030e930
[   11.476687] stack_dump: 0x200030e900: 0000000000000000 000000200030ca18 000000200030e950 0000000000000000 000000200030e950 000000200021c532 0000000000000000 0000000000000000
[   11.492137] stack_dump: 0x200030e940: 000000200030ea80 0000002000216736 0000000000000000 0000000000000000 0000000000012378 00000000000007d0 0000000000000008 0000000000000008
[   11.507587] stack_dump: 0x200030e980: 0000000000014e00 0000816d00000000 00010102464c457f 0000000000000000 0000000100f30002 00000000c0000092 0000000000000040 0000000000014540
[   11.523039] stack_dump: 0x200030e9c0: 0038004000000005 0022002300400004 000000200030d410 000000200030cb48 0000000000000000 000000200030d4f8 0000000000000000 0000000000000000
[   11.538488] stack_dump: 0x200030ea00: 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000002000000000 0000000000000003 00000000fffffffe 0000000000000000
[   11.553939] stack_dump: 0x200030ea40: 000000200030d520 0000000000000000 0000000000000000 000000200021eef0 000000200030ca18 00000020003003c0 000000200030eac0 0000002000216828
[   11.569389] stack_dump: 0x200030ea80: 000000200030eab0 000000200021eef0 0000000000000000 000000200021eef0 000000200030ca18 0000000000000000 000000200030eb20 00000020002168f6
[   11.584840] stack_dump: 0x200030eac0: 0000000000000064 00000000000000f0 000000200030eb10 0000000000000000 000000200030eba0 000000200021eef0 0000000000000000 000000200030eba8
[   11.600290] stack_dump: 0x200030eb00: 000000200030ca18 fffffffffffffff4 000000200030eb90 00000020002165e2 0000000000000000 0000000000000000 000000200030bc90 0000000000000000
[   11.615741] stack_dump: 0x200030eb40: 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000064 0000000000000c00
[   11.631191] stack_dump: 0x200030eb80: 000000200030eba0 0000002000216676 000000200030ebe0 00000020002013da 0000000000000000 0000000000026400 0000000000000000 0000000000000c00
[   11.646641] stack_dump: 0x200030ebc0: 000000200030b6d0 0000000000000002 000000200030ec00 0000002000202710 0000000000000000 0000000000000000 0000000000000000 0000000000000000
[   11.662091] stack_dump: 0x200030ec00: 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000 0000000000000000
[   11.677552] sched_dumpstack: backtrace| 2: 0x00000020002195d6 0x000000200021cc92 0x0000002000217818 0x000000200020c9dc 0x00000020002014fa 0x0000002000200b60 0x0000002000200724 0x00000020002001ca
[   11.694823] sched_dumpstack: backtrace| 2: 0x000000200020a026 0x000000200030e8a0 0x000000200020d338 0x000000200021daae 0x000000200021c532 0x0000002000216736 0x0000002000216828 0x00000020002168f6
[   11.712097] sched_dumpstack: backtrace| 2: 0x00000020002165e2 0x0000002000216676 0x00000020002013da 0x0000002000202710 0x000000200020a026 0x000000200030e8a0 0x000000200020d338 0x000000200021daae
[   11.729369] sched_dumpstack: backtrace| 2: 0x000000200021c532 0x0000002000216736 0x0000002000216828 0x00000020002168f6 0x00000020002165e2 0x0000002000216676 0x00000020002013da 0x0000002000202710
[   11.746635] dump_tasks:    PID GROUP PRI POLICY   TYPE    NPX STATE   EVENT      SIGMASK          STACKBASE  STACKSIZE      USED   FILLED    COMMAND
[   11.759916] dump_tasks:   ----   --- --- -------- ------- --- ------- ---------- ---------------- 0x2000300640      2048      1720    83.9%!   irq
[   11.773036] dump_task:       0     0   0 FIFO     Kthread -   Ready              0000000000000000 0x200030a020      3040       896    29.4%    Idle_Task
[   11.786659] dump_task:       1     0 100 RR       Kthread -   Ready              0000000000000000 0x200030c070      1936       528    27.2%    lpwork 0x2000300100 0x2000300180
[   11.802277] dump_task:       2     0 240 RR       Kthread -   Running            0000000000000000 0x200030e040      3008      1432    47.6%    AppBringUp
[   11.815996] sched_dumpstack: backtrace| 0: 0x000000200020ced4 0x000000200020166e 0x00000020002012f0 0x00000020002006b4 0x000000200020004a
[   11.828316] sched_dumpstack: backtrace| 1: 0x00000020002026a8
[   11.834051] sched_dumpstack: backtrace| 2: 0x00000020002195d6 0x000000200021cc92 0x00000020002173da 0x000000200021914e 0x00000020002178b2 0x000000200020c9dc 0x00000020002014fa 0x0000002000200b60
[   11.851324] sched_dumpstack: backtrace| 2: 0x0000002000200724 0x00000020002001ca 0x000000200020a026 0x000000200030e8a0 0x000000200020d338 0x000000200021daae 0x000000200021c532 0x0000002000216736
[   11.868597] sched_dumpstack: backtrace| 2: 0x0000002000216828 0x00000020002168f6 0x00000020002165e2 0x0000002000216676 0x00000020002013da 0x0000002000202710 0x000000200020a026 0x000000200030e8a0
[   11.885870] sched_dumpstack: backtrace| 2: 0x000000200020d338 0x000000200021daae 0x000000200021c532 0x0000002000216736 0x0000002000216828 0x00000020002168f6 0x00000020002165e2 0x0000002000216676
[   11.903137] sched_dumpstack: backtrace| 2: 0x00000020002013da 0x0000002000202710
```

#### After fix

```
Breakpoint 1, gran_initialize (heapstart=0x2000400000, heapsize=2097152, log2gran=log2gran@entry=12 '\f', log2align=log2align@entry=12 '\f') at mm_gran/mm_graninit.c:118
118       alignedstart = ((uintptr_t)heapstart + mask) & ~mask;
(gdb) p/x mask
$1 = 0xfff
(gdb) n
[xh2a.u7] Found 8 triggers
125       ngranules    = alignedsize >> log2gran;
(gdb) p/x alignedstart
$2 = 0x2000400000
(gdb) p/x heapstart
$3 = 0x2000400000
```
and
```
BCWelcome to NuttX on XH2A (xh2a-evb)!

NuttShell (NSH)
nsh> cat /proc/meminfo
      total       used       free    maxused    maxfree  nused  nfree name
    1004544      12008     992536      25368     985008     57      5 Kmem
    2097152     122880    1974272               1974272               Page
nsh> hello
Hello, World!!
nsh>
```