### PR TITLE
arch/arm: remove all "select ARMV8M_HAVE_STACKCHECK".

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -115,7 +115,6 @@ config ARCH_CHIP_CSK6
 	select ARCH_HAVE_TICKLESS
 	select ARCH_HAVE_TIMEKEEPING
 	select ARM_HAVE_MPU_UNIFIED
-	select ARMV8M_HAVE_STACKCHECK
 	select ARCH_HAVE_ADJTIME
 	select ARCH_CORTEXM33
 	---help---
@@ -585,7 +584,6 @@ config ARCH_CHIP_STM32H5
 	select ARCH_HAVE_TICKLESS
 	select ARCH_HAVE_TRUSTZONE
 	select ARM_HAVE_MPU_UNIFIED
-	select ARMV8M_HAVE_STACKCHECK
 	---help---
 		STMicro STM32 H5 architectures (ARM Cortex-M33).
 
@@ -601,7 +599,6 @@ config ARCH_CHIP_STM32L5
 	select ARCH_HAVE_TICKLESS
 	select ARCH_HAVE_TRUSTZONE
 	select ARM_HAVE_MPU_UNIFIED
-	select ARMV8M_HAVE_STACKCHECK
 	---help---
 		STMicro STM32 L5 architectures (ARM Cortex-M33).
 
@@ -617,7 +614,6 @@ config ARCH_CHIP_STM32U5
 	select ARCH_HAVE_SPI_BITORDER
 	select ARCH_HAVE_TICKLESS
 	select ARM_HAVE_MPU_UNIFIED
-	select ARMV8M_HAVE_STACKCHECK
 	select ARCH_HAVE_TRUSTZONE
 	---help---
 		STMicro STM32 U5 architectures (ARM Cortex-M33).


### PR DESCRIPTION
Stack checking is not optional on armv8m. This option is never used.

## Summary

Noted during porting to iMX93 M33 core (ARMV8M).

ARMV8M implementations always have stack checking built in. There
is no reason to have an option to conditionally enable support for this.
This is not to be confused with actually enabling stack checking, through
ARMV8M_STACKCHECK_*

I believe these config entries were copied from ARMV7M implementations
or left over after early changes to ARMV8M.

## Impact

None. There is no "config ARMV8M_HAVE_STACKCHECK" which gets selected.

## Testing

- Select tree before this change
- Configure for nucleo-h563zi which uses stm32h5 which selects this option.
- Run configure
- ARMV8M_HAVE_STACKCHECK is not present in .config
- make
- Select tree with the proposed change
- run olddefconfig, no .config change reported
- ARMV8M_HAVE_STACKCHECK didn't magically appear in .config
- make
- compare builds before and after > only checksum/datestamp is different, equal sizes

Commands:
```
make distclean
git switch master
tools/configure.sh nucleo-h563zi:nsh
cat .config | grep ARMV8M_HAVE_STACKCHECK
make
cp nuttx nuttx_before
git switch armv8m_stack_check_option
make olddefconfig
tools/configure.sh nucleo-h563zi:nsh
cat .config | grep ARMV8M_HAVE_STACKCHECK
make
hexdump -C nuttx_before > /tmp/a.txt && hexdump -C nuttx > /tmp/b.txt && diff /tmp/a.txt /tmp/b.txt
```

Log:
```
Switched to branch 'master'
Your branch is up to date with 'origin/master'.
  Copy files
  Select CONFIG_HOST_LINUX=y
  Refreshing...
CP: arch/dummy/Kconfig to /home/maarten/work/nuttx/nuttx/arch/dummy/dummy_kconfig
CP: boards/dummy/Kconfig to /home/maarten/work/nuttx/nuttx/boards/dummy/dummy_kconfig
LN: platform/board to /home/maarten/work/nuttx/apps/platform/dummy
LN: include/arch to arch/arm/include
LN: include/arch/board to /home/maarten/work/nuttx/nuttx/boards/arm/stm32h5/nucleo-h563zi/include
LN: drivers/platform to /home/maarten/work/nuttx/nuttx/drivers/dummy
LN: include/arch/chip to /home/maarten/work/nuttx/nuttx/arch/arm/include/stm32h5
LN: arch/arm/src/chip to /home/maarten/work/nuttx/nuttx/arch/arm/src/stm32h5
LN: arch/arm/src/board to /home/maarten/work/nuttx/nuttx/boards/arm/stm32h5/nucleo-h563zi/src
mkkconfig in /home/maarten/work/nuttx/apps/audioutils
mkkconfig in /home/maarten/work/nuttx/apps/benchmarks
mkkconfig in /home/maarten/work/nuttx/apps/boot
mkkconfig in /home/maarten/work/nuttx/apps/canutils
mkkconfig in /home/maarten/work/nuttx/apps/crypto
mkkconfig in /home/maarten/work/nuttx/apps/database
mkkconfig in /home/maarten/work/nuttx/apps/examples/elf/tests
mkkconfig in /home/maarten/work/nuttx/apps/examples/elf
mkkconfig in /home/maarten/work/nuttx/apps/examples/mcuboot
mkkconfig in /home/maarten/work/nuttx/apps/examples/module
mkkconfig in /home/maarten/work/nuttx/apps/examples/rust
mkkconfig in /home/maarten/work/nuttx/apps/examples/sotest
mkkconfig in /home/maarten/work/nuttx/apps/examples
mkkconfig in /home/maarten/work/nuttx/apps/fsutils
mkkconfig in /home/maarten/work/nuttx/apps/games
mkkconfig in /home/maarten/work/nuttx/apps/graphics
mkkconfig in /home/maarten/work/nuttx/apps/industry
mkkconfig in /home/maarten/work/nuttx/apps/inertial
mkkconfig in /home/maarten/work/nuttx/apps/interpreters/luamodules
mkkconfig in /home/maarten/work/nuttx/apps/interpreters
mkkconfig in /home/maarten/work/nuttx/apps/logging
mkkconfig in /home/maarten/work/nuttx/apps/lte
mkkconfig in /home/maarten/work/nuttx/apps/math
mkkconfig in /home/maarten/work/nuttx/apps/mlearning
mkkconfig in /home/maarten/work/nuttx/apps/netutils
mkkconfig in /home/maarten/work/nuttx/apps/sdr
mkkconfig in /home/maarten/work/nuttx/apps/system
mkkconfig in /home/maarten/work/nuttx/apps/tee
mkkconfig in /home/maarten/work/nuttx/apps/testing/arch
mkkconfig in /home/maarten/work/nuttx/apps/testing/cxx
mkkconfig in /home/maarten/work/nuttx/apps/testing/drivers
mkkconfig in /home/maarten/work/nuttx/apps/testing/fs
mkkconfig in /home/maarten/work/nuttx/apps/testing/libc
mkkconfig in /home/maarten/work/nuttx/apps/testing/mm
mkkconfig in /home/maarten/work/nuttx/apps/testing/sched
mkkconfig in /home/maarten/work/nuttx/apps/testing
mkkconfig in /home/maarten/work/nuttx/apps/videoutils
mkkconfig in /home/maarten/work/nuttx/apps/wireless/bluetooth
mkkconfig in /home/maarten/work/nuttx/apps/wireless/ieee802154
mkkconfig in /home/maarten/work/nuttx/apps/wireless
mkkconfig in /home/maarten/work/nuttx/apps
Loaded configuration '.config'
Configuration saved to '.config'
Create version.h
LN: platform/board to /home/maarten/work/nuttx/apps/platform/dummy
Register: dd
Register: nsh
Register: sh
LD: nuttx
Memory region         Used Size  Region Size  %age Used
           flash:      212124 B         2 MB     10.11%
            sram:        9720 B       256 KB      3.71%
CP: nuttx.bin

Switched to branch 'armv8m_stack_check_option'
CP: arch/dummy/Kconfig to /home/maarten/work/nuttx/nuttx/arch/dummy/dummy_kconfig
CP: boards/dummy/Kconfig to /home/maarten/work/nuttx/nuttx/boards/dummy/dummy_kconfig
LN: platform/board to /home/maarten/work/nuttx/apps/platform/dummy
LN: include/arch to arch/arm/include
LN: include/arch/board to /home/maarten/work/nuttx/nuttx/boards/arm/stm32h5/nucleo-h563zi/include
LN: drivers/platform to /home/maarten/work/nuttx/nuttx/drivers/dummy
LN: include/arch/chip to /home/maarten/work/nuttx/nuttx/arch/arm/include/stm32h5
LN: arch/arm/src/chip to /home/maarten/work/nuttx/nuttx/arch/arm/src/stm32h5
LN: arch/arm/src/board to /home/maarten/work/nuttx/nuttx/boards/arm/stm32h5/nucleo-h563zi/src
Loaded configuration '.config'
No change to configuration in '.config'
No configuration change.
Create version.h
LN: platform/board to /home/maarten/work/nuttx/apps/platform/dummy
Register: dd
Register: nsh
Register: sh
LD: nuttx
Memory region         Used Size  Region Size  %age Used
           flash:      212124 B         2 MB     10.11%
            sram:        9720 B       256 KB      3.71%
CP: nuttx.bin
13191,13193c13191,13193
< 000350c0  00 00 00 00 c4 00 00 20  c4 00 00 20 66 63 31 61  |....... ... fc1a|
< 000350d0  65 39 62 37 62 65 20 46  65 62 20 32 30 20 32 30  |e9b7be Feb 20 20|
< 000350e0  32 36 20 31 35 3a 31 31  3a 30 35 00 ff 00 00 00  |26 15:11:05.....|
---
> 000350c0  00 00 00 00 c4 00 00 20  c4 00 00 20 66 37 62 38  |....... ... f7b8|
> 000350d0  39 61 65 63 37 65 20 46  65 62 20 32 30 20 32 30  |9aec7e Feb 20 20|
> 000350e0  32 36 20 31 35 3a 31 32  3a 30 35 00 ff 00 00 00  |26 15:12:05.....|

```
