### PR TITLE
doc/userled: Fix printf example

### DIFF
--- a/Documentation/components/drivers/character/leds/userled.rst
+++ b/Documentation/components/drivers/character/leds/userled.rst
@@ -29,7 +29,7 @@ Also is possible for users to control the LEDs from "nsh>" using the "printf" co
 .. code-block:: bash
 
   NuttShell (NSH)
-  nsh> printf \x000000a5 > /dev/userleds
+  nsh> printf \\x000000a5 > /dev/userleds
 
 This command will turn ON the LEDs mapped to bits 0, 2, 5 and 7.
 


### PR DESCRIPTION
It is needed to escape \ itself.

## Summary

This is small fix for the documentation. Please, note that I did not test this patch. (I tested the command itself.)

I am not completely sure if this depends on the terminal. I use `tio` to connect to the board.

If it is terminal-dependent, I am going to add a note to the documentation about that.

## Impact

Documentation.

## Testing

```
printf \\x00000001 > /dev/userleds
```

switches on the LED and

```
printf \\x00000000 > /dev/userleds
```

switches the LED off.