### PR TITLE
cmake/nuttx_mkconfig: Improve .config comparison logic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -349,6 +349,19 @@ if(NOT EXISTS ${CMAKE_BINARY_DIR}/.config OR NOT "${NUTTX_DEFCONFIG}" STREQUAL
        ${CMAKE_BINARY_DIR}/.config)
   set(ENV{KCONFIG_CONFIG} ${CMAKE_BINARY_DIR}/.config)
 
+  # Set CONFIG_BASE_DEFCONFIG so .config matches Make behavior (configure.sh)
+  file(READ ${CMAKE_BINARY_DIR}/.config _config_init_content)
+  string(
+    REGEX
+    REPLACE "CONFIG_BASE_DEFCONFIG=\"[^\"]*\""
+            "CONFIG_BASE_DEFCONFIG=\"${NUTTX_BOARD}/${NUTTX_CONFIG}\""
+            _config_init_content "${_config_init_content}")
+  if(NOT _config_init_content MATCHES "CONFIG_BASE_DEFCONFIG=")
+    string(APPEND _config_init_content
+           "\nCONFIG_BASE_DEFCONFIG=\"${NUTTX_BOARD}/${NUTTX_CONFIG}\"\n")
+  endif()
+  file(WRITE ${CMAKE_BINARY_DIR}/.config "${_config_init_content}")
+
   # store original expanded .config
   configure_file(${CMAKE_BINARY_DIR}/.config ${CMAKE_BINARY_DIR}/.config.orig
                  COPYONLY)


### PR DESCRIPTION
## Summary

CMake left `CONFIG_BASE_DEFCONFIG` empty in `.config`, while Make sets it (e.g. `stm32h745i-disco:nsh`). This change updates `cmake/nuttx_mkconfig.cmake` to write the computed value into `.config`: read `.config`, replace or append the `CONFIG_BASE_DEFCONFIG` line, then write it back. Matches Make behavior where `configure.sh` and `Unix.mk` keep this value in `.config`.




Fixes https://github.com/apache/nuttx/issues/16695.

## How to reproduce (from [issue #16695](https://github.com/apache/nuttx/issues/16695))

Steps from the issue comments:

**Using Makefile:**
```bash
./tools/configure.sh stm32h745i-disco:nsh
cp .config config_stm32h745_makefile
make distclean -j
```

**Using CMake (before fix):**
```bash
rm -rf build .config
cmake -B build -DBOARD_CONFIG=stm32h745i-disco:nsh -GNinja
grep CONFIG_BASE_DEFCONFIG build/.config
```

Compare `config_stm32h745_makefile` and `config_stm32h745_cmake` (e.g. `meld config_stm32h745_makefile config_stm32h745_cmake`): Make sets `CONFIG_BASE_DEFCONFIG="stm32h745i-disco:nsh"`, while CMake left it `CONFIG_BASE_DEFCONFIG=""`.

## Build / config logs

**Before fix** (tree at `56112efbd3` or with pre-fix `nuttx_mkconfig.cmake`):

```text
$ rm -rf build .config
$ cmake -B build -DBOARD_CONFIG=stm32h745i-disco:nsh -GNinja
-- Found Python3: ...
-- Initializing NuttX
...
-- Configuring done
-- Generating done
-- Build files have been written to: .../build

$ grep CONFIG_BASE_DEFCONFIG build/.config
CONFIG_BASE_DEFCONFIG=""
```

**After fix** (this PR):

```text
$ rm -rf build .config
$ cmake -B build -DBOARD_CONFIG=stm32h745i-disco:nsh -GNinja
-- Found Python3: ...
-- Initializing NuttX
...
-- Configuring done
-- Generating done
-- Build files have been written to: .../build

$ grep CONFIG_BASE_DEFCONFIG build/.config
CONFIG_BASE_DEFCONFIG="stm32h745i-disco/nsh-dirty"
```

(`-dirty` appears when the source tree has local changes; on a clean tree you get `stm32h745i-disco/nsh`.)

## Impact

- **Users:** CMake `.config` now has `CONFIG_BASE_DEFCONFIG` set (e.g. for `/proc/version` and tooling that reads `.config`).
- **Build:** Only CMake config generation is changed; Make and Kconfig unchanged.
- **Compatibility:** No change to Make; CMake still uses `board/config` format.

## Testing

**Host:** macOS (Darwin, arm64), CMake 4.2.3, Ninja 1.13.2. **Board:** stm32h745i-disco:nsh.

- **Before:** Make → `.config` had `CONFIG_BASE_DEFCONFIG="stm32h745i-disco:nsh"`; CMake → `build/.config` had `CONFIG_BASE_DEFCONFIG=""`.
- **After:** `cmake -B build -DBOARD_CONFIG=stm32h745i-disco:nsh -GNinja`; `grep CONFIG_BASE_DEFCONFIG build/.config` → `CONFIG_BASE_DEFCONFIG="stm32h745i-disco/nsh-dirty"`. Make path unchanged.

[build_log.txt](https://github.com/user-attachments/files/25496579/build_log.txt)