### PR TITLE
rptun: select SCHED_WAITPID as dependency

### DIFF
--- a/drivers/rptun/Kconfig
+++ b/drivers/rptun/Kconfig
@@ -7,6 +7,7 @@ menuconfig RPTUN
 	bool "Remote Proc Tunnel Driver Support"
 	default n
 	select RPMSG_VIRTIO
+	depends on SCHED_WAITPID
 	---help---
 		RPTUN driver is used for multi-cores' communication.
 


### PR DESCRIPTION
rptun.c calls nxsched_waitpid(). Make the dependency explicit to avoid build issues.

## Summary

Using RPTUN requires manual selection of SCHED_WAITPID which is
not obvious. Automate this through Kconfig.

## Impact

None. Build fails when not SCHED_WAITPID selected in defconfig.

## Testing

This is a trivial change.
Build rptun without SCHED_WAITPID > fails.
With fix, regenerate .config and build succeeds.