### PR TITLE
sched/clock: fix CLOCK_BOOTTIME and CLOCK_MONOTONIC handling

### DIFF
--- a/sched/clock/clock_gettime.c
+++ b/sched/clock/clock_gettime.c
@@ -97,7 +97,7 @@ int nxclock_gettime(clockid_t clock_id, FAR struct timespec *tp)
       return -EINVAL;
     }
 
-  if (clock_id == CLOCK_MONOTONIC || clock_id == CLOCK_BOOTTIME)
+  if (clock_id == CLOCK_MONOTONIC)
     {
       /* The the time elapsed since the timer was initialized at power on
        * reset, excluding the time that the system is suspended.


### PR DESCRIPTION
## Summary

The current implementation retrieves time from the same source for both CLOCK_BOOTTIME and CLOCK_MONOTONIC, which is incorrect. CLOCK_BOOTTIME includes time spent in system suspend, whereas CLOCK_MONOTONIC does not.

This patch fixes the incorrect clock source handling and ensures the two clocks are distinguished properly.

## Impact

No Impact to build.

Fix CLOCK_BOOTTIME and CLOCK_MONOTONIC implementation issue.

## Testing

**ostest passed on a2g-tc397-5v-tft:nsh**

```
NuttShell (NSH)
nsh>
nsh> uname -a
NuttX 0.0.0 7f73e3b05a Feb 25 2026 10:08:40 tricore a2g-tc397-5v-tft
nsh>
nsh> ostest

(...)

user_main: scheduler lock test
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Finished

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         5        5
mxordblk    1f8b8    1f8b8
uordblks     4c78     4c78
fordblks    24188    24188

user_main: nxevent test

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         5        5
mxordblk    1f8b8    1f8b8
uordblks     4c78     4c78
fordblks    24188    24188

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena       28e00    28e00
ordblks         1        5
mxordblk    24220    1f8b8
uordblks     4be0     4c78
fordblks    24220    24188
user_main: Exiting
ostest_main: Exiting with status 0
nsh>
```

**ostest passed on rv-virt:smp64**

```
NuttShell (NSH)
nsh>
nsh>
nsh> uname -a
NuttX 0.0.0 7f73e3b05a-dirty Feb 25 2026 10:13:08 risc-v rv-virt
nsh>
nsh> ostest

(...)

user_main: vfork() test
vfork_test: Child 418 ran successfully

user_main: smp call test
smp_call_test: Test start
smp_call_test: Call cpu 0, nowait
smp_call_test: Call cpu 0, wait
smp_call_test: Call cpu 1, nowait
smp_call_test: Call cpu 1, wait
smp_call_test: Call cpu 2, nowait
smp_call_test: Call cpu 2, wait
smp_call_test: Call cpu 3, nowait
smp_call_test: Call cpu 3, wait
smp_call_test: Call cpu 4, nowait
smp_call_test: Call cpu 4, wait
smp_call_test: Call cpu 5, nowait
smp_call_test: Call cpu 5, wait
smp_call_test: Call cpu 6, nowait
smp_call_test: Call cpu 6, wait
smp_call_test: Call cpu 7, nowait
smp_call_test: Call cpu 7, wait
smp_call_test: Call multi cpu, nowait
smp_call_test: Call in interrupt, wait
smp_call_test: Call multi cpu, wait
smp_call_test: Test success

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fc07c0  1fc07c0
ordblks         1        8
mxordblk  1fb5688  1f606d8
uordblks     b138    1dc58
fordblks  1fb5688  1fa2b68
user_main: Exiting
ostest_main: Exiting with status 0
nsh>
```
