### PR TITLE
boards/arm/stm32f0l0g0: CMake fix build b-l072z-lrwan1:nxlines_oled

### DIFF
--- a/boards/arm/stm32f0l0g0/common/CMakeLists.txt
+++ b/boards/arm/stm32f0l0g0/common/CMakeLists.txt
@@ -1,0 +1,24 @@
+# ##############################################################################
+# boards/arm/stm32f0l0g0/common/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)
+target_include_directories(board PRIVATE include)

--- a/boards/arm/stm32f0l0g0/common/src/CMakeLists.txt
+++ b/boards/arm/stm32f0l0g0/common/src/CMakeLists.txt
@@ -1,0 +1,30 @@
+# ##############################################################################
+# boards/arm/stm32f0l0g0/common/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_ARCH_BOARD_COMMON)
+
+  if(CONFIG_LCD_SSD1306)
+    list(APPEND SRCS stm32_ssd1306.c)
+  endif()
+
+endif()
+target_sources(board PRIVATE ${SRCS})


### PR DESCRIPTION
## Summary

- CMake fix build for b-l072z-lrwan1:nxlines_oled

```
b-l072z-lrwan1/src/stm32_lcd_ssd1306.c:38:10: fatal error: stm32_ssd1306.h: No such file or directory
   38 | #include "stm32_ssd1306.h"
      |          ^~~~~~~~~~~~~~~~~
```
## Impact

Impact on user: NO

Impact on build: This PR fix build for b-l072z-lrwan1:nxlines_oled

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

<details>
<summary>b-l072z-lrwan1:nxlines_oled</summary>

```
D:\nuttxtmp\nuttx>cmake -B build -DBOARD_CONFIG=b-l072z-lrwan1:nxlines_oled -GNinja
-- Found Python3: C:/Users/bit/AppData/Local/Programs/Python/Python313/python.exe (found version "3.13.3") found components: Interpreter
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Initializing NuttX
Loaded configuration 'D:/nuttxtmp/nuttx/build/.config.compressed'
Minimal configuration saved to 'D:/nuttxtmp/nuttx/build/defconfig.tmp'
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  b-l072z-lrwan1
--   Config: nxlines_oled
--   Appdir: D:/nuttxtmp/apps
-- Building for: Ninja
-- The C compiler identification is GNU 14.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/mingw/mingw64/bin/gcc.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- NuttX Host Tools
-- CMake C compiler: GNU
-- CMake system name: Windows
-- CMake host system processor: AMD64
   TOOLS_DIR path is "D:/nuttxtmp/nuttx"
   HOST = WINDOWS NATIVE
-- Configuring done (0.8s)
-- Generating done (0.0s)
-- Build files have been written to: D:/nuttxtmp/nuttx/build/bin_host
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-g++.exe - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (13.6s)
-- Generating done (2.4s)
-- Build files have been written to: D:/nuttxtmp/nuttx/build

D:\nuttxtmp\nuttx>cmake --build build
[35/1297] Building C object arch/CMakeFiles/arch.dir/arm/src/stm32f0l0g0/stm32_i2c.c.o
D:/nuttxtmp/nuttx/arch/arm/src/stm32f0l0g0/stm32_i2c.c:255:2: warning: #warning TODO: check I2C clock source and clock frequency. It must be HSI! [-Wcpp]
  255 | #warning TODO: check I2C clock source and clock frequency. It must be HSI!
      |  ^~~~~~~
[1295/1297] Linking C executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:       92648 B       192 KB     47.12%
            sram:        6688 B        20 KB     32.66%
[1297/1297] Generating nuttx.bin
```
</details>