### PR TITLE
boards/arm/s32k3xx/mr-canhubk3: add missing sram.ld for run-from-SRAM

### DIFF
--- a/arch/arm/src/s32k3xx/s32k3xx_start.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_start.c
@@ -139,9 +139,10 @@ void s32k3xx_start(void)
   register uint64_t *src;
   register uint64_t *dest;
 
-  /* Technically startup.S did initialize SRAM
-   * but if don't set init value here again
-   * then on a cold boot we go into a bootloop somehow
+#ifdef CONFIG_BOOT_RUNFROMFLASH
+  /* Reinitialize SRAM ECC - required on cold boot when running from flash.
+   * Skipped for SRAM boot: the loader already wrote ECC-correct data and
+   * zeroing here would destroy live code.
    */
 
   dest = (uint64_t *)SRAM_BASE_ADDR;
@@ -149,6 +150,7 @@ void s32k3xx_start(void)
     {
       *dest++ = STARTUP_ECC_INITVALUE;
     }
+#endif
 
   /* ITCM */
 

--- a/arch/arm/src/s32k3xx/startup.S
+++ b/arch/arm/src/s32k3xx/startup.S
@@ -20,6 +20,8 @@
 
 /* Copyright 2022 NXP */
 
+#include <nuttx/config.h>
+
     .syntax unified
     .arch armv7-m
 	.text
@@ -36,7 +38,10 @@ __start:
     mov   r6, #0
     mov   r7, #0
 
-    /* Initialize SRAM ECC */
+#ifdef CONFIG_BOOT_RUNFROMFLASH
+    /* Initialize SRAM ECC - skip when running from SRAM since the loader
+     * already wrote ECC-correct data and zeroing would destroy live code.
+     */
     ldr r1, =SRAM_BASE_ADDR
     ldr r2, =SRAM_INIT_END_ADDR
 
@@ -51,6 +56,7 @@ SRAM_LOOP:
     subs r2, 8
     bge SRAM_LOOP
 SRAM_LOOP_END:
+#endif
     b s32k3xx_start
 
 .align 4

--- a/boards/arm/s32k3xx/mr-canhubk3/scripts/sram.ld
+++ b/boards/arm/s32k3xx/mr-canhubk3/scripts/sram.ld
@@ -1,0 +1,139 @@
+/****************************************************************************
+ * boards/arm/s32k3xx/mr-canhubk3/scripts/sram.ld
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+MEMORY
+{
+  BOOT_HEADER (R)   : ORIGIN = 0x00400000, LENGTH = 0x00001000
+  flash       (rx)  : ORIGIN = 0x00401000, LENGTH = 0x003cffff
+  sram0_stdby (rwx) : ORIGIN = 0x20400000, LENGTH = 32K
+  sram        (rwx) : ORIGIN = 0x20400000, LENGTH = 272K
+  itcm        (rwx) : ORIGIN = 0x00000000, LENGTH = 64K
+  dtcm        (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
+}
+
+OUTPUT_ARCH(arm)
+EXTERN(_vectors)
+ENTRY(_stext)
+
+SECTIONS
+{
+
+  .text :
+  {
+    _stext = ABSOLUTE(.);
+    *(.vectors)
+    *(.text.__start)
+    *(.text .text.*)
+    *(.fixup)
+    *(.gnu.warning)
+    *(.rodata .rodata.*)
+    *(.gnu.linkonce.t.*)
+    *(.glue_7)
+    *(.glue_7t)
+    *(.got)
+    *(.gcc_except_table)
+    *(.gnu.linkonce.r.*)
+    _etext = ABSOLUTE(.);
+  } > sram
+
+  .init_section :
+  {
+    _sinit = ABSOLUTE(.);
+    KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+    KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
+    _einit = ABSOLUTE(.);
+  } > sram
+
+  .ARM.extab :
+  {
+    *(.ARM.extab*)
+  } > sram
+
+  .ARM.exidx :
+  {
+    __exidx_start = ABSOLUTE(.);
+    *(.ARM.exidx*)
+    __exidx_end = ABSOLUTE(.);
+  } > sram
+
+  /* Due ECC initialization sequence __data_start__ and __data_end__ should be aligned on 8 bytes */
+  .data :
+  {
+    . = ALIGN(8);
+    _sdata = ABSOLUTE(.);
+    *(.data .data.*)
+    *(.gnu.linkonce.d.*)
+    CONSTRUCTORS
+    . = ALIGN(8);
+    _edata = ABSOLUTE(.);
+  } > sram
+
+  .ramfunc ALIGN(8):
+  {
+    _sramfuncs = ABSOLUTE(.);
+    *(.ramfunc  .ramfunc.*)
+    _eramfuncs = ABSOLUTE(.);
+  } > sram
+
+  _framfuncs = LOADADDR(.ramfunc);
+
+  /* Due ECC initialization sequence __bss_start__ and __bss_end__ should be aligned on 8 bytes */
+  .bss :
+  {
+    . = ALIGN(8);
+    _sbss = ABSOLUTE(.);
+    *(.bss .bss.*)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+    . = ALIGN(8);
+    _ebss = ABSOLUTE(.);
+  } > sram
+
+  CM7_0_START_ADDRESS = ORIGIN(sram);
+
+  /* Stabs debugging sections. */
+
+  .stab 0 : { *(.stab) }
+  .stabstr 0 : { *(.stabstr) }
+  .stab.excl 0 : { *(.stab.excl) }
+  .stab.exclstr 0 : { *(.stab.exclstr) }
+  .stab.index 0 : { *(.stab.index) }
+  .stab.indexstr 0 : { *(.stab.indexstr) }
+  .comment 0 : { *(.comment) }
+  .debug_abbrev 0 : { *(.debug_abbrev) }
+  .debug_info 0 : { *(.debug_info) }
+  .debug_line 0 : { *(.debug_line) }
+  .debug_pubnames 0 : { *(.debug_pubnames) }
+  .debug_aranges 0 : { *(.debug_aranges) }
+
+  SRAM_BASE_ADDR         = ORIGIN(sram);
+  SRAM_END_ADDR          = ORIGIN(sram) + LENGTH(sram);
+  SRAM_STDBY_BASE_ADDR   = ORIGIN(sram0_stdby);
+  SRAM_STDBY_END_ADDR    = ORIGIN(sram0_stdby) + LENGTH(sram0_stdby);
+  SRAM_INIT_END_ADDR     = ORIGIN(sram) + 320K;
+  ITCM_BASE_ADDR         = ORIGIN(itcm);
+  ITCM_END_ADDR          = ORIGIN(itcm) + LENGTH(itcm);
+  DTCM_BASE_ADDR         = ORIGIN(dtcm);
+  DTCM_END_ADDR          = ORIGIN(dtcm) + LENGTH(dtcm);
+  FLASH_BASE_ADDR        = ORIGIN(BOOT_HEADER);
+  FLASH_END_ADDR         = ORIGIN(flash) + LENGTH(flash);
+}


### PR DESCRIPTION
## Summary

The NXP mr-canhubk3 board's `scripts/Make.defs` selects `sram.ld` when `CONFIG_BOOT_RUNFROMISRAM=y`, but the file was never added, so builds for run-from-internal-SRAM fail with a missing linker script. This change adds `boards/arm/s32k3xx/mr-canhubk3/scripts/sram.ld`, derived from the existing `flash.ld`. The new script places all sections in SRAM (no `AT > flash`) and defines the same symbols (`_framfuncs`, `FLASH_BASE_ADDR`, `FLASH_END_ADDR`, etc.) required by startup and MPU code so the link succeeds. No changes to `Make.defs` or defconfigs; only the missing file is added.

Fixes #18365.

## Impact

- **Users:** Builds with `CONFIG_BOOT_RUNFROMISRAM=y` for mr-canhubk3 now succeed; run-from-flash configs are unchanged.
- **Build:** One new file; no changes to existing scripts or build logic.
- **Hardware / documentation / security:** No impact.
- **Compatibility:** No change for existing run-from-flash configs.

## Testing

- **Host:** macOS; ARM cross-compiler: `arm-none-eabi-gcc` (e.g. via Homebrew). NuttX apps from `../nuttx-apps`.
- **Board / config:** mr-canhubk3 with `nsh` defconfig.
- **Run-from-flash:** Configured with `CONFIG_BOOT_RUNFROMFLASH=y`, ran `make`. Build completed; `nuttx` and `nuttx.bin` produced and linked with `flash.ld`.
- **Run-from-SRAM:** Set `CONFIG_BOOT_RUNFROMISRAM=y` in `.config`, ran `make clean` then `make`. Build completed; linker used `sram.ld` (e.g. `CPP: .../sram.ld -> .../sram.ld.tmp`, `LD: nuttx`). Memory report showed SRAM in use (~34% of 272K); `nuttx` is a valid ARM ELF for SRAM.
- **Conclusion:** Run-from-flash still works; run-from-SRAM build works with the new `sram.ld`. No regressions observed.
