### PR TITLE
lzf: prevent lzf header struct optimization

### DIFF
--- a/include/lzf.h
+++ b/include/lzf.h
@@ -64,26 +64,26 @@
 
 /* LZF headers */
 
-struct lzf_header_s         /* Common data header */
+begin_packed_struct struct lzf_header_s         /* Common data header */
 {
   uint8_t lzf_magic[2];     /* [0]='Z', [1]='V' */
   uint8_t lzf_type;         /* LZF_TYPE0_HDR or LZF_TYPE1_HDR */
-};
+} end_packed_struct;
 
-struct lzf_type0_header_s   /* Uncompressed data header */
+begin_packed_struct struct lzf_type0_header_s   /* Uncompressed data header */
 {
   uint8_t lzf_magic[2];     /* [0]='Z', [1]='V' */
   uint8_t lzf_type;         /* LZF_TYPE0_HDR */
   uint8_t lzf_len[2];       /* Data length (big-endian) */
-};
+} end_packed_struct;
 
-struct lzf_type1_header_s   /* Compressed data header */
+begin_packed_struct struct lzf_type1_header_s   /* Compressed data header */
 {
   uint8_t lzf_magic[2];     /* [0]='Z', [1]='V' */
   uint8_t lzf_type;         /* LZF_TYPE1_HDR */
   uint8_t lzf_clen[2];      /* Compressed data length (big-endian) */
   uint8_t lzf_ulen[2];      /* Uncompressed data length (big-endian) */
-};
+} end_packed_struct;
 
 /* LZF hash table */
 


### PR DESCRIPTION
Add packed attribute to lzf header structs to prevent the compiler from optimizing lzf_magic array initialization into wider store instructions (e.g. st.h), which can cause misaligned access exceptions on architectures that do not support unaligned memory access.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Add begin_packed_struct/end_packed_struct attributes to the three LZF header structs (lzf_header_s, lzf_type0_header_s, lzf_type1_header_s) in lzf.h. Without packed attributes, the compiler may optimize the lzf_magic[2] array initialization into a wider store instruction (e.g. st.h), causing misaligned access exceptions on architectures that do not support unaligned memory access.

## Impact

- Fixes misaligned access exceptions on strict-alignment architectures
- No functional change on architectures that support unaligned access
- No breaking changes

## Testing

Build & runtime verification on sim:nsh with CONFIG_LIBC_LZF=y and CONFIG_SYSTEM_LZF=y.

Test 1 — Text data compress/decompress:

```
nsh> echo ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 > /tmp/testdata
nsh> lzf -cv /tmp/testdata
/tmp/testdata: -- replaced with /tmp/testdata.lzf
nsh> lzf -dv /tmp/testdata.lzf
/tmp/testdata.lzf: -- replaced with /tmp/testdata
nsh> cat /tmp/testdata
ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789
```
Result: PASS — decompressed content matches original.

Test 2 — Binary data (4KB zeros) compress/decompress:
```
nsh> dd if=/dev/zero of=/tmp/zeros bs=1024 count=4
4096 bytes (4 blocks) copied
nsh> lzf -cv /tmp/zeros
/tmp/zeros: -- replaced with /tmp/zeros.lzf
nsh> lzf -dv /tmp/zeros.lzf
/tmp/zeros.lzf: -- replaced with /tmp/zeros
nsh> dd if=/tmp/zeros of=/dev/null bs=1024
4096 bytes (4 blocks) copied
```
Result: PASS — decompressed size matches original (4096 bytes).
