### PR TITLE
video/v4l2: fix leaks and out of bounds bugs in v4l2

### DIFF
--- a/drivers/video/v4l2_cap.c
+++ b/drivers/video/v4l2_cap.c
@@ -2147,6 +2147,11 @@ static int capture_reqbufs(FAR struct file *filep,
       return -EINVAL;
     }
 
+  if (reqbufs->count == 0)
+    {
+      return 0;
+    }
+
   imgdata  = cmng->imgdata;
   type_inf = get_capture_type_inf(cmng, reqbufs->type);
   if (type_inf == NULL)


### PR DESCRIPTION
We fixed some boundary condition and out of bounds bugs in v4l2.

## Summary

- Fix an array out of bounds issue
- Fix a boundary condition problem

## Impact

NONE

## Testing

Tested in Simulator environment and passed