### PR TITLE
arch/tricore: initialize spinlock used by tricore systimer

### DIFF
--- a/arch/tricore/src/common/tricore_systimer.c
+++ b/arch/tricore/src/common/tricore_systimer.c
@@ -303,6 +303,7 @@ tricore_systimer_initialize(volatile void *tbase, int irq, uint64_t freq)
   struct tricore_systimer_lowerhalf_s *priv = &g_tricore_oneshot_lowerhalf;
 
   priv->tbase = tbase;
+  spin_lock_init(&priv->lock);
 
   ASSERT(freq <= UINT32_MAX);
 


### PR DESCRIPTION
## Summary

Add explicit spin_lock_init in tricore_systimer_initialize() for the lock used by tricore systimer.

## Impact

Improves robustness by explicitly initializing priv->lock before first use.

## Testing

ostest passed on board a2g-tc397-5v-tft

```
NuttShell (NSH) NuttX-12.12.0
nsh> uname -a
NuttX 12.12.0 d2c18ab155 Feb 11 2026 16:31:51 tricore a2g-tc397-5v-tft

nsh> ostest
stdio_test: write fd=1
stdio_test: Standard I/O Check: printf
stdio_test: write fd=2
stdio_test: Standard I/O Check: fprintf to stderr
ostest_main: putenv(Variable1=BadValue3)
ostest_main: setenv(Variable1, GoodValue1, TRUE)
ostest_main: setenv(Variable2, BadValue1, FALSE)
ostest_main: setenv(Variable2, GoodValue2, TRUE)
ostest_main: setenv(Variable3, GoodValue3, FALSE)
ostest_main: setenv(Variable3, BadValue2, FALSE)
show_variable: Variable=Variable1 has value=GoodValue1
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3
ostest_main: Started user_main at PID=4

user_main: Begin argument test
user_main: Started with argc=5
user_main: argv[0]="ostest"
user_main: argv[1]="Arg1"
user_main: argv[2]="Arg2"
user_main: argv[3]="Arg3"
user_main: argv[4]="Arg4"

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         1        1
mxordblk    24220    24220
uordblks     4be0     4be0
fordblks    24220    24220

user_main: getopt() test
getopt():  Simple test
getopt():  Invalid argument
getopt():  Missing optional argument
getopt_long():  Simple test
getopt_long():  No short options
getopt_long():  Argument for --option=argument
getopt_long():  Invalid long option
getopt_long():  Mixed long and short options
getopt_long():  Invalid short option
getopt_long():  Missing optional arguments
getopt_long_only():  Mixed long and short options
getopt_long_only():  Single hyphen long options

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         1        1
mxordblk    24220    24220
uordblks     4be0     4be0
fordblks    24220    24220

user_main: libc tests

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         1        1
mxordblk    24220    24220
uordblks     4be0     4be0
fordblks    24220    24220
show_variable: Variable=Variable1 has value=GoodValue1
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3
show_variable: Variable=Variable1 has no value
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         1        2
mxordblk    24220    24220
uordblks     4be0     4bc0
fordblks    24220    24240
show_variable: Variable=Variable1 has no value
show_variable: Variable=Variable2 has no value
show_variable: Variable=Variable3 has no value

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         2        2
mxordblk    24220    24220
uordblks     4bc0     4b48
fordblks    24240    242b8

user_main: setvbuf test
setvbuf_test: Test NO buffering
setvbuf_test: Using NO buffering
setvbuf_test: Test default FULL buffering
setvbuf_test: Using default FULL buffering
setvbuf_test: Test FULL buffering, buffer size 64
setvbuf_test: Using FULL buffering, buffer size 64
setvbuf_test: Test FULL buffering, pre-allocated buffer
setvbuf_test: Using FULL buffering, pre-allocated buffer
setvbuf_test: Test LINE buffering, buffer size 64
setvbuf_test: Using LINE buffering, buffer size 64
setvbuf_test: Test FULL buffering, pre-allocated buffer
setvbuf_test: Using FULL buffering, pre-allocated buffer

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         2        2
mxordblk    24220    24220
uordblks     4b48     4b48
fordblks    242b8    242b8

user_main: /dev/null test
dev_null: Read 0 bytes from /dev/null
dev_null: Wrote 1024 bytes to /dev/null

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         2        2
mxordblk    24220    24220
uordblks     4b48     4b48
fordblks    242b8    242b8

user_main: task_restart test

Test task_restart()
restart_main: setenv(VarName, VarValue, TRUE)
restart_main: Started restart_main at PID=5
restart_main: Started with argc=4
restart_main: argv[0]="ostest"
restart_main: argv[1]="This is argument 1"
restart_main: argv[2]="Argument 2 here"
restart_main: argv[3]="Lastly, the 3rd argument"
restart_main: Variable=VarName has value=VarValue
restart_main: I am still here
restart_main: I am still here
restart_main: Started restart_main at PID=5
restart_main: Started with argc=4
restart_main: argv[0]="ostest"
restart_main: argv[1]="This is argument 1"
restart_main: argv[2]="Argument 2 here"
restart_main: argv[3]="Lastly, the 3rd argument"
restart_main: Variable=VarName has value=VarValue
restart_main: Started with argc=4
restart_main: argv[0]="ostest"
restart_main: argv[1]="This is argument 1"
restart_main: argv[2]="Argument 2 here"
restart_main: argv[3]="Lastly, the 3rd argument"
restart_main: Variable=VarName has value=VarValue
restart_main: Exiting

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         2        2
mxordblk    24220    24220
uordblks     4b48     4b80
fordblks    242b8    24280

user_main: waitpid test

Test waitpid()
waitpid_start_child: Started waitpid_main at PID=6
waitpid_start_child: Started waitpid_main at PID=7
waitpid_start_child: Started waitpid_main at PID=8
waitpid_test: Waiting for PID=6 with waitpid()
waitpid_main: PID 6 Started
waitpid_main: PID 7 Started
waitpid_main: PID 8 Started
waitpid_main: PID 6 exitting with result=14
waitpid_main: PID 7 exitting with result=14
waitpid_main: PID 8 exitting with result=14
waitpid_test: PID 6 waitpid succeeded with stat_loc=0e00
waitpid_last: Waiting for PID=8 with waitpid()
waitpid_last: PASS: PID 8 waitpid failed with ECHILD.  That may be
              acceptable because child status is disabled on this thread.

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         2        2
mxordblk    24220    24220
uordblks     4b80     4b80
fordblks    24280    24280

user_main: mutex test
Initializing mutex
Starting thread 1
Starting thread 2
                Thread1 Thread2
        Loops   32      32
        Errors  0       0

Testing moved mutex
Starting moved mutex thread 1
Starting moved mutex thread 2
                Thread1 Thread2
        Moved Loops     32      32
        Moved Errors    0       0

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         2        2
mxordblk    24220    24220
uordblks     4b80     4b80
fordblks    24280    24280

user_main: timed mutex test
mutex_test: Initializing mutex
mutex_test: Starting thread
pthread:  Started
pthread:  Waiting for lock or timeout
mutex_test: Unlocking
pthread:  Got the lock
pthread:  Waiting for lock or timeout
pthread:  Got the timeout.  Terminating
mutex_test: PASSED

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         2        2
mxordblk    24220    24220
uordblks     4b80     4b80
fordblks    24280    24280

user_main: cancel test
cancel_test: Test 1a: Normal Cancellation
cancel_test: Starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sem_waiter: Taking mutex
sem_waiter: Starting wait for condition
cancel_test: Canceling thread
cancel_test: Joining
cancel_test: waiter exited with result=0xffffffff
cancel_test: PASS thread terminated with PTHREAD_CANCELED
cancel_test: Test 2: Asynchronous Cancellation
... Skipped
cancel_test: Test 3: Cancellation of detached thread
cancel_test: Re-starting thread
restart_thread: Destroying cond
restart_thread: Destroying mutex
restart_thread: Re-starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sem_waiter: Taking mutex
sem_waiter: Starting wait for condition
cancel_test: Canceling thread
cancel_test: Joining
cancel_test: PASS pthread_join failed with status=ESRCH
cancel_test: Test 5: Non-cancelable threads
cancel_test: Re-starting thread (non-cancelable)
restart_thread: Destroying cond
restart_thread: Destroying mutex
restart_thread: Re-starting thread
start_thread: Initializing mutex
start_thread: Initializing cond
start_thread: Starting thread
start_thread: Yielding
sem_waiter: Taking mutex
sem_waiter: Starting wait for condition
sem_waiter: Setting non-cancelable
cancel_test: Canceling thread
cancel_test: Joining
sem_waiter: Releasing mutex
sem_waiter: Setting cancelable
cancel_test: waiter exited with result=0xffffffff
cancel_test: PASS thread terminated with PTHREAD_CANCELED
cancel_test: Test 6: Cancel message queue wait
cancel_test: Starting thread (cancelable)
Skipped
cancel_test: Test 7: Cancel signal wait
cancel_test: Starting thread (cancelable)
Skipped

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         2        2
mxordblk    24220    24220
uordblks     4b80     4b80
fordblks    24280    24280

user_main: robust test
robust_test: Initializing mutex
robust_test: Starting thread
robust_waiter: Taking mutex
robust_waiter: Exiting with mutex
robust_test: Take the lock again
robust_test: Make the mutex consistent again.
robust_test: Take the lock again
robust_test: Joining
robust_test: waiter exited with result=0
robust_test: Test complete with nerrors=0

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         2        2
mxordblk    24220    24220
uordblks     4b80     4b80
fordblks    24280    24280

user_main: semaphore test
sem_test: Initializing semaphore to 0
sem_test: Starting waiter thread 1
sem_test: Set thread 1 priority to 191
waiter_func: Thread 1 Started
waiter_func: Thread 1 initial semaphore value = 0
waiter_func: Thread 1 waiting on semaphore
sem_test: Starting waiter thread 2
sem_test: Set thread 2 priority to 128
waiter_func: Thread 2 Started
waiter_func: Thread 2 initial semaphore value = -1
waiter_func: Thread 2 waiting on semaphore
sem_test: Starting poster thread 3
sem_test: Set thread 3 priority to 64
poster_func: Thread 3 started
poster_func: Thread 3 semaphore value = -2
poster_func: Thread 3 posting semaphore
waiter_func: Thread 1 awakened
waiter_func: Thread 1 new semaphore value = -1
waiter_func: Thread 1 done
poster_func: Thread 3 new semaphore value = -1
poster_func: Thread 3 semaphore value = -1
poster_func: Thread 3 posting semaphore
waiter_func: Thread 2 awakened
waiter_func: Thread 2 new semaphore value = 0
waiter_func: Thread 2 done
poster_func: Thread 3 new semaphore value = 0
poster_func: Thread 3 done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         2        2
mxordblk    24220    24220
uordblks     4b80     4b80
fordblks    24280    24280

user_main: timed semaphore test
semtimed_test: Initializing semaphore to 0
semtimed_test: Waiting for two second timeout
semtimed_test: PASS: first test returned timeout
BEFORE: (1456790446 sec, 76015950 nsec)
AFTER:  (1456790448 sec, 89957250 nsec)
semtimed_test: Starting poster thread
semtimed_test: Set thread 1 priority to 191
semtimed_test: Starting poster thread 3
semtimed_test: Set thread 3 priority to 64
semtimed_test: Waiting for two second timeout
poster_func: Waiting for 1 second
poster_func: Posting
semtimed_test: PASS: sem_timedwait succeeded
BEFORE: (1456790448 sec, 115992340 nsec)
AFTER:  (1456790449 sec, 141724250 nsec)

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         2        2
mxordblk    24220    24220
uordblks     4b80     4b80
fordblks    24280    24280

user_main: condition variable test
cond_test: Initializing mutex
cond_test: Initializing cond
cond_test: Starting waiter
cond_test: Set thread 1 priority to 128
waiter_thread: Started
cond_test: Starting signaler
cond_test: Set thread 2 priority to 64
thread_signaler: Started
thread_signaler: Terminating
cond_test: signaler terminated, now cancel the waiter
cond_test:      Waiter  Signaler
cond_test: Loops        32      32
cond_test: Errors       0       0
cond_test:
cond_test: 0 times, waiter did not have to wait for data
cond_test: 0 times, data was already available when the signaler run
cond_test: 0 times, the waiter was in an unexpected state when the signaler ran

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         2        2
mxordblk    24220    24220
uordblks     4b80     4b80
fordblks    24280    24280

user_main: pthread_exit() test
pthread_exit_test: Started pthread_exit_main at PID=29
pthread_exit_main 29: Starting pthread_exit_thread
pthread_exit_main 29: Sleeping for 5 seconds
pthread_exit_thread 30: Sleeping for 10 second
pthread_exit_main 29: Calling pthread_exit()
pthread_exit_thread 30: Still running...

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         2        3
mxordblk    24220    21860
uordblks     4b80     5460
fordblks    24280    239a0

user_main: pthread_rwlock test
pthread_rwlock: Initializing rwlock
pthread_exit_thread 30: Exiting

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         3        2
mxordblk    21860    24220
uordblks     5460     4b90
fordblks    239a0    24270

user_main: pthread_rwlock_cancel test
pthread_rwlock_cancel: Starting test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         2        2
mxordblk    24220    24220
uordblks     4b90     4b90
fordblks    24270    24270

user_main: timed wait test
thread_waiter: Initializing mutex
timedwait_test: Initializing cond
timedwait_test: Starting waiter
timedwait_test: Set thread 2 priority to 177
thread_waiter: Taking mutex
thread_waiter: Starting 5 second wait for condition
timedwait_test: Joining
thread_waiter: pthread_cond_timedwait timed out
thread_waiter: Releasing mutex
thread_waiter: Exit with status 0x12345678
timedwait_test: waiter exited with result=0x12345678

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         2        2
mxordblk    24220    24220
uordblks     4b90     4b90
fordblks    24270    24270

user_main: message queue test
mqueue_test: Starting receiver
mqueue_test: Set receiver priority to 128
receiver_thread: Starting
mqueue_test: Starting sender
mqueue_test: Set sender thread priority to 64
mqueue_test: Waiting for sender to complete
sender_thread: Starting
receiver_thread: mq_receive succeeded on msg 0
sender_thread: mq_send succeeded on msg 0
receiver_thread: mq_receive succeeded on msg 1
sender_thread: mq_send succeeded on msg 1
receiver_thread: mq_receive succeeded on msg 2
sender_thread: mq_send succeeded on msg 2
receiver_thread: mq_receive succeeded on msg 3
sender_thread: mq_send succeeded on msg 3
receiver_thread: mq_receive succeeded on msg 4
sender_thread: mq_send succeeded on msg 4
receiver_thread: mq_receive succeeded on msg 5
sender_thread: mq_send succeeded on msg 5
receiver_thread: mq_receive succeeded on msg 6
sender_thread: mq_send succeeded on msg 6
receiver_thread: mq_receive succeeded on msg 7
sender_thread: mq_send succeeded on msg 7
receiver_thread: mq_receive succeeded on msg 8
sender_thread: mq_send succeeded on msg 8
receiver_thread: mq_receive succeeded on msg 9
sender_thread: mq_send succeeded on msg 9
sender_thread: returning nerrors=0
mqueue_test: Killing receiver
receiver_thread: mq_receive interrupted!
receiver_thread: returning nerrors=0
mqueue_test: Canceling receiver
mqueue_test: receiver has already terminated

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         2        3
mxordblk    24220    22108
uordblks     4b90     4c00
fordblks    24270    24200

user_main: timed message queue test
timedmqueue_test: Starting sender
timedmqueue_test: Waiting for sender to complete
sender_thread: Starting
sender_thread: mq_timedsend succeeded on msg 0
sender_thread: mq_timedsend succeeded on msg 1
sender_thread: mq_timedsend succeeded on msg 2
sender_thread: mq_timedsend succeeded on msg 3
sender_thread: mq_timedsend succeeded on msg 4
sender_thread: mq_timedsend succeeded on msg 5
sender_thread: mq_timedsend succeeded on msg 6
sender_thread: mq_timedsend succeeded on msg 7
sender_thread: mq_timedsend succeeded on msg 8
sender_thread: mq_timedsend 9 timed out as expected
sender_thread: returning nerrors=0
timedmqueue_test: Starting receiver
timedmqueue_test: Waiting for receiver to complete
receiver_thread: Starting
receiver_thread: mq_timedreceive succeed on msg 0
receiver_thread: mq_timedreceive succeed on msg 1
receiver_thread: mq_timedreceive succeed on msg 2
receiver_thread: mq_timedreceive succeed on msg 3
receiver_thread: mq_timedreceive succeed on msg 4
receiver_thread: mq_timedreceive succeed on msg 5
receiver_thread: mq_timedreceive succeed on msg 6
receiver_thread: mq_timedreceive succeed on msg 7
receiver_thread: mq_timedreceive succeed on msg 8
receiver_thread: Receive 9 timed out as expected
receiver_thread: returning nerrors=0
timedmqueue_test: Test complete

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         3        3
mxordblk    22108    22108
uordblks     4c00     4c00
fordblks    24200    24200

user_main: sigprocmask test
sigprocmask_test: SUCCESS

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         3        3
mxordblk    22108    22108
uordblks     4c00     4c00
fordblks    24200    24200

user_main: signal handler test
sighand_test: Initializing semaphore to 0
sighand_test: Starting waiter task
sighand_test: Started waiter_main pid=47
waiter_main: Waiter started
waiter_main: Unmasking signal 32
waiter_main: Registering signal handler
waiter_main: oact.sigaction=0 oact.sa_flags=0 oact.sa_mask=0000000000000000
waiter_main: Waiting on semaphore
sighand_test: Signaling pid=47 with signo=32 sigvalue=42
waiter_main: sem_wait() successfully interrupted by signal
waiter_main: done
sighand_test: done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         3        2
mxordblk    22108    22108
uordblks     4c00     4c18
fordblks    24200    241e8

user_main: nested signal handler test
signest_test: Starting signal waiter task at priority 101
waiter_main: Waiter started
waiter_main: Setting signal mask
waiter_main: Registering signal handler
waiter_main: Waiting on semaphore
signest_test: Started waiter_main pid=53
signest_test: Starting interfering task at priority 102
interfere_main: Waiting on semaphore
signest_test: Started interfere_main pid=54
signest_test: Simple case:
  Total signalled 1240  Odd=620 Even=620
  Total handled   1240  Odd=620 Even=620
  Total nested    0    Odd=0   Even=0
signest_test: With task locking
  Total signalled 2480  Odd=1240 Even=1240
  Total handled   2480  Odd=1240 Even=1240
  Total nested    0    Odd=0   Even=0
signest_test: With intefering thread
  Total signalled 3720  Odd=1860 Even=1860
  Total handled   3720  Odd=1860 Even=1860
  Total nested    0    Odd=0   Even=0
signest_test: done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         2        5
mxordblk    22108    1f8b8
uordblks     4c18     4c78
fordblks    241e8    24188

user_main: wdog test
wdog_test start...
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 1 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 10 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 100 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 1000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 10000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 100000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
wdtest_once 1000000 ns
dump_assert_info: Current Version: NuttX  12.12.0 d2c18ab155 Feb 11 2026 16:31:51 tricore
dump_assert_info: Assertion failed : at file: /sched/wdog/wdog.h:130 task: ostest process: ostest 0x80028f5a
tricore_dump_lowcsa: LPCXI:00170CE1     PC:800122E6        A2:700014C0        A3:70033880
tricore_dump_lowcsa: D0:80028CC6        D1:7000CB38        D2:00170CE1        D3:003FFFC0
tricore_dump_lowcsa: A4:70001440        A5:FFFFFFFF        A6:00000000        A7:0000002D
tricore_dump_lowcsa: D4:F0000000        D5:00000000        D6:70000000        D7:00000006

tricore_dump_upcsa: UPCXI:00170CDD     PSW:18000884       SP:7000D2F8        A11:80010430
tricore_dump_upcsa: D8:800016D3        D9:00000000        D10:FFFFFFFF       D11:70000000
tricore_dump_upcsa: A12:7000ED98       A13:70001440       A14:70000000       A15:00000000
tricore_dump_upcsa: D12:00000082       D13:70000000       D14:00000006       D15:00000000

tricore_dump_trapctrl: PSTR:00000000      DSTR:00000000      DATR:00000000      DEADD:00000000

dump_stackinfo: User Stack:
dump_stackinfo:   base: 0x7000cc08
dump_stackinfo:   size: 00002024
dump_stackinfo:     sp: 0x7000d2f8
stack_dump: 0x7000d2d8: 64656863 7000d2e0 00000000 0000000a 00000000 7000d2f0 8000adcc 7000d2f8
stack_dump: 0x7000d2f8: 8000ade8 80001236 800016d3 00000082 7000ee44 7000a864 80028f5a deadbeef
stack_dump: 0x7000d318: deadbeef 00000000 7000ed98 70001440 00000000 800016d3 00000082 7474754e
stack_dump: 0x7000d338: dead0058 deadbeef deadbeef deadbeef dead00ef 00000037 deadbeef 0aadbeef
stack_dump: 0x7000d358: 7000d378 00000000 00000000 00000000 2e323100 302e3231 7000a900 00000017
stack_dump: 0x7000d378: deadbeef 3264beef 61383163 35353162 62654620 20313120 36323032 3a363120
stack_dump: 0x7000d398: 353a3133 dead0031 000022ba 00000000 000022b9 00000000 69727468 65726f63
stack_dump: 0x7000d3b8: 00000000 000f4628 000022ba 00000000 deadbeef deadbeef deadbeef deadbeef
stack_dump: 0x7000d3d8: 70000198 70000198 7000cb38 80028cc6 000022b9 40000000 00000000 00000000
ostest_main: Exiting with status 0
```

