### PR TITLE
github/workflow: Fix the PR Labeling for Build System

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -108,7 +108,10 @@ jobs:
                   .split('.').join('\\.')            // .  becomes \.
                   .split('*').join('[^/]*')          // *  becomes [^/]*
                   .split('[^/]*[^/]*').join('.*');   // ** becomes .*
-                archLabels.push({ label, pattern });
+                archLabels.push({
+                  label,                        // Arch: arm
+                  pattern: '^' + pattern + '$'  // Match the Line Start and Line End
+                });
 
               } else {
                 // We don't support all rules of `actions/labeler`


### PR DESCRIPTION
## Summary

Our New PR Labeler incorrectly labels the Changed Files for Build System. Here is a Sample PR that contains changes for Arm32 CMake and Makefile: https://github.com/lupyuen6/nuttx/pull/59

```
arch/arm/CMakeLists.txt
arch/arm/Makefile
```

But our PR Labeler incorrectly labels the above as `Area: Build system, Arch: Arm`, which triggers a Complete CI Build across All Architectures (according to arch.yml). The correct label should be `Arch: Arm`, which will trigger only the Arm32 Build: https://github.com/lupyuen8/nuttx/pull/1

This PR fixes the PR Labeling. The New PR Labeler is explained here:
- https://lupyuen.org/articles/prtarget
- https://github.com/apache/nuttx/issues/18359

### Modified Files

`.github/workflows/labeler.yml`: Changed the Regex Pattern. Now we match the Start Of Line and End Of Line.

## Impact

  * _Is a new or modified feature?_ This solution fixes the way PRs are labeled for `Area: Build system`

  * _Impact on build:_ Builds will work the same. Except that the PR Labeler will now label `Area: Build system` correctly.

  * _Impact on documentation:_ I wrote a Detailed Article that explains why pull_request_target is unsafe, and how we reimplemented PR Labeling safely: https://lupyuen.org/articles/prtarget

  * _Impact on security:_ NO

  * _Impact on compatibility:_ NO

  * _Impact on user:_ NO

  * _Impact on hardware:_ NO

  * _Anything else:_ We documented all Design Decisions here: https://github.com/apache/nuttx/issues/18359

  * When this PR has been Merged: I shall standby 24 x 7 to watch over GitHub CI and ensure that everything works exactly the same as before. (Unless I'm out for Marathon Training: 7 hours / 42 km)

  * Later the same changes shall be ported to the NuttX Apps repo

## Testing

We confirm that the changes are verified on our own NuttX Repo and work as intended. Here are the Test Cases:

https://gist.github.com/lupyuen/5748c468315b5ba0567464a5cca69403

### Arch Labeling

- Simple PR should be labeled correctly and trigger a Simple Build: Arm32-only, Arm64-only, RISC-V-only, Arch + Board, Arch + Board + Doc, ...
- Complex PR should be labeled correctly and trigger a Complete Build: Drivers, Include, Arm32 + Arm64, Arm32 + RISC-V, ...
- Doc PR should be labeled correctly and trigger a Doc Build only
- Area PR should be labeled correctly
  - Root CMakeLists.txt / Makefile: Should be labeled correctly as `Area: Build system` and trigger a Complete Build
  - Arch Arm32 CMakeLists.txt / Makefile: Should be labeled correctly as `Arch: arm` and trigger an Arm32-only Build

### Size Labeling

- Size XS, S, M, L, XL should be labeled correctly
- Added / modified / removed lines in a Single File: Should be labeled correctly
- Added / modified / removed lines in Multiple Files: Should be labeled correctly
- Deleted files should be ignored

### Response Time

- PR Labeling must complete within 1.5 minutes

  Why? The Build Workflow begins in the Fetch-Source stage, checking out the Entire Repo and uploading everything in 1.5 minutes, followed by the Select-Builds stage (arch.yml) reading the PR Labels. Before 1.5 minutes, rightfully our workflow_run trigger would have written the PR Labels to the PR.

  PR Labeling now completes in 13 elapsed seconds, spanning 2 jobs. (Previously: 35 elapsed seconds, in 1 job)

### Zizmor Security Scan

- Zizmor Security Scan should not report any Security Issues. However Zizmor flags `workflow_run` as a Potential Security Issue, because it's unable to analyse the code inside the workflow. `workflow_run` is not forbidden in the [ASF GitHub Actions Security Policy](https://infra.apache.org/github-actions-policy.html).

Test Logs are here: https://gist.github.com/lupyuen/5748c468315b5ba0567464a5cca69403
