### PR TITLE
docs/rasperrypi-pico-2: Small typo correction

### DIFF
--- a/Documentation/platforms/arm/rp23xx/boards/raspberrypi-pico-2/index.rst
+++ b/Documentation/platforms/arm/rp23xx/boards/raspberrypi-pico-2/index.rst
@@ -220,7 +220,7 @@ nsh
 Basic NuttShell configuration (console enabled in UART0, at 115200 bps).
 
 usbnsh
----
+------
 
 Basic NuttShell configuration (console enabled via USB CDC/ACM).
 


### PR DESCRIPTION
## Summary

The header underline did not extend far enough for Sphinx to correctly parse it as a header.

## Impact

Correct documentation rendering.

## Testing

Local verification of render in the browser. Here is the before image:

<img width="1078" height="476" alt="image" src="https://github.com/user-attachments/assets/6bb3195e-a628-47d7-804a-446042f7bb9a" />