### PR TITLE
tools: flash_writer.py fix Python 3.13 compatibility

### DIFF
--- a/tools/flash_writer.py
+++ b/tools/flash_writer.py
@@ -24,7 +24,12 @@ import os
 import re
 import subprocess
 import sys
-import telnetlib
+try:
+    import telnetlib
+except ImportError:
+    telnetlib = None
+    # telnetlib was removed in Python 3.13
+
 import time
 
 import xmodem


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

* Fixes the issue : https://github.com/apache/nuttx/issues/17727
* Making flash_writer.py compatible for Python 3.13
* Changes made without stripping of backward compatibility.

## Impact

* Reduced an error of missing module.

## Testing

<img width="956" height="39" alt="image" src="https://github.com/user-attachments/assets/a5df230a-3746-4fb4-952f-0dce918f05a2" />


