### PR TITLE
pynuttx: missing `mm_initialize`

### DIFF
--- a/tools/pynuttx/nxgdb/mm.py
+++ b/tools/pynuttx/nxgdb/mm.py
@@ -374,7 +374,7 @@ class MMNode(gdb.Value, p.MMFreeNode):
     MM_MASK_BIT = MM_ALLOC_BIT | MM_PREVFREE_BIT
     MM_SIZEOF_ALLOCNODE = utils.sizeof("struct mm_allocnode_s")
     MM_ALLOCNODE_OVERHEAD = MM_SIZEOF_ALLOCNODE - utils.sizeof("mmsize_t")
-    MM_MIN_CHUNK = utils.get_symbol_value("MM_MIN_CHUNK", locspec="mm_initialize")
+    MM_MIN_CHUNK = utils.get_symbol_value("MM_MIN_CHUNK", locspec="mm_initialize_heap")
 
     def __init__(self, node: gdb.Value):
         if node.type.code == gdb.TYPE_CODE_PTR:


### PR DESCRIPTION
## Summary

Commit 6ed4ea63d renamed the function `mm_initialize` to `mm_initialize_heap`.
But the corresponding symbol name in pynuttx was not updated.
The memory-related pynuttx functions (e.g. `mm dump`) do not work anymore since then.

## Impact

The python-based support for gdb debugging now supports the memory-related features again.

## Testing

Previously the following stack trace was emitted when starting gdb with the pynuttx extension:
```
Ignore module: mm, error: Function "mm_initialize" not defined.
Traceback (most recent call last):
  File "external/nuttx/tools/pynuttx/nxgdb/__init__.py", line 54, in init_gdb_commands
    module = importlib.import_module(f"{__package__}.{m}")
  File "/usr/lib/python3.13/importlib/__init__.py", line 88, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
           ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "<frozen importlib._bootstrap>", line 1387, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1360, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1331, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 935, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 1026, in exec_module
  File "<frozen importlib._bootstrap>", line 488, in _call_with_frames_removed
  File "external/nuttx/tools/pynuttx/nxgdb/mm.py", line 366, in <module>
    class MMNode(gdb.Value, p.MMFreeNode):
    ...<148 lines>...
            return MMNode.MM_ALLOCNODE_OVERHEAD
  File "external/nuttx/tools/pynuttx/nxgdb/mm.py", line 377, in MMNode
    MM_MIN_CHUNK = utils.get_symbol_value("MM_MIN_CHUNK", locspec="mm_initialize")
  File "external/nuttx/tools/pynuttx/nxgdb/utils.py", line 450, in get_symbol_value
    gdb.execute(f"list {locspec}", to_string=True)
    ~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
gdb.error: Function "mm_initialize" not defined.
```
(a similar stack trace was repeated multiple times for various commands)

Now there is no stacktrace anymore. The gdb command `mm dump` works again.