### PR TITLE
include/cxx/cmath: Use toolchain <cmath> with toolchain libm

### DIFF
--- a/include/cxx/cmath
+++ b/include/cxx/cmath
@@ -30,7 +30,16 @@
 #include <nuttx/config.h>
 #include <nuttx/compiler.h>
 
-#include <math.h>
+#if defined(CONFIG_LIBM_TOOLCHAIN)
+/* In toolchain libm mode, use toolchain <cmath> so it can include_next the
+ * matching C math.h header and populate std::* consistently.
+ */
+
+#  include_next <cmath>
+
+#else
+
+#  include <math.h>
 
 #undef signbit
 #undef fpclassify
@@ -221,5 +230,7 @@ namespace std
 #endif
 
 }
+
+#endif
 
 #endif // __INCLUDE_CXX_CMATH


### PR DESCRIPTION
## Summary

This addresses the unresolved case in issue #18232 after #18308 was merged.

When `CONFIG_LIBM_TOOLCHAIN=y`, `include/cxx/cmath` should not try to populate `std::*` from the NuttX shim path. In this mode, `cmath` now delegates to the toolchain C++ wrapper via:

```c
#include_next <cmath>
```

This lets libstdc++/toolchain `<cmath>` pull in its matching C `math.h` (`include_next <math.h>`) and correctly provide `std::abs`, `std::acos`, etc.

For non-toolchain-libm configurations, existing NuttX behavior in `include/cxx/cmath` is unchanged.

## Why this is needed

In the reported configuration:

- `CONFIG_LIBM_TOOLCHAIN=y`
- `CONFIG_LIBCXXTOOLCHAIN=y`
- `CONFIG_LIBSUPCXX_TOOLCHAIN=y`

users still hit errors like:

- `'abs' has not been declared in 'std'`
- `'acos' has not been declared in 'std'`

(Reference: https://github.com/apache/nuttx/issues/18232#issuecomment-3861302869)

## Impact

- Fixes toolchain-libm + toolchain-libstdc++ interoperability in `<math.h>/<cmath>` include flows.
- Keeps non-`CONFIG_LIBM_TOOLCHAIN` behavior unchanged.
- Changes only one file: `include/cxx/cmath`.

## Testing

Host: macOS (Apple Silicon)

1. Reproducer compile with `g++-15` and `CONFIG_LIBM_TOOLCHAIN` stubs:
   - `#include <math.h>` with `using namespace std;` passed.
   - `#include <cmath>` with `using namespace std;` passed.
2. Repeated the above reproducer 3 consecutive iterations: all passed.
3. Cross-check with `clang++` in the same include configuration: passed.
4. Style checks:
   - `tools/checkpatch.sh -f include/cxx/cmath` passed.
   - `git diff --check -- include/cxx/cmath` passed.

Fixes #18232
