### PR TITLE
sched/sched: fix typos and remove unused declarations in sched.h

### DIFF
--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -307,12 +307,6 @@ extern volatile spinlock_t g_cpu_tasklistlock;
  * Public Function Prototypes
  ****************************************************************************/
 
-void nxsched_process_tick(void);
-
-#if defined(CONFIG_HRTIMER) && defined(CONFIG_SCHED_TICKLESS)
-int nxsched_hrtimer_tick_start(clock_t tick);
-#endif
-
 int nxthread_create(FAR const char *name, uint8_t ttype, int priority,
                     FAR void *stack_addr, int stack_size, main_t entry,
                     FAR char * const argv[], FAR char * const envp[]);


### PR DESCRIPTION
## Summary

This patch removes unnecessary and unimplemented function declarations in sched.h, 
fixing typos and cleaning up the header file.

## Impact

Typo fixing, no impact to any functions

## Testing

**ostest passed on rv-virt:smp64**

```
NuttShell (NSH)
nsh> 
nsh> 
nsh> uname -a
NuttX 0.0.0 b86e56abb7 Feb 25 2026 13:42:37 risc-v rv-virt
nsh> 
nsh> ostest

(...)

user_main: smp call test
smp_call_test: Test start
smp_call_test: Call cpu 0, nowait
smp_call_test: Call cpu 0, wait
smp_call_test: Call cpu 1, nowait
smp_call_test: Call cpu 1, wait
smp_call_test: Call cpu 2, nowait
smp_call_test: Call cpu 2, wait
smp_call_test: Call cpu 3, nowait
smp_call_test: Call cpu 3, wait
smp_call_test: Call cpu 4, nowait
smp_call_test: Call cpu 4, wait
smp_call_test: Call cpu 5, nowait
smp_call_test: Call cpu 5, wait
smp_call_test: Call cpu 6, nowait
smp_call_test: Call cpu 6, wait
smp_call_test: Call cpu 7, nowait
smp_call_test: Call cpu 7, wait
smp_call_test: Call multi cpu, nowait
smp_call_test: Call in interrupt, wait
smp_call_test: Call multi cpu, wait
smp_call_test: Test success

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fc07e0  1fc07e0
ordblks         1        8
mxordblk  1fb56a8  1f21b20
uordblks     b138    64488
fordblks  1fb56a8  1f5c358
user_main: Exiting
ostest_main: Exiting with status 0
nsh>

```