### PR TITLE
Makefile: Remove make depend files by make distclean

### DIFF
--- a/arch/arm/src/Makefile
+++ b/arch/arm/src/Makefile
@@ -282,6 +282,7 @@ distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds) $(HEAD_ASRC:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/arch/arm64/src/Makefile
+++ b/arch/arm64/src/Makefile
@@ -255,6 +255,7 @@ distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds) $(HEAD_ASRC:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/arch/avr/src/Makefile
+++ b/arch/avr/src/Makefile
@@ -140,6 +140,7 @@ distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds) $(HEAD_ASRC:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/arch/hc/src/Makefile
+++ b/arch/hc/src/Makefile
@@ -152,6 +152,7 @@ distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds) $(HEAD_ASRC:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/arch/mips/src/Makefile
+++ b/arch/mips/src/Makefile
@@ -138,6 +138,7 @@ distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds) $(HEAD_ASRC:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/arch/misoc/src/Makefile
+++ b/arch/misoc/src/Makefile
@@ -141,6 +141,7 @@ distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds) $(HEAD_ASRC:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/arch/or1k/src/Makefile
+++ b/arch/or1k/src/Makefile
@@ -181,6 +181,7 @@ distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds) $(HEAD_ASRC:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/arch/renesas/src/Makefile
+++ b/arch/renesas/src/Makefile
@@ -146,6 +146,7 @@ distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds) $(HEAD_ASRC:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/arch/risc-v/src/Makefile
+++ b/arch/risc-v/src/Makefile
@@ -254,6 +254,7 @@ distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds) $(HEAD_ASRC:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -529,6 +529,7 @@ distclean:: clean
 	$(Q) if [ -e board/Makefile ]; then \
 		$(MAKE) -C board distclean ; \
 	fi
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds) $(HOSTSRCS:.c=.ddh))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 	$(call DELFILE, config.h)

--- a/arch/tricore/src/Makefile
+++ b/arch/tricore/src/Makefile
@@ -235,6 +235,7 @@ distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds)
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/arch/x86/src/Makefile
+++ b/arch/x86/src/Makefile
@@ -194,6 +194,7 @@ distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds) $(HEAD_ASRC:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/arch/x86_64/src/Makefile
+++ b/arch/x86_64/src/Makefile
@@ -224,6 +224,7 @@ distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/arch/xtensa/src/Makefile
+++ b/arch/xtensa/src/Makefile
@@ -235,6 +235,7 @@ distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds) $(HEAD_CSRC:.c=.ddc) $(HEAD_ASRC:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/audio/Makefile
+++ b/audio/Makefile
@@ -71,6 +71,7 @@ clean:
 	$(call CLEAN)
 
 distclean: clean
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/binfmt/Makefile
+++ b/binfmt/Makefile
@@ -95,6 +95,7 @@ clean:
 	$(call CLEAN)
 
 distclean: clean
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/boards/Makefile
+++ b/boards/Makefile
@@ -88,6 +88,7 @@ clean: clean_context
 	$(call CLEAN)
 
 distclean: clean
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds) $(CXXSRCS:.cxx=.ddx))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/crypto/Makefile
+++ b/crypto/Makefile
@@ -117,6 +117,7 @@ clean:
 	$(call CLEAN)
 
 distclean: clean
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/drivers/Makefile
+++ b/drivers/Makefile
@@ -128,6 +128,7 @@ clean:
 	$(call CLEAN)
 
 distclean:: clean
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/fs/Makefile
+++ b/fs/Makefile
@@ -108,6 +108,7 @@ clean:
 	$(call CLEAN)
 
 distclean:: clean
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/graphics/Makefile
+++ b/graphics/Makefile
@@ -131,6 +131,7 @@ clean:
 	$(call CLEAN)
 
 distclean: clean clean_context
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/libs/libc/Makefile
+++ b/libs/libc/Makefile
@@ -225,6 +225,7 @@ distclean:: clean
 	$(Q) $(MAKE) -C zoneinfo distclean BIN=$(BIN)
 	$(Q) $(MAKE) -C elf distclean
 	$(call DELFILE, exec_symtab.c)
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds))
 	$(call DELFILE, .depend)
 	$(call DELDIR, bin)
 	$(call DELDIR, kbin)

--- a/libs/libc/zoneinfo/Makefile
+++ b/libs/libc/zoneinfo/Makefile
@@ -120,6 +120,7 @@ clean:
 	$(call CLEAN)
 
 distclean: clean
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 	$(call DELFILE, .tzunpack)

--- a/libs/libdsp/Makefile
+++ b/libs/libdsp/Makefile
@@ -78,6 +78,7 @@ clean:
 	$(call CLEAN)
 
 distclean: clean
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/libs/libm/Makefile
+++ b/libs/libm/Makefile
@@ -104,6 +104,7 @@ clean:
 distclean:: clean
 	$(call DELDIR, bin)
 	$(call DELDIR, kbin)
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds))
 	$(call DELFILE, .depend)
 
 -include bin$(DELIM)Make.dep

--- a/libs/libnx/Makefile
+++ b/libs/libnx/Makefile
@@ -267,6 +267,7 @@ clean:
 distclean: clean
 	$(call DELDIR, bin)
 	$(call DELDIR, kbin)
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds))
 	$(call DELFILE, .depend)
 	$(Q) $(MAKE) -C nxfonts -f Makefile.sources distclean EXTRAFLAGS="$(EXTRAFLAGS)"
 

--- a/libs/libxx/Makefile
+++ b/libs/libxx/Makefile
@@ -96,6 +96,7 @@ clean:
 	$(call CLEAN)
 
 distclean:: clean
+	$(call DELFILE, $(CXXSRCS:.cxx=.ddx) $(CPPSRCS:.cpp=.ddp))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/mm/Makefile
+++ b/mm/Makefile
@@ -128,6 +128,7 @@ clean:
 distclean:: clean
 	$(call DELDIR, bin)
 	$(call DELDIR, kbin)
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds))
 	$(call DELFILE, .depend)
 
 -include bin$(DELIM)Make.dep

--- a/net/Makefile
+++ b/net/Makefile
@@ -105,6 +105,7 @@ clean:
 	$(call CLEAN)
 
 distclean: clean
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/openamp/Makefile
+++ b/openamp/Makefile
@@ -65,6 +65,7 @@ clean:
 	$(call CLEAN)
 
 distclean:: clean
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/pass1/Makefile
+++ b/pass1/Makefile
@@ -60,6 +60,7 @@ clean:
 	$(call CLEAN)
 
 distclean: clean
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 	$(call DELFILE, *.c)

--- a/sched/Makefile
+++ b/sched/Makefile
@@ -82,6 +82,7 @@ clean:
 	$(call CLEAN)
 
 distclean: clean
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/syscall/Makefile
+++ b/syscall/Makefile
@@ -120,6 +120,7 @@ endif
 
 distclean: clean
 	$(call DELFILE, .context)
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 	$(call DELFILE, proxies$(DELIM)*.c)

--- a/video/Makefile
+++ b/video/Makefile
@@ -58,6 +58,7 @@ clean:
 	$(call CLEAN)
 
 distclean: clean
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/wireless/Makefile
+++ b/wireless/Makefile
@@ -63,6 +63,7 @@ clean:
 	$(call CLEAN)
 
 distclean: clean
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 


### PR DESCRIPTION
## Summary
This PR enhances the `make distclean` target across the codebase to remove intermediate dependency files (like .ddc and .dds) that may remain when the build process is interrupted. These files are generated during the make depend process and should be cleaned up to ensure a complete clean state.

## Impact
None

## Testing
Tested that .ddc and .dds files are removed by make distclean. 
