### PR TITLE
contributing: Add review etiquette to contributing guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -349,6 +349,14 @@ Breaking these rules will be punished.
 See: https://github.com/apache/nuttx/blob/master/INVIOLABLES.md
 
 
+### 1.18. Review etiquette.
+
+Reviewers should **NOT** flag a PR or a comment with the thumbs-down emoji. This
+is considered offensive in some cultures.
+
+Instead, mark the PR with a request for changes and state precisely the changes
+needed for the PR. Conversation surrounding code review should be constructive
+and respectful.
 
 
 ## 2. Contribution Templates.


### PR DESCRIPTION
## Summary

Introduces a (possibly to-be extended) portion of the contributing guidelines for review etiquette following discussions on the mailing list.

**NOTE:** This addition only contains the etiquette discussed in the mailing list since I believe there is full consensus on it. Other etiquette additions should be discussed in the mailing list before being added.

Closes #18357.

## Impact

Hopefully improve the review process.

## Testing

N/A, just a markdown file.