### PR TITLE
codeowners: Shorten file by using wildcards

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,562 +1,97 @@
-.asf.yaml tomek@cedro.info bashton@brennanashton.com xiaoxiang@xiaomi.com jbampton@gmail.com
-.codespell-ignore-lines devel@sumpfralle.de
-.codespellrc devel@sumpfralle.de matteo.golin@gmail.com serg@podtynnyi.com raiden00@railab.me tkaratapanis@census-labs.com
-.editorconfig michallenc@seznam.cz
-.github/CODEOWNERS matteo.golin@gmail.com
-.github/ISSUE_TEMPLATE/001_bug_report.yml 101105604+simbit18@users.noreply.github.com raiden00@railab.me eren.terzioglu@espressif.com
-.github/ISSUE_TEMPLATE/002_feature_request.yml 101105604+simbit18@users.noreply.github.com raiden00@railab.me
-.github/ISSUE_TEMPLATE/003_help.yml 101105604+simbit18@users.noreply.github.com raiden00@railab.me
-.github/ISSUE_TEMPLATE/config.yml 101105604+simbit18@users.noreply.github.com
+.github/ISSUE_TEMPLATE/* 101105604+simbit18@users.noreply.github.com raiden00@railab.me eren.terzioglu@espressif.com
 .github/PULL_REQUEST_TEMPLATE.md David.Sidrane@NscDg.com tomek@cedro.info
 .github/SECURITY.md bashton@brennanashton.com abdelatif.guettouche@espressif.com
-.github/actions/ci-container/action.yaml bashton@brennanashton.com yamamoto@midokura.com 59230071+hartmannathan@users.noreply.github.com gustavo.nihei@espressif.com
-.github/actions/free-disk-space/action.yaml thomas.narayana-swamy@wandercraft.eu
-.github/dependabot.yml 172697+naveensrinivasan@users.noreply.github.com
-.github/gcc.json bashton@brennanashton.com yamamoto@midokura.com
+.github/actions/* luppy@appkaki.com 101105604+simbit18@users.noreply.github.com
+.github/dependabot.yml luppy@appkaki.com 101105604+simbit18@users.noreply.github.com
 .github/labeler.yml raiden00@railab.me luppy@appkaki.com
 .github/linters/setup.cfg cclauss@me.com raiden00@railab.me xiaoxiang@xiaomi.com xuxingliang@xiaomi.com David.Sidrane@Nscdg.com
 .github/nxstyle.json bashton@brennanashton.com
-.github/workflows/arch.yml luppy@appkaki.com
-.github/workflows/build.yml bashton@brennanashton.com luppy@appkaki.com yamamoto@midokura.com 101105604+simbit18@users.noreply.github.com xiaoxiang@xiaomi.com
-.github/workflows/check.yml yamamoto@midokura.com jbampton@gmail.com liuhaitao@xiaomi.com 49699333+dependabot[bot]@users.noreply.github.com devel@sumpfralle.de
-.github/workflows/doc.yml bashton@brennanashton.com jbampton@gmail.com yamamoto@midokura.com matias@protobits.dev matteo.golin@gmail.com
-.github/workflows/docker_linux.yml bashton@brennanashton.com abdelatif.guettouche@espressif.com 49699333+dependabot[bot]@users.noreply.github.com thomas.narayana-swamy@wandercraft.eu gustavo.nihei@espressif.com
-.github/workflows/issue_labeler.yml 101105604+simbit18@users.noreply.github.com raiden00@railab.me
-.github/workflows/labeler.yml raiden00@railab.me 49699333+dependabot[bot]@users.noreply.github.com
-.github/workflows/lint.yml bashton@brennanashton.com 49699333+dependabot[bot]@users.noreply.github.com jbampton@gmail.com cclauss@me.com 172697+naveensrinivasan@users.noreply.github.com
-.gitignore you@example.com xiaoxiang@xiaomi.com resyfer.dev@gmail.com 58759586+curuvar@users.noreply.github.com
-.gitmessage matteo.golin@gmail.com
-.pre-commit-config.yaml filipe.cavalcanti@espressif.com devel@sumpfralle.de
-.yamllint jbampton@gmail.com
-AUTHORS alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com f.panag@amco.gr fft@feedforward.com.cn rzr@users.sf.net
-CMakeLists.txt anchao@xiaomi.com xuxin19@xiaomi.com guoshichao@xiaomi.com raiden00@railab.me 101105604+simbit18@users.noreply.github.com
-CONTRIBUTING.md tomek@cedro.info matias@protobits.dev devel@sumpfralle.de 59230071+hartmannathan@users.noreply.github.com v01d@users.noreply.github.com
-Documentation/.gitignore matias@protobits.dev matteo.golin@gmail.com
-Documentation/Makefile matias@protobits.dev resyfer.dev@gmail.com raiden00@railab.me matteo.golin@gmail.com
-Documentation/Pipfile matias@protobits.dev bashton@brennanashton.com adam@adamfeuer.com nicco.maggioni@gmail.com matteo.golin@gmail.com
-Documentation/Pipfile.lock 49699333+dependabot[bot]@users.noreply.github.com nicco.maggioni@gmail.com bashton@brennanashton.com matias@protobits.dev adam@adamfeuer.com
-Documentation/_extensions/warnings_filter.py raiden00@railab.me
-Documentation/_static/custom.css matias@protobits.dev
-Documentation/_static/favicon.ico matias@protobits.dev
-Documentation/_templates/layout.html matias@protobits.dev xiaoxiang@xiaomi.com
-Documentation/applications/audioutils/fmsynt/index.rst raiden00@railab.me
-Documentation/applications/audioutils/index.rst raiden00@railab.me
-Documentation/applications/audioutils/mml_parser/index.rst raiden00@railab.me
-Documentation/applications/audioutils/nxaudio/index.rst raiden00@railab.me
-Documentation/applications/benchmarks/cachespeed/index.rst chenrun1@xiaomi.com
-Documentation/applications/benchmarks/coremark-pro/index.rst chenrun1@xiaomi.com
-Documentation/applications/benchmarks/coremark/index.rst raiden00@railab.me
-Documentation/applications/benchmarks/cyclictest/index.rst pressl.stepan@gmail.com
-Documentation/applications/benchmarks/dhrystone/index.rst chenrun1@xiaomi.com
-Documentation/applications/benchmarks/fio/index.rst chenrun1@xiaomi.com
-Documentation/applications/benchmarks/index.rst raiden00@railab.me
-Documentation/applications/benchmarks/iozone/index.rst chenrun1@xiaomi.com
+.github/workflows/* luppy@appkaki.com raiden00@railab.me 101105604+simbit18@users.noreply.github.com
+
+.pre-commit-config.yaml luppy@appkaki.com raiden00@railab.me 101105604+simbit18@users.noreply.github.com
+
+AUTHORS alin.jerpelea@sony.com
+CONTRIBUTING.md tomek@cedro.info
+
+Documentation/applications/* raiden00@railab.me
 Documentation/applications/benchmarks/mtd/index.rst tiago.medicci@espressif.com
-Documentation/applications/benchmarks/osperf/index.rst chenrun1@xiaomi.com
-Documentation/applications/benchmarks/ramspeed/index.rst chenrun1@xiaomi.com
-Documentation/applications/benchmarks/superpi/index.rst chenrun1@xiaomi.com
-Documentation/applications/boot/index.rst raiden00@railab.me
-Documentation/applications/boot/mcuboot/index.rst raiden00@railab.me
-Documentation/applications/boot/miniboot/index.rst raiden00@railab.me
 Documentation/applications/boot/nxboot/index.rst michallenc@seznam.cz devel@sumpfralle.de
-Documentation/applications/canutils/candump/index.rst raiden00@railab.me
-Documentation/applications/canutils/canlib/index.rst raiden00@railab.me
-Documentation/applications/canutils/cansend/index.rst raiden00@railab.me
-Documentation/applications/canutils/index.rst raiden00@railab.me
-Documentation/applications/canutils/lely-canopen/index.rst raiden00@railab.me
-Documentation/applications/canutils/libcanutils/index.rst raiden00@railab.me
-Documentation/applications/canutils/libdronecan/index.rst raiden00@railab.me
-Documentation/applications/canutils/libobd2/index.rst raiden00@railab.me
-Documentation/applications/canutils/libopecyphal/index.rst raiden00@railab.me
-Documentation/applications/canutils/slcan/index.rst raiden00@railab.me
-Documentation/applications/crypto/controlse/index.rst raiden00@railab.me
-Documentation/applications/crypto/index.rst raiden00@railab.me
-Documentation/applications/crypto/libsodium/index.rst raiden00@railab.me
-Documentation/applications/crypto/libtomcrypt/index.rst raiden00@railab.me
-Documentation/applications/crypto/mbedtls/index.rst raiden00@railab.me
-Documentation/applications/crypto/tinycrypt/index.rst raiden00@railab.me
-Documentation/applications/crypto/tinydtls/index.rst raiden00@railab.me
-Documentation/applications/crypto/wolfssl/index.rst raiden00@railab.me
-Documentation/applications/examples/abntcodi/index.rst raiden00@railab.me
-Documentation/applications/examples/adc/index.rst raiden00@railab.me matteo.golin@gmail.com
-Documentation/applications/examples/adjtime/index.rst raiden00@railab.me
-Documentation/applications/examples/adxl372_test/index.rst raiden00@railab.me
-Documentation/applications/examples/ajoystick/index.rst raiden00@railab.me
-Documentation/applications/examples/alarm/index.rst raiden00@railab.me
-Documentation/applications/examples/apa102/index.rst raiden00@railab.me
-Documentation/applications/examples/apds9960/index.rst devel@sumpfralle.de raiden00@railab.me
-Documentation/applications/examples/audio_rttl/index.rst raiden00@railab.me
-Documentation/applications/examples/bastest/index.rst raiden00@railab.me
-Documentation/applications/examples/battery/index.rst raiden00@railab.me
-Documentation/applications/examples/bme680/index.rst raiden00@railab.me
-Documentation/applications/examples/bmi160/index.rst raiden00@railab.me
-Documentation/applications/examples/bmp180/index.rst raiden00@railab.me
-Documentation/applications/examples/bmp280/index.rst raiden00@railab.me
-Documentation/applications/examples/bridge/index.rst raiden00@railab.me
-Documentation/applications/examples/buttons/index.rst raiden00@railab.me
-Documentation/applications/examples/calib_udelay/index.rst raiden00@railab.me
-Documentation/applications/examples/camera/index.rst raiden00@railab.me devel@sumpfralle.de
-Documentation/applications/examples/can/index.rst raiden00@railab.me windsor.schmidt@gmail.com
-Documentation/applications/examples/capture/index.rst raiden00@railab.me
-Documentation/applications/examples/cbortest/index.rst raiden00@railab.me
-Documentation/applications/examples/cctype/index.rst raiden00@railab.me
-Documentation/applications/examples/chat/index.rst raiden00@railab.me
-Documentation/applications/examples/chrono/index.rst raiden00@railab.me
-Documentation/applications/examples/configdata/index.rst raiden00@railab.me
-Documentation/applications/examples/cordic/index.rst raiden00@railab.me
-Documentation/applications/examples/cpuhog/index.rst raiden00@railab.me
-Documentation/applications/examples/cromfs/index.rst raiden00@railab.me
-Documentation/applications/examples/dac/index.rst raiden00@railab.me
-Documentation/applications/examples/dhcpd/index.rst raiden00@railab.me
-Documentation/applications/examples/discover/index.rst raiden00@railab.me
-Documentation/applications/examples/djoystick/index.rst raiden00@railab.me
-Documentation/applications/examples/dronecan/index.rst raiden00@railab.me
-Documentation/applications/examples/elf/index.rst raiden00@railab.me laczenjms@gmail.com anchao.archer@bytedance.com windsor.schmidt@gmail.com
-Documentation/applications/examples/embedlog/index.rst raiden00@railab.me
-Documentation/applications/examples/esp32_himem/index.rst raiden00@railab.me
-Documentation/applications/examples/etl/index.rst raiden00@railab.me
-Documentation/applications/examples/fb/index.rst raiden00@railab.me
-Documentation/applications/examples/fboverlay/index.rst raiden00@railab.me
-Documentation/applications/examples/flash_test/index.rst raiden00@railab.me
-Documentation/applications/examples/flowc/index.rst raiden00@railab.me
-Documentation/applications/examples/fmsynth/index.rst raiden00@railab.me
-Documentation/applications/examples/foc/index.rst raiden00@railab.me
-Documentation/applications/examples/ft80x/index.rst raiden00@railab.me
-Documentation/applications/examples/ftpc/index.rst raiden00@railab.me
-Documentation/applications/examples/ftpd/index.rst raiden00@railab.me
-Documentation/applications/examples/fxos8700cq_test/index.rst raiden00@railab.me
-Documentation/applications/examples/gpio/index.rst raiden00@railab.me
+Documentation/applications/examples/elf/index.rst laczenjms@gmail.com anchao.archer@bytedance.com windsor.schmidt@gmail.com
 Documentation/applications/examples/gps/index.rst matteo.golin@gmail.com raiden00@railab.me
-Documentation/applications/examples/hall/index.rst raiden00@railab.me
-Documentation/applications/examples/hdc1008_demo/index.rst raiden00@railab.me
-Documentation/applications/examples/hello/index.rst raiden00@railab.me
-Documentation/applications/examples/hello_nim/index.rst raiden00@railab.me
-Documentation/applications/examples/hello_wasm/index.rst raiden00@railab.me
-Documentation/applications/examples/hello_zig/index.rst raiden00@railab.me
-Documentation/applications/examples/helloxx/index.rst raiden00@railab.me
-Documentation/applications/examples/hidkbd/index.rst raiden00@railab.me
-Documentation/applications/examples/hts221_reader/index.rst raiden00@railab.me
-Documentation/applications/examples/i2cchar/index.rst raiden00@railab.me
-Documentation/applications/examples/i2sloop/index.rst raiden00@railab.me
-Documentation/applications/examples/igmp/index.rst raiden00@railab.me
-Documentation/applications/examples/ina219/index.rst raiden00@railab.me
-Documentation/applications/examples/ina226/index.rst raiden00@railab.me 101105604+simbit18@users.noreply.github.com
-Documentation/applications/examples/index.rst raiden00@railab.me
-Documentation/applications/examples/ini_dumper/index.rst raiden00@railab.me
-Documentation/applications/examples/ipcfg/index.rst raiden00@railab.me
-Documentation/applications/examples/ipforward/index.rst raiden00@railab.me
-Documentation/applications/examples/json/index.rst raiden00@railab.me
-Documentation/applications/examples/keyboard/index.rst raiden00@railab.me
-Documentation/applications/examples/leds/index.rst raiden00@railab.me
 Documentation/applications/examples/leds_rust/index.rst luppy@appkaki.com
 Documentation/applications/examples/leds_zig/index.rst matheus-catarino@hotmail.com
-Documentation/applications/examples/libtest/index.rst raiden00@railab.me
-Documentation/applications/examples/lis3dsh_reader/index.rst raiden00@railab.me
-Documentation/applications/examples/lp503x/index.rst raiden00@railab.me
-Documentation/applications/examples/lsm303_reader/index.rst raiden00@railab.me
-Documentation/applications/examples/lsm6dsl_reader/index.rst raiden00@railab.me
-Documentation/applications/examples/ltr308/index.rst raiden00@railab.me
-Documentation/applications/examples/lua_module/index.rst raiden00@railab.me
-Documentation/applications/examples/lvgldemo/index.rst raiden00@railab.me
-Documentation/applications/examples/lvglterm/index.rst raiden00@railab.me
-Documentation/applications/examples/max31855/index.rst raiden00@railab.me
-Documentation/applications/examples/mcuboot/index.rst raiden00@railab.me filipe.cavalcanti@espressif.com acassis@gmail.com
-Documentation/applications/examples/media/index.rst raiden00@railab.me
-Documentation/applications/examples/mld/index.rst raiden00@railab.me
-Documentation/applications/examples/mlx90614/index.rst raiden00@railab.me
-Documentation/applications/examples/mml_parser/index.rst raiden00@railab.me
-Documentation/applications/examples/modbus/index.rst raiden00@railab.me
-Documentation/applications/examples/modbusmaster/index.rst raiden00@railab.me
-Documentation/applications/examples/module/index.rst raiden00@railab.me anchao.archer@bytedance.com
-Documentation/applications/examples/mount/index.rst raiden00@railab.me
-Documentation/applications/examples/mqttc/index.rst raiden00@railab.me
-Documentation/applications/examples/mtdpart/index.rst raiden00@railab.me
-Documentation/applications/examples/mtdrwb/index.rst raiden00@railab.me
-Documentation/applications/examples/netlink_route/index.rst raiden00@railab.me
-Documentation/applications/examples/netloop/index.rst raiden00@railab.me
-Documentation/applications/examples/netpkt/index.rst raiden00@railab.me
-Documentation/applications/examples/nettest/index.rst raiden00@railab.me
-Documentation/applications/examples/nimble/index.rst raiden00@railab.me
-Documentation/applications/examples/nng_test/index.rst raiden00@railab.me
-Documentation/applications/examples/noteprintf/index.rst raiden00@railab.me
-Documentation/applications/examples/nrf24l01_btle/index.rst raiden00@railab.me
-Documentation/applications/examples/nrf24l01_term/index.rst raiden00@railab.me
-Documentation/applications/examples/null/index.rst raiden00@railab.me
-Documentation/applications/examples/nunchuck/index.rst raiden00@railab.me
-Documentation/applications/examples/nx/index.rst raiden00@railab.me
-Documentation/applications/examples/nxdemo/index.rst raiden00@railab.me
-Documentation/applications/examples/nxflat/index.rst raiden00@railab.me
-Documentation/applications/examples/nxhello/index.rst raiden00@railab.me
-Documentation/applications/examples/nximage/index.rst raiden00@railab.me devel@sumpfralle.de
-Documentation/applications/examples/nxlines/index.rst raiden00@railab.me windsor.schmidt@gmail.com
-Documentation/applications/examples/nxscope/index.rst raiden00@railab.me
-Documentation/applications/examples/nxterm/index.rst raiden00@railab.me
-Documentation/applications/examples/nxtext/index.rst raiden00@railab.me
-Documentation/applications/examples/obd2/index.rst raiden00@railab.me
-Documentation/applications/examples/oneshot/index.rst raiden00@railab.me
-Documentation/applications/examples/opencyphal/index.rst raiden00@railab.me
-Documentation/applications/examples/pca9635/index.rst raiden00@railab.me
-Documentation/applications/examples/pdcurses/index.rst raiden00@railab.me
-Documentation/applications/examples/pf_ieee802154/index.rst raiden00@railab.me
-Documentation/applications/examples/pipe/index.rst raiden00@railab.me
-Documentation/applications/examples/poll/index.rst raiden00@railab.me
-Documentation/applications/examples/popen/index.rst raiden00@railab.me
-Documentation/applications/examples/posix_spawn/index.rst raiden00@railab.me anchao.archer@bytedance.com
-Documentation/applications/examples/powerled/index.rst raiden00@railab.me
-Documentation/applications/examples/powermonitor/index.rst raiden00@railab.me
-Documentation/applications/examples/pppd/index.rst raiden00@railab.me
-Documentation/applications/examples/pty_test/index.rst raiden00@railab.me
-Documentation/applications/examples/pwfb/index.rst raiden00@railab.me
-Documentation/applications/examples/pwlines/index.rst raiden00@railab.me
-Documentation/applications/examples/pwm/index.rst raiden00@railab.me
-Documentation/applications/examples/qencoder/index.rst raiden00@railab.me
-Documentation/applications/examples/random/index.rst raiden00@railab.me devel@sumpfralle.de
-Documentation/applications/examples/relays/index.rst raiden00@railab.me
-Documentation/applications/examples/rfid_readuid/index.rst raiden00@railab.me
-Documentation/applications/examples/rgbled/index.rst raiden00@railab.me
-Documentation/applications/examples/romfs/index.rst raiden00@railab.me
-Documentation/applications/examples/rpmsgsocket/index.rst raiden00@railab.me
-Documentation/applications/examples/rust/baremetal/index.rst huangqi3@xiaomi.com
-Documentation/applications/examples/rust/hello/index.rst huangqi3@xiaomi.com
-Documentation/applications/examples/rust/index.rst huangqi3@xiaomi.com
-Documentation/applications/examples/rust/slint/index.rst huangqi3@xiaomi.com
-Documentation/applications/examples/sendmail/index.rst raiden00@railab.me
-Documentation/applications/examples/serialblaster/index.rst raiden00@railab.me
-Documentation/applications/examples/serialrx/index.rst raiden00@railab.me
-Documentation/applications/examples/serloop/index.rst raiden00@railab.me windsor.schmidt@gmail.com
-Documentation/applications/examples/shm_test/index.rst raiden00@railab.me
-Documentation/applications/examples/sht3x/index.rst raiden00@railab.me
-Documentation/applications/examples/slcd/index.rst raiden00@railab.me
-Documentation/applications/examples/smps/index.rst raiden00@railab.me
-Documentation/applications/examples/sotest/index.rst raiden00@railab.me windsor.schmidt@gmail.com anchao.archer@bytedance.com
+Documentation/applications/examples/mcuboot/index.rst filipe.cavalcanti@espressif.com acassis@gmail.com
+Documentation/applications/examples/module/index.rst anchao.archer@bytedance.com
+Documentation/applications/examples/sotest/index.rst windsor.schmidt@gmail.com anchao.archer@bytedance.com
 Documentation/applications/examples/spislv_test/index.rst moura.fmo@gmail.com
-Documentation/applications/examples/stat/index.rst raiden00@railab.me
-Documentation/applications/examples/sx127x_demo/index.rst raiden00@railab.me
-Documentation/applications/examples/system/index.rst raiden00@railab.me
-Documentation/applications/examples/tcp_ipc_client/index.rst raiden00@railab.me acassis@gmail.com
-Documentation/applications/examples/tcp_ipc_server/index.rst raiden00@railab.me acassis@gmail.com
-Documentation/applications/examples/tcpblaster/index.rst raiden00@railab.me
-Documentation/applications/examples/tcpecho/index.rst raiden00@railab.me
-Documentation/applications/examples/telnetd/index.rst raiden00@railab.me
-Documentation/applications/examples/termios/index.rst raiden00@railab.me
-Documentation/applications/examples/thttpd/index.rst raiden00@railab.me
-Documentation/applications/examples/tiff/index.rst raiden00@railab.me
-Documentation/applications/examples/timer/index.rst raiden00@railab.me
-Documentation/applications/examples/timer_gpio/index.rst raiden00@railab.me
-Documentation/applications/examples/touchscreen/index.rst raiden00@railab.me
-Documentation/applications/examples/udgram/index.rst raiden00@railab.me
-Documentation/applications/examples/udp/index.rst raiden00@railab.me
-Documentation/applications/examples/udpblaster/index.rst raiden00@railab.me
-Documentation/applications/examples/uid/index.rst raiden00@railab.me
-Documentation/applications/examples/unionfs/index.rst raiden00@railab.me
-Documentation/applications/examples/usbserial/index.rst raiden00@railab.me windsor.schmidt@gmail.com devel@sumpfralle.de
-Documentation/applications/examples/userfs/index.rst raiden00@railab.me
-Documentation/applications/examples/usrsocktest/index.rst raiden00@railab.me
-Documentation/applications/examples/ustream/index.rst raiden00@railab.me
-Documentation/applications/examples/veml6070/index.rst raiden00@railab.me
-Documentation/applications/examples/watchdog/index.rst raiden00@railab.me
-Documentation/applications/examples/watcher/index.rst raiden00@railab.me
-Documentation/applications/examples/webserver/index.rst raiden00@railab.me
-Documentation/applications/examples/wget/index.rst raiden00@railab.me
-Documentation/applications/examples/wgetjson/index.rst raiden00@railab.me
-Documentation/applications/examples/wiegand/index.rst raiden00@railab.me
-Documentation/applications/examples/ws2812/index.rst raiden00@railab.me
-Documentation/applications/examples/ws2812esp32rmt/index.rst raiden00@railab.me
-Documentation/applications/examples/xbc_test/index.rst raiden00@railab.me
-Documentation/applications/examples/xedge_demo/index.rst jorge.gzm@gmail.com
-Documentation/applications/examples/xmlrpc/index.rst raiden00@railab.me
-Documentation/applications/examples/zerocross/index.rst raiden00@railab.me
-Documentation/applications/fsutils/flash_eraseall/index.rst raiden00@railab.me
-Documentation/applications/fsutils/index.rst raiden00@railab.me
-Documentation/applications/fsutils/inifile/index.rst raiden00@railab.me
-Documentation/applications/fsutils/inih/index.rst raiden00@railab.me
-Documentation/applications/fsutils/ipcfg/index.rst raiden00@railab.me
-Documentation/applications/fsutils/libtinycbor/index.rst raiden00@railab.me
-Documentation/applications/fsutils/mkfatfs/index.rst raiden00@railab.me
-Documentation/applications/fsutils/mkgpt/index.rst raiden00@railab.me
-Documentation/applications/fsutils/mkmbr/index.rst raiden00@railab.me
-Documentation/applications/fsutils/mksmartfs/index.rst raiden00@railab.me
-Documentation/applications/fsutils/passwd/index.rst raiden00@railab.me
-Documentation/applications/games/brickmatch/index.rst raiden00@railab.me eren.terzioglu@espressif.com acassis@gmail.com
-Documentation/applications/games/index.rst acassis@gmail.com raiden00@railab.me
+Documentation/applications/examples/usbserial/index.rst windsor.schmidt@gmail.com devel@sumpfralle.de
+Documentation/applications/games/brickmatch/index.rst eren.terzioglu@espressif.com acassis@gmail.com
 Documentation/applications/games/match4/index.rst eren.terzioglu@espressif.com
 Documentation/applications/games/snake/index.rst eren.terzioglu@espressif.com
-Documentation/applications/graphics/ft80x/index.rst raiden00@railab.me
-Documentation/applications/graphics/index.rst raiden00@railab.me
-Documentation/applications/graphics/libjpeg/index.rst raiden00@railab.me
-Documentation/applications/graphics/libyuv/index.rst raiden00@railab.me
-Documentation/applications/graphics/lvgl/index.rst raiden00@railab.me
-Documentation/applications/graphics/nxwidgets/index.rst raiden00@railab.me devel@sumpfralle.de
-Documentation/applications/graphics/nxwm/cnxconsole.rst raiden00@railab.me devel@sumpfralle.de 59230071+hartmannathan@users.noreply.github.com
-Documentation/applications/graphics/nxwm/index.rst raiden00@railab.me
-Documentation/applications/graphics/pdcurs34/index.rst raiden00@railab.me
-Documentation/applications/graphics/screenshot/index.rst raiden00@railab.me
-Documentation/applications/graphics/slcd/index.rst raiden00@railab.me
-Documentation/applications/graphics/tiff/index.rst raiden00@railab.me
-Documentation/applications/graphics/twm4nx/index.rst raiden00@railab.me devel@sumpfralle.de
-Documentation/applications/index.rst raiden00@railab.me matias@protobits.dev xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com lucas.vaz@espressif.com
-Documentation/applications/industry/abnt_codi/index.rst raiden00@railab.me devel@sumpfralle.de
-Documentation/applications/industry/foc/index.rst raiden00@railab.me
-Documentation/applications/industry/index.rst raiden00@railab.me
-Documentation/applications/industry/modbus/index.rst raiden00@railab.me
-Documentation/applications/industry/scpi/index.rst raiden00@railab.me
-Documentation/applications/inertial/index.rst raiden00@railab.me
-Documentation/applications/inertial/madgwick/index.rst raiden00@railab.me
-Documentation/applications/interpreters/bas/index.rst raiden00@railab.me
-Documentation/applications/interpreters/duktape/index.rst raiden00@railab.me
-Documentation/applications/interpreters/ficl/index.rst raiden00@railab.me
-Documentation/applications/interpreters/index.rst raiden00@railab.me
-Documentation/applications/interpreters/lua/index.rst raiden00@railab.me
-Documentation/applications/interpreters/luajit/index.rst raiden00@railab.me
-Documentation/applications/interpreters/minibasic/index.rst raiden00@railab.me devel@sumpfralle.de
 Documentation/applications/interpreters/python/index.rst tiago.medicci@espressif.com
-Documentation/applications/interpreters/quickjs/index.rst raiden00@railab.me
-Documentation/applications/interpreters/toywasm/index.rst raiden00@railab.me
-Documentation/applications/interpreters/wamr/index.rst yfliu2008@qq.com raiden00@railab.me
-Documentation/applications/interpreters/wasm3/index.rst raiden00@railab.me
-Documentation/applications/logging/embedlog/index.rst raiden00@railab.me
-Documentation/applications/logging/index.rst raiden00@railab.me
-Documentation/applications/logging/nxscope/index.rst raiden00@railab.me
-Documentation/applications/lte/alt1250/index.rst raiden00@railab.me
-Documentation/applications/lte/index.rst raiden00@railab.me
-Documentation/applications/lte/lapi/index.rst raiden00@railab.me
-Documentation/applications/math/index.rst raiden00@railab.me
-Documentation/applications/math/libtommath/index.rst raiden00@railab.me
-Documentation/applications/mlearing/cmsis/index.rst raiden00@railab.me
-Documentation/applications/mlearing/darknet/index.rst raiden00@railab.me
-Documentation/applications/mlearing/index.rst raiden00@railab.me
-Documentation/applications/mlearing/libnnablart/index.rst raiden00@railab.me
-Documentation/applications/netutils/chat/index.rst raiden00@railab.me
-Documentation/applications/netutils/cjson/index.rst raiden00@railab.me
-Documentation/applications/netutils/codecs/index.rst raiden00@railab.me
-Documentation/applications/netutils/cwebsocket/index.rst raiden00@railab.me
-Documentation/applications/netutils/dhcp6c/index.rst raiden00@railab.me
-Documentation/applications/netutils/dhcpc/index.rst raiden00@railab.me
-Documentation/applications/netutils/dhcpd/index.rst raiden00@railab.me
-Documentation/applications/netutils/discover/index.rst raiden00@railab.me
-Documentation/applications/netutils/esp8266/index.rst raiden00@railab.me
-Documentation/applications/netutils/esp8266/index/rst raiden00@railab.me
-Documentation/applications/netutils/ftpc/index.rst raiden00@railab.me
-Documentation/applications/netutils/ftpd/index.rst raiden00@railab.me
-Documentation/applications/netutils/index.rst raiden00@railab.me
-Documentation/applications/netutils/iper/index.rst raiden00@railab.me
-Documentation/applications/netutils/iptables/index.rst acassis@gmail.com raiden00@railab.me
-Documentation/applications/netutils/libcurl4nx/index.rst raiden00@railab.me
-Documentation/applications/netutils/mqttc/index.rst raiden00@railab.me
-Documentation/applications/netutils/netcat/index.rst raiden00@railab.me
-Documentation/applications/netutils/netinit/index.rst raiden00@railab.me
-Documentation/applications/netutils/netlib/index.rst raiden00@railab.me
-Documentation/applications/netutils/nng/index.rst raiden00@railab.me
-Documentation/applications/netutils/ntpclient/index.rst raiden00@railab.me
-Documentation/applications/netutils/ping/index.rst raiden00@railab.me
-Documentation/applications/netutils/pppd/index.rst raiden00@railab.me
-Documentation/applications/netutils/ptpd/index.rst raiden00@railab.me
-Documentation/applications/netutils/rexec/index.rst raiden00@railab.me
-Documentation/applications/netutils/rexecd/index.rst raiden00@railab.me
-Documentation/applications/netutils/rtptools/index.rst raiden00@railab.me
-Documentation/applications/netutils/smtp/index.rst raiden00@railab.me
-Documentation/applications/netutils/telnetc/index.rst raiden00@railab.me
-Documentation/applications/netutils/telnetd/index.rst raiden00@railab.me
-Documentation/applications/netutils/tftpc/index.rst raiden00@railab.me
-Documentation/applications/netutils/thttpd/index.rst raiden00@railab.me
-Documentation/applications/netutils/wakaama/index.rst raiden00@railab.me
-Documentation/applications/netutils/wakeonlan/index.rst raiden00@railab.me
-Documentation/applications/netutils/webclient/index.rst raiden00@railab.me
-Documentation/applications/netutils/webserver/index.rst raiden00@railab.me
-Documentation/applications/netutils/xmlrpc/index.rst raiden00@railab.me
 Documentation/applications/nsh/builtin.rst xiaoxiang@xiaomi.com raiden00@railab.me
-Documentation/applications/nsh/commands.rst xiaoxiang@xiaomi.com raiden00@railab.me bashton@brennanashton.com zhengjunbo1@xiaomi.com yinshengkai@xiaomi.com
+Documentation/applications/nsh/commands.rst xiaoxiang@xiaomi.com bashton@brennanashton.com zhengjunbo1@xiaomi.com yinshengkai@xiaomi.com
 Documentation/applications/nsh/config.rst xiaoxiang@xiaomi.com bashton@brennanashton.com fangxinyong@xiaomi.com dongjiuzhu1@xiaomi.com raiden00@railab.me
 Documentation/applications/nsh/customizing.rst xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com raiden00@railab.me
 Documentation/applications/nsh/index.rst xiaoxiang@xiaomi.com raiden00@railab.me
-Documentation/applications/nsh/installation.rst xiaoxiang@xiaomi.com fangxinyong@xiaomi.com dongjiuzhu1@xiaomi.com raiden00@railab.me liguiding1@xiaomi.com
-Documentation/applications/nsh/login.rst xiaoxiang@xiaomi.com raiden00@railab.me 59230071+hartmannathan@users.noreply.github.com devel@sumpfralle.de dongjiuzhu1@xiaomi.com
-Documentation/applications/nsh/nsh.rst xiaoxiang@xiaomi.com fangxinyong@xiaomi.com dongjiuzhu1@xiaomi.com raiden00@railab.me 101105604+simbit18@users.noreply.github.com
-Documentation/applications/nsh/running_apps.rst raiden00@railab.me devel@sumpfralle.de
-Documentation/applications/sdr/index.rst raiden00@railab.me windsor.schmidt@gmail.com
-Documentation/applications/sdr/liquid_dsp/index.rst raiden00@railab.me
-Documentation/applications/system/adb/index.rst raiden00@railab.me
-Documentation/applications/system/argtable3/index.rst raiden00@railab.me
-Documentation/applications/system/cdcacm/index.rst raiden00@railab.me
-Documentation/applications/system/cfgdata/index.rst raiden00@railab.me
-Documentation/applications/system/cle/index.rst raiden00@railab.me
-Documentation/applications/system/composite/index.rst raiden00@railab.me
-Documentation/applications/system/coredump/index.rst raiden00@railab.me
-Documentation/applications/system/crimon/index.rst devel@sumpfralle.de raiden00@railab.me
-Documentation/applications/system/cu/index.rst raiden00@railab.me
-Documentation/applications/system/dd/index.rst raiden00@railab.me
-Documentation/applications/system/debugpoint/index.rst huangqi3@xiaomi.com
-Documentation/applications/system/dhcp6c/index.rst raiden00@railab.me
-Documentation/applications/system/dhcpc/index.rst raiden00@railab.me
-Documentation/applications/system/dumpstack/index.rst raiden00@railab.me
-Documentation/applications/system/fastboot/index.rst 140773670+JianyuWang0623@users.noreply.github.com raiden00@railab.me wangjianyu3@xiaomi.com
-Documentation/applications/system/fdt/index.rst raiden00@railab.me
-Documentation/applications/system/flash_eraseall/index.rst raiden00@railab.me
+Documentation/applications/nsh/installation.rst xiaoxiang@xiaomi.com fangxinyong@xiaomi.com dongjiuzhu1@xiaomi.com liguiding1@xiaomi.com
+Documentation/applications/nsh/login.rst xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com devel@sumpfralle.de dongjiuzhu1@xiaomi.com
+Documentation/applications/nsh/nsh.rst xiaoxiang@xiaomi.com fangxinyong@xiaomi.com dongjiuzhu1@xiaomi.com 101105604+simbit18@users.noreply.github.com
+Documentation/applications/nsh/running_apps.rst devel@sumpfralle.de
+Documentation/applications/sdr/index.rst windsor.schmidt@gmail.com
+Documentation/applications/system/fastboot/index.rst 140773670+JianyuWang0623@users.noreply.github.com wangjianyu3@xiaomi.com
 Documentation/applications/system/gcov/index.rst wangmingrong1@xiaomi.com raiden00@railab.me
-Documentation/applications/system/gdbstub/index.rst raiden00@railab.me
 Documentation/applications/system/gprof/index.rst yinshengkai@xiaomi.com
-Documentation/applications/system/hex2bin/index.rst raiden00@railab.me
-Documentation/applications/system/hexed/index.rst raiden00@railab.me
-Documentation/applications/system/hostname/index.rst raiden00@railab.me
-Documentation/applications/system/i2c/index.rst raiden00@railab.me devel@sumpfralle.de
-Documentation/applications/system/index.rst raiden00@railab.me
-Documentation/applications/system/input/index.rst raiden00@railab.me
-Documentation/applications/system/iptables/index.rst raiden00@railab.me
-Documentation/applications/system/libuv/index.rst raiden00@railab.me acassis@gmail.com
-Documentation/applications/system/lm75/index.rst raiden00@railab.me
-Documentation/applications/system/lzf/index.rst raiden00@railab.me
-Documentation/applications/system/mdio/index.rst raiden00@railab.me
-Documentation/applications/system/netdb/index.rst raiden00@railab.me
-Documentation/applications/system/nsh/index.rst raiden00@railab.me
-Documentation/applications/system/ntpc/index.rst raiden00@railab.me
-Documentation/applications/system/nxcamera/index.rst raiden00@railab.me
 Documentation/applications/system/nxcodec/index.rst shizhenghui@xiaomi.com devel@sumpfralle.de
-Documentation/applications/system/nxdiag/config.rst raiden00@railab.me
-Documentation/applications/system/nxdiag/index.rst raiden00@railab.me eren.terzioglu@espressif.com
-Documentation/applications/system/nxlooper/index.rst raiden00@railab.me
-Documentation/applications/system/nxplayer/index.rst raiden00@railab.me
-Documentation/applications/system/nxrecorder/index.rst raiden00@railab.me
-Documentation/applications/system/ofloader/index.rst raiden00@railab.me
-Documentation/applications/system/ping/index.rst raiden00@railab.me
-Documentation/applications/system/ping6/index.rst raiden00@railab.me
-Documentation/applications/system/popen/index.rst raiden00@railab.me
-Documentation/applications/system/psmq/index.rst raiden00@railab.me
-Documentation/applications/system/ptpd/index.rst raiden00@railab.me
-Documentation/applications/system/readline/index.rst raiden00@railab.me
-Documentation/applications/system/sched_note/index.rst raiden00@railab.me
-Documentation/applications/system/setlogmask/index.rst raiden00@railab.me
-Documentation/applications/system/spi/index.rst raiden00@railab.me acassis@gmail.com devel@sumpfralle.de
-Documentation/applications/system/stackmonitor/index.rst raiden00@railab.me
+Documentation/applications/system/nxdiag/index.rst eren.terzioglu@espressif.com
 Documentation/applications/system/syslogd/index.rst matteo.golin@gmail.com
-Documentation/applications/system/system/index.rst raiden00@railab.me
-Documentation/applications/system/taskset/index.rst raiden00@railab.me
-Documentation/applications/system/tcpdump/index.rst raiden00@railab.me
-Documentation/applications/system/tee/index.rst raiden00@railab.me
-Documentation/applications/system/telnet/index.rst raiden00@railab.me
-Documentation/applications/system/telnetd/index.rst raiden00@railab.me
-Documentation/applications/system/termcurses/index.rst raiden00@railab.me
-Documentation/applications/system/trace/index.rst raiden00@railab.me
-Documentation/applications/system/ubloxmodem/index.rst raiden00@railab.me
-Documentation/applications/system/uniqueid/index.rst raiden00@railab.me
-Documentation/applications/system/uorb/index.rst dongjiuzhu1@xiaomi.com anchao.archer@bytedance.com raiden00@railab.me xiaoxiang@xiaomi.com
-Documentation/applications/system/usbmsc/index.rst raiden00@railab.me
-Documentation/applications/system/vi/index.rst raiden00@railab.me
-Documentation/applications/system/ymodem/index.rst raiden00@railab.me acassis@gmail.com devel@sumpfralle.de
-Documentation/applications/system/zlib/index.rst raiden00@railab.me
-Documentation/applications/system/zmodem/index.rst raiden00@railab.me devel@sumpfralle.de windsor.schmidt@gmail.com
-Documentation/applications/testing/arch_libc/index.rst raiden00@railab.me
-Documentation/applications/testing/atomic/index.rst raiden00@railab.me
-Documentation/applications/testing/batterydump/index.rst raiden00@railab.me
-Documentation/applications/testing/cmocka/index.rst raiden00@railab.me
-Documentation/applications/testing/cpuload/index.rst raiden00@railab.me
-Documentation/applications/testing/crypto/index.rst raiden00@railab.me
-Documentation/applications/testing/cxxtest/index.rst raiden00@railab.me devel@sumpfralle.de
+Documentation/applications/system/uorb/index.rst dongjiuzhu1@xiaomi.com anchao.archer@bytedance.com xiaoxiang@xiaomi.com
+Documentation/applications/system/ymodem/index.rst acassis@gmail.com devel@sumpfralle.de
+Documentation/applications/system/zmodem/index.rst devel@sumpfralle.de windsor.schmidt@gmail.com
+Documentation/applications/testing/cxxtest/index.rst devel@sumpfralle.de
 Documentation/applications/testing/drivertest/index.rst buxiasen@xiaomi.com raiden00@railab.me
-Documentation/applications/testing/fatutf8/index.rst raiden00@railab.me
-Documentation/applications/testing/fdsantest/index.rst raiden00@railab.me
 Documentation/applications/testing/fmemopen/index.rst michallenc@seznam.cz
-Documentation/applications/testing/fopencookie/index.rst raiden00@railab.me
-Documentation/applications/testing/fstest/index.rst raiden00@railab.me
 Documentation/applications/testing/getprime/index.rst matteo.golin@gmail.com raiden00@railab.me
-Documentation/applications/testing/index.rst raiden00@railab.me michallenc@seznam.cz
-Documentation/applications/testing/irtest/index.rst raiden00@railab.me
-Documentation/applications/testing/lpt/index.rst raiden00@railab.me
 Documentation/applications/testing/memstress/index.rst crafcat7@outlook.com
-Documentation/applications/testing/memtester/index.rst raiden00@railab.me
-Documentation/applications/testing/mm/index.rst raiden00@railab.me
-Documentation/applications/testing/monkey/index.rst raiden00@railab.me
-Documentation/applications/testing/mtd_config_fs/index.rst raiden00@railab.me
 Documentation/applications/testing/nand_sim/index.rst resyfer.dev@gmail.com devel@sumpfralle.de
-Documentation/applications/testing/nist-sts/index.rst raiden00@railab.me
-Documentation/applications/testing/nxfss/index.rst raiden00@railab.me
 Documentation/applications/testing/open_memstream/index.rst michallenc@seznam.cz
-Documentation/applications/testing/ostest/index.rst raiden00@railab.me
 Documentation/applications/testing/ramtest/index.rst crafcat7@outlook.com
-Documentation/applications/testing/scanftest/index.rst raiden00@railab.me
 Documentation/applications/testing/sd_bench/index.rst stuart.ianna@motec.com.au
 Documentation/applications/testing/sd_stress/index.rst stuart.ianna@motec.com.au raiden00@railab.me
-Documentation/applications/testing/sensortest/index.rst raiden00@railab.me
-Documentation/applications/testing/setest/index.rst raiden00@railab.me
-Documentation/applications/testing/smart/index.rst raiden00@railab.me
-Documentation/applications/testing/smart_test/index.rst raiden00@railab.me
-Documentation/applications/testing/smp/index.rst raiden00@railab.me
-Documentation/applications/testing/uclibcxx_test/index.rst raiden00@railab.me
 Documentation/applications/testing/unity/index.rst matteo.golin@gmail.com raiden00@railab.me
-Documentation/applications/tools/index.rst raiden00@railab.me windsor.schmidt@gmail.com devel@sumpfralle.de
-Documentation/applications/wireless/btsak/index.rst raiden00@railab.me windsor.schmidt@gmail.com
-Documentation/applications/wireless/gs2200m/index.rst raiden00@railab.me
-Documentation/applications/wireless/i8sak/index.rst raiden00@railab.me devel@sumpfralle.de
-Documentation/applications/wireless/i8shark/index.rst raiden00@railab.me
-Documentation/applications/wireless/index.rst raiden00@railab.me
-Documentation/applications/wireless/ipwan/index.rst raiden00@railab.me
-Documentation/applications/wireless/libmac/index.rst raiden00@railab.me
-Documentation/applications/wireless/nimble/index.rst raiden00@railab.me
-Documentation/applications/wireless/nimble/porting.rst raiden00@railab.me
-Documentation/applications/wireless/wapi/commands.rst raiden00@railab.me
-Documentation/applications/wireless/wapi/index.rst raiden00@railab.me
-Documentation/applications/wireless/wapi/wireless.rst raiden00@railab.me
-Documentation/components/arch/index.rst raiden00@railab.me
-Documentation/components/audio/index.rst raiden00@railab.me
+Documentation/applications/tools/index.rst windsor.schmidt@gmail.com devel@sumpfralle.de
+Documentation/applications/wireless/btsak/index.rst windsor.schmidt@gmail.com
+Documentation/applications/wireless/i8sak/index.rst devel@sumpfralle.de
+
+Documentation/components/* raiden00@railab.me
 Documentation/components/binfmt.rst matias@protobits.dev xiaoxiang@xiaomi.com code@bje.id.au bashton@brennanashton.com devel@sumpfralle.de
-Documentation/components/boards.rst raiden00@railab.me
-Documentation/components/cmake.rst raiden00@railab.me
-Documentation/components/crypto.rst raiden00@railab.me
-Documentation/components/drivers/block/index.rst raiden00@railab.me matias@protobits.dev bashton@brennanashton.com xiaoxiang@xiaomi.com
-Documentation/components/drivers/block/ramdisk.rst raiden00@railab.me
-Documentation/components/drivers/character/1wire.rst raiden00@railab.me
-Documentation/components/drivers/character/analog/adc/adc1242/index.rst michallenc@seznam.cz
+Documentation/components/drivers/block/index.rst matias@protobits.dev bashton@brennanashton.com xiaoxiang@xiaomi.com
+
+Documentation/components/drivers/character/analog/* michallenc@seznam.cz
 Documentation/components/drivers/character/analog/adc/ads1115/index.rst 99093620+justapotato213@users.noreply.github.com matteo.golin@gmail.com devel@sumpfralle.de
-Documentation/components/drivers/character/analog/adc/ads7828/index.rst michallenc@seznam.cz
-Documentation/components/drivers/character/analog/adc/hx711/index.rst michallenc@seznam.cz devel@sumpfralle.de
-Documentation/components/drivers/character/analog/adc/index.rst michallenc@seznam.cz
-Documentation/components/drivers/character/analog/adc/ltc1867l/index.rst michallenc@seznam.cz
-Documentation/components/drivers/character/analog/adc/max1161x/index.rst michallenc@seznam.cz
+Documentation/components/drivers/character/analog/adc/hx711/index.rst devel@sumpfralle.de
 Documentation/components/drivers/character/analog/adc/mcp3008/index.rst matteo.golin@gmail.com
-Documentation/components/drivers/character/analog/adc/pga11x/index.rst michallenc@seznam.cz
-Documentation/components/drivers/character/analog/dac/dac7554/index.rst michallenc@seznam.cz
-Documentation/components/drivers/character/analog/dac/dac7571/index.rst michallenc@seznam.cz
-Documentation/components/drivers/character/analog/dac/index.rst michallenc@seznam.cz devel@sumpfralle.de
+Documentation/components/drivers/character/analog/dac/index.rst devel@sumpfralle.de
 Documentation/components/drivers/character/analog/dac/mcp47x6/index.rst devel@sumpfralle.de
-Documentation/components/drivers/character/analog/dac/mcp48xx/index.rst michallenc@seznam.cz
-Documentation/components/drivers/character/analog/index.rst michallenc@seznam.cz
-Documentation/components/drivers/character/bch.rst raiden00@railab.me
-Documentation/components/drivers/character/can.rst matias@protobits.dev raiden00@railab.me zhaohaiyang1@xiaomi.com
-Documentation/components/drivers/character/contactless.rst raiden00@railab.me
-Documentation/components/drivers/character/crypto/index.rst raiden00@railab.me
-Documentation/components/drivers/character/crypto/se05x.rst raiden00@railab.me
-Documentation/components/drivers/character/eeprom.rst raiden00@railab.me
-Documentation/components/drivers/character/efuse.rst raiden00@railab.me
-Documentation/components/drivers/character/i2s.rst raiden00@railab.me
-Documentation/components/drivers/character/index.rst matias@protobits.dev raiden00@railab.me bashton@brennanashton.com xiaoxiang@xiaomi.com michallenc@seznam.cz
-Documentation/components/drivers/character/input/index.rst raiden00@railab.me acassis@gmail.com
-Documentation/components/drivers/character/input/keypad.rst raiden00@railab.me
-Documentation/components/drivers/character/input/sbutton.rst acassis@gmail.com
-Documentation/components/drivers/character/ipcc.rst raiden00@railab.me
-Documentation/components/drivers/character/leds/index.rst raiden00@railab.me jlange@2g-eng.com acassis@gmail.com
+
+Documentation/components/drivers/character/* raiden00@railab.me
+Documentation/components/drivers/character/can.rst matias@protobits.dev zhaohaiyang1@xiaomi.com
+Documentation/components/drivers/character/index.rst matias@protobits.dev bashton@brennanashton.com xiaoxiang@xiaomi.com michallenc@seznam.cz
+Documentation/components/drivers/character/input/index.rst acassis@gmail.com
+Documentation/components/drivers/character/leds/index.rst jlange@2g-eng.com acassis@gmail.com
 Documentation/components/drivers/character/leds/ktd2052.rst jlange@2g-eng.com
 Documentation/components/drivers/character/leds/userled.rst acassis@gmail.com devel@sumpfralle.de
-Documentation/components/drivers/character/leds/ws2812.rst raiden00@railab.me
-Documentation/components/drivers/character/loop.rst raiden00@railab.me
-Documentation/components/drivers/character/math.rst raiden00@railab.me
-Documentation/components/drivers/character/modem.rst raiden00@railab.me
-Documentation/components/drivers/character/motor/foc.rst raiden00@railab.me
-Documentation/components/drivers/character/motor/index.rst raiden00@railab.me
 Documentation/components/drivers/character/note.rst xiaoxiang@xiaomi.com Yuuichi.A.Nakamura@sony.com yinshengkai@xiaomi.com devel@sumpfralle.de
-Documentation/components/drivers/character/nullzero.rst raiden00@railab.me
-Documentation/components/drivers/character/quadrature.rst michallenc@seznam.cz matias@protobits.dev raiden00@railab.me devel@sumpfralle.de
-Documentation/components/drivers/character/rc.rst raiden00@railab.me
-Documentation/components/drivers/character/rf.rst raiden00@railab.me
+Documentation/components/drivers/character/quadrature.rst michallenc@seznam.cz matias@protobits.dev devel@sumpfralle.de
 Documentation/components/drivers/character/serial.rst matias@protobits.dev liguiding1@xiaomi.com acassis@gmail.com 59230071+hartmannathan@users.noreply.github.com bashton@brennanashton.com
 Documentation/components/drivers/character/timers/capture.rst 44554692+comejv@users.noreply.github.com
-Documentation/components/drivers/character/timers/index.rst raiden00@railab.me 44554692+comejv@users.noreply.github.com
-Documentation/components/drivers/character/timers/pwm.rst michallenc@seznam.cz raiden00@railab.me devel@sumpfralle.de
-Documentation/components/drivers/character/timers/rtc.rst raiden00@railab.me
-Documentation/components/drivers/character/timers/timer.rst raiden00@railab.me
-Documentation/components/drivers/character/timers/watchdog.rst raiden00@railab.me
+Documentation/components/drivers/character/timers/index.rst 44554692+comejv@users.noreply.github.com
+Documentation/components/drivers/character/timers/pwm.rst michallenc@seznam.cz devel@sumpfralle.de
 Documentation/components/drivers/character/touchscreen.rst matias@protobits.dev rongyichang@xiaomi.com raiden00@railab.me
 Documentation/components/drivers/character/wireless/index.rst kevinwit1999@gmail.com
 Documentation/components/drivers/character/wireless/lpwan/index.rst kevinwit1999@gmail.com
 Documentation/components/drivers/character/wireless/lpwan/sx126x.rst kevinwit1999@gmail.com devel@sumpfralle.de
+
 Documentation/components/drivers/index.rst matias@protobits.dev raiden00@railab.me xuxingliang@xiaomi.com dongjiuzhu1@xiaomi.com xiaoxiang@xiaomi.com
 Documentation/components/drivers/special/audio.rst raiden00@railab.me
 Documentation/components/drivers/special/clk.rst raiden00@railab.me
@@ -584,110 +119,59 @@ Documentation/components/drivers/special/rptun.rst raiden00@railab.me
 Documentation/components/drivers/special/rwbuffer.rst raiden00@railab.me
 Documentation/components/drivers/special/sdio.rst matias@protobits.dev
 Documentation/components/drivers/special/segger.rst raiden00@railab.me neo.xu1990@gmail.com
+
 Documentation/components/drivers/special/sensors.rst raiden00@railab.me matteo.golin@gmail.com devel@sumpfralle.de elias.hawa2468@gmail.com online@bskdany.com
-Documentation/components/drivers/special/sensors/adt7320.rst matteo.golin@gmail.com
-Documentation/components/drivers/special/sensors/adxl345.rst matteo.golin@gmail.com
-Documentation/components/drivers/special/sensors/adxl362.rst matteo.golin@gmail.com
-Documentation/components/drivers/special/sensors/adxl372.rst matteo.golin@gmail.com
-Documentation/components/drivers/special/sensors/aht10.rst matteo.golin@gmail.com
-Documentation/components/drivers/special/sensors/ak09912.rst matteo.golin@gmail.com
-Documentation/components/drivers/special/sensors/gnss_lowerhalf.rst matteo.golin@gmail.com
+Documentation/components/drivers/special/sensors/* matteo.golin@gmail.com
 Documentation/components/drivers/special/sensors/l86xxx.rst elias.hawa2468@gmail.com matteo.golin@gmail.com
-Documentation/components/drivers/special/sensors/lis2mdl.rst matteo.golin@gmail.com
-Documentation/components/drivers/special/sensors/lsm330.rst matteo.golin@gmail.com
-Documentation/components/drivers/special/sensors/lsm6dso32.rst matteo.golin@gmail.com
-Documentation/components/drivers/special/sensors/mcp9600.rst matteo.golin@gmail.com
-Documentation/components/drivers/special/sensors/mpl115a.rst matteo.golin@gmail.com
 Documentation/components/drivers/special/sensors/nau7802.rst online@bskdany.com devel@sumpfralle.de
 Documentation/components/drivers/special/sensors/sensors_cluster.rst raiden00@railab.me devel@sumpfralle.de
-Documentation/components/drivers/special/sensors/sensors_legacy.rst raiden00@railab.me devel@sumpfralle.de matteo.golin@gmail.com
-Documentation/components/drivers/special/sensors/sensors_uorb.rst raiden00@railab.me matteo.golin@gmail.com dongjiuzhu1@xiaomi.com devel@sumpfralle.de online@bskdany.com
-Documentation/components/drivers/special/sensors/sht4x.rst matteo.golin@gmail.com
+Documentation/components/drivers/special/sensors/sensors_legacy.rst raiden00@railab.me devel@sumpfralle.de
+Documentation/components/drivers/special/sensors/sensors_uorb.rst raiden00@railab.me dongjiuzhu1@xiaomi.com devel@sumpfralle.de online@bskdany.com
+
+Documentation/components/drivers/special/* raiden00@railab.me
 Documentation/components/drivers/special/spi.rst matias@protobits.dev
 Documentation/components/drivers/special/syslog.rst xiaoxiang@xiaomi.com matteo.golin@gmail.com yinshengkai@xiaomi.com anchao@lixiang.com f.j.panag@gmail.com
 Documentation/components/drivers/special/usbdev.rst matias@protobits.dev bashton@brennanashton.com
 Documentation/components/drivers/special/usbhost.rst matias@protobits.dev yfliu2008@qq.com devel@sumpfralle.de
-Documentation/components/drivers/special/usbmisc.rst raiden00@railab.me
-Documentation/components/drivers/special/usbmonitor.rst wangjianyu3@xiaomi.com devel@sumpfralle.de raiden00@railab.me
+Documentation/components/drivers/special/usbmonitor.rst wangjianyu3@xiaomi.com devel@sumpfralle.de
 Documentation/components/drivers/special/usbmonitor_wireshark_linux_example_adb.pcapng wangjianyu3@xiaomi.com
-Documentation/components/drivers/special/usrsock.rst raiden00@railab.me
-Documentation/components/drivers/special/video.rst raiden00@railab.me
-Documentation/components/drivers/special/virtio.rst raiden00@railab.me
-Documentation/components/drivers/special/wireless.rst matteo.golin@gmail.com raiden00@railab.me
 Documentation/components/drivers/special/wireless/rn2xx3.rst matteo.golin@gmail.com
 Documentation/components/drivers/thermal/index.rst wangjianyu3@xiaomi.com devel@sumpfralle.de
-Documentation/components/filesystem/aio.rst raiden00@railab.me
-Documentation/components/filesystem/binfs.rst raiden00@railab.me
-Documentation/components/filesystem/cromfs.rst raiden00@railab.me
-Documentation/components/filesystem/fat.rst resyfer.dev@gmail.com raiden00@railab.me devel@sumpfralle.de
-Documentation/components/filesystem/hostfs.rst raiden00@railab.me
+
+Documentation/components/filesystem/* raiden00@railab.me
+Documentation/components/filesystem/fat.rst resyfer.dev@gmail.com devel@sumpfralle.de
 Documentation/components/filesystem/how_nxffs_works.rst ludovicvanasse@gmail.com
-Documentation/components/filesystem/index.rst resyfer.dev@gmail.com raiden00@railab.me devel@sumpfralle.de ludovicvanasse@gmail.com guohao15@xiaomi.com
+Documentation/components/filesystem/index.rst resyfer.dev@gmail.com devel@sumpfralle.de ludovicvanasse@gmail.com guohao15@xiaomi.com
 Documentation/components/filesystem/inotify.rst guohao15@xiaomi.com michallenc@seznam.cz
 Documentation/components/filesystem/littlefs.rst matteo.golin@gmail.com raiden00@railab.me
-Documentation/components/filesystem/mmap.rst raiden00@railab.me
 Documentation/components/filesystem/mnemofs.rst resyfer.dev@gmail.com devel@sumpfralle.de
-Documentation/components/filesystem/nfs.rst raiden00@railab.me
 Documentation/components/filesystem/nuttxfs.rst ludovicvanasse@gmail.com
-Documentation/components/filesystem/nxffs.rst raiden00@railab.me ludovicvanasse@gmail.com
+Documentation/components/filesystem/nxffs.rst ludovicvanasse@gmail.com
 Documentation/components/filesystem/nxflat.rst ludovicvanasse@gmail.com
-Documentation/components/filesystem/partition.rst raiden00@railab.me acassis@gmail.com
-Documentation/components/filesystem/procfs.rst raiden00@railab.me
+Documentation/components/filesystem/partition.rst acassis@gmail.com
 Documentation/components/filesystem/pseudofs.rst ludovicvanasse@gmail.com
-Documentation/components/filesystem/romfs.rst raiden00@railab.me
-Documentation/components/filesystem/rpmsgfs.rst yfliu2008@qq.com raiden00@railab.me
-Documentation/components/filesystem/shmfs.rst yfliu2008@qq.com raiden00@railab.me
-Documentation/components/filesystem/smartfs.rst raiden00@railab.me devel@sumpfralle.de
+Documentation/components/filesystem/rpmsgfs.rst yfliu2008@qq.com
+Documentation/components/filesystem/shmfs.rst yfliu2008@qq.com
+Documentation/components/filesystem/smartfs.rst devel@sumpfralle.de
 Documentation/components/filesystem/special_files_dev_num.rst ludovicvanasse@gmail.com
-Documentation/components/filesystem/spiffs.rst raiden00@railab.me
-Documentation/components/filesystem/tmpfs.rst yfliu2008@qq.com raiden00@railab.me devel@sumpfralle.de
-Documentation/components/filesystem/unionfs.rst raiden00@railab.me
-Documentation/components/filesystem/userfs.rst raiden00@railab.me
+Documentation/components/filesystem/tmpfs.rst yfliu2008@qq.com devel@sumpfralle.de
 Documentation/components/filesystem/v9fs.rst chenrun1@xiaomi.com
-Documentation/components/filesystem/zipfs.rst raiden00@railab.me
-Documentation/components/index.rst matias@protobits.dev raiden00@railab.me xiaoxiang@xiaomi.com
-Documentation/components/libs/index.rst raiden00@railab.me ville.juven@unikie.com
-Documentation/components/libs/libc/index.rst raiden00@railab.me yfliu2008@qq.com devel@sumpfralle.de anchao.archer@bytedance.com xuxin19@xiaomi.com
-Documentation/components/libs/libc/stream.rst xiaoxiang@xiaomi.com
-Documentation/components/libs/libc/zoneinfo.rst raiden00@railab.me petro.karashchenko@gmail.com
-Documentation/components/libs/libdsp.rst raiden00@railab.me
-Documentation/components/libs/libm.rst raiden00@railab.me
-Documentation/components/libs/libnx/index.rst raiden00@railab.me
-Documentation/components/libs/libnx/nxfonts.rst raiden00@railab.me
-Documentation/components/libs/libxx.rst raiden00@railab.me
-Documentation/components/mm/index.rst raiden00@railab.me
-Documentation/components/mm/shm.rst raiden00@railab.me
+
+Documentation/components/* raiden00@railab.me
 Documentation/components/net/delay_act_and_tcp_perf.rst ludovicvanasse@gmail.com
-Documentation/components/net/index.rst raiden00@railab.me wengzhe@xiaomi.com ludovicvanasse@gmail.com meijian@xiaomi.com
-Documentation/components/net/ipfilter.rst wengzhe@xiaomi.com
-Documentation/components/net/nat.rst wengzhe@xiaomi.com
-Documentation/components/net/netdev.rst wengzhe@xiaomi.com
-Documentation/components/net/netdriver.rst wengzhe@xiaomi.com
-Documentation/components/net/netguardsize.rst raiden00@railab.me
-Documentation/components/net/netlink.rst meijian@xiaomi.com
-Documentation/components/net/pkt.rst wengzhe@xiaomi.com
-Documentation/components/net/sixlowpan.rst raiden00@railab.me
-Documentation/components/net/slip.rst raiden00@railab.me devel@sumpfralle.de
-Documentation/components/net/socketcan.rst raiden00@railab.me anchao@lixiang.com
-Documentation/components/net/tcp_network_perf.rst ludovicvanasse@gmail.com
-Documentation/components/net/wqueuedeadlocks.rst raiden00@railab.me 59230071+hartmannathan@users.noreply.github.com
-Documentation/components/nxflat.rst matias@protobits.dev xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com diegoherranz@diegoherranz.com raiden00@railab.me
-Documentation/components/nxgraphics/appendix.rst matias@protobits.dev xiaoxiang@xiaomi.com devel@sumpfralle.de raiden00@railab.me 59230071+hartmannathan@users.noreply.github.com
+Documentation/components/nxflat.rst matias@protobits.dev xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com diegoherranz@diegoherranz.com
+Documentation/components/nxgraphics/appendix.rst matias@protobits.dev xiaoxiang@xiaomi.com devel@sumpfralle.de 59230071+hartmannathan@users.noreply.github.com
 Documentation/components/nxgraphics/framebuffer_char_driver.rst ludovicvanasse@gmail.com
 Documentation/components/nxgraphics/index.rst matias@protobits.dev xiaoxiang@xiaomi.com bashton@brennanashton.com devel@sumpfralle.de ludovicvanasse@gmail.com
-Documentation/components/nxgraphics/nx.rst matias@protobits.dev raiden00@railab.me xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
+Documentation/components/nxgraphics/nx.rst matias@protobits.dev xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
 Documentation/components/nxgraphics/nxcursor.rst matias@protobits.dev xiaoxiang@xiaomi.com
-Documentation/components/nxgraphics/nxfonts.rst matias@protobits.dev raiden00@railab.me xiaoxiang@xiaomi.com
+Documentation/components/nxgraphics/nxfonts.rst matias@protobits.dev xiaoxiang@xiaomi.com
 Documentation/components/nxgraphics/nxgl.rst matias@protobits.dev xiaoxiang@xiaomi.com devel@sumpfralle.de
 Documentation/components/nxgraphics/nxtk.rst matias@protobits.dev xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
 Documentation/components/nxgraphics/nxwm_threading.rst ludovicvanasse@gmail.com
 Documentation/components/nxgraphics/sample.rst matias@protobits.dev xiaoxiang@xiaomi.com
-Documentation/components/openamp.rst raiden00@railab.me
 Documentation/components/paging.rst matias@protobits.dev tiago.medicci@espressif.com zhangyuan21@xiaomi.com devel@sumpfralle.de yfliu2008@qq.com
-Documentation/components/syscall.rst raiden00@railab.me yfliu2008@qq.com devel@sumpfralle.de
-Documentation/components/tools/index.rst raiden00@railab.me acassis@gmail.com simbit18@gmail.com
-Documentation/components/video.rst raiden00@railab.me
-Documentation/components/wireless.rst raiden00@railab.me
+
 Documentation/conf.py matias@protobits.dev bashton@brennanashton.com matteo.golin@gmail.com raiden00@railab.me abhishekchoithani24@gmail.com
 Documentation/contributing/coding_style.rst matias@protobits.dev 59230071+hartmannathan@users.noreply.github.com filipe.cavalcanti@espressif.com acassis@gmail.com devel@sumpfralle.de
 Documentation/contributing/doc_templates/board.rst matteo.golin@gmail.com
@@ -696,24 +180,9 @@ Documentation/contributing/index.rst matias@protobits.dev raiden00@railab.me xia
 Documentation/contributing/making-changes.rst adam@adamfeuer.com acassis@gmail.com 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com devel@sumpfralle.de
 Documentation/contributing/releases.rst matteo.golin@gmail.com
 Documentation/contributing/workflow.rst raiden00@railab.me matias@protobits.dev xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
-Documentation/debugging/coredump.rst raiden00@railab.me
-Documentation/debugging/coresight.rst raiden00@railab.me devel@sumpfralle.de
-Documentation/debugging/cortexmhardfaults.rst raiden00@railab.me
-Documentation/debugging/debugging_elf_loadable_modules.rst raiden00@railab.me
-Documentation/debugging/debuggingflash_nuttxonarm.rst raiden00@railab.me devel@sumpfralle.de
-Documentation/debugging/disabling_stackdumpdebug.rst raiden00@railab.me
-Documentation/debugging/gdb/irqinfo.rst raiden00@railab.me
-Documentation/debugging/gdbserver.rst raiden00@railab.me
-Documentation/debugging/gdbwithpython.rst raiden00@railab.me
-Documentation/debugging/index.rst raiden00@railab.me
-Documentation/debugging/kasan.rst raiden00@railab.me
-Documentation/debugging/mte.rst raiden00@railab.me
-Documentation/debugging/qemugdb.rst raiden00@railab.me
-Documentation/debugging/stackcheck.rst raiden00@railab.me
-Documentation/debugging/stackrecord.rst raiden00@railab.me
-Documentation/debugging/tasktrace.rst raiden00@railab.me
-Documentation/debugging/tasktraceinternal.rst raiden00@railab.me
-Documentation/debugging/tasktraceuser.rst raiden00@railab.me
+
+Documentation/debugging/* raiden00@railab.me
+
 Documentation/faq/index.rst acassis@gmail.com michal.lyszczek@bofc.pl 59230071+hartmannathan@users.noreply.github.com
 Documentation/glossary.rst matias@protobits.dev
 Documentation/guides/armv7m_runtimestackcheck.rst ludovicvanasse@gmail.com
@@ -775,15 +244,10 @@ Documentation/guides/usbtrace.rst matias@protobits.dev xiaoxiang@xiaomi.com deve
 Documentation/guides/usingkernelthreads.rst ludovicvanasse@gmail.com acassis@gmail.com
 Documentation/guides/versioning_and_task_names.rst ludovicvanasse@gmail.com
 Documentation/guides/zerolatencyinterrupts.rst 59230071+hartmannathan@users.noreply.github.com liguiding1@xiaomi.com {ID}+{username}@users.noreply.github.com raiden00@railab.me xiaoxiang@xiaomi.com
-Documentation/implementation/bottomhalf_interrupt.rst raiden00@railab.me yfliu2008@qq.com
-Documentation/implementation/critical_sections.rst raiden00@railab.me buxiasen@xiaomi.com 59230071+hartmannathan@users.noreply.github.com devel@sumpfralle.de yfliu2008@qq.com
-Documentation/implementation/device_drivers.rst raiden00@railab.me devel@sumpfralle.de
-Documentation/implementation/drivers_design.rst raiden00@railab.me windsor.schmidt@gmail.com
-Documentation/implementation/index.rst raiden00@railab.me acassis@gmail.com
-Documentation/implementation/interrupt_controls.rst raiden00@railab.me
-Documentation/implementation/preemption_latency.rst raiden00@railab.me
-Documentation/implementation/processes_vs_tasks.rst raiden00@railab.me 59230071+hartmannathan@users.noreply.github.com
+
+Documentation/implementation/* raiden00@railab.me
 Documentation/implementation/simulation.rst acassis@gmail.com devel@sumpfralle.de ludovicvanasse@gmail.com 101105604+simbit18@users.noreply.github.com
+
 Documentation/index.rst matias@protobits.dev xiaoxiang@xiaomi.com raiden00@railab.me acassis@gmail.com p-szafonimateusz@xiaomi.com
 Documentation/introduction/about.rst matias@protobits.dev xiaoxiang@xiaomi.com devel@sumpfralle.de raiden00@railab.me 59230071+hartmannathan@users.noreply.github.com
 Documentation/introduction/development_environments.rst matias@protobits.dev devel@sumpfralle.de xiaoxiang@xiaomi.com
@@ -792,10 +256,8 @@ Documentation/introduction/inviolables.rst raiden00@railab.me adam@adamfeuer.com
 Documentation/introduction/licensing.rst matias@protobits.dev
 Documentation/introduction/resources.rst matias@protobits.dev bashton@brennanashton.com raiden00@railab.me filipedoocv@gmail.com xiaoxiang@xiaomi.com
 Documentation/introduction/trademarks.rst matias@protobits.dev xiaoxiang@xiaomi.com
+
 Documentation/known-warnings.txt resyfer.dev@gmail.com raiden00@railab.me
-Documentation/legacy_README.md filipedoocv@gmail.com raiden00@railab.me devel@sumpfralle.de anchao.archer@bytedance.com
-Documentation/logos/NuttX_Logo.svg acassis@gmail.com
-Documentation/logos/NuttX_Simple.svg acassis@gmail.com
 Documentation/logos/index.rst acassis@gmail.com devel@sumpfralle.de
 Documentation/make.bat xiaoxiang@xiaomi.com matias@protobits.dev
 Documentation/platforms/arm/a1x/boards/pcduino-a10/README.txt raiden00@railab.me
@@ -852,77 +314,11 @@ Documentation/platforms/arm/imxrt/boards/imxrt1170-evk/index.rst peter.vanderper
 Documentation/platforms/arm/imxrt/boards/teensy-4.x/index.rst michallenc@seznam.cz 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com
 Documentation/platforms/arm/imxrt/index.rst michallenc@seznam.cz 59230071+hartmannathan@users.noreply.github.com raiden00@railab.me acassis@gmail.com devel@sumpfralle.de
 Documentation/platforms/arm/index.rst matias@protobits.dev
-Documentation/platforms/arm/kinetis/boards/freedom-k28f/README.txt raiden00@railab.me
-Documentation/platforms/arm/kinetis/boards/freedom-k28f/index.rst raiden00@railab.me
-Documentation/platforms/arm/kinetis/boards/freedom-k64f/README.txt raiden00@railab.me yangsong8@xiaomi.com
-Documentation/platforms/arm/kinetis/boards/freedom-k64f/index.rst raiden00@railab.me
-Documentation/platforms/arm/kinetis/boards/freedom-k66f/README.txt raiden00@railab.me yangsong8@xiaomi.com
-Documentation/platforms/arm/kinetis/boards/freedom-k66f/index.rst raiden00@railab.me
-Documentation/platforms/arm/kinetis/boards/kwikstik-k40/README.txt raiden00@railab.me
-Documentation/platforms/arm/kinetis/boards/kwikstik-k40/index.rst raiden00@railab.me
-Documentation/platforms/arm/kinetis/boards/teensy-3.x/README.txt raiden00@railab.me devel@sumpfralle.de
-Documentation/platforms/arm/kinetis/boards/teensy-3.x/index.rst raiden00@railab.me
-Documentation/platforms/arm/kinetis/boards/twr-k60n512/README.txt raiden00@railab.me devel@sumpfralle.de
-Documentation/platforms/arm/kinetis/boards/twr-k60n512/index.rst raiden00@railab.me
-Documentation/platforms/arm/kinetis/boards/twr-k64f120m/README.txt raiden00@railab.me devel@sumpfralle.de
-Documentation/platforms/arm/kinetis/boards/twr-k64f120m/index.rst raiden00@railab.me
-Documentation/platforms/arm/kinetis/index.rst raiden00@railab.me emmanuelferdman@gmail.com
-Documentation/platforms/arm/kl/boards/freedom-kl25z/README.txt raiden00@railab.me devel@sumpfralle.de
-Documentation/platforms/arm/kl/boards/freedom-kl25z/index.rst raiden00@railab.me
-Documentation/platforms/arm/kl/boards/freedom-kl26z/README.txt raiden00@railab.me devel@sumpfralle.de
-Documentation/platforms/arm/kl/boards/freedom-kl26z/index.rst raiden00@railab.me
-Documentation/platforms/arm/kl/boards/teensy-lc/README.txt raiden00@railab.me
-Documentation/platforms/arm/kl/boards/teensy-lc/index.rst raiden00@railab.me
-Documentation/platforms/arm/kl/index.rst raiden00@railab.me
-Documentation/platforms/arm/lc823450/boards/lc823450-xgevk/README.txt raiden00@railab.me
-Documentation/platforms/arm/lc823450/boards/lc823450-xgevk/index.rst raiden00@railab.me
-Documentation/platforms/arm/lc823450/index.rst raiden00@railab.me emmanuelferdman@gmail.com
-Documentation/platforms/arm/lpc17xx/boards/lincoln60/README.txt raiden00@railab.me devel@sumpfralle.de
-Documentation/platforms/arm/lpc17xx/boards/lincoln60/index.rst raiden00@railab.me
-Documentation/platforms/arm/lpc17xx/boards/lpcxpresso-lpc1768/README.txt raiden00@railab.me devel@sumpfralle.de
-Documentation/platforms/arm/lpc17xx/boards/lpcxpresso-lpc1768/index.rst raiden00@railab.me
-Documentation/platforms/arm/lpc17xx/boards/mbed/README.txt raiden00@railab.me
-Documentation/platforms/arm/lpc17xx/boards/mbed/index.rst raiden00@railab.me
-Documentation/platforms/arm/lpc17xx/boards/mcb1700/README.txt raiden00@railab.me
-Documentation/platforms/arm/lpc17xx/boards/mcb1700/index.rst raiden00@railab.me
-Documentation/platforms/arm/lpc17xx/boards/olimex-lpc1766stk/README.txt raiden00@railab.me devel@sumpfralle.de 59230071+hartmannathan@users.noreply.github.com
-Documentation/platforms/arm/lpc17xx/boards/olimex-lpc1766stk/index.rst raiden00@railab.me
-Documentation/platforms/arm/lpc17xx/boards/open1788/README.txt raiden00@railab.me
-Documentation/platforms/arm/lpc17xx/boards/open1788/index.rst raiden00@railab.me
-Documentation/platforms/arm/lpc17xx/boards/pnev5180b/README.txt raiden00@railab.me
-Documentation/platforms/arm/lpc17xx/boards/pnev5180b/index.rst raiden00@railab.me
-Documentation/platforms/arm/lpc17xx/boards/u-blox-c027/README.txt raiden00@railab.me
-Documentation/platforms/arm/lpc17xx/boards/u-blox-c027/index.rst raiden00@railab.me
-Documentation/platforms/arm/lpc17xx/boards/zkit-arm-1769/README.txt raiden00@railab.me
-Documentation/platforms/arm/lpc17xx/boards/zkit-arm-1769/index.rst raiden00@railab.me
-Documentation/platforms/arm/lpc17xx/index.rst raiden00@railab.me emmanuelferdman@gmail.com devel@sumpfralle.de
-Documentation/platforms/arm/lpc214x/boards/mcu123-lpc214x/README.txt raiden00@railab.me
-Documentation/platforms/arm/lpc214x/boards/mcu123-lpc214x/index.rst raiden00@railab.me
-Documentation/platforms/arm/lpc214x/boards/zp214xpa/README.txt raiden00@railab.me
-Documentation/platforms/arm/lpc214x/boards/zp214xpa/index.rst raiden00@railab.me
-Documentation/platforms/arm/lpc214x/index.rst raiden00@railab.me
-Documentation/platforms/arm/lpc2378/boards/olimex-lpc2378/README.txt raiden00@railab.me
-Documentation/platforms/arm/lpc2378/boards/olimex-lpc2378/index.rst raiden00@railab.me
-Documentation/platforms/arm/lpc2378/index.rst raiden00@railab.me
-Documentation/platforms/arm/lpc31xx/boards/ea3131/index.rst matteo.golin@gmail.com raiden00@railab.me
-Documentation/platforms/arm/lpc31xx/boards/ea3152/index.rst matteo.golin@gmail.com raiden00@railab.me
-Documentation/platforms/arm/lpc31xx/boards/olimex-lpc-h3131/index.rst matteo.golin@gmail.com raiden00@railab.me devel@sumpfralle.de
-Documentation/platforms/arm/lpc31xx/index.rst raiden00@railab.me
-Documentation/platforms/arm/lpc40xx/boards/lpc4088-devkit/README.txt raiden00@railab.me
-Documentation/platforms/arm/lpc40xx/boards/lpc4088-quickstart/README.txt raiden00@railab.me
-Documentation/platforms/arm/lpc40xx/boards/lx_cpu/README.txt raiden00@railab.me emmanuelferdman@gmail.com
-Documentation/platforms/arm/lpc40xx/boards/lx_cpu/index.rst raiden00@railab.me
-Documentation/platforms/arm/lpc40xx/index.rst raiden00@railab.me
-Documentation/platforms/arm/lpc43xx/boards/bambino-200e/README.txt raiden00@railab.me devel@sumpfralle.de
-Documentation/platforms/arm/lpc43xx/boards/lpc4330-xplorer/README.txt raiden00@railab.me
-Documentation/platforms/arm/lpc43xx/boards/lpc4337-ws/README.txt raiden00@railab.me devel@sumpfralle.de
-Documentation/platforms/arm/lpc43xx/boards/lpc4357-evb/README.txt raiden00@railab.me devel@sumpfralle.de
-Documentation/platforms/arm/lpc43xx/boards/lpc4370-link2/README.txt raiden00@railab.me devel@sumpfralle.de
-Documentation/platforms/arm/lpc43xx/boards/lpc4370-link2/index.rst raiden00@railab.me
-Documentation/platforms/arm/lpc43xx/index.rst raiden00@railab.me emmanuelferdman@gmail.com
-Documentation/platforms/arm/lpc54xx/boards/lpcxpresso-lpc54628/README.txt raiden00@railab.me
-Documentation/platforms/arm/lpc54xx/boards/lpcxpresso-lpc54628/index.rst raiden00@railab.me
-Documentation/platforms/arm/lpc54xx/index.rst raiden00@railab.me emmanuelferdman@gmail.com
+
+Documentation/platforms/arm/kinetis/* raiden00@railab.me
+Documentation/platforms/arm/kl/* raiden00@railab.me
+Documentation/platforms/arm/lc823450/* raiden00@railab.me
+Documentation/platforms/arm/lpc* raiden00@railab.me devel@sumpfralle.de
 Documentation/platforms/arm/max326xx/boards/max32660-evsys/README.txt raiden00@railab.me
 Documentation/platforms/arm/max326xx/boards/max32660-evsys/index.rst raiden00@railab.me
 Documentation/platforms/arm/max326xx/index.rst raiden00@railab.me devel@sumpfralle.de
@@ -1178,8 +574,7 @@ Documentation/platforms/arm64/a527/index.rst luppy@appkaki.com
 Documentation/platforms/arm64/a64/boards/pinephone/#index.rst# raiden00@railab.me
 Documentation/platforms/arm64/a64/boards/pinephone/index.rst raiden00@railab.me matteo.golin@gmail.com
 Documentation/platforms/arm64/a64/index.rst raiden00@railab.me
-Documentation/platforms/arm64/bcm2711/boards/raspberrypi-4b/index.rst matteo.golin@gmail.com
-Documentation/platforms/arm64/bcm2711/index.rst matteo.golin@gmail.com
+Documentation/platforms/arm64/bcm2711/* matteo.golin@gmail.com
 Documentation/platforms/arm64/fvp-v8r/boards/fvp-armv8r/index.rst matteo.golin@gmail.com raiden00@railab.me
 Documentation/platforms/arm64/fvp-v8r/index.rst raiden00@railab.me
 Documentation/platforms/arm64/imx8/boards/imx8qm-mek/index.rst matteo.golin@gmail.com raiden00@railab.me
@@ -1277,20 +672,9 @@ Documentation/platforms/risc-v/c906/boards/smartl-c906/index.rst raiden00@railab
 Documentation/platforms/risc-v/c906/index.rst raiden00@railab.me
 Documentation/platforms/risc-v/eic7700x/boards/starpro64/index.rst luppy@appkaki.com
 Documentation/platforms/risc-v/eic7700x/index.rst luppy@appkaki.com
-Documentation/platforms/risc-v/esp32c3-legacy/boards/esp32c3-devkit-rust-1/README.txt eren.terzioglu@espressif.com
-Documentation/platforms/risc-v/esp32c3-legacy/boards/esp32c3-devkit-rust-1/index.rst eren.terzioglu@espressif.com
-Documentation/platforms/risc-v/esp32c3-legacy/boards/esp32c3-devkit/ROMFS.txt eren.terzioglu@espressif.com
-Documentation/platforms/risc-v/esp32c3-legacy/boards/esp32c3-devkit/index.rst eren.terzioglu@espressif.com
-Documentation/platforms/risc-v/esp32c3-legacy/index.rst eren.terzioglu@espressif.com tiago.medicci@espressif.com tiago.medicci@gmail.com almir.okato@espressif.com
-Documentation/platforms/risc-v/esp32c3/boards/esp32c3-generic/index.rst eren.terzioglu@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com laczenjms@gmail.com
-Documentation/platforms/risc-v/esp32c3/boards/esp32c3-xiao/index.rst rcsim10@gmail.com
-Documentation/platforms/risc-v/esp32c3/index.rst eren.terzioglu@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com abdelatif.guettouche@espressif.com lucas.vaz@espressif.com
-Documentation/platforms/risc-v/esp32c6/boards/esp32c6-devkitc/index.rst eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com tiago.medicci@espressif.com martin.vajnar@gmail.com devel@sumpfralle.de
-Documentation/platforms/risc-v/esp32c6/boards/esp32c6-devkitm/index.rst eren.terzioglu@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com
-Documentation/platforms/risc-v/esp32c6/boards/esp32c6-xiao/index.rst rcsim10@gmail.com
-Documentation/platforms/risc-v/esp32c6/index.rst filipe.cavalcanti@espressif.com tiago.medicci@espressif.com eren.terzioglu@espressif.com chenwen@espressif.com lucas.vaz@espressif.com
-Documentation/platforms/risc-v/esp32h2/boards/esp32h2-devkit/index.rst eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com tiago.medicci@espressif.com devel@sumpfralle.de
-Documentation/platforms/risc-v/esp32h2/index.rst eren.terzioglu@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com tiago.medicci@gmail.com almir.okato@espressif.com
+
+Documentation/platforms/risc-v/esp32* tiago.medicci@espressif.com filipe.cavalcanti@espressif.com eren.terzioglu@espressif.com
+
 Documentation/platforms/risc-v/fe310/boards/hifive1-revb/README-qemu.txt raiden00@railab.me
 Documentation/platforms/risc-v/fe310/boards/hifive1-revb/README.txt raiden00@railab.me
 Documentation/platforms/risc-v/fe310/boards/hifive1-revb/index.rst raiden00@railab.me
@@ -1348,31 +732,9 @@ Documentation/platforms/x86/qemu/index.rst raiden00@railab.me emmanuelferdman@gm
 Documentation/platforms/x86_64/index.rst raiden00@railab.me
 Documentation/platforms/x86_64/intel64/boards/qemu-intel64/index.rst raiden00@railab.me p-szafonimateusz@xiaomi.com devel@sumpfralle.de
 Documentation/platforms/x86_64/intel64/index.rst raiden00@railab.me devel@sumpfralle.de p-szafonimateusz@xiaomi.com
-Documentation/platforms/xtensa/esp32/boards/esp32-2432S028/index.rst halysson1007@gmail.com matteo.golin@gmail.com
-Documentation/platforms/xtensa/esp32/boards/esp32-audio-kit/index.rst acassis@gmail.com tiago.medicci@espressif.com matteo.golin@gmail.com
-Documentation/platforms/xtensa/esp32/boards/esp32-devkitc/index.rst tiago.medicci@espressif.com lucas.vaz@espressif.com matias@protobits.dev acassis@gmail.com yamamoto@midokura.com
-Documentation/platforms/xtensa/esp32/boards/esp32-ethernet-kit/index.rst lucas.vaz@espressif.com matteo.golin@gmail.com raiden00@railab.me tiago.medicci@espressif.com gustavo.nihei@espressif.com
-Documentation/platforms/xtensa/esp32/boards/esp32-lyrat/index.rst lucas.vaz@espressif.com tiago.medicci@gmail.com bashton@brennanashton.com filipe.cavalcanti@espressif.com tiago.medicci@espressif.com
-Documentation/platforms/xtensa/esp32/boards/esp32-pico-kit/esp32-pico-kit-v4.1-f-layout.jpeg lucas.vaz@espressif.com
-Documentation/platforms/xtensa/esp32/boards/esp32-pico-kit/index.rst lucas.vaz@espressif.com matteo.golin@gmail.com
-Documentation/platforms/xtensa/esp32/boards/esp32-wrover-kit/index.rst lucas.vaz@espressif.com gustavo.nihei@espressif.com filipe.cavalcanti@espressif.com jari.vanewijk@nxp.com tiago.medicci@espressif.com
-Documentation/platforms/xtensa/esp32/index.rst matias@protobits.dev abdelatif.guettouche@espressif.com filipe.cavalcanti@espressif.com tiago.medicci@espressif.com lucas.vaz@espressif.com
-Documentation/platforms/xtensa/esp32s2/boards/esp32s2-kaluga-1/index.rst lucas.vaz@espressif.com eren.terzioglu@espressif.com acassis@gmail.com matteo.golin@gmail.com bashton@brennanashton.com
-Documentation/platforms/xtensa/esp32s2/boards/esp32s2-saola-1/index.rst tiago.medicci@espressif.com lucas.vaz@espressif.com eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com acassis@gmail.com
-Documentation/platforms/xtensa/esp32s2/boards/esp32s2-saola-1/tone.wav tiago.medicci@espressif.com
-Documentation/platforms/xtensa/esp32s2/index.rst tiago.medicci@espressif.com filipe.cavalcanti@espressif.com tiago.medicci@gmail.com lucas.vaz@espressif.com eren.terzioglu@espressif.com
-Documentation/platforms/xtensa/esp32s3/boards/esp32s3-8048S043/index.rst halysson1007@gmail.com
-Documentation/platforms/xtensa/esp32s3/boards/esp32s3-devkit/index.rst lucas.vaz@espressif.com tiago.medicci@espressif.com wangjianyu3@xiaomi.com yamamoto@midokura.com eren.terzioglu@espressif.com
-Documentation/platforms/xtensa/esp32s3/boards/esp32s3-eye/index.rst acassis@gmail.com lucas.vaz@espressif.com matteo.golin@gmail.com
-Documentation/platforms/xtensa/esp32s3/boards/esp32s3-korvo-2/index.rst tiago.medicci@espressif.com Yinzhe.Wu@sony.com matteo.golin@gmail.com
-Documentation/platforms/xtensa/esp32s3/boards/esp32s3-lcd-ev/index.rst eren.terzioglu@espressif.com matteo.golin@gmail.com
-Documentation/platforms/xtensa/esp32s3/boards/esp32s3-lhcbit/index.rst jorge.gzm@gmail.com matteo.golin@gmail.com devel@sumpfralle.de
-Documentation/platforms/xtensa/esp32s3/boards/esp32s3-lhcbit/lcb-bit-botton.jpeg jorge.gzm@gmail.com
-Documentation/platforms/xtensa/esp32s3/boards/esp32s3-lhcbit/lcb-bit-top.jpeg jorge.gzm@gmail.com
-Documentation/platforms/xtensa/esp32s3/boards/esp32s3-xiao/index.rst rcsim10@gmail.com matteo.golin@gmail.com
-Documentation/platforms/xtensa/esp32s3/boards/lckfb-szpi-esp32s3/index.rst wangjianyu3@xiaomi.com matteo.golin@gmail.com
-Documentation/platforms/xtensa/esp32s3/index.rst tiago.medicci@espressif.com filipe.cavalcanti@espressif.com acassis@gmail.com lucas.vaz@espressif.com marco.casaroli@gmail.com
-Documentation/platforms/xtensa/index.rst matias@protobits.dev
+
+Documentation/platforms/xtensa/* acassis@gmail.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com eren.terzioglu@espressif.com
+
 Documentation/platforms/z16/index.rst raiden00@railab.me
 Documentation/platforms/z16/z16f/boards/z16f2800100zcog/README.txt raiden00@railab.me
 Documentation/platforms/z16/z16f/boards/z16f2800100zcog/index.rst raiden00@railab.me
@@ -1398,62 +760,18 @@ Documentation/platforms/z80/z8/index.rst raiden00@railab.me emmanuelferdman@gmai
 Documentation/platforms/z80/z80/boards/z80sim/README.txt raiden00@railab.me
 Documentation/platforms/z80/z80/boards/z80sim/index.rst raiden00@railab.me
 Documentation/platforms/z80/z80/index.rst raiden00@railab.me emmanuelferdman@gmail.com
-Documentation/quickstart/compiling_cmake.rst yfliu2008@qq.com raiden00@railab.me yzwliam@126.com acassis@gmail.com
-Documentation/quickstart/compiling_make.rst raiden00@railab.me
-Documentation/quickstart/configuring.rst matias@protobits.dev adam@adamfeuer.com yinshengkai@xiaomi.com acassis@gmail.com tiago.medicci@espressif.com
-Documentation/quickstart/debugging.rst matias@protobits.dev adam@adamfeuer.com diegoherranz@diegoherranz.com anjiahao@xiaomi.com wangmingrong1@xiaomi.com
-Documentation/quickstart/index.rst matias@protobits.dev adam@adamfeuer.com raiden00@railab.me xiaoxiang@xiaomi.com
-Documentation/quickstart/install.rst matias@protobits.dev adam@adamfeuer.com pilnyt@seznam.cz xiaoxiang@xiaomi.com acassis@gmail.com
-Documentation/quickstart/organization.rst matias@protobits.dev raiden00@railab.me adam@adamfeuer.com bashton@brennanashton.com zhengjunbo1@xiaomi.com
-Documentation/quickstart/running.rst matias@protobits.dev adam@adamfeuer.com xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com acassis@gmail.com
-Documentation/reference/index.rst matias@protobits.dev
-Documentation/reference/os/addrenv.rst matias@protobits.dev xiaoxiang@xiaomi.com ville.juven@unikie.com
-Documentation/reference/os/app_vs_os.rst matias@protobits.dev devel@sumpfralle.de
-Documentation/reference/os/arch.rst matias@protobits.dev zhangyuan21@xiaomi.com michal.lyszczek@bofc.pl xiaoxiang@xiaomi.com anchao@lixiang.com
-Documentation/reference/os/board.rst matias@protobits.dev
-Documentation/reference/os/conventions.rst matias@protobits.dev yfliu2008@qq.com xiaoxiang@xiaomi.com
-Documentation/reference/os/events.rst anchao@lixiang.com fangxinyong@xiaomi.com
-Documentation/reference/os/index.rst matias@protobits.dev lucas.vaz@espressif.com wengzhe@xiaomi.com 59230071+hartmannathan@users.noreply.github.com anchao@lixiang.com
-Documentation/reference/os/iob.rst matias@protobits.dev anchao@xiaomi.com xiaoxiang@xiaomi.com windsor.schmidt@gmail.com
-Documentation/reference/os/led.rst matias@protobits.dev xiaoxiang@xiaomi.com
-Documentation/reference/os/mutex.rst anjiahao@xiaomi.com lucas.vaz@espressif.com devel@sumpfralle.de acassis@gmail.com
-Documentation/reference/os/newreno.rst liqinhui@xiaomi.com devel@sumpfralle.de raiden00@railab.me
-Documentation/reference/os/notifier.rst tianxin7@xiaomi.com lucas.vaz@espressif.com resyfer.dev@gmail.com
-Documentation/reference/os/nuttx.rst matias@protobits.dev xiaoxiang@xiaomi.com
-Documentation/reference/os/paging.rst matias@protobits.dev bashton@brennanashton.com
-Documentation/reference/os/shm.rst matias@protobits.dev xiaoxiang@xiaomi.com
-Documentation/reference/os/smp.rst matias@protobits.dev xiaoxiang@xiaomi.com bashton@brennanashton.com
-Documentation/reference/os/time_clock.rst matias@protobits.dev xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com ouyangxiangzhen@xiaomi.com acassis@gmail.com
-Documentation/reference/os/wqueue.rst matias@protobits.dev 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com
-Documentation/reference/user/01_task_control.rst matias@protobits.dev xiaoxiang@xiaomi.com bashton@brennanashton.com 59230071+hartmannathan@users.noreply.github.com
-Documentation/reference/user/02_task_scheduling.rst matias@protobits.dev xiaoxiang@xiaomi.com raiden00@railab.me kr.git@kerogit.eu acassis@gmail.com
-Documentation/reference/user/03_task_control.rst matias@protobits.dev xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com
-Documentation/reference/user/04_message_queue.rst matias@protobits.dev 59230071+hartmannathan@users.noreply.github.com anjiahao@xiaomi.com
-Documentation/reference/user/05_counting_semaphore.rst matias@protobits.dev petro.karashchenko@gmail.com anjiahao@xiaomi.com xiaoxiang@xiaomi.com bashton@brennanashton.com
-Documentation/reference/user/06_clocks_timers.rst matias@protobits.dev liguiding1@xiaomi.com raiden00@railab.me xiaoxiang@xiaomi.com
-Documentation/reference/user/07_signals.rst matias@protobits.dev xiaoxiang@xiaomi.com ysgn0101@gmail.com raiden00@railab.me
-Documentation/reference/user/08_pthread.rst matias@protobits.dev p-szafonimateusz@xiaomi.com xiaoxiang@xiaomi.com bashton@brennanashton.com ysgn0101@gmail.com
-Documentation/reference/user/09_env_vars.rst matias@protobits.dev xiaoxiang@xiaomi.com windsor.schmidt@gmail.com
-Documentation/reference/user/10_filesystem.rst matias@protobits.dev hujun5@xiaomi.com xiaoxiang@xiaomi.com jukkax@ssrc.tii.ae petro.karashchenko@gmail.com
-Documentation/reference/user/11_network.rst matias@protobits.dev xiaoxiang@xiaomi.com bashton@brennanashton.com
-Documentation/reference/user/12_shared_memory.rst matias@protobits.dev xiaoxiang@xiaomi.com raiden00@railab.me
-Documentation/reference/user/13_boardctl.rst matias@protobits.dev xiaoxiang@xiaomi.com raiden00@railab.me michal.lyszczek@bofc.pl
-Documentation/reference/user/13_logging.rst matias@protobits.dev
-Documentation/reference/user/index.rst matias@protobits.dev bashton@brennanashton.com xiaoxiang@xiaomi.com
-Documentation/reference/user/structures.rst matias@protobits.dev raiden00@railab.me xiaoxiang@xiaomi.com bashton@brennanashton.com
-Documentation/standards/index.rst p-szafonimateusz@xiaomi.com
-Documentation/standards/posix.rst p-szafonimateusz@xiaomi.com
-Documentation/substitutions.rst matias@protobits.dev xiaoxiang@xiaomi.com
+
+Documentation/quickstart/* matias@protobits.dev
+Documentation/reference/os/* matias@protobits.dev
+Documentation/reference/user/* matias@protobits.dev
+Documentation/standards/* p-szafonimateusz@xiaomi.com
+
 INVIOLABLES.md adam@adamfeuer.com abdelatif.guettouche@gmail.com
-Kconfig raiden00@railab.me dongjiuzhu1@xiaomi.com anchao@xiaomi.com yinshengkai@xiaomi.com
+
 LICENSE alin.jerpelea@sony.com anjiahao@xiaomi.com zhangyuan21@xiaomi.com abdelatif.guettouche@gmail.com xiaoxiang@xiaomi.com
-Makefile abdelatif.guettouche@gmail.com xiaoxiang@xiaomi.com fft@feedforward.com.cn
 NOTICE abdelatif.guettouche@gmail.com bashton@brennanashton.com matias@protobits.dev xiaoxiang@xiaomi.com
 README.md matias@protobits.dev filipedoocv@gmail.com 59230071+hartmannathan@users.noreply.github.com anchao@xiaomi.com xiaoxiang@xiaomi.com
-ReleaseNotes alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com baggio63446333@users.noreply.github.com
-arch/Kconfig xiaoxiang@xiaomi.com ville.juven@unikie.com anchao@xiaomi.com masayuki.ishikawa@gmail.com
-arch/arm/Kconfig anchao@xiaomi.com xiaoxiang@xiaomi.com raiden00@railab.me
-arch/arm/include/.gitignore xiaoxiang@xiaomi.com
+
 arch/arm/include/a1x/a10_irq.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com
 arch/arm/include/a1x/chip.h alin.jerpelea@sony.com
 arch/arm/include/a1x/irq.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com
@@ -1587,17 +905,9 @@ arch/arm/include/mps/irq.h anjiahao@xiaomi.com alin.jerpelea@sony.com
 arch/arm/include/mx8mp/chip.h philippe.leduc@wandercraft.eu alin.jerpelea@sony.com
 arch/arm/include/mx8mp/irq.h philippe.leduc@wandercraft.eu alin.jerpelea@sony.com
 arch/arm/include/mx8mp/mx8mp_irq.h philippe.leduc@wandercraft.eu devel@sumpfralle.de alin.jerpelea@sony.com
-arch/arm/include/nrf52/chip.h janne.rosberg@offcode.fi alin.jerpelea@sony.com dave@marples.net raiden00pl@gmail.com
-arch/arm/include/nrf52/irq.h janne.rosberg@offcode.fi alin.jerpelea@sony.com raiden00@railab.me zhiqiang@zglue.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/include/nrf52/nrf52_irq.h zhiqiang@zglue.com alin.jerpelea@sony.com raiden00@railab.me raiden00pl@gmail.com matias@protobits.dev
-arch/arm/include/nrf53/chip.h raiden00@railab.me alin.jerpelea@sony.com
-arch/arm/include/nrf53/irq.h raiden00@railab.me alin.jerpelea@sony.com
-arch/arm/include/nrf53/nrf5340_irq.h raiden00@railab.me alin.jerpelea@sony.com
-arch/arm/include/nrf53/nrf5340_irq_cpuapp.h raiden00@railab.me alin.jerpelea@sony.com
-arch/arm/include/nrf53/nrf5340_irq_cpunet.h raiden00@railab.me alin.jerpelea@sony.com
-arch/arm/include/nrf91/chip.h raiden00@railab.me alin.jerpelea@sony.com
-arch/arm/include/nrf91/irq.h raiden00@railab.me alin.jerpelea@sony.com
-arch/arm/include/nrf91/nrf9160_irq.h raiden00@railab.me alin.jerpelea@sony.com
+
+arch/arm/include/nrf* raiden00@railab.me alin.jerpelea@sony.com
+
 arch/arm/include/nuc1xx/chip.h alin.jerpelea@sony.com loketep@yahoo.com xiaoxiang@xiaomi.com
 arch/arm/include/nuc1xx/irq.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com
 arch/arm/include/nuc1xx/nuc120_irq.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com
@@ -1724,7 +1034,6 @@ arch/arm/include/xmc4/irq.h alin.jerpelea@sony.com raiden00pl@gmail.com 59230071
 arch/arm/include/xmc4/xmc4500_irq.h alin.jerpelea@sony.com raiden00pl@gmail.com gustavo.nihei@espressif.com 59230071+hartmannathan@users.noreply.github.com
 arch/arm/include/xmc4/xmc4700_irq.h raiden00pl@gmail.com alin.jerpelea@sony.com gustavo.nihei@espressif.com 59230071+hartmannathan@users.noreply.github.com
 arch/arm/include/xmc4/xmc4800_irq.h raiden00pl@gmail.com alin.jerpelea@sony.com gustavo.nihei@espressif.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/.gitignore xiaoxiang@xiaomi.com y.512.nakamura@gmail.com yamamoto@midokura.com
 arch/arm/src/Makefile xiaoxiang@xiaomi.com anchao@xiaomi.com alin.jerpelea@sony.com
 arch/arm/src/a1x/Kconfig xiaoxiang@xiaomi.com 101105604+simbit18@users.noreply.github.com
 arch/arm/src/a1x/a1x_boot.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com tiago.medicci@espressif.com gnutt@linux-qpx1.site
@@ -3647,7 +2956,6 @@ arch/arm/src/mx8mp/mx8mp_start.c philippe.leduc@wandercraft.eu alin.jerpelea@son
 arch/arm/src/mx8mp/mx8mp_start.h philippe.leduc@wandercraft.eu alin.jerpelea@sony.com
 arch/arm/src/mx8mp/mx8mp_timerisr.c philippe.leduc@wandercraft.eu alin.jerpelea@sony.com
 arch/arm/src/mx8mp/mx8mp_userspace.h philippe.leduc@wandercraft.eu alin.jerpelea@sony.com
-arch/arm/src/nrf52/.gitignore matias@protobits.dev raiden00@railab.me
 arch/arm/src/nrf52/Kconfig raiden00@railab.me matias@protobits.dev raiden00pl@gmail.com petro.karashchenko@gmail.com janne.rosberg@offcode.fi
 arch/arm/src/nrf52/chip.h janne.rosberg@offcode.fi alin.jerpelea@sony.com raiden00pl@gmail.com
 arch/arm/src/nrf52/hardware/nrf52_clock.h raiden00pl@gmail.com alin.jerpelea@sony.com matias@protobits.dev raiden00@railab.me
@@ -3746,7 +3054,6 @@ arch/arm/src/nrf52/nrf52_wdt_lowerhalf.h matias@protobits.dev alin.jerpelea@sony
 arch/arm/src/nrf52/sdc/README.md matias@protobits.dev
 arch/arm/src/nrf52/sdc/nrf.h matias@protobits.dev petro.karashchenko@gmail.com alin.jerpelea@sony.com gustavo.nihei@espressif.com
 arch/arm/src/nrf52/sdc/nrf_peripherals.h raiden00@railab.me alin.jerpelea@sony.com
-arch/arm/src/nrf53/.gitignore raiden00@railab.me
 arch/arm/src/nrf53/Kconfig raiden00@railab.me 101105604+simbit18@users.noreply.github.com xiaoxiang@xiaomi.com chengkai@xiaomi.com hujun5@xiaomi.com
 arch/arm/src/nrf53/chip.h raiden00@railab.me alin.jerpelea@sony.com
 arch/arm/src/nrf53/hardware/nrf53_clock.h raiden00@railab.me devel@sumpfralle.de alin.jerpelea@sony.com
@@ -3839,7 +3146,6 @@ arch/arm/src/nrf53/nrf53_utils.c raiden00@railab.me alin.jerpelea@sony.com
 arch/arm/src/nrf53/sdc/README.md raiden00@railab.me
 arch/arm/src/nrf53/sdc/nrf.h raiden00@railab.me alin.jerpelea@sony.com
 arch/arm/src/nrf53/sdc/nrf_peripherals.h raiden00@railab.me alin.jerpelea@sony.com
-arch/arm/src/nrf91/.gitignore raiden00@railab.me
 arch/arm/src/nrf91/Kconfig raiden00@railab.me 101105604+simbit18@users.noreply.github.com devel@sumpfralle.de wangjianyu3@xiaomi.com
 arch/arm/src/nrf91/chip.h raiden00@railab.me alin.jerpelea@sony.com
 arch/arm/src/nrf91/hardware/nrf91_clock.h raiden00@railab.me devel@sumpfralle.de alin.jerpelea@sony.com
@@ -4117,950 +3423,16 @@ arch/arm/src/rp2040/rp2040_ws2812.h 58759586+curuvar@users.noreply.github.com xi
 arch/arm/src/rp2040/rp2040_ws2812.pio 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com devel@sumpfralle.de
 arch/arm/src/rp2040/rp2040_xosc.c y.512.nakamura@gmail.com ian@iandouglasscott.com xiaoxiang@xiaomi.com yinshengkai@xiaomi.com
 arch/arm/src/rp2040/rp2040_xosc.h y.512.nakamura@gmail.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/Kconfig marco.casaroli@gmail.com bijunda@dreame.tech serg@podtynnyi.com raiden00@railab.me
-arch/arm/src/rp23xx/chip.h marco.casaroli@gmail.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_accessctrl.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_adc.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_bootram.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_busctrl.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_clocks.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_coresight_trace.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_dma.h bijunda@dreame.tech pbjd97@gmail.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_dreq.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_glitch_detector.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_hstx_ctrl.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_hstx_fifo.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_i2c.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_intctrl.h 101105604+simbit18@users.noreply.github.com bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_io_bank0.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_io_qspi.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_m33.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_m33_eppb.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_memorymap.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_otp.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_otp_data.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_pads_bank0.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_pads_qspi.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_pio.h bijunda@dreame.tech pbjd97@gmail.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_pll.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_powman.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_psm.h bijunda@dreame.tech serg@podtynnyi.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_pwm.h bijunda@dreame.tech serg@podtynnyi.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_qmi.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_resets.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_rosc.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_rp_ap.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_sha256.h bijunda@dreame.tech alin.jerpelea@sony.com pbjd97@gmail.com
-arch/arm/src/rp23xx/hardware/rp23xx_sio.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_spi.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_tbman.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_ticks.h serg@podtynnyi.com
-arch/arm/src/rp23xx/hardware/rp23xx_timer.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_trng.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_uart.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_usbctrl_dpsram.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_usbctrl_regs.h bijunda@dreame.tech devel@sumpfralle.de alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_watchdog.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_xip.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_xip_aux.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/hardware/rp23xx_xosc.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_adc.c marco.casaroli@gmail.com bijunda@dreame.tech simbit18@gmail.com raiden00@railab.me alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_adc.h marco.casaroli@gmail.com alin.jerpelea@sony.com bijunda@dreame.tech
-arch/arm/src/rp23xx/rp23xx_clock.c marco.casaroli@gmail.com bijunda@dreame.tech serg@podtynnyi.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_clock.h marco.casaroli@gmail.com serg@podtynnyi.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_config.h marco.casaroli@gmail.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_cpuidlestack.c marco.casaroli@gmail.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_cpuindex.c marco.casaroli@gmail.com bijunda@dreame.tech alin.jerpelea@sony.com pbjd97@gmail.com
-arch/arm/src/rp23xx/rp23xx_cpustart.c marco.casaroli@gmail.com bijunda@dreame.tech pbjd97@gmail.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-arch/arm/src/rp23xx/rp23xx_dmac.c bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_dmac.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_gpio.c marco.casaroli@gmail.com bijunda@dreame.tech pbjd97@gmail.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_gpio.h marco.casaroli@gmail.com paolo.volpi@gmail.com bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_heaps.c marco.casaroli@gmail.com pbjd97@gmail.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_i2c.c bijunda@dreame.tech xiaoxiang@xiaomi.com wangzhi16@xiaomi.com simbit18@gmail.com serg@podtynnyi.com
-arch/arm/src/rp23xx/rp23xx_i2c.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_i2c_slave.c bijunda@dreame.tech xiaoxiang@xiaomi.com wangzhi16@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_i2s.c bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_i2s.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_i2s_pio.c bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_i2s_pio.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_idle.c bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_irq.c marco.casaroli@gmail.com pbjd97@gmail.com ian@iandouglasscott.com xiaoxiang@xiaomi.com wangzhi16@xiaomi.com
-arch/arm/src/rp23xx/rp23xx_pio.c bijunda@dreame.tech hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_pio.h bijunda@dreame.tech devel@sumpfralle.de alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_pio_instructions.h bijunda@dreame.tech pbjd97@gmail.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_pll.c marco.casaroli@gmail.com bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_pll.h marco.casaroli@gmail.com bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_pwm.c bijunda@dreame.tech serg@podtynnyi.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_pwm.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_rom.h marco.casaroli@gmail.com serg@podtynnyi.com pbjd97@gmail.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_serial.c marco.casaroli@gmail.com bijunda@dreame.tech serg@podtynnyi.com pbjd97@gmail.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_serial.h marco.casaroli@gmail.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_smpcall.c pbjd97@gmail.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_spi.c bijunda@dreame.tech paolo.volpi@gmail.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_spi.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_start.c marco.casaroli@gmail.com peter@PeterdeMac-mini.local serg@podtynnyi.com pbjd97@gmail.com bijunda@dreame.tech
-arch/arm/src/rp23xx/rp23xx_testset.c bijunda@dreame.tech serg@podtynnyi.com lipengfei28@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_timerisr.c marco.casaroli@gmail.com serg@podtynnyi.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_uart.c marco.casaroli@gmail.com bijunda@dreame.tech hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_uart.h marco.casaroli@gmail.com bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_usbdev.c marco.casaroli@gmail.com bijunda@dreame.tech xiaoxiang@xiaomi.com wangzhi16@xiaomi.com hujun5@xiaomi.com
-arch/arm/src/rp23xx/rp23xx_usbdev.h marco.casaroli@gmail.com bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_wdt.c marco.casaroli@gmail.com serg@podtynnyi.com bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_wdt.h marco.casaroli@gmail.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_ws2812.c bijunda@dreame.tech raiden00@railab.me alin.jerpelea@sony.com huangqi3@xiaomi.com
-arch/arm/src/rp23xx/rp23xx_ws2812.h bijunda@dreame.tech alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_ws2812.pio bijunda@dreame.tech alin.jerpelea@sony.com devel@sumpfralle.de
-arch/arm/src/rp23xx/rp23xx_xosc.c marco.casaroli@gmail.com bijunda@dreame.tech serg@podtynnyi.com ian@iandouglasscott.com alin.jerpelea@sony.com
-arch/arm/src/rp23xx/rp23xx_xosc.h marco.casaroli@gmail.com alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/Kconfig jerry_tang@realsil.com.cn petro.karashchenko@gmail.com
-arch/arm/src/rtl8720c/amebaZ.c jerry_tang@realsil.com.cn alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/ameba_efuse.c jerry_tang@realsil.com.cn alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/ameba_efuse.h jerry_tang@realsil.com.cn petro.karashchenko@gmail.com alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/ameba_flash.c jerry_tang@realsil.com.cn xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/ameba_flash.h jerry_tang@realsil.com.cn petro.karashchenko@gmail.com alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/ameba_hci.c jerry_tang@realsil.com.cn xiaoxiang@xiaomi.com anchao@xiaomi.com alin.jerpelea@sony.com wanggang26@xiaomi.com
-arch/arm/src/rtl8720c/ameba_heap.c jerry_tang@realsil.com.cn xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/ameba_idle.c jerry_tang@realsil.com.cn alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/ameba_lto.S jerry_tang@realsil.com.cn alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/ameba_nvic.c jerry_tang@realsil.com.cn xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/ameba_start.c jerry_tang@realsil.com.cn anjiahao@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/rtl8720c/ameba_uart.c jerry_tang@realsil.com.cn xiaoxiang@xiaomi.com yangsong8@xiaomi.com 59230071+hartmannathan@users.noreply.github.com anchao@lixiang.com
-arch/arm/src/rtl8720c/ameba_uart.h jerry_tang@realsil.com.cn petro.karashchenko@gmail.com alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/ameba_vectors.c jerry_tang@realsil.com.cn xiaoxiang@xiaomi.com anchao@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/ameba_wdt.c jerry_tang@realsil.com.cn xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/amebaz_coex.c jerry_tang@realsil.com.cn xiaoxiang@xiaomi.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/amebaz_coex.h jerry_tang@realsil.com.cn 101105604+simbit18@users.noreply.github.com alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/amebaz_depend.c jerry_tang@realsil.com.cn xiaoxiang@xiaomi.com ville.juven@unikie.com 59230071+hartmannathan@users.noreply.github.com anchao@xiaomi.com
-arch/arm/src/rtl8720c/amebaz_depend.h jerry_tang@realsil.com.cn petro.karashchenko@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/rtl8720c/amebaz_driver.c jerry_tang@realsil.com.cn xiaoxiang@xiaomi.com anjiahao@xiaomi.com anchao@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/amebaz_driver.h jerry_tang@realsil.com.cn xiaoxiang@xiaomi.com petro.karashchenko@gmail.com anjiahao@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/amebaz_firmware.c jerry_tang@realsil.com.cn alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/amebaz_hci_board.c jerry_tang@realsil.com.cn xiaoxiang@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/amebaz_hci_board.h jerry_tang@realsil.com.cn petro.karashchenko@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/amebaz_netdev.c jerry_tang@realsil.com.cn anchao@xiaomi.com xiaoxiang@xiaomi.com zhanghongyu@xiaomi.com petro.karashchenko@gmail.com
-arch/arm/src/rtl8720c/amebaz_netdev.h jerry_tang@realsil.com.cn petro.karashchenko@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/amebaz_wlan.c jerry_tang@realsil.com.cn alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/amebaz_wlan.h jerry_tang@realsil.com.cn petro.karashchenko@gmail.com alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/chip.h jerry_tang@realsil.com.cn anchao@xiaomi.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/include/chip.h jerry_tang@realsil.com.cn alin.jerpelea@sony.com
-arch/arm/src/rtl8720c/include/irq.h jerry_tang@realsil.com.cn petro.karashchenko@gmail.com alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/Kconfig jari.vanewijk@nxp.com peter.vanderperk@nxp.com David.Sidrane@NscDg.com anchao@xiaomi.com
-arch/arm/src/s32k1xx/chip.h alin.jerpelea@sony.com 57130844+PetervdPerk-NXP@users.noreply.github.com
-arch/arm/src/s32k1xx/hardware/s32k116_pinmux.h alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/hardware/s32k118_pinmux.h alin.jerpelea@sony.com jari.vanewijk@nxp.com
-arch/arm/src/s32k1xx/hardware/s32k11x_dmamux.h David.Sidrane@NscDg.com alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/hardware/s32k142_pinmux.h alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/hardware/s32k144_pinmux.h alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/hardware/s32k146_pinmux.h alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/hardware/s32k148_pinmux.h alin.jerpelea@sony.com 57130844+PetervdPerk-NXP@users.noreply.github.com
-arch/arm/src/s32k1xx/hardware/s32k14x_dmamux.h David.Sidrane@NscDg.com alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_cmu.h alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_crc.h alin.jerpelea@sony.com daniellizewski@geotab.com gustavo.nihei@espressif.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_dmamux.h alin.jerpelea@sony.com David.Sidrane@NscDg.com gustavo.nihei@espressif.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_edma.h alin.jerpelea@sony.com David.Sidrane@NscDg.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_enet.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com devel@sumpfralle.de
-arch/arm/src/s32k1xx/hardware/s32k1xx_ewm.h alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_flashcfg.h alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_flexcan.h peter.vanderperk@nxp.com alin.jerpelea@sony.com ryanmacdonald@geotab.local
-arch/arm/src/s32k1xx/hardware/s32k1xx_flexio.h jari.vanewijk@nxp.com xiaoxiang@xiaomi.com carlossanchez@geotab.com alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_ftfc.h peter.vanderperk@nxp.com alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com gustavo.nihei@espressif.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_ftm.h jari.vanewijk@nxp.com peter.vanderperk@nxp.com alin.jerpelea@sony.com devel@sumpfralle.de carlossanchez@geotab.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_gpio.h alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_lmem.h alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_lpi2c.h alin.jerpelea@sony.com David.Sidrane@NscDg.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_lpspi.h alin.jerpelea@sony.com jari.vanewijk@nxp.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_lpuart.h alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_mcm.h alin.jerpelea@sony.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_memorymap.h alin.jerpelea@sony.com jari.vanewijk@nxp.com David.Sidrane@NscDg.com gustavo.nihei@espressif.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_mpu.h alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_pcc.h alin.jerpelea@sony.com jari.vanewijk@nxp.com gustavo.nihei@espressif.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_pinmux.h alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_pmc.h alin.jerpelea@sony.com gustavo.nihei@espressif.com cis.van.mierlo@nxp.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_port.h alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_rcm.h alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_rtc.h 57130844+PetervdPerk-NXP@users.noreply.github.com alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_scg.h alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_sim.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_smc.h alin.jerpelea@sony.com cis.van.mierlo@nxp.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com
-arch/arm/src/s32k1xx/hardware/s32k1xx_wdog.h alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/arm/src/s32k1xx/s32k11x/s32k11x_clockmapping.c alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/s32k11x/s32k11x_clocknames.h jari.vanewijk@nxp.com alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/s32k11x/s32k11x_irq.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com wangzhi16@xiaomi.com
-arch/arm/src/s32k1xx/s32k11x/s32k11x_irq.h alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/arm/src/s32k1xx/s32k11x/s32k11x_periphfeatures.c alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/s32k11x/s32k11x_timerisr.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/s32k1xx/s32k14x/s32k14x_clockmapping.c alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/s32k14x/s32k14x_clocknames.h jari.vanewijk@nxp.com alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/s32k14x/s32k14x_clrpend.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/s32k1xx/s32k14x/s32k14x_irq.c xiaoxiang@xiaomi.com hujun5@xiaomi.com wangzhi16@xiaomi.com anjiahao@xiaomi.com
-arch/arm/src/s32k1xx/s32k14x/s32k14x_irq.h alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/s32k14x/s32k14x_periphfeatures.c alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/s32k14x/s32k14x_timerisr.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/s32k1xx/s32k1xx_clockconfig.c cis.van.mierlo@nxp.com alin.jerpelea@sony.com 57130844+PetervdPerk-NXP@users.noreply.github.com devel@sumpfralle.de
-arch/arm/src/s32k1xx/s32k1xx_clockconfig.h cis.van.mierlo@nxp.com 57130844+PetervdPerk-NXP@users.noreply.github.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/s32k1xx_config.h alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/s32k1xx_edma.c David.Sidrane@NscDg.com xiaoxiang@xiaomi.com abdelatif.guettouche@gmail.com anjiahao@xiaomi.com
-arch/arm/src/s32k1xx/s32k1xx_edma.h alin.jerpelea@sony.com David.Sidrane@NscDg.com xiaoxiang@xiaomi.com devel@sumpfralle.de
-arch/arm/src/s32k1xx/s32k1xx_eeeprom.c peter.vanderperk@nxp.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com anchao@xiaomi.com code@bje.id.au
-arch/arm/src/s32k1xx/s32k1xx_eeeprom.h peter.vanderperk@nxp.com alin.jerpelea@sony.com petro.karashchenko@gmail.com jari.vanewijk@nxp.com
-arch/arm/src/s32k1xx/s32k1xx_enet.c xiaoxiang@xiaomi.com 57130844+PetervdPerk-NXP@users.noreply.github.com zhanghongyu@xiaomi.com anchao@xiaomi.com
-arch/arm/src/s32k1xx/s32k1xx_enet.h alin.jerpelea@sony.com petro.karashchenko@gmail.com peter.vanderperk@nxp.com
-arch/arm/src/s32k1xx/s32k1xx_flashcfg.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com
-arch/arm/src/s32k1xx/s32k1xx_flexcan.c peter.vanderperk@nxp.com xiaoxiang@xiaomi.com anchao@xiaomi.com carlossanchez@geotab.com David.Sidrane@NscDg.com
-arch/arm/src/s32k1xx/s32k1xx_flexcan.h peter.vanderperk@nxp.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-arch/arm/src/s32k1xx/s32k1xx_flexio_i2c.c peter.vanderperk@nxp.com simbit18@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com huangqi3@xiaomi.com
-arch/arm/src/s32k1xx/s32k1xx_flexio_i2c.h peter.vanderperk@nxp.com alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/s32k1xx_idle.c alin.jerpelea@sony.com gustavo.nihei@espressif.com abdelatif.guettouche@gmail.com
-arch/arm/src/s32k1xx/s32k1xx_lowputc.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com devel@sumpfralle.de carlossanchez@geotab.com
-arch/arm/src/s32k1xx/s32k1xx_lowputc.h alin.jerpelea@sony.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
-arch/arm/src/s32k1xx/s32k1xx_lpi2c.c David.Sidrane@NscDg.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com jari.vanewijk@nxp.com
-arch/arm/src/s32k1xx/s32k1xx_lpi2c.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/s32k1xx/s32k1xx_lpi2c_slave.c jari.vanewijk@nxp.com xiaoxiang@xiaomi.com zhangshoukui@xiaomi.com 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/s32k1xx_lpi2c_slave.h jari.vanewijk@nxp.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com f.panag@amco.gr
-arch/arm/src/s32k1xx/s32k1xx_lpspi.c cis.van.mierlo@nxp.com alin.jerpelea@sony.com David.Sidrane@NscDg.com xiaoxiang@xiaomi.com
-arch/arm/src/s32k1xx/s32k1xx_lpspi.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com juha.niskanen@haltian.com
-arch/arm/src/s32k1xx/s32k1xx_periphclocks.c jari.vanewijk@nxp.com alin.jerpelea@sony.com cis.van.mierlo@nxp.com xiaoxiang@xiaomi.com
-arch/arm/src/s32k1xx/s32k1xx_periphclocks.h alin.jerpelea@sony.com cis.van.mierlo@nxp.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com
-arch/arm/src/s32k1xx/s32k1xx_pin.c alin.jerpelea@sony.com jari.vanewijk@nxp.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com
-arch/arm/src/s32k1xx/s32k1xx_pin.h alin.jerpelea@sony.com 57130844+PetervdPerk-NXP@users.noreply.github.com xiaoxiang@xiaomi.com hartman.nathan@gmail.com
-arch/arm/src/s32k1xx/s32k1xx_pindma.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com huangqi3@xiaomi.com
-arch/arm/src/s32k1xx/s32k1xx_pindump.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/s32k1xx/s32k1xx_pingpio.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com jari.vanewijk@nxp.com
-arch/arm/src/s32k1xx/s32k1xx_pinirq.c 57130844+PetervdPerk-NXP@users.noreply.github.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com wangzhi16@xiaomi.com
-arch/arm/src/s32k1xx/s32k1xx_pminitialize.c cis.van.mierlo@nxp.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/s32k1xx_progmem.c peter.vanderperk@nxp.com alin.jerpelea@sony.com petro.karashchenko@gmail.com sammytran@geotab.com devel@sumpfralle.de
-arch/arm/src/s32k1xx/s32k1xx_progmem.h peter.vanderperk@nxp.com alin.jerpelea@sony.com petro.karashchenko@gmail.com jari.vanewijk@nxp.com
-arch/arm/src/s32k1xx/s32k1xx_pwm.c jari.vanewijk@nxp.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com carlossanchez@geotab.com anchao@xiaomi.com
-arch/arm/src/s32k1xx/s32k1xx_pwm.h jari.vanewijk@nxp.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/s32k1xx/s32k1xx_resetcause_procfs.c jari.vanewijk@nxp.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/s32k1xx_resetcause_procfs.h jari.vanewijk@nxp.com alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/s32k1xx_rtc.c 57130844+PetervdPerk-NXP@users.noreply.github.com peter.vanderperk@nxp.com alin.jerpelea@sony.com hujun5@xiaomi.com xiaoxiang@xiaomi.com
-arch/arm/src/s32k1xx/s32k1xx_rtc.h 57130844+PetervdPerk-NXP@users.noreply.github.com alin.jerpelea@sony.com peter.vanderperk@nxp.com petro.karashchenko@gmail.com
-arch/arm/src/s32k1xx/s32k1xx_serial.c David.Sidrane@NscDg.com cis.van.mierlo@nxp.com bashton@brennanashton.com alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/s32k1xx_serial.h David.Sidrane@NscDg.com alin.jerpelea@sony.com David.Sidrane@Nscdg.com devel@sumpfralle.de
-arch/arm/src/s32k1xx/s32k1xx_start.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com peter.vanderperk@nxp.com 57130844+PetervdPerk-NXP@users.noreply.github.com
-arch/arm/src/s32k1xx/s32k1xx_start.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/s32k1xx/s32k1xx_uid.c jari.vanewijk@nxp.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/s32k1xx_uid.h jari.vanewijk@nxp.com alin.jerpelea@sony.com
-arch/arm/src/s32k1xx/s32k1xx_wdog.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/s32k3xx/Kconfig jari.vanewijk@nxp.com David.Sidrane@NscDg.com peter.vanderperk@nxp.com xiaoxiang@xiaomi.com 101105604+simbit18@users.noreply.github.com
-arch/arm/src/s32k3xx/chip.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k344_pinmux.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_adc.h jari.vanewijk@nxp.com xiaoxiang@xiaomi.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_axbs.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_dcm.h jari.vanewijk@nxp.com xiaoxiang@xiaomi.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_dmamux.h peter.vanderperk@nxp.com jari.vanewijk@nxp.com 101105604+simbit18@users.noreply.github.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_edma.h jari.vanewijk@nxp.com peter.vanderperk@nxp.com David.Sidrane@NscDg.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_eim.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_emac.h jari.vanewijk@nxp.com peter.vanderperk@nxp.com devel@sumpfralle.de
-arch/arm/src/s32k3xx/hardware/s32k3xx_emios.h jari.vanewijk@nxp.com peter.vanderperk@nxp.com xiaoxiang@xiaomi.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_firc.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_flexcan.h jari.vanewijk@nxp.com xiaoxiang@xiaomi.com peter.vanderperk@nxp.com ryanmacdonald@geotab.local
-arch/arm/src/s32k3xx/hardware/s32k3xx_flexio.h jari.vanewijk@nxp.com xiaoxiang@xiaomi.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_fmu.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_fs26.h jari.vanewijk@nxp.com peter.vanderperk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_fxosc.h jari.vanewijk@nxp.com devel@sumpfralle.de peter.vanderperk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_hse.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_intm.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_lpi2c.h jari.vanewijk@nxp.com xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_lpspi.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_lpuart.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_mc_cgm.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_mc_me.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_mc_rgm.h jari.vanewijk@nxp.com f.panag@amco.gr xiaoxiang@xiaomi.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_mcm.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_memorymap.h jari.vanewijk@nxp.com peter.vanderperk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_mscm.h jari.vanewijk@nxp.com devel@sumpfralle.de
-arch/arm/src/s32k3xx/hardware/s32k3xx_mu.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_pflash.h jari.vanewijk@nxp.com peter.vanderperk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_pinmux.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_pit.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_pll.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_pmc.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_pramc.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_qspi.h jari.vanewijk@nxp.com peter.vanderperk@nxp.com xiaoxiang@xiaomi.com devel@sumpfralle.de
-arch/arm/src/s32k3xx/hardware/s32k3xx_rtc.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_sema42.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_sirc.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_siul2.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_stm.h jari.vanewijk@nxp.com peter.vanderperk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_swt.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_sxosc.h jari.vanewijk@nxp.com devel@sumpfralle.de
-arch/arm/src/s32k3xx/hardware/s32k3xx_tspc.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_virtwrapper.h jari.vanewijk@nxp.com peter.vanderperk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_wkpu.h jari.vanewijk@nxp.com xiaoxiang@xiaomi.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_xbic.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/hardware/s32k3xx_xrdc.h jari.vanewijk@nxp.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/s32k3xx/s32k3xx_allocateheap.c jari.vanewijk@nxp.com xiaoxiang@xiaomi.com
-arch/arm/src/s32k3xx/s32k3xx_clockconfig.c jari.vanewijk@nxp.com devel@sumpfralle.de peter.vanderperk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_clockconfig.h jari.vanewijk@nxp.com peter.vanderperk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_clocknames.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_clrpend.c jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_config.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_edma.c jari.vanewijk@nxp.com David.Sidrane@NscDg.com peter.vanderperk@nxp.com anjiahao@xiaomi.com hujun5@xiaomi.com
-arch/arm/src/s32k3xx/s32k3xx_edma.h jari.vanewijk@nxp.com David.Sidrane@NscDg.com devel@sumpfralle.de
-arch/arm/src/s32k3xx/s32k3xx_emac.c jari.vanewijk@nxp.com peter.vanderperk@nxp.com anchao@xiaomi.com xiaoxiang@xiaomi.com petro.karashchenko@gmail.com
-arch/arm/src/s32k3xx/s32k3xx_emac.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_flashboot.c jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_flexcan.c jari.vanewijk@nxp.com peter.vanderperk@nxp.com anchao@xiaomi.com carlossanchez@geotab.com xiaoxiang@xiaomi.com
-arch/arm/src/s32k3xx/s32k3xx_flexcan.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_fs26.c jari.vanewijk@nxp.com xiaoxiang@xiaomi.com
-arch/arm/src/s32k3xx/s32k3xx_fs26.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_idle.c jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_irq.c jari.vanewijk@nxp.com xiaoxiang@xiaomi.com hujun5@xiaomi.com wangzhi16@xiaomi.com anjiahao@xiaomi.com
-arch/arm/src/s32k3xx/s32k3xx_irq.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_lowputc.c jari.vanewijk@nxp.com David.Sidrane@NscDg.com devel@sumpfralle.de
-arch/arm/src/s32k3xx/s32k3xx_lowputc.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_lpi2c.c jari.vanewijk@nxp.com David.Sidrane@NscDg.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com wangzhi16@xiaomi.com
-arch/arm/src/s32k3xx/s32k3xx_lpi2c.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_lpspi.c jari.vanewijk@nxp.com anjiahao@xiaomi.com xiaoxiang@xiaomi.com David.Sidrane@NscDg.com peter.vanderperk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_lpspi.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_mpuinit.c peter.vanderperk@nxp.com gustavo.nihei@espressif.com lipengfei28@xiaomi.com
-arch/arm/src/s32k3xx/s32k3xx_mpuinit.h peter.vanderperk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_periphclocks.c jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_periphclocks.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_pin.c jari.vanewijk@nxp.com shen497@purdue.edu
-arch/arm/src/s32k3xx/s32k3xx_pin.h jari.vanewijk@nxp.com devel@sumpfralle.de
-arch/arm/src/s32k3xx/s32k3xx_pindma.c jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_pingpio.c jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_pinirq.c jari.vanewijk@nxp.com xiaoxiang@xiaomi.com wangzhi16@xiaomi.com
-arch/arm/src/s32k3xx/s32k3xx_progmem.c peter.vanderperk@nxp.com anchao@xiaomi.com
-arch/arm/src/s32k3xx/s32k3xx_progmem.h peter.vanderperk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_qspi.c jari.vanewijk@nxp.com peter.vanderperk@nxp.com anjiahao@xiaomi.com lipengfei28@xiaomi.com wangbowen6@xiaomi.com
-arch/arm/src/s32k3xx/s32k3xx_qspi.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_serial.c David.Sidrane@NscDg.com jari.vanewijk@nxp.com xiaoxiang@xiaomi.com hujun5@xiaomi.com yangsong8@xiaomi.com
-arch/arm/src/s32k3xx/s32k3xx_serial.h David.Sidrane@NscDg.com jari.vanewijk@nxp.com devel@sumpfralle.de
-arch/arm/src/s32k3xx/s32k3xx_start.c peter.vanderperk@nxp.com jari.vanewijk@nxp.com xiaoxiang@xiaomi.com alexander@auterion.com
-arch/arm/src/s32k3xx/s32k3xx_start.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_swt.h jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_timerisr.c jari.vanewijk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_userspace.c peter.vanderperk@nxp.com
-arch/arm/src/s32k3xx/s32k3xx_userspace.h peter.vanderperk@nxp.com
-arch/arm/src/s32k3xx/startup.S jari.vanewijk@nxp.com peter.vanderperk@nxp.com
-arch/arm/src/sam34/Kconfig macscomp@gmail.com yjdwbj@gmail.com xiaoxiang@xiaomi.com bernd@bwct.de
-arch/arm/src/sam34/chip.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam3u_memorymap.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam3u_pinmap.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam3u_pio.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam3x_memorymap.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam3x_pinmap.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam4cm_aes.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam4cm_ipc.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam4cm_memorymap.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam4cm_pinmap.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam4cm_slcdc.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/hardware/sam4cm_supc.h alin.jerpelea@sony.com devel@sumpfralle.de xiaoxiang@xiaomi.com
-arch/arm/src/sam34/hardware/sam4e_memorymap.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam4e_pinmap.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam4e_pio.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam4l_bpm.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/hardware/sam4l_bscif.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam4l_flashcalw.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/hardware/sam4l_gpio.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam4l_lcdca.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam4l_memorymap.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam4l_pdca.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam4l_picouart.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/hardware/sam4l_pinmap.h alin.jerpelea@sony.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/hardware/sam4l_pm.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/hardware/sam4l_scif.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam4l_usart.h alin.jerpelea@sony.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com
-arch/arm/src/sam34/hardware/sam4l_wdt.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam4s_memorymap.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam4s_pinmap.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam4s_pio.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam_acc.h alin.jerpelea@sony.com gustavo.nihei@espressif.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/hardware/sam_adc.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam_aes.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam_afec.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/hardware/sam_can.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam_chipid.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam_cmcc.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam_dacc.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam_dmac.h alin.jerpelea@sony.com devel@sumpfralle.de
-arch/arm/src/sam34/hardware/sam_eefc.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam_emac.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam_gpbr.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam_hsmci.h alin.jerpelea@sony.com rtucker@mookins.com
-arch/arm/src/sam34/hardware/sam_matrix.h alin.jerpelea@sony.com yjdwbj@gmail.com
-arch/arm/src/sam34/hardware/sam_memorymap.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/hardware/sam_pdc.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam_pinmap.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/hardware/sam_pmc.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam_pwm.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam_rstc.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam_rswdt.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam_rtc.h alin.jerpelea@sony.com f.panag@amco.gr
-arch/arm/src/sam34/hardware/sam_rtt.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam_smc.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/hardware/sam_spi.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam_ssc.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam_supc.h alin.jerpelea@sony.com devel@sumpfralle.de
-arch/arm/src/sam34/hardware/sam_tc.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/hardware/sam_twi.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam_uart.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/hardware/sam_udp.h alin.jerpelea@sony.com
-arch/arm/src/sam34/hardware/sam_udphs.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/hardware/sam_wdt.h alin.jerpelea@sony.com
-arch/arm/src/sam34/sam3u_gpio.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/sam3u_periphclks.h alin.jerpelea@sony.com
-arch/arm/src/sam34/sam3x_gpio.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/sam3x_periphclks.h alin.jerpelea@sony.com
-arch/arm/src/sam34/sam4cm_cpuidlestack.c masayuki.ishikawa@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com abdelatif.guettouche@gmail.com
-arch/arm/src/sam34/sam4cm_cpuindex.c masayuki.ishikawa@gmail.com hujun5@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/sam4cm_cpustart.c masayuki.ishikawa@gmail.com xiaoxiang@xiaomi.com abdelatif.guettouche@espressif.com hujun5@xiaomi.com
-arch/arm/src/sam34/sam4cm_freerun.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com
-arch/arm/src/sam34/sam4cm_freerun.h alin.jerpelea@sony.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com
-arch/arm/src/sam34/sam4cm_gpio.h alin.jerpelea@sony.com
-arch/arm/src/sam34/sam4cm_idle.c masayuki.ishikawa@gmail.com alin.jerpelea@sony.com gustavo.nihei@espressif.com abdelatif.guettouche@gmail.com
-arch/arm/src/sam34/sam4cm_oneshot.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com petro.karashchenko@gmail.com hartman.nathan@gmail.com
-arch/arm/src/sam34/sam4cm_oneshot.h alin.jerpelea@sony.com petro.karashchenko@gmail.com hartman.nathan@gmail.com gustavo.nihei@espressif.com
-arch/arm/src/sam34/sam4cm_oneshot_lowerhalf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/arm/src/sam34/sam4cm_periphclks.h alin.jerpelea@sony.com
-arch/arm/src/sam34/sam4cm_smpcall.c hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/sam34/sam4cm_supc.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/sam4cm_supc.h alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/arm/src/sam34/sam4cm_tc.c abdelatif.guettouche@gmail.com anjiahao@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/sam34/sam4cm_tc.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-arch/arm/src/sam34/sam4cm_tickless.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com hartman.nathan@gmail.com gustavo.nihei@espressif.com
-arch/arm/src/sam34/sam4e_gpio.h alin.jerpelea@sony.com
-arch/arm/src/sam34/sam4e_periphclks.h alin.jerpelea@sony.com
-arch/arm/src/sam34/sam4l_clockconfig.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com devel@sumpfralle.de gustavo.nihei@espressif.com
-arch/arm/src/sam34/sam4l_gpio.c alin.jerpelea@sony.com hujun5@xiaomi.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/sam4l_gpio.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/sam4l_periphclks.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com
-arch/arm/src/sam34/sam4l_periphclks.h alin.jerpelea@sony.com
-arch/arm/src/sam34/sam4s_gpio.h alin.jerpelea@sony.com wolfgang@jupiterfoundation.org
-arch/arm/src/sam34/sam4s_nand.c yjdwbj@gmail.com xiaoxiang@xiaomi.com yamamoto@midokura.com alin.jerpelea@sony.com
-arch/arm/src/sam34/sam4s_nand.h yjdwbj@gmail.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/sam34/sam4s_periphclks.h alin.jerpelea@sony.com
-arch/arm/src/sam34/sam_aes.c sebastien@lorquet.fr alin.jerpelea@sony.com anjiahao@xiaomi.com macscomp@gmail.com
-arch/arm/src/sam34/sam_aes.h alin.jerpelea@sony.com gustavo.nihei@espressif.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/sam_allocateheap.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/sam_clockconfig.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/sam_clockconfig.h alin.jerpelea@sony.com
-arch/arm/src/sam34/sam_cmcc.c alin.jerpelea@sony.com wangbowen6@xiaomi.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/sam_cmcc.h alin.jerpelea@sony.com
-arch/arm/src/sam34/sam_crypto.c anjiahao@xiaomi.com petro.karashchenko@gmail.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/arm/src/sam34/sam_dmac.c abdelatif.guettouche@gmail.com anjiahao@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/sam_dmac.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/sam_emac.c xiaoxiang@xiaomi.com anchao@xiaomi.com zhanghongyu@xiaomi.com wengzhe@xiaomi.com
-arch/arm/src/sam34/sam_emac.h alin.jerpelea@sony.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/sam_gpio.c alin.jerpelea@sony.com wolfgang@jupiterfoundation.org hujun5@xiaomi.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/sam_gpio.h alin.jerpelea@sony.com
-arch/arm/src/sam34/sam_gpioirq.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com mark@mjs.pw
-arch/arm/src/sam34/sam_hsmci.c xiaoxiang@xiaomi.com anthony@vergeaero.com rtucker@mookins.com anjiahao@xiaomi.com
-arch/arm/src/sam34/sam_hsmci.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com juha.niskanen@haltian.com
-arch/arm/src/sam34/sam_irq.c xiaoxiang@xiaomi.com mark@mjs.pw hujun5@xiaomi.com wangzhi16@xiaomi.com
-arch/arm/src/sam34/sam_lowputc.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com hujun5@xiaomi.com yangsong8@xiaomi.com
-arch/arm/src/sam34/sam_lowputc.h alin.jerpelea@sony.com
-arch/arm/src/sam34/sam_mpuinit.c alin.jerpelea@sony.com gustavo.nihei@espressif.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/sam_mpuinit.h alin.jerpelea@sony.com
-arch/arm/src/sam34/sam_periphclks.h alin.jerpelea@sony.com
-arch/arm/src/sam34/sam_rtc.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com hujun5@xiaomi.com paul-a.patience@polymtl.ca
-arch/arm/src/sam34/sam_rtc.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/sam_rtt.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com mark@mjs.pw
-arch/arm/src/sam34/sam_rtt.h alin.jerpelea@sony.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/sam_serial.c bashton@brennanashton.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com juha.niskanen@haltian.com
-arch/arm/src/sam34/sam_spi.c xiaoxiang@xiaomi.com petro.karashchenko@gmail.com alin.jerpelea@sony.com anjiahao@xiaomi.com
-arch/arm/src/sam34/sam_spi.h alin.jerpelea@sony.com sebastien@lorquet.fr xiaoxiang@xiaomi.com
-arch/arm/src/sam34/sam_start.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com masayuki.ishikawa@gmail.com anjiahao@xiaomi.com
-arch/arm/src/sam34/sam_start.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/sam_tc.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com mark@mjs.pw gustavo.nihei@espressif.com
-arch/arm/src/sam34/sam_tc.h alin.jerpelea@sony.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/sam_timerisr.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com mark@mjs.pw paul-a.patience@polymtl.ca
-arch/arm/src/sam34/sam_twi.c macscomp@gmail.com anjiahao@xiaomi.com ticso@cicely.de xiaoxiang@xiaomi.com
-arch/arm/src/sam34/sam_twi.h macscomp@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com juha.niskanen@haltian.com
-arch/arm/src/sam34/sam_udp.c yamamoto@midokura.com wolfgang@jupiterfoundation.org alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/sam_udp.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/sam_userspace.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sam34/sam_userspace.h alin.jerpelea@sony.com
-arch/arm/src/sam34/sam_vectors.c buxiasen@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/sam34/sam_wdt.c yamamoto@midokura.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com macscomp@gmail.com
-arch/arm/src/sam34/sam_wdt.h alin.jerpelea@sony.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/Kconfig 56726697+TimJTi@users.noreply.github.com janne.rosberg@offcode.fi petro.karashchenko@gmail.com 101105604+simbit18@users.noreply.github.com
-arch/arm/src/sama5/chip.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/_sama5d2x_memorymap.h alin.jerpelea@sony.com adam@adamfeuer.com tiago.medicci@espressif.com adam@starcat.io
-arch/arm/src/sama5/hardware/_sama5d2x_pinmap.h adam@starcat.io adam@adamfeuer.com alin.jerpelea@sony.com
-arch/arm/src/sama5/hardware/_sama5d2x_pio.h alin.jerpelea@sony.com adam@adamfeuer.com gustavo.nihei@espressif.com 56726697+TimJTi@users.noreply.github.com
-arch/arm/src/sama5/hardware/_sama5d3x4x_pio.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/_sama5d3x_memorymap.h alin.jerpelea@sony.com adam@adamfeuer.com tiago.medicci@espressif.com spudarnia@yahoo.com
-arch/arm/src/sama5/hardware/_sama5d3x_mpddrc.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/_sama5d3x_pinmap.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/_sama5d4x_memorymap.h alin.jerpelea@sony.com tiago.medicci@espressif.com adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/hardware/_sama5d4x_mpddrc.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/_sama5d4x_pinmap.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_adc.h alin.jerpelea@sony.com 56726697+TimJTi@users.noreply.github.com adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/hardware/sam_aic.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_aximx.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_bsc.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_can.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_classd.h 56726697+TimJTi@users.noreply.github.com 101105604+simbit18@users.noreply.github.com alin.jerpelea@sony.com
-arch/arm/src/sama5/hardware/sam_dbgu.h alin.jerpelea@sony.com adam@adamfeuer.com gustavo.nihei@espressif.com
-arch/arm/src/sama5/hardware/sam_dmac.h alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com devel@sumpfralle.de
-arch/arm/src/sama5/hardware/sam_ehci.h alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/hardware/sam_emac.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_emaca.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_emacb.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_flexcom.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_flexcom_spi.h 56726697+TimJTi@users.noreply.github.com alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_flexcom_twi.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_flexcom_usart.h alin.jerpelea@sony.com adam@adamfeuer.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/hardware/sam_gmac.h alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/hardware/sam_gpbr.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_hsmc.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_hsmci.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_isi.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_lcdc.h alin.jerpelea@sony.com 56726697+TimJTi@users.noreply.github.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_matrix.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_mcan.h 56726697+TimJTi@users.noreply.github.com alin.jerpelea@sony.com
-arch/arm/src/sama5/hardware/sam_memorymap.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_mpddrc.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_ohci.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_pinmap.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_pio.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_pit.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_pmc.h alin.jerpelea@sony.com adam@adamfeuer.com 56726697+TimJTi@users.noreply.github.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/hardware/sam_pwm.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_qspi.h janne.rosberg@offcode.fi alin.jerpelea@sony.com
-arch/arm/src/sama5/hardware/sam_rstc.h adam@starcat.io alin.jerpelea@sony.com lwazeh@gmail.com
-arch/arm/src/sama5/hardware/sam_rtc.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_rxlp.h alin.jerpelea@sony.com adam@adamfeuer.com gustavo.nihei@espressif.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/hardware/sam_sckc.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_sdmmc.h adam@starcat.io alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/hardware/sam_sfc.h 56726697+TimJTi@users.noreply.github.com alin.jerpelea@sony.com
-arch/arm/src/sama5/hardware/sam_sfr.h alin.jerpelea@sony.com adam@adamfeuer.com 56726697+TimJTi@users.noreply.github.com
-arch/arm/src/sama5/hardware/sam_spi.h alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/hardware/sam_ssc.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_tc.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_trng.h alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/hardware/sam_twi.h alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/hardware/sam_uart.h alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/hardware/sam_udphs.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/hardware/sam_wdt.h alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/hardware/sam_xdmac.h alin.jerpelea@sony.com kevin.liu.mchp@gmail.com adam@adamfeuer.com f.panag@amco.gr
-arch/arm/src/sama5/hardware/sama5d2_sdmmc.h adam@starcat.io alin.jerpelea@sony.com
-arch/arm/src/sama5/sam_adc.c 56726697+TimJTi@users.noreply.github.com abdelatif.guettouche@gmail.com xiaoxiang@xiaomi.com adam@adamfeuer.com
-arch/arm/src/sama5/sam_adc.h adam@adamfeuer.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com abdelatif.guettouche@gmail.com
-arch/arm/src/sama5/sam_allocateheap.c alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_boot.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com adam@adamfeuer.com tiago.medicci@espressif.com
-arch/arm/src/sama5/sam_boot.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/sam_can.c xiaoxiang@xiaomi.com anjiahao@xiaomi.com alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/sam_can.h alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com juha.niskanen@haltian.com
-arch/arm/src/sama5/sam_classd.c 56726697+TimJTi@users.noreply.github.com 101105604+simbit18@users.noreply.github.com anchao@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/arm/src/sama5/sam_classd.h 56726697+TimJTi@users.noreply.github.com alin.jerpelea@sony.com
-arch/arm/src/sama5/sam_clockconfig.c alin.jerpelea@sony.com adam@adamfeuer.com spudarnia@yahoo.com 56726697+TimJTi@users.noreply.github.com
-arch/arm/src/sama5/sam_clockconfig.h alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_config.h alin.jerpelea@sony.com adam@adamfeuer.com 56726697+TimJTi@users.noreply.github.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_dbgu.c adam@adamfeuer.com alin.jerpelea@sony.com yamamoto@midokura.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_dbgu.h alin.jerpelea@sony.com adam@adamfeuer.com devel@sumpfralle.de xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_dmac.c abdelatif.guettouche@gmail.com xiaoxiang@xiaomi.com adam@adamfeuer.com anjiahao@xiaomi.com
-arch/arm/src/sama5/sam_dmac.h alin.jerpelea@sony.com janne.rosberg@offcode.fi adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_ehci.c xiaoxiang@xiaomi.com anjiahao@xiaomi.com lwazeh@gmail.com adam@adamfeuer.com
-arch/arm/src/sama5/sam_emaca.c xiaoxiang@xiaomi.com anchao@xiaomi.com zhanghongyu@xiaomi.com wengzhe@xiaomi.com
-arch/arm/src/sama5/sam_emacb.c xiaoxiang@xiaomi.com anchao@xiaomi.com zhanghongyu@xiaomi.com wengzhe@xiaomi.com
-arch/arm/src/sama5/sam_ethernet.c adam@adamfeuer.com alin.jerpelea@sony.com
-arch/arm/src/sama5/sam_ethernet.h alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_flexcom_serial.c liuhaitao@xiaomi.com 56726697+TimJTi@users.noreply.github.com alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/sam_flexcom_spi.c 56726697+TimJTi@users.noreply.github.com janne.rosberg@offcode.fi devel@sumpfralle.de xiaoxiang@xiaomi.com anchao@xiaomi.com
-arch/arm/src/sama5/sam_flexcom_spi.h 56726697+TimJTi@users.noreply.github.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/sama5/sam_freerun.c adam@adamfeuer.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com petro.karashchenko@gmail.com
-arch/arm/src/sama5/sam_freerun.h adam@adamfeuer.com alin.jerpelea@sony.com
-arch/arm/src/sama5/sam_gf1024.c alin.jerpelea@sony.com adam@adamfeuer.com gustavo.nihei@espressif.com
-arch/arm/src/sama5/sam_gf512.c alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/sam_gmac.c xiaoxiang@xiaomi.com adam@adamfeuer.com anchao@xiaomi.com zhanghongyu@xiaomi.com
-arch/arm/src/sama5/sam_hsmci.c anjiahao@xiaomi.com xiaoxiang@xiaomi.com anthony@vergeaero.com adam@adamfeuer.com
-arch/arm/src/sama5/sam_hsmci.h alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_hsmci_clkdiv.c alin.jerpelea@sony.com adam@adamfeuer.com adam@starcat.io
-arch/arm/src/sama5/sam_irq.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com adam@adamfeuer.com wangzhi16@xiaomi.com
-arch/arm/src/sama5/sam_irq.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/sam_isi.c alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_isi.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/sam_lcd.c 56726697+TimJTi@users.noreply.github.com yamamoto@midokura.com adam@adamfeuer.com alin.jerpelea@sony.com
-arch/arm/src/sama5/sam_lcd.h alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_lowputc.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com hujun5@xiaomi.com adam@adamfeuer.com
-arch/arm/src/sama5/sam_lowputc.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/sam_mcan.c 56726697+TimJTi@users.noreply.github.com michallenc@seznam.cz petro.karashchenko@gmail.com zhaohaiyang1@xiaomi.com gustavo.nihei@espressif.com
-arch/arm/src/sama5/sam_mcan.h 56726697+TimJTi@users.noreply.github.com alin.jerpelea@sony.com
-arch/arm/src/sama5/sam_memories.c buxiasen@xiaomi.com alin.jerpelea@sony.com adam@adamfeuer.com yamamoto@midokura.com
-arch/arm/src/sama5/sam_memories.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/sam_memorymap.c alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/sam_memorymap.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/sam_nand.c xiaoxiang@xiaomi.com anjiahao@xiaomi.com adam@adamfeuer.com alin.jerpelea@sony.com
-arch/arm/src/sama5/sam_nand.h alin.jerpelea@sony.com adam@adamfeuer.com anjiahao@xiaomi.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_ohci.c anjiahao@xiaomi.com xiaoxiang@xiaomi.com lwazeh@gmail.com adam@adamfeuer.com
-arch/arm/src/sama5/sam_oneshot.c adam@adamfeuer.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com petro.karashchenko@gmail.com
-arch/arm/src/sama5/sam_oneshot.h adam@adamfeuer.com alin.jerpelea@sony.com hartman.nathan@gmail.com
-arch/arm/src/sama5/sam_oneshot_lowerhalf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com adam@adamfeuer.com gustavo.nihei@espressif.com
-arch/arm/src/sama5/sam_pck.c alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_pck.h alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_periphclks.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/sam_pgalloc.c alin.jerpelea@sony.com adam@adamfeuer.com buxiasen@xiaomi.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_pio.c alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/sam_pio.h alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_pioirq.c alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com spudarnia@yahoo.com
-arch/arm/src/sama5/sam_pmc.c alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_pmc.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/sam_pmecc.c adam@adamfeuer.com anjiahao@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_pmecc.h adam@adamfeuer.com anjiahao@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-arch/arm/src/sama5/sam_pwm.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com adam@adamfeuer.com mark@mjs.pw
-arch/arm/src/sama5/sam_pwm.h alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_qspi.c janne.rosberg@offcode.fi wangbowen6@xiaomi.com lipengfei28@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/arm/src/sama5/sam_qspi.h janne.rosberg@offcode.fi alin.jerpelea@sony.com
-arch/arm/src/sama5/sam_rtc.c alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com huangqi3@xiaomi.com
-arch/arm/src/sama5/sam_rtc.h alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_sckc.c alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_sckc.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/sam_sdmmc.c adam@starcat.io xiaoxiang@xiaomi.com anjiahao@xiaomi.com anthony@vergeaero.com yamamoto@midokura.com
-arch/arm/src/sama5/sam_sdmmc.h adam@starcat.io xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/sama5/sam_serial.c 56726697+TimJTi@users.noreply.github.com adam@adamfeuer.com liuhaitao@xiaomi.com mark@mjs.pw
-arch/arm/src/sama5/sam_serial.h alin.jerpelea@sony.com adam@adamfeuer.com devel@sumpfralle.de liuhaitao@xiaomi.com
-arch/arm/src/sama5/sam_serialinit.c alin.jerpelea@sony.com adam@adamfeuer.com liuhaitao@xiaomi.com devel@sumpfralle.de
-arch/arm/src/sama5/sam_sfc.c 56726697+TimJTi@users.noreply.github.com raiden00@railab.me alin.jerpelea@sony.com
-arch/arm/src/sama5/sam_sfc.h 56726697+TimJTi@users.noreply.github.com alin.jerpelea@sony.com
-arch/arm/src/sama5/sam_spi.c 56726697+TimJTi@users.noreply.github.com xiaoxiang@xiaomi.com petro.karashchenko@gmail.com adam@adamfeuer.com
-arch/arm/src/sama5/sam_spi.h alin.jerpelea@sony.com adam@adamfeuer.com sebastien@lorquet.fr xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_ssc.c xiaoxiang@xiaomi.com anjiahao@xiaomi.com adam@adamfeuer.com Yuuichi.A.Nakamura@sony.com
-arch/arm/src/sama5/sam_ssc.h alin.jerpelea@sony.com adam@adamfeuer.com juha.niskanen@haltian.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_systemreset.c adam@starcat.io 56726697+TimJTi@users.noreply.github.com lwazeh@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_systemreset.h 56726697+TimJTi@users.noreply.github.com
-arch/arm/src/sama5/sam_tc.c anjiahao@xiaomi.com xiaoxiang@xiaomi.com abdelatif.guettouche@gmail.com adam@adamfeuer.com
-arch/arm/src/sama5/sam_tc.h adam@adamfeuer.com alin.jerpelea@sony.com adam@starcat.io xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_tickless.c alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com hartman.nathan@gmail.com
-arch/arm/src/sama5/sam_timerisr.c alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com mark@mjs.pw
-arch/arm/src/sama5/sam_trng.c alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com
-arch/arm/src/sama5/sam_trng.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/sam_tsd.c 56726697+TimJTi@users.noreply.github.com xiaoxiang@xiaomi.com adam@adamfeuer.com dongjiuzhu1@xiaomi.com
-arch/arm/src/sama5/sam_tsd.h alin.jerpelea@sony.com adam@adamfeuer.com 56726697+TimJTi@users.noreply.github.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_twi.c janne.rosberg@offcode.fi petro.karashchenko@gmail.com anjiahao@xiaomi.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_twi.h alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com juha.niskanen@haltian.com
-arch/arm/src/sama5/sam_udphs.c yamamoto@midokura.com xiaoxiang@xiaomi.com 56726697+TimJTi@users.noreply.github.com adam@adamfeuer.com
-arch/arm/src/sama5/sam_udphs.h alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sam_usbhost.c alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com lwazeh@gmail.com
-arch/arm/src/sama5/sam_usbhost.h alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com mark@mjs.pw
-arch/arm/src/sama5/sam_wdt.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com adam@adamfeuer.com mark@mjs.pw
-arch/arm/src/sama5/sam_wdt.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/sam_xdmac.c kevin.liu.mchp@gmail.com abdelatif.guettouche@gmail.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com
-arch/arm/src/sama5/sama5d2x_memorymap.c alin.jerpelea@sony.com adam@adamfeuer.com tiago.medicci@espressif.com
-arch/arm/src/sama5/sama5d2x_periphclks.h alin.jerpelea@sony.com adam@adamfeuer.com spudarnia@yahoo.com
-arch/arm/src/sama5/sama5d2x_pio.c adam@adamfeuer.com adam@starcat.io alin.jerpelea@sony.com 56726697+TimJTi@users.noreply.github.com
-arch/arm/src/sama5/sama5d2x_pio.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/sama5d3x4x_pio.c alin.jerpelea@sony.com adam@adamfeuer.com xiaoxiang@xiaomi.com
-arch/arm/src/sama5/sama5d3x4x_pio.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/sama5d3x_memorymap.c alin.jerpelea@sony.com adam@adamfeuer.com tiago.medicci@espressif.com
-arch/arm/src/sama5/sama5d3x_periphclks.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/sama5/sama5d4x_memorymap.c alin.jerpelea@sony.com adam@adamfeuer.com tiago.medicci@espressif.com
-arch/arm/src/sama5/sama5d4x_periphclks.h alin.jerpelea@sony.com adam@adamfeuer.com
-arch/arm/src/samd2l2/Kconfig acassis@gmail.com xiaoxiang@xiaomi.com
-arch/arm/src/samd2l2/chip.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/hardware/samd20_memorymap.h alin.jerpelea@sony.com f.panag@amco.gr
-arch/arm/src/samd2l2/hardware/samd20_pinmap.h alin.jerpelea@sony.com f.panag@amco.gr
-arch/arm/src/samd2l2/hardware/samd21_memorymap.h alin.jerpelea@sony.com f.panag@amco.gr
-arch/arm/src/samd2l2/hardware/samd21_pinmap.h alin.jerpelea@sony.com f.panag@amco.gr
-arch/arm/src/samd2l2/hardware/samd_ac.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/hardware/samd_adc.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/hardware/samd_dac.h alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/arm/src/samd2l2/hardware/samd_dmac.h alin.jerpelea@sony.com devel@sumpfralle.de xiaoxiang@xiaomi.com
-arch/arm/src/samd2l2/hardware/samd_eic.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd2l2/hardware/samd_evsys.h alin.jerpelea@sony.com f.panag@amco.gr
-arch/arm/src/samd2l2/hardware/samd_fuses.h alin.jerpelea@sony.com f.panag@amco.gr
-arch/arm/src/samd2l2/hardware/samd_gclk.h alin.jerpelea@sony.com f.panag@amco.gr
-arch/arm/src/samd2l2/hardware/samd_i2c_master.h alin.jerpelea@sony.com f.panag@amco.gr
-arch/arm/src/samd2l2/hardware/samd_i2c_slave.h alin.jerpelea@sony.com f.panag@amco.gr
-arch/arm/src/samd2l2/hardware/samd_i2s.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/hardware/samd_nvmctrl.h alin.jerpelea@sony.com f.panag@amco.gr xiaoxiang@xiaomi.com
-arch/arm/src/samd2l2/hardware/samd_pm.h alin.jerpelea@sony.com f.panag@amco.gr
-arch/arm/src/samd2l2/hardware/samd_port.h alin.jerpelea@sony.com f.panag@amco.gr
-arch/arm/src/samd2l2/hardware/samd_sercom.h alin.jerpelea@sony.com f.panag@amco.gr
-arch/arm/src/samd2l2/hardware/samd_spi.h alin.jerpelea@sony.com f.panag@amco.gr
-arch/arm/src/samd2l2/hardware/samd_sysctrl.h alin.jerpelea@sony.com f.panag@amco.gr
-arch/arm/src/samd2l2/hardware/samd_tc.h alin.jerpelea@sony.com bernd@bwct.de
-arch/arm/src/samd2l2/hardware/samd_tcc.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/hardware/samd_usart.h alin.jerpelea@sony.com f.panag@amco.gr
-arch/arm/src/samd2l2/hardware/samd_wdt.h alin.jerpelea@sony.com f.panag@amco.gr
-arch/arm/src/samd2l2/hardware/saml21_memorymap.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/hardware/saml21_pinmap.h alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/arm/src/samd2l2/hardware/saml_adc.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/hardware/saml_aes.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd2l2/hardware/saml_dac.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/hardware/saml_dmac.h alin.jerpelea@sony.com devel@sumpfralle.de xiaoxiang@xiaomi.com
-arch/arm/src/samd2l2/hardware/saml_eic.h alin.jerpelea@sony.com devel@sumpfralle.de
-arch/arm/src/samd2l2/hardware/saml_evsys.h alin.jerpelea@sony.com devel@sumpfralle.de
-arch/arm/src/samd2l2/hardware/saml_fuses.h alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/arm/src/samd2l2/hardware/saml_gclk.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd2l2/hardware/saml_i2c_master.h alin.jerpelea@sony.com f.panag@amco.gr
-arch/arm/src/samd2l2/hardware/saml_i2c_slave.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com devel@sumpfralle.de
-arch/arm/src/samd2l2/hardware/saml_mclk.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/hardware/saml_nvmctrl.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/hardware/saml_opamp.h alin.jerpelea@sony.com hartman.nathan@gmail.com
-arch/arm/src/samd2l2/hardware/saml_osc32kctrl.h alin.jerpelea@sony.com f.panag@amco.gr
-arch/arm/src/samd2l2/hardware/saml_oscctrl.h alin.jerpelea@sony.com f.panag@amco.gr xiaoxiang@xiaomi.com
-arch/arm/src/samd2l2/hardware/saml_pm.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com devel@sumpfralle.de
-arch/arm/src/samd2l2/hardware/saml_port.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/hardware/saml_rstc.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/hardware/saml_sercom.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/hardware/saml_spi.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/hardware/saml_supc.h alin.jerpelea@sony.com devel@sumpfralle.de
-arch/arm/src/samd2l2/hardware/saml_trng.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/hardware/saml_usart.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/hardware/saml_usb.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/hardware/saml_wdt.h alin.jerpelea@sony.com devel@sumpfralle.de f.panag@amco.gr
-arch/arm/src/samd2l2/sam_ac.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd2l2/sam_ac.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/sam_adc.c acassis@gmail.com alin.jerpelea@sony.com michallenc@seznam.cz xiaoxiang@xiaomi.com
-arch/arm/src/samd2l2/sam_adc.h alexvasiljev@gmail.com alin.jerpelea@sony.com acassis@gmail.com
-arch/arm/src/samd2l2/sam_clockconfig.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/sam_config.h alin.jerpelea@sony.com acassis@gmail.com
-arch/arm/src/samd2l2/sam_dac.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/sam_dmac.c abdelatif.guettouche@gmail.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/samd2l2/sam_dmac.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com hartman.nathan@gmail.com bertvoldenuit@gmail.com
-arch/arm/src/samd2l2/sam_eic.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd2l2/sam_eic.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/sam_evsys.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/sam_fuses.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/sam_gclk.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd2l2/sam_i2c_master.c alin.jerpelea@sony.com anjiahao@xiaomi.com xiaoxiang@xiaomi.com alexvasiljev@gmail.com
-arch/arm/src/samd2l2/sam_i2c_master.h alin.jerpelea@sony.com acassis@gmail.com
-arch/arm/src/samd2l2/sam_i2c_slave.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/sam_idle.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com zhuyanlin1@xiaomi.com gustavo.nihei@espressif.com
-arch/arm/src/samd2l2/sam_irq.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com wangzhi16@xiaomi.com
-arch/arm/src/samd2l2/sam_irq.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/sam_irqprio.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd2l2/sam_lowputc.c acassis@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com f.panag@amco.gr
-arch/arm/src/samd2l2/sam_lowputc.h alin.jerpelea@sony.com acassis@gmail.com
-arch/arm/src/samd2l2/sam_periphclks.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/sam_pinmap.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/sam_pm.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/sam_port.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com f.panag@amco.gr
-arch/arm/src/samd2l2/sam_port.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/sam_sercom.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com f.panag@amco.gr
-arch/arm/src/samd2l2/sam_sercom.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd2l2/sam_serial.c acassis@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com yamamoto@midokura.com
-arch/arm/src/samd2l2/sam_serial.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/sam_spi.c xiaoxiang@xiaomi.com petro.karashchenko@gmail.com anjiahao@xiaomi.com juha.niskanen@haltian.com
-arch/arm/src/samd2l2/sam_spi.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd2l2/sam_start.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com yamamoto@midokura.com devel@sumpfralle.de
-arch/arm/src/samd2l2/sam_start.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/sam_timerisr.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd2l2/sam_usart.c alin.jerpelea@sony.com
-arch/arm/src/samd2l2/sam_usart.h alin.jerpelea@sony.com acassis@gmail.com xiaoxiang@xiaomi.com
-arch/arm/src/samd2l2/sam_usb.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com anchao@xiaomi.com gustavo.nihei@espressif.com
-arch/arm/src/samd2l2/sam_usb.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd2l2/sam_userspace.c alin.jerpelea@sony.com
-arch/arm/src/samd2l2/sam_userspace.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/samd_clockconfig.c alin.jerpelea@sony.com ticso@cicely.de 101105604+simbit18@users.noreply.github.com alexvasiljev@gmail.com
-arch/arm/src/samd2l2/samd_gclk.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com
-arch/arm/src/samd2l2/samd_periphclks.h alin.jerpelea@sony.com
-arch/arm/src/samd2l2/saml_clockconfig.c alin.jerpelea@sony.com alexvasiljev@gmail.com 101105604+simbit18@users.noreply.github.com xiaoxiang@xiaomi.com
-arch/arm/src/samd2l2/saml_gclk.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com
-arch/arm/src/samd2l2/saml_periphclks.h alin.jerpelea@sony.com
-arch/arm/src/samd5e5/Kconfig jlange@2g-eng.com leomar@falker.com.br petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/chip.h alin.jerpelea@sony.com
-arch/arm/src/samd5e5/hardware/sam_aes.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/hardware/sam_cmcc.h alin.jerpelea@sony.com
-arch/arm/src/samd5e5/hardware/sam_dmac.h alin.jerpelea@sony.com devel@sumpfralle.de xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/hardware/sam_eic.h alin.jerpelea@sony.com leomar@falker.com.br devel@sumpfralle.de
-arch/arm/src/samd5e5/hardware/sam_evsys.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/hardware/sam_fuses.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/hardware/sam_gclk.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/hardware/sam_gmac.h jlange@2g-eng.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com
-arch/arm/src/samd5e5/hardware/sam_i2c_master.h alin.jerpelea@sony.com leomar@falker.com.br f.panag@amco.gr
-arch/arm/src/samd5e5/hardware/sam_i2c_slave.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com devel@sumpfralle.de
-arch/arm/src/samd5e5/hardware/sam_mclk.h alin.jerpelea@sony.com
-arch/arm/src/samd5e5/hardware/sam_memorymap.h alin.jerpelea@sony.com jlange@2g-eng.com xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/hardware/sam_nvmctrl.h alin.jerpelea@sony.com leomar@falker.com.br
-arch/arm/src/samd5e5/hardware/sam_osc32kctrl.h alin.jerpelea@sony.com
-arch/arm/src/samd5e5/hardware/sam_oscctrl.h alin.jerpelea@sony.com f.panag@amco.gr
-arch/arm/src/samd5e5/hardware/sam_pac.h alin.jerpelea@sony.com
-arch/arm/src/samd5e5/hardware/sam_pinmap.h alin.jerpelea@sony.com gustavo.nihei@espressif.com jlange@2g-eng.com
-arch/arm/src/samd5e5/hardware/sam_pm.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/hardware/sam_port.h alin.jerpelea@sony.com
-arch/arm/src/samd5e5/hardware/sam_rstc.h alin.jerpelea@sony.com
-arch/arm/src/samd5e5/hardware/sam_spi.h alin.jerpelea@sony.com
-arch/arm/src/samd5e5/hardware/sam_supc.h alin.jerpelea@sony.com devel@sumpfralle.de
-arch/arm/src/samd5e5/hardware/sam_tc.h leomar@falker.com.br 101105604+simbit18@users.noreply.github.com ysgn0101@gmail.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-arch/arm/src/samd5e5/hardware/sam_trng.h alin.jerpelea@sony.com
-arch/arm/src/samd5e5/hardware/sam_usart.h alin.jerpelea@sony.com
-arch/arm/src/samd5e5/hardware/sam_usb.h leomar@falker.com.br alin.jerpelea@sony.com
-arch/arm/src/samd5e5/hardware/sam_wdt.h leomar@falker.com.br alin.jerpelea@sony.com devel@sumpfralle.de f.panag@amco.gr
-arch/arm/src/samd5e5/hardware/samd5e5_memorymap.h alin.jerpelea@sony.com
-arch/arm/src/samd5e5/hardware/samd5e5_pinmap.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/sam_clockconfig.c leomar@falker.com.br alin.jerpelea@sony.com xiaoxiang@xiaomi.com hartman.nathan@gmail.com
-arch/arm/src/samd5e5/sam_clockconfig.h alin.jerpelea@sony.com
-arch/arm/src/samd5e5/sam_cmcc.c alin.jerpelea@sony.com wangbowen6@xiaomi.com xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/sam_cmcc.h alin.jerpelea@sony.com
-arch/arm/src/samd5e5/sam_config.h alin.jerpelea@sony.com
-arch/arm/src/samd5e5/sam_dmac.c abdelatif.guettouche@gmail.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/samd5e5/sam_dmac.h alin.jerpelea@sony.com hartman.nathan@gmail.com xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/sam_eic.c alin.jerpelea@sony.com leomar@falker.com.br yamamoto@midokura.com xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/sam_eic.h alin.jerpelea@sony.com leomar@falker.com.br
-arch/arm/src/samd5e5/sam_ethernet.c jlange@2g-eng.com alin.jerpelea@sony.com
-arch/arm/src/samd5e5/sam_ethernet.h jlange@2g-eng.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/sam_freerun.c leomar@falker.com.br alin.jerpelea@sony.com petro.karashchenko@gmail.com
-arch/arm/src/samd5e5/sam_freerun.h leomar@falker.com.br alin.jerpelea@sony.com
-arch/arm/src/samd5e5/sam_gclk.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/sam_gclk.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/sam_gmac.c jlange@2g-eng.com xiaoxiang@xiaomi.com anchao@xiaomi.com zhanghongyu@xiaomi.com wengzhe@xiaomi.com
-arch/arm/src/samd5e5/sam_i2c_master.c alin.jerpelea@sony.com anjiahao@xiaomi.com leomar@falker.com.br xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/sam_i2c_master.h leomar@falker.com.br alin.jerpelea@sony.com
-arch/arm/src/samd5e5/sam_idle.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com zhuyanlin1@xiaomi.com gustavo.nihei@espressif.com
-arch/arm/src/samd5e5/sam_irq.c xiaoxiang@xiaomi.com hujun5@xiaomi.com wangzhi16@xiaomi.com anjiahao@xiaomi.com
-arch/arm/src/samd5e5/sam_lowputc.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/sam_lowputc.h alin.jerpelea@sony.com
-arch/arm/src/samd5e5/sam_mpuinit.c alin.jerpelea@sony.com gustavo.nihei@espressif.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/sam_mpuinit.h alin.jerpelea@sony.com
-arch/arm/src/samd5e5/sam_oneshot.c leomar@falker.com.br petro.karashchenko@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/sam_oneshot.h leomar@falker.com.br alin.jerpelea@sony.com devel@sumpfralle.de gustavo.nihei@espressif.com
-arch/arm/src/samd5e5/sam_oneshot_lowerhalf.c leomar@falker.com.br xiaoxiang@xiaomi.com alin.jerpelea@sony.com devel@sumpfralle.de
-arch/arm/src/samd5e5/sam_periphclks.h alin.jerpelea@sony.com
-arch/arm/src/samd5e5/sam_port.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/sam_port.h alin.jerpelea@sony.com leomar@falker.com.br 101105604+simbit18@users.noreply.github.com
-arch/arm/src/samd5e5/sam_progmem.c leomar@falker.com.br anjiahao@xiaomi.com xiaoxiang@xiaomi.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com
-arch/arm/src/samd5e5/sam_progmem.h leomar@falker.com.br alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/sam_sercom.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/sam_sercom.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/sam_serial.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com yamamoto@midokura.com yangsong8@xiaomi.com
-arch/arm/src/samd5e5/sam_serial.h alin.jerpelea@sony.com
-arch/arm/src/samd5e5/sam_spi.c xiaoxiang@xiaomi.com anjiahao@xiaomi.com petro.karashchenko@gmail.com juha.niskanen@haltian.com
-arch/arm/src/samd5e5/sam_spi.h xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/samd5e5/sam_start.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com anjiahao@xiaomi.com petro.karashchenko@gmail.com
-arch/arm/src/samd5e5/sam_start.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/sam_tc.c leomar@falker.com.br anjiahao@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com yamamoto@midokura.com
-arch/arm/src/samd5e5/sam_tc.h leomar@falker.com.br alin.jerpelea@sony.com anjiahao@xiaomi.com petro.karashchenko@gmail.com
-arch/arm/src/samd5e5/sam_tickless.c leomar@falker.com.br xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/samd5e5/sam_timerisr.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com leomar@falker.com.br
-arch/arm/src/samd5e5/sam_usart.c alin.jerpelea@sony.com
-arch/arm/src/samd5e5/sam_usart.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/sam_usb.c leomar@falker.com.br xiaoxiang@xiaomi.com anjiahao@xiaomi.com 101105604+simbit18@users.noreply.github.com
-arch/arm/src/samd5e5/sam_usb.h alin.jerpelea@sony.com leomar@falker.com.br xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/sam_usbhost.c leomar@falker.com.br xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/samd5e5/sam_usbhost.h leomar@falker.com.br alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samd5e5/sam_userspace.c alin.jerpelea@sony.com
-arch/arm/src/samd5e5/sam_userspace.h alin.jerpelea@sony.com
-arch/arm/src/samd5e5/sam_wdt.c leomar@falker.com.br xiaoxiang@xiaomi.com alin.jerpelea@sony.com anchao@xiaomi.com 101105604+simbit18@users.noreply.github.com
-arch/arm/src/samd5e5/sam_wdt.h leomar@falker.com.br alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/Kconfig michallenc@seznam.cz petro.karashchenko@gmail.com pressste@fel.cvut.cz david_s5@usa.net
-arch/arm/src/samv7/chip.h alin.jerpelea@sony.com
-arch/arm/src/samv7/hardware/sam_afec.h alin.jerpelea@sony.com michallenc@seznam.cz xiaoxiang@xiaomi.com
-arch/arm/src/samv7/hardware/sam_chipid.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-arch/arm/src/samv7/hardware/sam_dacc.h alin.jerpelea@sony.com
-arch/arm/src/samv7/hardware/sam_eefc.h alin.jerpelea@sony.com
-arch/arm/src/samv7/hardware/sam_emac.h alin.jerpelea@sony.com hartman.nathan@gmail.com
-arch/arm/src/samv7/hardware/sam_hsmci.h alin.jerpelea@sony.com
-arch/arm/src/samv7/hardware/sam_matrix.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/hardware/sam_mcan.h michallenc@seznam.cz alin.jerpelea@sony.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/hardware/sam_memorymap.h alin.jerpelea@sony.com michallenc@seznam.cz
-arch/arm/src/samv7/hardware/sam_pinmap.h alin.jerpelea@sony.com michallenc@seznam.cz xiaoxiang@xiaomi.com
-arch/arm/src/samv7/hardware/sam_pio.h alin.jerpelea@sony.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com
-arch/arm/src/samv7/hardware/sam_pmc.h alin.jerpelea@sony.com
-arch/arm/src/samv7/hardware/sam_pwm.h michallenc@seznam.cz petro.karashchenko@gmail.com alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com
-arch/arm/src/samv7/hardware/sam_qspi.h alin.jerpelea@sony.com michallenc@seznam.cz
-arch/arm/src/samv7/hardware/sam_rstc.h alin.jerpelea@sony.com huangqi3@xiaomi.com
-arch/arm/src/samv7/hardware/sam_rtc.h alin.jerpelea@sony.com
-arch/arm/src/samv7/hardware/sam_sdramc.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/hardware/sam_smc.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/hardware/sam_spi.h alin.jerpelea@sony.com
-arch/arm/src/samv7/hardware/sam_ssc.h alin.jerpelea@sony.com
-arch/arm/src/samv7/hardware/sam_supc.h alin.jerpelea@sony.com devel@sumpfralle.de
-arch/arm/src/samv7/hardware/sam_sysc.h alin.jerpelea@sony.com
-arch/arm/src/samv7/hardware/sam_tc.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-arch/arm/src/samv7/hardware/sam_trng.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/hardware/sam_twihs.h alin.jerpelea@sony.com
-arch/arm/src/samv7/hardware/sam_uart.h alin.jerpelea@sony.com petro.karashchenko@gmail.com simon@ingenieurbuero-filgis.de xiaoxiang@xiaomi.com
-arch/arm/src/samv7/hardware/sam_usbhs.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/hardware/sam_utmi.h alin.jerpelea@sony.com
-arch/arm/src/samv7/hardware/sam_wdt.h alin.jerpelea@sony.com
-arch/arm/src/samv7/hardware/sam_xdmac.h alin.jerpelea@sony.com f.panag@amco.gr
-arch/arm/src/samv7/hardware/same70_memorymap.h alin.jerpelea@sony.com
-arch/arm/src/samv7/hardware/same70_pinmap.h alin.jerpelea@sony.com
-arch/arm/src/samv7/hardware/samv71_memorymap.h alin.jerpelea@sony.com
-arch/arm/src/samv7/hardware/samv71_pinmap.h alin.jerpelea@sony.com
-arch/arm/src/samv7/sam_1wire.c michallenc@seznam.cz devel@sumpfralle.de petro.karashchenko@gmail.com alin.jerpelea@sony.com
-arch/arm/src/samv7/sam_1wire.h michallenc@seznam.cz alin.jerpelea@sony.com
-arch/arm/src/samv7/sam_afec.c michallenc@seznam.cz petro.karashchenko@gmail.com xiaoxiang@xiaomi.com simon@ingenieurbuero-filgis.de pressste@fel.cvut.cz
-arch/arm/src/samv7/sam_afec.h michallenc@seznam.cz xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/samv7/sam_allocateheap.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/sam_clockconfig.c alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/sam_clockconfig.h alin.jerpelea@sony.com
-arch/arm/src/samv7/sam_config.h alin.jerpelea@sony.com petro.karashchenko@gmail.com michallenc@seznam.cz frank.benkert@avat.de
-arch/arm/src/samv7/sam_dac.c Piotr.Mienkowski@schmid-telecom.ch michallenc@seznam.cz alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/sam_dac.h Piotr.Mienkowski@schmid-telecom.ch alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/sam_eefc.c kevin.liu.mchp@gmail.com michallenc@seznam.cz lipengfei28@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/samv7/sam_eefc.h kevin.liu.mchp@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/sam_emac.c xiaoxiang@xiaomi.com petro.karashchenko@gmail.com anchao@xiaomi.com imcafee3141592@gmail.com
-arch/arm/src/samv7/sam_ethernet.c alin.jerpelea@sony.com
-arch/arm/src/samv7/sam_ethernet.h alin.jerpelea@sony.com simon@ingenieurbuero-filgis.de devel@sumpfralle.de petro.karashchenko@gmail.com
-arch/arm/src/samv7/sam_freerun.c alin.jerpelea@sony.com Piotr.Mienkowski@schmid-telecom.ch petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/sam_freerun.h alin.jerpelea@sony.com
-arch/arm/src/samv7/sam_gpio.c alin.jerpelea@sony.com david_s5@usa.net michallenc@seznam.cz Michael.Spahlinger@avat.de
-arch/arm/src/samv7/sam_gpio.h alin.jerpelea@sony.com david_s5@usa.net michallenc@seznam.cz
-arch/arm/src/samv7/sam_gpioirq.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com michallenc@seznam.cz mark@mjs.pw
-arch/arm/src/samv7/sam_hsmci.c xiaoxiang@xiaomi.com michallenc@seznam.cz petro.karashchenko@gmail.com anjiahao@xiaomi.com
-arch/arm/src/samv7/sam_hsmci.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/sam_hsmci_clkdiv.c alin.jerpelea@sony.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com
-arch/arm/src/samv7/sam_irq.c xiaoxiang@xiaomi.com mark@mjs.pw petro.karashchenko@gmail.com hujun5@xiaomi.com
-arch/arm/src/samv7/sam_lin.h petro.karashchenko@gmail.com alin.jerpelea@sony.com
-arch/arm/src/samv7/sam_lin_sock.c petro.karashchenko@gmail.com devel@sumpfralle.de alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/sam_lowputc.c petro.karashchenko@gmail.com xiaoxiang@xiaomi.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/samv7/sam_mcan.c michallenc@seznam.cz Frank.Benkert@avat.de xiaoxiang@xiaomi.com anjiahao@xiaomi.com
-arch/arm/src/samv7/sam_mcan.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com acassis@gmail.com
-arch/arm/src/samv7/sam_mpuinit.c alin.jerpelea@sony.com gustavo.nihei@espressif.com petro.karashchenko@gmail.com lipengfei28@xiaomi.com
-arch/arm/src/samv7/sam_mpuinit.h alin.jerpelea@sony.com
-arch/arm/src/samv7/sam_oneshot.c Stefan.Kolb@avat.de alin.jerpelea@sony.com Piotr.Mienkowski@schmid-telecom.ch petro.karashchenko@gmail.com
-arch/arm/src/samv7/sam_oneshot.h alin.jerpelea@sony.com Stefan.Kolb@avat.de hartman.nathan@gmail.com petro.karashchenko@gmail.com
-arch/arm/src/samv7/sam_oneshot_lowerhalf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/arm/src/samv7/sam_pck.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/sam_pck.h alin.jerpelea@sony.com
-arch/arm/src/samv7/sam_periphclks.h alin.jerpelea@sony.com michallenc@seznam.cz
-arch/arm/src/samv7/sam_progmem.c kevin.liu.mchp@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com
-arch/arm/src/samv7/sam_progmem.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com
-arch/arm/src/samv7/sam_pwm.c michallenc@seznam.cz petro.karashchenko@gmail.com pressste@fel.cvut.cz xiaoxiang@xiaomi.com simon@ingenieurbuero-filgis.de
-arch/arm/src/samv7/sam_pwm.h michallenc@seznam.cz petro.karashchenko@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/sam_qencoder.c petro.karashchenko@gmail.com pressste@fel.cvut.cz xiaoxiang@xiaomi.com devel@sumpfralle.de michallenc@seznam.cz
-arch/arm/src/samv7/sam_qencoder.h petro.karashchenko@gmail.com michallenc@seznam.cz alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/sam_qspi.c xiaoxiang@xiaomi.com Yuuichi.A.Nakamura@sony.com alin.jerpelea@sony.com anjiahao@xiaomi.com
-arch/arm/src/samv7/sam_qspi.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/sam_qspi_spi.c michallenc@seznam.cz anjiahao@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com
-arch/arm/src/samv7/sam_qspi_spi.h michallenc@seznam.cz xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/samv7/sam_rswdt.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com petro.karashchenko@gmail.com mark@mjs.pw
-arch/arm/src/samv7/sam_serial.c michallenc@seznam.cz xiaoxiang@xiaomi.com bashton@brennanashton.com simon@ingenieurbuero-filgis.de
-arch/arm/src/samv7/sam_serial.h michallenc@seznam.cz alin.jerpelea@sony.com
-arch/arm/src/samv7/sam_serial_spi.c michallenc@seznam.cz alin.jerpelea@sony.com
-arch/arm/src/samv7/sam_serial_spi.h michallenc@seznam.cz alin.jerpelea@sony.com
-arch/arm/src/samv7/sam_spi.c frank.benkert@avat.de petro.karashchenko@gmail.com xiaoxiang@xiaomi.com Frank.Benkert@avat.de
-arch/arm/src/samv7/sam_spi.h Frank.Benkert@avat.de alin.jerpelea@sony.com sebastien@lorquet.fr xiaoxiang@xiaomi.com
-arch/arm/src/samv7/sam_spi_slave.c gustavo.nihei@espressif.com anjiahao@xiaomi.com xiaoxiang@xiaomi.com Stefan.Kolb@avat.de
-arch/arm/src/samv7/sam_ssc.c xiaoxiang@xiaomi.com anjiahao@xiaomi.com Yuuichi.A.Nakamura@sony.com acassis@gmail.com
-arch/arm/src/samv7/sam_ssc.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/sam_start.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com lipengfei28@xiaomi.com michallenc@seznam.cz
-arch/arm/src/samv7/sam_start.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/sam_systemreset.c david_s5@usa.net michallenc@seznam.cz alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/sam_systemreset.h michallenc@seznam.cz alin.jerpelea@sony.com
-arch/arm/src/samv7/sam_tc.c petro.karashchenko@gmail.com Piotr.Mienkowski@schmid-telecom.ch abdelatif.guettouche@gmail.com anjiahao@xiaomi.com
-arch/arm/src/samv7/sam_tc.h petro.karashchenko@gmail.com alin.jerpelea@sony.com Piotr.Mienkowski@schmid-telecom.ch xiaoxiang@xiaomi.com
-arch/arm/src/samv7/sam_tc_lowerhalf.c petro.karashchenko@gmail.com xiaoxiang@xiaomi.com pressl.stepan@gmail.com alin.jerpelea@sony.com
-arch/arm/src/samv7/sam_tc_lowerhalf.h petro.karashchenko@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/sam_tickless.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com Stefan.Kolb@avat.de hartman.nathan@gmail.com
-arch/arm/src/samv7/sam_timerisr.c michallenc@seznam.cz jpa@git.mail.kapsi.fi alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/sam_trng.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com petro.karashchenko@gmail.com
-arch/arm/src/samv7/sam_trng.h alin.jerpelea@sony.com
-arch/arm/src/samv7/sam_twihs.c Michael.Spahlinger@avat.de xiaoxiang@xiaomi.com anjiahao@xiaomi.com david_s5@nscdg.com
-arch/arm/src/samv7/sam_twihs.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com juha.niskanen@haltian.com
-arch/arm/src/samv7/sam_uid.c kevin.liu.mchp@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/sam_uid.h kevin.liu.mchp@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/sam_us.c michallenc@seznam.cz lipengfei28@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/samv7/sam_us.h michallenc@seznam.cz alin.jerpelea@sony.com
-arch/arm/src/samv7/sam_usbdev.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/samv7/sam_usbdevhs.c jonathan.gonzaga@kryptus.com xiaoxiang@xiaomi.com wangzhi16@xiaomi.com mail@frank-benkert.de
-arch/arm/src/samv7/sam_userspace.c alin.jerpelea@sony.com
-arch/arm/src/samv7/sam_userspace.h alin.jerpelea@sony.com
-arch/arm/src/samv7/sam_wdt.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com frank.benkert@avat.de michallenc@seznam.cz
-arch/arm/src/samv7/sam_wdt.h alin.jerpelea@sony.com
-arch/arm/src/samv7/sam_xdmac.c michallenc@seznam.cz abdelatif.guettouche@gmail.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com
-arch/arm/src/samv7/sam_xdmac.h alin.jerpelea@sony.com michallenc@seznam.cz anchao@lixiang.com petro.karashchenko@gmail.com
-arch/arm/src/samv7/same70_periphclks.h alin.jerpelea@sony.com
-arch/arm/src/samv7/samv71_periphclks.h alin.jerpelea@sony.com
+
+arch/arm/src/rp23xx/* marco.casaroli@gmail.com alin.jerpelea@sony.com bijunda@dreame.tech
+arch/arm/src/rtl8720c/* jerry_tang@realsil.com.cn petro.karashchenko@gmail.com alin.jerpelea@sony.com
+arch/arm/src/s32k1xx/* jari.vanewijk@nxp.com peter.vanderperk@nxp.com David.Sidrane@NscDg.com alin.jerpelea@sony.com gustavo.nihei@espressif.com
+arch/arm/src/sam34/* alin.jerpelea@sony.com
+arch/arm/src/sama5/* alin.jerpelea@sony.com adam@adamfeuer.com 56726697+TimJTi@users.noreply.github.com
+arch/arm/src/samd2l2/* alin.jerpelea@sony.com
+arch/arm/src/samd5e5/* alin.jerpelea@sony.com xiaoxiang@xiaomi.com leomar@falker.com.br
+arch/arm/src/samv7/* michallenc@seznam.cz petro.karashchenko@gmail.com pressste@fel.cvut.cz alin.jerpelea@sony.com xiaoxiang@xiaomi.com
+
 arch/arm/src/stm32/Kconfig raiden00pl@gmail.com raiden00@railab.me danieloak@gmail.com
 arch/arm/src/stm32/chip.h raiden00pl@gmail.com alin.jerpelea@sony.com paul-a.patience@polymtl.ca
 arch/arm/src/stm32/hardware/stm32_adc.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
@@ -6318,324 +4690,12 @@ arch/arm/src/stm32wl5/stm32wl5_userspace.c michal.lyszczek@bofc.pl alin.jerpelea
 arch/arm/src/stm32wl5/stm32wl5_userspace.h michal.lyszczek@bofc.pl alin.jerpelea@sony.com
 arch/arm/src/stm32wl5/stm32wl5_waste.c michal.lyszczek@bofc.pl alin.jerpelea@sony.com
 arch/arm/src/stm32wl5/stm32wl5_waste.h michal.lyszczek@bofc.pl alin.jerpelea@sony.com
-arch/arm/src/str71x/chip.h alin.jerpelea@sony.com
-arch/arm/src/str71x/str71x.h alin.jerpelea@sony.com juha.niskanen@haltian.com xiaoxiang@xiaomi.com
-arch/arm/src/str71x/str71x_adc12.h alin.jerpelea@sony.com
-arch/arm/src/str71x/str71x_apb.h alin.jerpelea@sony.com
-arch/arm/src/str71x/str71x_bspi.h alin.jerpelea@sony.com juha.niskanen@haltian.com
-arch/arm/src/str71x/str71x_can.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/str71x/str71x_decodeirq.c hujun5@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/str71x/str71x_eic.h alin.jerpelea@sony.com acassis@gmail.com
-arch/arm/src/str71x/str71x_emi.h alin.jerpelea@sony.com devel@sumpfralle.de
-arch/arm/src/str71x/str71x_flash.h alin.jerpelea@sony.com
-arch/arm/src/str71x/str71x_gpio.h alin.jerpelea@sony.com
-arch/arm/src/str71x/str71x_head.S alin.jerpelea@sony.com xiaoxiang@xiaomi.com juha.niskanen@haltian.com
-arch/arm/src/str71x/str71x_i2c.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/str71x/str71x_irq.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com anchao@xiaomi.com
-arch/arm/src/str71x/str71x_lowputc.c alin.jerpelea@sony.com paul-a.patience@polymtl.ca xiaoxiang@xiaomi.com
-arch/arm/src/str71x/str71x_map.h alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com
-arch/arm/src/str71x/str71x_pcu.h alin.jerpelea@sony.com devel@sumpfralle.de
-arch/arm/src/str71x/str71x_prccu.c alin.jerpelea@sony.com juha.niskanen@haltian.com xiaoxiang@xiaomi.com
-arch/arm/src/str71x/str71x_rccu.h alin.jerpelea@sony.com
-arch/arm/src/str71x/str71x_rtc.h alin.jerpelea@sony.com
-arch/arm/src/str71x/str71x_serial.c yamamoto@midokura.com alin.jerpelea@sony.com yangsong8@xiaomi.com
-arch/arm/src/str71x/str71x_timer.h alin.jerpelea@sony.com
-arch/arm/src/str71x/str71x_timerisr.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com mark@mjs.pw
-arch/arm/src/str71x/str71x_uart.h alin.jerpelea@sony.com
-arch/arm/src/str71x/str71x_usb.h alin.jerpelea@sony.com
-arch/arm/src/str71x/str71x_wdog.h alin.jerpelea@sony.com
-arch/arm/src/str71x/str71x_xti.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com mark@mjs.pw
-arch/arm/src/str71x/str71x_xti.h alin.jerpelea@sony.com acassis@gmail.com
-arch/arm/src/tiva/Kconfig lwazeh@gmail.com matthewtrescott@gmail.com hartman.nathan@gmail.com dvosahlik@gmail.com
-arch/arm/src/tiva/cc13xx/cc13x0_rom.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/cc13xx/cc13x0_rom.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/cc13xx/cc13x0_trim.c alin.jerpelea@sony.com
-arch/arm/src/tiva/cc13xx/cc13x2_aux_sysif.c 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/cc13xx/cc13x2_aux_sysif.h 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com
-arch/arm/src/tiva/cc13xx/cc13x2_cc26x2_v1_rom.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/cc13xx/cc13x2_cc26x2_v1_rom.h alin.jerpelea@sony.com gustavo.nihei@espressif.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/cc13xx/cc13x2_cc26x2_v2_rom.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com gustavo.nihei@espressif.com
-arch/arm/src/tiva/cc13xx/cc13x2_v1_trim.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/cc13xx/cc13x2_v2_trim.c 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/cc13xx/cc13xx_chipinfo.c alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/arm/src/tiva/cc13xx/cc13xx_enableclks.c alin.jerpelea@sony.com
-arch/arm/src/tiva/cc13xx/cc13xx_enableclks.h alin.jerpelea@sony.com
-arch/arm/src/tiva/cc13xx/cc13xx_enablepwr.c alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com hujun5@xiaomi.com masayuki.ishikawa@gmail.com
-arch/arm/src/tiva/cc13xx/cc13xx_enablepwr.h alin.jerpelea@sony.com
-arch/arm/src/tiva/cc13xx/cc13xx_gpio.c alin.jerpelea@sony.com hujun5@xiaomi.com xiaoxiang@xiaomi.com masayuki.ishikawa@gmail.com
-arch/arm/src/tiva/cc13xx/cc13xx_gpio.h alin.jerpelea@sony.com
-arch/arm/src/tiva/cc13xx/cc13xx_gpioirq.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com wangzhi16@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/tiva/cc13xx/cc13xx_prcm.c 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com
-arch/arm/src/tiva/cc13xx/cc13xx_prcm.h 59230071+hartmannathan@users.noreply.github.com juha.niskanen@haltian.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/cc13xx/cc13xx_start.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com petro.karashchenko@gmail.com
-arch/arm/src/tiva/chip.h alin.jerpelea@sony.com sgshirshak@gmail.com
-arch/arm/src/tiva/common/lm4xx_tm3c_sysctrl.c 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com zhangyuan21@xiaomi.com gustavo.nihei@espressif.com
-arch/arm/src/tiva/common/lmxx_tm4c_enableclks.h alin.jerpelea@sony.com lwazeh@gmail.com xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/tiva/common/lmxx_tm4c_enablepwr.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/tiva/common/lmxx_tm4c_gpioirq.c xiaoxiang@xiaomi.com wangzhi16@xiaomi.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/tiva/common/lmxx_tm4c_start.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com filipedoocv@gmail.com
-arch/arm/src/tiva/common/tiva_adclib.c 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com gustavo.nihei@espressif.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/common/tiva_adclow.c anjiahao@xiaomi.com xiaoxiang@xiaomi.com abdelatif.guettouche@gmail.com alin.jerpelea@sony.com
-arch/arm/src/tiva/common/tiva_allocateheap.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/tiva/common/tiva_can.c matthewtrescott@gmail.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com simbit18@gmail.com petro.karashchenko@gmail.com
-arch/arm/src/tiva/common/tiva_dumpgpio.c alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/common/tiva_eeprom.c 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com zhangyuan21@xiaomi.com
-arch/arm/src/tiva/common/tiva_flash.c xiaoxiang@xiaomi.com hartman.nathan@gmail.com alin.jerpelea@sony.com
-arch/arm/src/tiva/common/tiva_hciuart.c lwazeh@gmail.com anjiahao@xiaomi.com hujun5@xiaomi.com juha.niskanen@haltian.com
-arch/arm/src/tiva/common/tiva_i2c.c alin.jerpelea@sony.com anjiahao@xiaomi.com xiaoxiang@xiaomi.com wangzhi16@xiaomi.com
-arch/arm/src/tiva/common/tiva_idle.c masayuki.ishikawa@gmail.com alin.jerpelea@sony.com gustavo.nihei@espressif.com abdelatif.guettouche@gmail.com
-arch/arm/src/tiva/common/tiva_irq.c xiaoxiang@xiaomi.com hartman.nathan@gmail.com wangzhi16@xiaomi.com anjiahao@xiaomi.com
-arch/arm/src/tiva/common/tiva_lowputc.c 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com hartman.nathan@gmail.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/common/tiva_mpuinit.c alin.jerpelea@sony.com gustavo.nihei@espressif.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/common/tiva_pwm.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com sydeney.araujo@ee.ufcg.edu.br hartman.nathan@gmail.com
-arch/arm/src/tiva/common/tiva_qencoder.c hartman.nathan@gmail.com xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com
-arch/arm/src/tiva/common/tiva_serial.c 59230071+hartmannathan@users.noreply.github.com bashton@brennanashton.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/common/tiva_sock_can.c dvosahlik@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com devel@sumpfralle.de anchao@xiaomi.com
-arch/arm/src/tiva/common/tiva_ssi.c petro.karashchenko@gmail.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/tiva/common/tiva_timerisr.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/common/tiva_timerlib.c hartman.nathan@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com juha.niskanen@haltian.com
-arch/arm/src/tiva/common/tiva_timerlow32.c 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com barbiani@gmail.com
-arch/arm/src/tiva/common/tiva_userspace.c alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/cc13x0/cc13x0_adi2_refsys.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/cc13x0/cc13x0_adi3_refsys.h alin.jerpelea@sony.com David.Sidrane@Nscdg.com
-arch/arm/src/tiva/hardware/cc13x0/cc13x0_adi4_aux.h 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/cc13x0/cc13x0_aon_batmon.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/cc13x0/cc13x0_aon_ioc.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/cc13x0/cc13x0_aon_rtc.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/hardware/cc13x0/cc13x0_aon_sysctl.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/cc13x0/cc13x0_aon_wuc.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/cc13x0/cc13x0_aux_smph.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/tiva/hardware/cc13x0/cc13x0_aux_wuc.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/hardware/cc13x0/cc13x0_ccfg.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com marcr@zeitcontrol.de
-arch/arm/src/tiva/hardware/cc13x0/cc13x0_ddi.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/tiva/hardware/cc13x0/cc13x0_ddi0_osc.h alin.jerpelea@sony.com devel@sumpfralle.de
-arch/arm/src/tiva/hardware/cc13x0/cc13x0_fcfg1.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/cc13x0/cc13x0_flash.h alin.jerpelea@sony.com marcr@zeitcontrol.de
-arch/arm/src/tiva/hardware/cc13x0/cc13x0_gpio.h alin.jerpelea@sony.com marcr@zeitcontrol.de xiaoxiang@xiaomi.com
-arch/arm/src/tiva/hardware/cc13x0/cc13x0_i2c.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/hardware/cc13x0/cc13x0_ioc.h alin.jerpelea@sony.com petro.karashchenko@gmail.com marcr@zeitcontrol.de gustavo.nihei@espressif.com
-arch/arm/src/tiva/hardware/cc13x0/cc13x0_memorymap.h 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com marcr@zeitcontrol.de petro.karashchenko@gmail.com
-arch/arm/src/tiva/hardware/cc13x0/cc13x0_prcm.h alin.jerpelea@sony.com marcr@zeitcontrol.de gustavo.nihei@espressif.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/hardware/cc13x0/cc13x0_smph.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/tiva/hardware/cc13x0/cc13x0_timer.h alin.jerpelea@sony.com petro.karashchenko@gmail.com marcr@zeitcontrol.de gustavo.nihei@espressif.com
-arch/arm/src/tiva/hardware/cc13x0/cc13x0_uart.h alin.jerpelea@sony.com bashton@brennanashton.com marcr@zeitcontrol.de
-arch/arm/src/tiva/hardware/cc13x0/cc13x0_vims.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_adi2_refsys.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_adi3_refsys.h 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_adi4_aux.h 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aon_batmon.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aon_ioc.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aon_pmctl.h 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aon_rtc.h 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aux_smph.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_aux_sysif.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_ccfg.h 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com marcr@zeitcontrol.de
-arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_ddi.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_ddi0_osc.h alin.jerpelea@sony.com devel@sumpfralle.de
-arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_fcfg1.h 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_flash.h 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com marcr@zeitcontrol.de
-arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_gpio.h alin.jerpelea@sony.com marcr@zeitcontrol.de
-arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_i2c.h alin.jerpelea@sony.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_ioc.h alin.jerpelea@sony.com petro.karashchenko@gmail.com marcr@zeitcontrol.de
-arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_memorymap.h 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com marcr@zeitcontrol.de
-arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_prcm.h 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com marcr@zeitcontrol.de xiaoxiang@xiaomi.com
-arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_smph.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_timer.h alin.jerpelea@sony.com marcr@zeitcontrol.de
-arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_uart.h alin.jerpelea@sony.com bashton@brennanashton.com petro.karashchenko@gmail.com marcr@zeitcontrol.de
-arch/arm/src/tiva/hardware/cc13x2_cc26x2/cc13x2_cc26x2_vims.h 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/lm/lm3s_ethernet.h alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/arm/src/tiva/hardware/lm/lm3s_flash.h alin.jerpelea@sony.com hartman.nathan@gmail.com gustavo.nihei@espressif.com lwazeh@gmail.com
-arch/arm/src/tiva/hardware/lm/lm3s_gpio.h alin.jerpelea@sony.com lwazeh@gmail.com
-arch/arm/src/tiva/hardware/lm/lm3s_memorymap.h alin.jerpelea@sony.com lwazeh@gmail.com gustavo.nihei@espressif.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/hardware/lm/lm3s_pinmap.h alin.jerpelea@sony.com lwazeh@gmail.com gustavo.nihei@espressif.com
-arch/arm/src/tiva/hardware/lm/lm3s_sysctrl.h alin.jerpelea@sony.com lwazeh@gmail.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com
-arch/arm/src/tiva/hardware/lm/lm3s_timer.h alin.jerpelea@sony.com hartman.nathan@gmail.com
-arch/arm/src/tiva/hardware/lm/lm4f_gpio.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/lm/lm4f_memorymap.h alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/arm/src/tiva/hardware/lm/lm4f_pinmap.h alin.jerpelea@sony.com gustavo.nihei@espressif.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/hardware/lm/lm4f_sysctrl.h alin.jerpelea@sony.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com
-arch/arm/src/tiva/hardware/lm/lm4f_timer.h alin.jerpelea@sony.com hartman.nathan@gmail.com
-arch/arm/src/tiva/hardware/lm/lm_i2c.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/lm/lm_uart.h alin.jerpelea@sony.com bashton@brennanashton.com
-arch/arm/src/tiva/hardware/tiva_adc.h 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com
-arch/arm/src/tiva/hardware/tiva_adi2_refsys.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_adi3_refsys.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_adi4_aux.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_aon_batmon.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_aon_ioc.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_aon_pmctl.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_aon_rtc.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_aon_sysctl.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_aon_wuc.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_aux_smph.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_aux_sysif.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_aux_wuc.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_can.h matthewtrescott@gmail.com alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_ccfg.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_ddi.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_ddi0_osc.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_eeprom.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/tiva/hardware/tiva_epi.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_ethernet.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_fcfg1.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_flash.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_gpio.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_i2c.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_ioc.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_memorymap.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_pinmap.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_prcm.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_pwm.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_qencoder.h alin.jerpelea@sony.com hartman.nathan@gmail.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/hardware/tiva_smph.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_ssi.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com devel@sumpfralle.de
-arch/arm/src/tiva/hardware/tiva_sysctrl.h alin.jerpelea@sony.com petro.karashchenko@gmail.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/tiva/hardware/tiva_timer.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_uart.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/tiva/hardware/tiva_vims.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tiva_wdt.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/tiva/hardware/tm4c/tm4c123_gpio.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tm4c/tm4c123_i2c.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tm4c/tm4c123_sysctrl.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-arch/arm/src/tiva/hardware/tm4c/tm4c123_timer.h alin.jerpelea@sony.com hartman.nathan@gmail.com petro.karashchenko@gmail.com
-arch/arm/src/tiva/hardware/tm4c/tm4c129_gpio.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tm4c/tm4c129_i2c.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tm4c/tm4c129_sysctrl.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-arch/arm/src/tiva/hardware/tm4c/tm4c129_timer.h alin.jerpelea@sony.com hartman.nathan@gmail.com petro.karashchenko@gmail.com
-arch/arm/src/tiva/hardware/tm4c/tm4c_ethernet.h alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tm4c/tm4c_flash.h alin.jerpelea@sony.com hartman.nathan@gmail.com 101105604+simbit18@users.noreply.github.com
-arch/arm/src/tiva/hardware/tm4c/tm4c_memorymap.h fchk@istda.com hartman.nathan@gmail.com alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tm4c/tm4c_pinmap.h fchk@istda.com hartman.nathan@gmail.com alin.jerpelea@sony.com
-arch/arm/src/tiva/hardware/tm4c/tm4c_uart.h alin.jerpelea@sony.com bashton@brennanashton.com hartman.nathan@gmail.com
-arch/arm/src/tiva/lm/lm3s_ethernet.c xiaoxiang@xiaomi.com anchao@xiaomi.com zhanghongyu@xiaomi.com petro.karashchenko@gmail.com
-arch/arm/src/tiva/lm/lm3s_gpio.c 59230071+hartmannathan@users.noreply.github.com lwazeh@gmail.com alin.jerpelea@sony.com hujun5@xiaomi.com
-arch/arm/src/tiva/lm/lm3s_gpio.h alin.jerpelea@sony.com lwazeh@gmail.com petro.karashchenko@gmail.com hartman.nathan@gmail.com
-arch/arm/src/tiva/lm/lm4f_gpio.c 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com hujun5@xiaomi.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/lm/lm4f_gpio.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com petro.karashchenko@gmail.com hartman.nathan@gmail.com
-arch/arm/src/tiva/tiva_adc.h abdelatif.guettouche@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com paul-a.patience@polymtl.ca
-arch/arm/src/tiva/tiva_can.h matthewtrescott@gmail.com dvosahlik@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/tiva_chipinfo.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com
-arch/arm/src/tiva/tiva_eeprom.h sgshirshak@gmail.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/tiva_enableclks.h alin.jerpelea@sony.com
-arch/arm/src/tiva/tiva_enablepwr.h alin.jerpelea@sony.com
-arch/arm/src/tiva/tiva_ethernet.h alin.jerpelea@sony.com
-arch/arm/src/tiva/tiva_flash.h juha.niskanen@haltian.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/tiva/tiva_gpio.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/tiva_hciuart.h lwazeh@gmail.com alin.jerpelea@sony.com juha.niskanen@haltian.com petro.karashchenko@gmail.com
-arch/arm/src/tiva/tiva_i2c.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com juha.niskanen@haltian.com
-arch/arm/src/tiva/tiva_lowputc.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com hartman.nathan@gmail.com sharihin.dmitry93@gmail.com
-arch/arm/src/tiva/tiva_mpuinit.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/tiva/tiva_periphrdy.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/tiva/tiva_pwm.h young.mu@aliyun.com 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com augustofg96@gmail.com
-arch/arm/src/tiva/tiva_qencoder.h hartman.nathan@gmail.com young.mu@aliyun.com 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com
-arch/arm/src/tiva/tiva_ssi.h 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com sebastien@lorquet.fr
-arch/arm/src/tiva/tiva_start.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/tiva_sysctrl.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com petro.karashchenko@gmail.com
-arch/arm/src/tiva/tiva_timer.h hartman.nathan@gmail.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/tiva_userspace.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/tiva/tm4c/tm4c129_sysctrl.c alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/tm4c/tm4c_ethernet.c xiaoxiang@xiaomi.com anchao@xiaomi.com zhanghongyu@xiaomi.com wengzhe@xiaomi.com
-arch/arm/src/tiva/tm4c/tm4c_gpio.c 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com hujun5@xiaomi.com xiaoxiang@xiaomi.com
-arch/arm/src/tiva/tm4c/tm4c_gpio.h alin.jerpelea@sony.com lwazeh@gmail.com 59230071+hartmannathan@users.noreply.github.com hartman.nathan@gmail.com
-arch/arm/src/tlsr82/Kconfig wangbowen6@xiaomi.com devel@sumpfralle.de 101105604+simbit18@users.noreply.github.com anchao@xiaomi.com
-arch/arm/src/tlsr82/Toolchain.defs anchao@xiaomi.com wangbowen6@xiaomi.com xiaoxiang@xiaomi.com cuiziwei@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/chip.h wangbowen6@xiaomi.com alin.jerpelea@sony.com hujun5@xiaomi.com
-arch/arm/src/tlsr82/chip/b87/boot/cstartup_flash.S wangbowen6@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/tlsr82/hardware/tlsr82_adc.h wangbowen6@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/arm/src/tlsr82/hardware/tlsr82_aes.h wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/hardware/tlsr82_analog.h wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/hardware/tlsr82_clock.h wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/hardware/tlsr82_dfifo.h wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/hardware/tlsr82_dma.h wangbowen6@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/arm/src/tlsr82/hardware/tlsr82_gpio.h wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/hardware/tlsr82_irq.h wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/hardware/tlsr82_mspi.h wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/hardware/tlsr82_pwm.h wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/hardware/tlsr82_register.h wangbowen6@xiaomi.com hujun5@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/arm/src/tlsr82/hardware/tlsr82_spi.h wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/hardware/tlsr82_timer.h wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/hardware/tlsr82_uart.h wangbowen6@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tc32/div_mod.S wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tc32/tc32.h wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tc32/tc32_backtrace.c wangbowen6@xiaomi.com xiaoxiang@xiaomi.com buxiasen@xiaomi.com devel@sumpfralle.de hujun5@xiaomi.com
-arch/arm/src/tlsr82/tc32/tc32_doirq.c wangbowen6@xiaomi.com hujun5@xiaomi.com wangming9@xiaomi.com alin.jerpelea@sony.com masayuki.ishikawa@gmail.com
-arch/arm/src/tlsr82/tc32/tc32_exception.S wangbowen6@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tc32/tc32_fullcontextrestore.S wangbowen6@xiaomi.com anchao@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tc32/tc32_initialstate.c wangbowen6@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tc32/tc32_saveusercontext.S wangbowen6@xiaomi.com zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tc32/tc32_schedulesigaction.c wangbowen6@xiaomi.com hujun5@xiaomi.com xiaoxiang@xiaomi.com wangzhi16@xiaomi.com gustavo.nihei@espressif.com
-arch/arm/src/tlsr82/tc32/tc32_switchcontext.S wangbowen6@xiaomi.com anchao@xiaomi.com alin.jerpelea@sony.com f.panag@amco.gr
-arch/arm/src/tlsr82/tc32/tc32_syscall.c wangbowen6@xiaomi.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tc32/tc32_udelay.c wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_adc.c wangbowen6@xiaomi.com devel@sumpfralle.de gustavo.nihei@espressif.com anjiahao@xiaomi.com xiaoxiang@xiaomi.com
-arch/arm/src/tlsr82/tlsr82_adc.h wangbowen6@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_aes.c wangbowen6@xiaomi.com anjiahao@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_analog.c wangbowen6@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_analog.h wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_clock.c wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_clock.h wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_cpu.c wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_cpu.h wangbowen6@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_flash.c wangbowen6@xiaomi.com devel@sumpfralle.de menglingao@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_flash.h wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_flash_mtd.c wangbowen6@xiaomi.com xiaoxiang@xiaomi.com devel@sumpfralle.de gustavo.nihei@espressif.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_flash_mtd.h wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_gpio.c wangbowen6@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-arch/arm/src/tlsr82/tlsr82_gpio.h wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_gpio_cfg.c wangbowen6@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_gpio_cfg.h wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_gpio_default.h wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_irq.c wangbowen6@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_mspi.c wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_mspi.h wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_pwm.c wangbowen6@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/arm/src/tlsr82/tlsr82_pwm.h wangbowen6@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_serial.c wangbowen6@xiaomi.com devel@sumpfralle.de anjiahao@xiaomi.com 59230071+hartmannathan@users.noreply.github.com yangsong8@xiaomi.com
-arch/arm/src/tlsr82/tlsr82_serial.h wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_spi_console.c wangbowen6@xiaomi.com yangsong8@xiaomi.com anchao@lixiang.com xiaoxiang@xiaomi.com devel@sumpfralle.de
-arch/arm/src/tlsr82/tlsr82_spi_console.h wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_start.c wangbowen6@xiaomi.com xiaoxiang@xiaomi.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_timer.c wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_timer.h wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_timer_isr.c wangbowen6@xiaomi.com huangqi3@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_timer_lowerhalf.c wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_timer_lowerhalf.h wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_watchdog.c wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tlsr82/tlsr82_watchdog.h wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/arm/src/tms570/Kconfig xiaoxiang@xiaomi.com
-arch/arm/src/tms570/chip.h alin.jerpelea@sony.com
-arch/arm/src/tms570/hardware/tms570_esm.h alin.jerpelea@sony.com
-arch/arm/src/tms570/hardware/tms570_flash.h alin.jerpelea@sony.com
-arch/arm/src/tms570/hardware/tms570_gio.h alin.jerpelea@sony.com
-arch/arm/src/tms570/hardware/tms570_iomm.h alin.jerpelea@sony.com
-arch/arm/src/tms570/hardware/tms570_memorymap.h alin.jerpelea@sony.com
-arch/arm/src/tms570/hardware/tms570_pbist.h alin.jerpelea@sony.com
-arch/arm/src/tms570/hardware/tms570_pcr.h alin.jerpelea@sony.com
-arch/arm/src/tms570/hardware/tms570_pinmux.h alin.jerpelea@sony.com
-arch/arm/src/tms570/hardware/tms570_rti.h alin.jerpelea@sony.com
-arch/arm/src/tms570/hardware/tms570_sci.h alin.jerpelea@sony.com devel@sumpfralle.de
-arch/arm/src/tms570/hardware/tms570_sys.h alin.jerpelea@sony.com
-arch/arm/src/tms570/hardware/tms570_sys2.h alin.jerpelea@sony.com
-arch/arm/src/tms570/hardware/tms570_vim.h alin.jerpelea@sony.com
-arch/arm/src/tms570/hardware/tms570ls04x03x_memorymap.h alin.jerpelea@sony.com
-arch/arm/src/tms570/hardware/tms570ls04x03x_pinmux.h alin.jerpelea@sony.com
-arch/arm/src/tms570/tms570_boot.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com anchao@xiaomi.com
-arch/arm/src/tms570/tms570_boot.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/tms570/tms570_clockconfig.c 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com devel@sumpfralle.de
-arch/arm/src/tms570/tms570_clockconfig.h alin.jerpelea@sony.com
-arch/arm/src/tms570/tms570_esm.c hujun5@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com anchao@xiaomi.com
-arch/arm/src/tms570/tms570_esm.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com mark@mjs.pw
-arch/arm/src/tms570/tms570_gio.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/tms570/tms570_gio.h alin.jerpelea@sony.com
-arch/arm/src/tms570/tms570_gioirq.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com wangzhi16@xiaomi.com mark@mjs.pw
-arch/arm/src/tms570/tms570_irq.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com david.cab+bitbucket@gmail.com mark@mjs.pw
-arch/arm/src/tms570/tms570_irq.h alin.jerpelea@sony.com
-arch/arm/src/tms570/tms570_lowputc.c xiaoxiang@xiaomi.com hujun5@xiaomi.com alin.jerpelea@sony.com yangsong8@xiaomi.com
-arch/arm/src/tms570/tms570_lowputc.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/arm/src/tms570/tms570_selftest.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com hartman.nathan@gmail.com
-arch/arm/src/tms570/tms570_selftest.h alin.jerpelea@sony.com
-arch/arm/src/tms570/tms570_serial.c alin.jerpelea@sony.com bashton@brennanashton.com xiaoxiang@xiaomi.com mark@mjs.pw
-arch/arm/src/tms570/tms570_timerisr.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com mark@mjs.pw
+
+arch/arm/src/str71x/* alin.jerpelea@sony.com
+arch/arm/src/tiva/* alin.jerpelea@sony.com xiaoxiang@xiaomi.com hartman.nathan@gmail.com
+arch/arm/src/tlsr82/* wangbowen6@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
+arch/arm/src/tms570/* xiaoxiang@xiaomi.com alin.jerpelea@sony.com
+
 arch/arm/src/xmc4/Kconfig 101105604+simbit18@users.noreply.github.com adrien.desproges@gmail.com nicolas.lemble@gmail.com acassis@gmail.com
 arch/arm/src/xmc4/chip.h alin.jerpelea@sony.com raiden00pl@gmail.com
 arch/arm/src/xmc4/hardware/xmc4_ccu4.h thomas.narayana-swamy@wandercraft.eu nicolas.lemble@gmail.com alin.jerpelea@sony.com adrien.desproges@gmail.com
@@ -6688,16 +4748,15 @@ arch/arm/src/xmc4/xmc4_usic.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 arch/arm/src/xmc4/xmc4_usic.h alin.jerpelea@sony.com
 arch/arm/src/xmc4/xmc4_vadc.c adrien.desproges@gmail.com alin.jerpelea@sony.com devel@sumpfralle.de
 arch/arm/src/xmc4/xmc4_vadc.h adrien.desproges@gmail.com alin.jerpelea@sony.com devel@sumpfralle.de
+
 arch/arm64/Kconfig qinwei1@xiaomi.com wangming9@xiaomi.com luppy@appkaki.com ville.juven@unikie.com wangmingrong1@xiaomi.com
-arch/arm64/include/.gitignore qinwei1@xiaomi.com
 arch/arm64/include/a527/chip.h luppy@appkaki.com
 arch/arm64/include/a527/irq.h luppy@appkaki.com
 arch/arm64/include/a64/chip.h luppy@appkaki.com zhangyuan21@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 arch/arm64/include/a64/irq.h fft@feedforward.com.cn luppy@appkaki.com alin.jerpelea@sony.com
 arch/arm64/include/arch.h qinwei1@xiaomi.com ville.juven@unikie.com liguiding1@xiaomi.com chenzhijia@xiaomi.com hujun5@xiaomi.com
 arch/arm64/include/barriers.h lipengfei28@xiaomi.com
-arch/arm64/include/bcm2711/chip.h matteo.golin@gmail.com
-arch/arm64/include/bcm2711/irq.h matteo.golin@gmail.com
+arch/arm64/include/bcm2711/* matteo.golin@gmail.com
 arch/arm64/include/elf.h dongjiuzhu1@xiaomi.com anjiahao@xiaomi.com alin.jerpelea@sony.com
 arch/arm64/include/fvp-v8r/chip.h qinwei1@xiaomi.com zhangyuan21@xiaomi.com wangming9@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 arch/arm64/include/fvp-v8r/irq.h qinwei1@xiaomi.com hujun5@xiaomi.com alin.jerpelea@sony.com
@@ -6725,7 +4784,6 @@ arch/arm64/include/syscall.h qinwei1@xiaomi.com gpoulios@census-labs.com ville.j
 arch/arm64/include/types.h qinwei1@xiaomi.com chenxiaoyi@xiaomi.com alin.jerpelea@sony.com
 arch/arm64/include/zynq-mpsoc/chip.h fft@feedforward.com.cn 101105604+simbit18@users.noreply.github.com alin.jerpelea@sony.com
 arch/arm64/include/zynq-mpsoc/irq.h fft@feedforward.com.cn devel@sumpfralle.de alin.jerpelea@sony.com
-arch/arm64/src/.gitignore qinwei1@xiaomi.com
 arch/arm64/src/Makefile qinwei1@xiaomi.com mike_0528@163.com anchao@xiaomi.com yinshengkai@xiaomi.com anjiahao@xiaomi.com
 arch/arm64/src/Toolchain.defs qinwei1@xiaomi.com wangmingrong1@xiaomi.com cuiziwei@xiaomi.com anjiahao@xiaomi.com yanghuatao@xiaomi.com
 arch/arm64/src/a527/Kconfig luppy@appkaki.com
@@ -6765,34 +4823,7 @@ arch/arm64/src/a64/hardware/a64_pio.h luppy@appkaki.com alin.jerpelea@sony.com
 arch/arm64/src/a64/hardware/a64_twi.h fft@feedforward.com.cn 101105604+simbit18@users.noreply.github.com devel@sumpfralle.de alin.jerpelea@sony.com f.panag@amco.gr
 arch/arm64/src/a64/mipi_dsi.c luppy@appkaki.com alin.jerpelea@sony.com anchao@xiaomi.com
 arch/arm64/src/a64/mipi_dsi.h luppy@appkaki.com alin.jerpelea@sony.com
-arch/arm64/src/bcm2711/Kconfig matteo.golin@gmail.com 101105604+simbit18@users.noreply.github.com
-arch/arm64/src/bcm2711/bcm2711_boot.c matteo.golin@gmail.com
-arch/arm64/src/bcm2711/bcm2711_boot.h matteo.golin@gmail.com
-arch/arm64/src/bcm2711/bcm2711_gpio.c matteo.golin@gmail.com
-arch/arm64/src/bcm2711/bcm2711_gpio.h matteo.golin@gmail.com
-arch/arm64/src/bcm2711/bcm2711_i2c.c matteo.golin@gmail.com
-arch/arm64/src/bcm2711/bcm2711_i2c.h matteo.golin@gmail.com
-arch/arm64/src/bcm2711/bcm2711_lowputc.c matteo.golin@gmail.com
-arch/arm64/src/bcm2711/bcm2711_serial.c matteo.golin@gmail.com devel@sumpfralle.de
-arch/arm64/src/bcm2711/bcm2711_serial.h matteo.golin@gmail.com
-arch/arm64/src/bcm2711/bcm2711_spi.c matteo.golin@gmail.com
-arch/arm64/src/bcm2711/bcm2711_spi.h matteo.golin@gmail.com
-arch/arm64/src/bcm2711/bcm2711_timer.c matteo.golin@gmail.com ouyangxiangzhen@xiaomi.com
-arch/arm64/src/bcm2711/chip.h matteo.golin@gmail.com
-arch/arm64/src/bcm2711/hardware/bcm2711_armtimer.h matteo.golin@gmail.com
-arch/arm64/src/bcm2711/hardware/bcm2711_aux.h matteo.golin@gmail.com
-arch/arm64/src/bcm2711/hardware/bcm2711_bsc.h matteo.golin@gmail.com
-arch/arm64/src/bcm2711/hardware/bcm2711_dma.h matteo.golin@gmail.com
-arch/arm64/src/bcm2711/hardware/bcm2711_gpclk.h matteo.golin@gmail.com
-arch/arm64/src/bcm2711/hardware/bcm2711_gpio.h matteo.golin@gmail.com
-arch/arm64/src/bcm2711/hardware/bcm2711_irq.h matteo.golin@gmail.com
-arch/arm64/src/bcm2711/hardware/bcm2711_mailbox.h matteo.golin@gmail.com
-arch/arm64/src/bcm2711/hardware/bcm2711_memmap.h matteo.golin@gmail.com devel@sumpfralle.de
-arch/arm64/src/bcm2711/hardware/bcm2711_pcm.h matteo.golin@gmail.com
-arch/arm64/src/bcm2711/hardware/bcm2711_pwm.h matteo.golin@gmail.com
-arch/arm64/src/bcm2711/hardware/bcm2711_spi.h matteo.golin@gmail.com
-arch/arm64/src/bcm2711/hardware/bcm2711_systimer.h matteo.golin@gmail.com
-arch/arm64/src/bcm2711/hardware/bcm2711_uart.h matteo.golin@gmail.com
+arch/arm64/src/bcm2711/* matteo.golin@gmail.com
 arch/arm64/src/cmake/Toolchain.cmake wangmingrong1@xiaomi.com xuxin19@xiaomi.com cuiziwei@xiaomi.com Mike_0528@163.com yinshengkai@xiaomi.com
 arch/arm64/src/cmake/clang.cmake wangmingrong1@xiaomi.com
 arch/arm64/src/cmake/gcc.cmake wangmingrong1@xiaomi.com
@@ -6897,7 +4928,6 @@ arch/arm64/src/imx8/imx8qm_lowputc.S qinwei1@xiaomi.com alin.jerpelea@sony.com a
 arch/arm64/src/imx8/imx8qm_serial.c qinwei1@xiaomi.com yangsong8@xiaomi.com anchao@lixiang.com devel@sumpfralle.de alin.jerpelea@sony.com
 arch/arm64/src/imx9/Kconfig ville.juven@unikie.com jukkax@ssrc.tii.ae jani.paalijarvi@unikie.com tkaratapanis@census-labs.com eero.nurkkala@offcode.fi
 arch/arm64/src/imx9/chip.h ville.juven@unikie.com alin.jerpelea@sony.com
-arch/arm64/src/imx9/ddr/.gitignore eero.nurkkala@offcode.fi
 arch/arm64/src/imx9/ddr/hardware/imx9_ddr_training.h eero.nurkkala@offcode.fi alin.jerpelea@sony.com
 arch/arm64/src/imx9/ddr/imx9_ddr_training.c eero.nurkkala@offcode.fi alin.jerpelea@sony.com
 arch/arm64/src/imx9/ddr/imx9_ddr_training.h eero.nurkkala@offcode.fi alin.jerpelea@sony.com
@@ -7024,7 +5054,6 @@ arch/arm64/src/zynq-mpsoc/zynq_serial.c fft@feedforward.com.cn 101105604+simbit1
 arch/arm64/src/zynq-mpsoc/zynq_serial.h fft@feedforward.com.cn alin.jerpelea@sony.com
 arch/arm64/src/zynq-mpsoc/zynq_timer.c xuxingliang@xiaomi.com ouyangxiangzhen@xiaomi.com alin.jerpelea@sony.com
 arch/avr/Kconfig kr.git@kerogit.eu jordi@midokura.com liuhaitao@xiaomi.com
-arch/avr/include/.gitignore xiaoxiang@xiaomi.com
 arch/avr/include/arch.h alin.jerpelea@sony.com abdelatif.guettouche@gmail.com xiaoxiang@xiaomi.com
 arch/avr/include/at32uc3/irq.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com
 arch/avr/include/at90usb/irq.h alin.jerpelea@sony.com gustavo.nihei@espressif.com 59230071+hartmannathan@users.noreply.github.com
@@ -7051,55 +5080,12 @@ arch/avr/include/types.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com 59230071+ha
 arch/avr/include/xmega/chip.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 arch/avr/include/xmega/irq.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 arch/avr/include/xmega/xmegac_irq.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com
-arch/avr/src/.gitignore xiaoxiang@xiaomi.com yamamoto@midokura.com
 arch/avr/src/Makefile xiaoxiang@xiaomi.com alin.jerpelea@sony.com matias@protobits.dev
-arch/avr/src/at32uc3/Kconfig ramangopalan@gmail.com
-arch/avr/src/at32uc3/at32uc3.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com juha.niskanen@haltian.com
-arch/avr/src/at32uc3/at32uc3_abdac.h alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_adc.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_clkinit.c alin.jerpelea@sony.com ramangopalan@gmail.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_config.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com liuhaitao@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_eic.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_flashc.h alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_gpio.c alin.jerpelea@sony.com ramangopalan@gmail.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_gpio.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_gpioirq.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com wangzhi16@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_hmatrix.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_intc.h alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_irq.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com mark@mjs.pw
-arch/avr/src/at32uc3/at32uc3_lowconsole.c alin.jerpelea@sony.com zhangyuan21@xiaomi.com ramangopalan@gmail.com
-arch/avr/src/at32uc3/at32uc3_lowinit.c alin.jerpelea@sony.com zhangyuan21@xiaomi.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_memorymap.h alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_pdca.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_pinmux.h alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_pm.h ramangopalan@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_pwm.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_rtc.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_serial.c juha.niskanen@haltian.com alin.jerpelea@sony.com zhangyuan21@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_spi.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_ssc.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_tc.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_timerisr.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com mark@mjs.pw
-arch/avr/src/at32uc3/at32uc3_twi.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_usart.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_usbb.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3_wdt.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3a_pinmux.h alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com ramangopalan@gmail.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3a_pm.h ramangopalan@gmail.com alin.jerpelea@sony.com
-arch/avr/src/at32uc3/at32uc3b_pinmux.h alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com xiaoxiang@xiaomi.com
-arch/avr/src/at32uc3/at32uc3b_pm.h ramangopalan@gmail.com alin.jerpelea@sony.com
-arch/avr/src/at32uc3/chip.h alin.jerpelea@sony.com ramangopalan@gmail.com paul-a.patience@polymtl.ca xiaoxiang@xiaomi.com
-arch/avr/src/at90usb/at90usb.h alin.jerpelea@sony.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
-arch/avr/src/at90usb/at90usb_config.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com petro.karashchenko@gmail.com
-arch/avr/src/at90usb/at90usb_exceptions.S alin.jerpelea@sony.com xiaoxiang@xiaomi.com zhangyuan21@xiaomi.com  1 file changed, 2 insertions(+), 2 deletions(-)
-arch/avr/src/at90usb/at90usb_head.S alin.jerpelea@sony.com zhangyuan21@xiaomi.com xiaoxiang@xiaomi.com  1 file changed, 279 deletions(-)
-arch/avr/src/at90usb/at90usb_lowconsole.c alin.jerpelea@sony.com zhangyuan21@xiaomi.com xiaoxiang@xiaomi.com
-arch/avr/src/at90usb/at90usb_lowinit.c alin.jerpelea@sony.com zhangyuan21@xiaomi.com hartman.nathan@gmail.com
-arch/avr/src/at90usb/at90usb_memorymap.h alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
-arch/avr/src/at90usb/at90usb_serial.c alin.jerpelea@sony.com zhangyuan21@xiaomi.com xiaoxiang@xiaomi.com
-arch/avr/src/at90usb/at90usb_timerisr.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com mark@mjs.pw
-arch/avr/src/at90usb/at90usb_usbdev.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com juha.niskanen@haltian.com
-arch/avr/src/at90usb/chip.h alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
+
+arch/avr/src/at32uc3/* alin.jerpelea@sony.com xiaoxiang@xiaomi.com ramangopalan@gmail.com
+
+arch/avr/src/at90usb/* alin.jerpelea@sony.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
+
 arch/avr/src/atmega/Kconfig dikloper@cisco.com jeditekunum@gmail.com kr.git@kerogit.eu
 arch/avr/src/atmega/atmega.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com juha.niskanen@haltian.com
 arch/avr/src/atmega/atmega_config.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com liuhaitao@xiaomi.com
@@ -7111,6 +5097,7 @@ arch/avr/src/atmega/atmega_memorymap.h alin.jerpelea@sony.com 101105604+simbit18
 arch/avr/src/atmega/atmega_serial.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com mark@mjs.pw
 arch/avr/src/atmega/atmega_timerisr.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com dikloper@cisco.com
 arch/avr/src/atmega/chip.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
+
 arch/avr/src/avr/Kconfig kr.git@kerogit.eu xiaoxiang@xiaomi.com anchao@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
 arch/avr/src/avr/Toolchain.defs xiaoxiang@xiaomi.com alin.jerpelea@sony.com kr.git@kerogit.eu
 arch/avr/src/avr/avr.h alin.jerpelea@sony.com zhangyuan21@xiaomi.com sebastien@lorquet.fr anchao@xiaomi.com
@@ -7188,7 +5175,6 @@ arch/avr/src/common/avr_releasestack.c zhangyuan21@xiaomi.com alin.jerpelea@sony
 arch/avr/src/common/avr_udelay.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
 arch/avr/src/xmega/hardware/xmegac_memorymap.h alin.jerpelea@sony.com
 arch/ceva/Kconfig liguiding1@xiaomi.com
-arch/ceva/include/.gitignore liguiding1@xiaomi.com
 arch/ceva/include/arch.h liguiding1@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com zhuyanlin1@xiaomi.com
 arch/ceva/include/barriers.h lipengfei28@xiaomi.com
 arch/ceva/include/inttypes.h liguiding1@xiaomi.com alin.jerpelea@sony.com
@@ -7209,7 +5195,6 @@ arch/ceva/include/xm6/irq.h liguiding1@xiaomi.com xiaoxiang@xiaomi.com buxiasen@
 arch/ceva/include/xm6/math.h liguiding1@xiaomi.com alin.jerpelea@sony.com
 arch/ceva/include/xm6/reg.h liguiding1@xiaomi.com alin.jerpelea@sony.com
 arch/ceva/include/xm6/spinlock.h liguiding1@xiaomi.com lipengfei28@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/ceva/src/.gitignore liguiding1@xiaomi.com
 arch/ceva/src/Makefile liguiding1@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com marco.casaroli@gmail.com
 arch/ceva/src/common/ceva_board.c zhangyuan21@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
 arch/ceva/src/common/ceva_checkstack.c zhangyuan21@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com liguiding1@xiaomi.com
@@ -7274,10 +5259,8 @@ arch/ceva/src/xm6/xm6_mpu.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
 arch/ceva/src/xm6/xm6_psu.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com f.panag@amco.gr
 arch/ceva/src/xm6/xm6_signal_handler.S zhangyuan21@xiaomi.com alin.jerpelea@sony.com
 arch/ceva/src/xm6/xm6_svcall_handler.S zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/dummy/.gitignore liuhaitao@xiaomi.com
 arch/dummy/dummy_kconfig liuhaitao@xiaomi.com
 arch/hc/Kconfig liuhaitao@xiaomi.com jordi@midokura.com
-arch/hc/include/.gitignore xiaoxiang@xiaomi.com
 arch/hc/include/arch.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
 arch/hc/include/hc12/irq.h alin.jerpelea@sony.com buxiasen@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
 arch/hc/include/hc12/limits.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
@@ -7291,7 +5274,6 @@ arch/hc/include/limits.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 arch/hc/include/m9s12/irq.h xiaoxiang@xiaomi.com alin.jerpelea@sony.com yinshengkai@xiaomi.com
 arch/hc/include/syscall.h alin.jerpelea@sony.com petro.karashchenko@gmail.com 59230071+hartmannathan@users.noreply.github.com
 arch/hc/include/types.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
-arch/hc/src/.gitignore xiaoxiang@xiaomi.com yamamoto@midokura.com
 arch/hc/src/Makefile xiaoxiang@xiaomi.com alin.jerpelea@sony.com matias@protobits.dev
 arch/hc/src/common/hc_allocateheap.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
 arch/hc/src/common/hc_copystate.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
@@ -7342,7 +5324,6 @@ arch/hc/src/m9s12/m9s12_tim.h alin.jerpelea@sony.com petro.karashchenko@gmail.co
 arch/hc/src/m9s12/m9s12_timerisr.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com mark@mjs.pw
 arch/hc/src/m9s12/m9s12_vectors.S alin.jerpelea@sony.com zhangyuan21@xiaomi.com xiaoxiang@xiaomi.com devel@sumpfralle.de
 arch/mips/Kconfig abdelatif.guettouche@gmail.com jordi@midokura.com liuhaitao@xiaomi.com
-arch/mips/include/.gitignore xiaoxiang@xiaomi.com
 arch/mips/include/arch.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
 arch/mips/include/inttypes.h paul-a.patience@polymtl.ca yamamoto@midokura.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 arch/mips/include/irq.h anchao@xiaomi.com alin.jerpelea@sony.com hujun5@xiaomi.com xiaoxiang@xiaomi.com
@@ -7363,7 +5344,6 @@ arch/mips/include/pic32mz/irq_pic32mzxxxec.h alin.jerpelea@sony.com 59230071+har
 arch/mips/include/pic32mz/irq_pic32mzxxxef.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com
 arch/mips/include/syscall.h xiaoxiang@xiaomi.com alin.jerpelea@sony.com zhangyuan21@xiaomi.com
 arch/mips/include/types.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com yamamoto@midokura.com chenxiaoyi@xiaomi.com
-arch/mips/src/.gitignore xiaoxiang@xiaomi.com yamamoto@midokura.com
 arch/mips/src/Makefile xiaoxiang@xiaomi.com alin.jerpelea@sony.com matias@protobits.dev
 arch/mips/src/common/mips_allocateheap.c abdelatif.guettouche@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 arch/mips/src/common/mips_createstack.c abdelatif.guettouche@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
@@ -7498,18 +5478,6 @@ arch/mips/src/pic32mz/pic32mz_timer_lowerhalf.c abdelatif.guettouche@gmail.com x
 arch/mips/src/pic32mz/pic32mz_timerisr.c abdelatif.guettouche@gmail.com alin.jerpelea@sony.com zhangyuan21@xiaomi.com xiaoxiang@xiaomi.com
 arch/mips/src/pic32mz/pic32mz_usbdev.h abdelatif.guettouche@gmail.com 101105604+simbit18@users.noreply.github.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 arch/misoc/Kconfig keytwo@gmail.com liuhaitao@xiaomi.com jordi@midokura.com 59230071+hartmannathan@users.noreply.github.com
-arch/misoc/include/.gitignore xiaoxiang@xiaomi.com
-arch/misoc/include/arch.h xiaoxiang@xiaomi.com alin.jerpelea@sony.com keytwo@gmail.com
-arch/misoc/include/inttypes.h keytwo@gmail.com yamamoto@midokura.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/misoc/include/irq.h keytwo@gmail.com anchao@xiaomi.com alin.jerpelea@sony.com hujun5@xiaomi.com xiaoxiang@xiaomi.com
-arch/misoc/include/limits.h keytwo@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/misoc/include/lm32/irq.h keytwo@gmail.com alin.jerpelea@sony.com yinshengkai@xiaomi.com buxiasen@xiaomi.com
-arch/misoc/include/minerva/csrdefs.h keytwo@gmail.com alin.jerpelea@sony.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com
-arch/misoc/include/minerva/irq.h keytwo@gmail.com alin.jerpelea@sony.com buxiasen@xiaomi.com yinshengkai@xiaomi.com hujun5@xiaomi.com
-arch/misoc/include/stdarg.h keytwo@gmail.com alin.jerpelea@sony.com
-arch/misoc/include/syscall.h xiaoxiang@xiaomi.com keytwo@gmail.com alin.jerpelea@sony.com zhangyuan21@xiaomi.com
-arch/misoc/include/types.h keytwo@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com chenxiaoyi@xiaomi.com yamamoto@midokura.com
-arch/misoc/src/.gitignore xiaoxiang@xiaomi.com yamamoto@midokura.com
 arch/misoc/src/Makefile keytwo@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com matias@protobits.dev yamamoto@midokura.com
 arch/misoc/src/common/hw/common.h keytwo@gmail.com alin.jerpelea@sony.com gustavo.nihei@espressif.com
 arch/misoc/src/common/hw/ethmac_mem.h keytwo@gmail.com alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com
@@ -7580,57 +5548,10 @@ arch/misoc/src/minerva/minerva_switchcontext.c zhangyuan21@xiaomi.com alin.jerpe
 arch/misoc/src/minerva/minerva_syscall.S keytwo@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 arch/misoc/src/minerva/minerva_usestack.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
 arch/misoc/src/minerva/minerva_vectors.S keytwo@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/or1k/Kconfig matt@extent3d.com liuhaitao@xiaomi.com jordi@midokura.com
-arch/or1k/include/.gitignore matt@extent3d.com xiaoxiang@xiaomi.com
-arch/or1k/include/arch.h matt@extent3d.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com ville.juven@unikie.com jukkax@ssrc.tii.ae
-arch/or1k/include/inttypes.h matt@extent3d.com yamamoto@midokura.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/or1k/include/irq.h anchao@xiaomi.com matt@extent3d.com hujun5@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/or1k/include/limits.h matt@extent3d.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/or1k/include/mor1kx/irq.h matt@extent3d.com buxiasen@xiaomi.com alin.jerpelea@sony.com hujun5@xiaomi.com
-arch/or1k/include/spr.h matt@extent3d.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/or1k/include/types.h matt@extent3d.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com chenxiaoyi@xiaomi.com yamamoto@midokura.com
-arch/or1k/src/.gitignore matt@extent3d.com xiaoxiang@xiaomi.com yamamoto@midokura.com
-arch/or1k/src/Makefile matt@extent3d.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com matias@protobits.dev yamamoto@midokura.com
-arch/or1k/src/common/or1k_allocateheap.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_checkstack.c zhangyuan21@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com liguiding1@xiaomi.com
-arch/or1k/src/common/or1k_copyfullstate.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_cpuinfo.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_createstack.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_doirq.c zhangyuan21@xiaomi.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_etherstub.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_exit.c zhangyuan21@xiaomi.com anchao@xiaomi.com hujun5@xiaomi.com ville.juven@unikie.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_fullcontextrestore.S zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_getintstack.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com liguiding1@xiaomi.com
-arch/or1k/src/common/or1k_idle.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_initialize.c zhangyuan21@xiaomi.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_initialstate.c zhangyuan21@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_internal.h zhangyuan21@xiaomi.com xiaoxiang@xiaomi.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_lowputs.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_mdelay.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_modifyreg16.c zhangyuan21@xiaomi.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_modifyreg32.c zhangyuan21@xiaomi.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_modifyreg8.c zhangyuan21@xiaomi.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_nputs.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_pthread_start.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_registerdump.c zhangyuan21@xiaomi.com buxiasen@xiaomi.com alin.jerpelea@sony.com hujun5@xiaomi.com
-arch/or1k/src/common/or1k_releasestack.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_saveusercontext.S zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_schedulesigaction.c zhangyuan21@xiaomi.com hujun5@xiaomi.com xiaoxiang@xiaomi.com wangzhi16@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_stackframe.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_switchcontext.c zhangyuan21@xiaomi.com hujun5@xiaomi.com ville.juven@unikie.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_task_start.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_timer.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_udelay.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/common/or1k_usestack.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/mor1kx/Kconfig matt@extent3d.com xiaoxiang@xiaomi.com
-arch/or1k/src/mor1kx/Toolchain.defs xiaoxiang@xiaomi.com matt@extent3d.com alin.jerpelea@sony.com anjiahao@xiaomi.com petro.karashchenko@gmail.com
-arch/or1k/src/mor1kx/mor1kx_serial.c matt@extent3d.com alin.jerpelea@sony.com hujun5@xiaomi.com zhangyuan21@xiaomi.com yangsong8@xiaomi.com
-arch/or1k/src/mor1kx/mor1kx_start.c matt@extent3d.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com zhangyuan21@xiaomi.com petro.karashchenko@gmail.com
-arch/or1k/src/mor1kx/mor1kx_start.h matt@extent3d.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/or1k/src/mor1kx/or1k_irq.c zhangyuan21@xiaomi.com xiaoxiang@xiaomi.com wangzhi16@xiaomi.com alin.jerpelea@sony.com
-arch/or1k/src/mor1kx/or1k_vectortab.S zhangyuan21@xiaomi.com alin.jerpelea@sony.com
+
+arch/or1k/* matt@extent3d.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com zhangyuan21@xiaomi.com
+
 arch/renesas/Kconfig anjana@tataelxsi.co.in mransom@campbellsci.com petro.karashchenko@gmail.com jordi@midokura.com
-arch/renesas/include/.gitignore bindyaraja@gmail.com
 arch/renesas/include/arch.h alin.jerpelea@sony.com abdelatif.guettouche@gmail.com 59230071+hartmannathan@users.noreply.github.com
 arch/renesas/include/inttypes.h paul-a.patience@polymtl.ca alin.jerpelea@sony.com
 arch/renesas/include/irq.h anchao@xiaomi.com alin.jerpelea@sony.com hujun5@xiaomi.com yfliu2008@qq.com
@@ -7656,7 +5577,6 @@ arch/renesas/include/sh1Plimits.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com pe
 arch/renesas/include/sh1Ptypes.h alin.jerpelea@sony.com petro.karashchenko@gmail.com yamamoto@midokura.com gustavo.nihei@espressif.com
 arch/renesas/include/syscall.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com
 arch/renesas/include/types.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-arch/renesas/src/.gitignore xiaoxiang@xiaomi.com bindyaraja@gmail.com yamamoto@midokura.com
 arch/renesas/src/Makefile xiaoxiang@xiaomi.com alin.jerpelea@sony.com anjana@tataelxsi.co.in matias@protobits.dev
 arch/renesas/src/common/renesas_allocateheap.c zhangyuan21@xiaomi.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
 arch/renesas/src/common/renesas_createstack.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
@@ -7750,7 +5670,6 @@ arch/renesas/src/sh1/sh1_sigdeliver.c wangzhi16@xiaomi.com hujun5@xiaomi.com zha
 arch/renesas/src/sh1/sh1_timerisr.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com mark@mjs.pw zhangyuan21@xiaomi.com
 arch/renesas/src/sh1/sh1_vector.S alin.jerpelea@sony.com xiaoxiang@xiaomi.com zhangyuan21@xiaomi.com
 arch/risc-v/Kconfig huangqi3@xiaomi.com eren.terzioglu@espressif.com luppy@appkaki.com ville.juven@unikie.com anchao@lixiang.com
-arch/risc-v/include/.gitignore masayuki.ishikawa@gmail.com xiaoxiang@xiaomi.com
 arch/risc-v/include/arch.h pettitkd@gmail.com ville.juven@unikie.com xiaoxiang@xiaomi.com huangqi3@xiaomi.com alin.jerpelea@sony.com
 arch/risc-v/include/barriers.h ville.juven@unikie.com lipengfei28@xiaomi.com alin.jerpelea@sony.com
 arch/risc-v/include/bl602/chip.h lchen@bouffalolab.com xiaoxiang@xiaomi.com virusv@live.com yyang@bouffalolab.com alin.jerpelea@sony.com
@@ -7766,11 +5685,8 @@ arch/risc-v/include/elf.h masayuki.ishikawa@gmail.com ville.juven@unikie.com stu
 arch/risc-v/include/esp32c3-legacy/chip.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
 arch/risc-v/include/esp32c3-legacy/esp_efuse_table.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
 arch/risc-v/include/esp32c3-legacy/irq.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/include/esp32c3/.gitignore eren.terzioglu@espressif.com
 arch/risc-v/include/esp32c3/chip.h eren.terzioglu@espressif.com dongheng@espressif.com alan.carvalho@espressif.com alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/risc-v/include/esp32c6/.gitignore eren.terzioglu@espressif.com
 arch/risc-v/include/esp32c6/chip.h eren.terzioglu@espressif.com chenwen@espressif.com alin.jerpelea@sony.com
-arch/risc-v/include/esp32h2/.gitignore eren.terzioglu@espressif.com
 arch/risc-v/include/esp32h2/chip.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
 arch/risc-v/include/fe310/chip.h masayuki.ishikawa@gmail.com alin.jerpelea@sony.com
 arch/risc-v/include/fe310/irq.h masayuki.ishikawa@gmail.com huangqi3@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
@@ -7810,118 +5726,11 @@ arch/risc-v/include/stdarg.h pettitkd@gmail.com alin.jerpelea@sony.com ysgn0101@
 arch/risc-v/include/syscall.h huangqi3@xiaomi.com xiaoxiang@xiaomi.com ville.juven@unikie.com pettitkd@gmail.com alin.jerpelea@sony.com
 arch/risc-v/include/thead/c9xx_csr.h inochiama@outlook.com alin.jerpelea@sony.com
 arch/risc-v/include/types.h pettitkd@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com yfliu2008@qq.com yamamoto@midokura.com
-arch/risc-v/src/.gitignore masayuki.ishikawa@gmail.com xiaoxiang@xiaomi.com yamamoto@midokura.com
 arch/risc-v/src/Makefile pettitkd@gmail.com xiaoxiang@xiaomi.com anchao@xiaomi.com alin.jerpelea@sony.com mike_0528@163.com
-arch/risc-v/src/bl602/.gitignore virusv@live.com
-arch/risc-v/src/bl602/Kconfig lchen@bouffalolab.com virusv@live.com bashton@brennanashton.com liangzhang@bouffalolab.com xiaoxiang@xiaomi.com
-arch/risc-v/src/bl602/bl602_allocateheap.c lchen@bouffalolab.com abdelatif.guettouche@espressif.com virusv@live.com xiaoxiang@xiaomi.com inochiama@outlook.com
-arch/risc-v/src/bl602/bl602_boot2.h lchen@bouffalolab.com virusv@live.com yyang@bouffalolab.com bashton@brennanashton.com liangzhang@bouffalolab.com
-arch/risc-v/src/bl602/bl602_config.h lchen@bouffalolab.com virusv@live.com yyang@bouffalolab.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/bl602_dma.c bashton@brennanashton.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com f.panag@amco.gr devel@sumpfralle.de
-arch/risc-v/src/bl602/bl602_dma.h bashton@brennanashton.com alin.jerpelea@sony.com f.panag@amco.gr
-arch/risc-v/src/bl602/bl602_efuse.c virusv@live.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/bl602_efuse.h virusv@live.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/bl602_flash.c liangzhang@bouffalolab.com virusv@live.com bashton@brennanashton.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/bl602_flash.h liangzhang@bouffalolab.com alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/risc-v/src/bl602/bl602_glb.c lchen@bouffalolab.com bashton@brennanashton.com virusv@live.com yyang@bouffalolab.com liangzhang@bouffalolab.com
-arch/risc-v/src/bl602/bl602_glb.h bashton@brennanashton.com virusv@live.com liangzhang@bouffalolab.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/bl602_gpio.c bashton@brennanashton.com lchen@bouffalolab.com yyang@bouffalolab.com virusv@live.com liangzhang@bouffalolab.com
-arch/risc-v/src/bl602/bl602_gpio.h bashton@brennanashton.com liangzhang@bouffalolab.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/bl602_hbn.c virusv@live.com lchen@bouffalolab.com yyang@bouffalolab.com bashton@brennanashton.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/bl602_hbn.h virusv@live.com bashton@brennanashton.com gustavo.nihei@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/bl602_head.S huangqi3@xiaomi.com lchen@bouffalolab.com xiaoxiang@xiaomi.com inochiama@outlook.com jsun@bouffalolab.com
-arch/risc-v/src/bl602/bl602_i2c.c liangzhang@bouffalolab.com anjiahao@xiaomi.com gustavo.nihei@espressif.com bashton@brennanashton.com xiaoxiang@xiaomi.com
-arch/risc-v/src/bl602/bl602_i2c.h liangzhang@bouffalolab.com alin.jerpelea@sony.com gustavo.nihei@espressif.com govind.sk85@gmail.com
-arch/risc-v/src/bl602/bl602_irq.c lchen@bouffalolab.com huangqi3@xiaomi.com dongheng@espressif.com xiaoxiang@xiaomi.com virusv@live.com
-arch/risc-v/src/bl602/bl602_irq_dispatch.c lchen@bouffalolab.com huangqi3@xiaomi.com hotislandn@hotmail.com petro.karashchenko@gmail.com virusv@live.com
-arch/risc-v/src/bl602/bl602_lowputc.c lchen@bouffalolab.com bashton@brennanashton.com yyang@bouffalolab.com virusv@live.com xiaoxiang@xiaomi.com
-arch/risc-v/src/bl602/bl602_lowputc.h lchen@bouffalolab.com yyang@bouffalolab.com virusv@live.com bashton@brennanashton.com petro.karashchenko@gmail.com
-arch/risc-v/src/bl602/bl602_netdev.c virusv@live.com zhanghongyu@xiaomi.com gustavo.nihei@espressif.com anchao@xiaomi.com wengzhe@xiaomi.com
-arch/risc-v/src/bl602/bl602_netdev.h virusv@live.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/bl602_oneshot_lowerhalf.c lchen@bouffalolab.com yyang@bouffalolab.com gustavo.nihei@espressif.com virusv@live.com bashton@brennanashton.com
-arch/risc-v/src/bl602/bl602_oneshot_lowerhalf.h lchen@bouffalolab.com virusv@live.com liangzhang@bouffalolab.com yyang@bouffalolab.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/bl602_os_hal.c jsun@bouffalolab.com anjiahao@xiaomi.com xiaoxiang@xiaomi.com anchao@xiaomi.com liguiding1@xiaomi.com
-arch/risc-v/src/bl602/bl602_os_hal.h jsun@bouffalolab.com xiaoxiang@xiaomi.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/bl602_pwm_lowerhalf.c liangzhang@bouffalolab.com gustavo.nihei@espressif.com norman@rasmussen.co.za xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/bl602_pwm_lowerhalf.h liangzhang@bouffalolab.com alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/risc-v/src/bl602/bl602_romapi.h virusv@live.com bashton@brennanashton.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-arch/risc-v/src/bl602/bl602_rtc.c virusv@live.com devel@sumpfralle.de xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/bl602_rtc.h virusv@live.com gustavo.nihei@espressif.com f.panag@amco.gr petro.karashchenko@gmail.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/bl602_rtc_lowerhalf.c virusv@live.com gustavo.nihei@espressif.com anjiahao@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/bl602_serial.c lchen@bouffalolab.com bashton@brennanashton.com yyang@bouffalolab.com abdelatif.guettouche@espressif.com virusv@live.com
-arch/risc-v/src/bl602/bl602_spi.c liangzhang@bouffalolab.com bashton@brennanashton.com gustavo.nihei@espressif.com luppy@appkaki.com anjiahao@xiaomi.com
-arch/risc-v/src/bl602/bl602_spi.h liangzhang@bouffalolab.com bashton@brennanashton.com gustavo.nihei@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/bl602_spiflash.c liangzhang@bouffalolab.com gustavo.nihei@espressif.com xiaoxiang@xiaomi.com virusv@live.com bashton@brennanashton.com
-arch/risc-v/src/bl602/bl602_spiflash.h liangzhang@bouffalolab.com gustavo.nihei@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/bl602_start.c lchen@bouffalolab.com virusv@live.com inochiama@outlook.com xiaoxiang@xiaomi.com yyang@bouffalolab.com
-arch/risc-v/src/bl602/bl602_systemreset.c bashton@brennanashton.com virusv@live.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/bl602_systemreset.h bashton@brennanashton.com alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/risc-v/src/bl602/bl602_tim.c lchen@bouffalolab.com yyang@bouffalolab.com bashton@brennanashton.com gustavo.nihei@espressif.com virusv@live.com
-arch/risc-v/src/bl602/bl602_tim.h bashton@brennanashton.com gustavo.nihei@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/bl602/bl602_tim_lowerhalf.c lchen@bouffalolab.com yyang@bouffalolab.com gustavo.nihei@espressif.com petro.karashchenko@gmail.com bashton@brennanashton.com
-arch/risc-v/src/bl602/bl602_tim_lowerhalf.h lchen@bouffalolab.com virusv@live.com petro.karashchenko@gmail.com bashton@brennanashton.com yyang@bouffalolab.com
-arch/risc-v/src/bl602/bl602_timerisr.c lchen@bouffalolab.com huangqi3@xiaomi.com yyang@bouffalolab.com bashton@brennanashton.com virusv@live.com
-arch/risc-v/src/bl602/bl602_wdt_lowerhalf.c liangzhang@bouffalolab.com gustavo.nihei@espressif.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/risc-v/src/bl602/bl602_wdt_lowerhalf.h liangzhang@bouffalolab.com gustavo.nihei@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/chip.h lchen@bouffalolab.com ville.juven@unikie.com petro.karashchenko@gmail.com virusv@live.com yyang@bouffalolab.com
-arch/risc-v/src/bl602/hardware/bl602_aon.h bashton@brennanashton.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/hardware/bl602_cci.h bashton@brennanashton.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/hardware/bl602_cks.h bashton@brennanashton.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/hardware/bl602_clic.h bashton@brennanashton.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/hardware/bl602_dma.h bashton@brennanashton.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/hardware/bl602_ef.h bashton@brennanashton.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/hardware/bl602_glb.h yyang@bouffalolab.com lchen@bouffalolab.com bashton@brennanashton.com virusv@live.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/hardware/bl602_gpip.h bashton@brennanashton.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/hardware/bl602_hbn.h lchen@bouffalolab.com yyang@bouffalolab.com bashton@brennanashton.com virusv@live.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/hardware/bl602_i2c.h bashton@brennanashton.com liangzhang@bouffalolab.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/hardware/bl602_ir.h bashton@brennanashton.com alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/risc-v/src/bl602/hardware/bl602_l1c.h bashton@brennanashton.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/hardware/bl602_memorymap.h bashton@brennanashton.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/hardware/bl602_pds.h bashton@brennanashton.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/hardware/bl602_pwm.h bashton@brennanashton.com liangzhang@bouffalolab.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/hardware/bl602_rf.h bashton@brennanashton.com alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/risc-v/src/bl602/hardware/bl602_sec.h bashton@brennanashton.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/hardware/bl602_sf.h bashton@brennanashton.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/hardware/bl602_spi.h bashton@brennanashton.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/hardware/bl602_timer.h bashton@brennanashton.com lchen@bouffalolab.com yyang@bouffalolab.com virusv@live.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/hardware/bl602_tzc.h bashton@brennanashton.com alin.jerpelea@sony.com
-arch/risc-v/src/bl602/hardware/bl602_uart.h lchen@bouffalolab.com yyang@bouffalolab.com bashton@brennanashton.com xiaoxiang@xiaomi.com virusv@live.com
-arch/risc-v/src/bl808/Kconfig rovnerhenry@gmail.com 101105604+simbit18@users.noreply.github.com luppy@appkaki.com
-arch/risc-v/src/bl808/bl808_allocateheap.c luppy@appkaki.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/bl808_gpadc.c rovnerhenry@gmail.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/bl808_gpadc.h rovnerhenry@gmail.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/bl808_gpio.c rushabhvg@gmail.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/bl808_gpio.h rushabhvg@gmail.com rovnerhenry@gmail.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/bl808_head.S luppy@appkaki.com inochiama@outlook.com anchao@lixiang.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/bl808_i2c.c rovnerhenry@gmail.com devel@sumpfralle.de
-arch/risc-v/src/bl808/bl808_i2c.h rovnerhenry@gmail.com
-arch/risc-v/src/bl808/bl808_irq.c luppy@appkaki.com rovnerhenry@gmail.com inochiama@outlook.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/bl808_irq_dispatch.c luppy@appkaki.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/bl808_memorymap.h luppy@appkaki.com inochiama@outlook.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/bl808_mm_init.c luppy@appkaki.com yfliu2008@qq.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/bl808_mm_init.h luppy@appkaki.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/bl808_pgalloc.c luppy@appkaki.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/bl808_serial.c luppy@appkaki.com rovnerhenry@gmail.com yangsong8@xiaomi.com anchao@lixiang.com devel@sumpfralle.de
-arch/risc-v/src/bl808/bl808_serial.h luppy@appkaki.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/bl808/bl808_spi.c rovnerhenry@gmail.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/bl808/bl808_spi.h rovnerhenry@gmail.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/bl808_start.c luppy@appkaki.com inochiama@outlook.com devel@sumpfralle.de alin.jerpelea@sony.com rovnerhenry@gmail.com
-arch/risc-v/src/bl808/bl808_timer.c rovnerhenry@gmail.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/bl808_timer.h rovnerhenry@gmail.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/bl808_timerisr.c luppy@appkaki.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/bl808_wdt.c rovnerhenry@gmail.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/bl808_wdt.h rovnerhenry@gmail.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/chip.h luppy@appkaki.com huangqi3@xiaomi.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/hardware/bl808_glb.h rovnerhenry@gmail.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/hardware/bl808_gpadc.h rovnerhenry@gmail.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/hardware/bl808_i2c.h rovnerhenry@gmail.com
-arch/risc-v/src/bl808/hardware/bl808_m0ic.h rovnerhenry@gmail.com 101105604+simbit18@users.noreply.github.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/hardware/bl808_memorymap.h luppy@appkaki.com rovnerhenry@gmail.com alin.jerpelea@sony.com rushabhvg@gmail.com
-arch/risc-v/src/bl808/hardware/bl808_mm_glb.h rovnerhenry@gmail.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/hardware/bl808_plic.h luppy@appkaki.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/hardware/bl808_spi.h rovnerhenry@gmail.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/hardware/bl808_timer.h rovnerhenry@gmail.com alin.jerpelea@sony.com
-arch/risc-v/src/bl808/hardware/bl808_uart.h luppy@appkaki.com rovnerhenry@gmail.com alin.jerpelea@sony.com
+
+arch/risc-v/src/bl602/* bashton@brennanashton.com alin.jerpelea@sony.com yyang@bouffalolab.com virusv@live.com xiaoxiang@xiaomi.com
+arch/risc-v/src/bl808/* rovnerhenry@gmail.com luppy@appkaki.com alin.jerpelea@sony.com
+
 arch/risc-v/src/c906/Kconfig hotislandn@hotmail.com
 arch/risc-v/src/c906/c906.h hotislandn@hotmail.com alin.jerpelea@sony.com
 arch/risc-v/src/c906/c906_allocateheap.c hotislandn@hotmail.com gustavo.nihei@espressif.com zhangyuan21@xiaomi.com luppy@appkaki.com alin.jerpelea@sony.com
@@ -7950,105 +5759,9 @@ arch/risc-v/src/cmake/platform.cmake xuxin19@xiaomi.com anchao@lixiang.com yfliu
 arch/risc-v/src/common/Toolchain.defs huangqi3@xiaomi.com anchao@lixiang.com xiaoxiang@xiaomi.com anchao@xiaomi.com cuiziwei@xiaomi.com
 arch/risc-v/src/common/addrenv.h ville.juven@unikie.com alin.jerpelea@sony.com
 arch/risc-v/src/common/crt0.c ville.juven@unikie.com anjiahao@xiaomi.com xiaoxiang@xiaomi.com masayuki.ishikawa@gmail.com yfliu2008@qq.com
-arch/risc-v/src/common/espressif/.gitignore eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com
-arch/risc-v/src/common/espressif/Bootloader.mk eren.terzioglu@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/Kconfig eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com tiago.medicci@espressif.com martin.vajnar@gmail.com eng.davidiogo@gmail.com
-arch/risc-v/src/common/espressif/Wireless.mk tiago.medicci@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com eren.terzioglu@espressif.com
-arch/risc-v/src/common/espressif/chip.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_adc.c filipe.cavalcanti@espressif.com devel@sumpfralle.de
-arch/risc-v/src/common/espressif/esp_adc.h filipe.cavalcanti@espressif.com
-arch/risc-v/src/common/espressif/esp_allocateheap.c eren.terzioglu@espressif.com inochiama@outlook.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_config.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_crypto.c eren.terzioglu@espressif.com
-arch/risc-v/src/common/espressif/esp_dedic_gpio.c eren.terzioglu@espressif.com
-arch/risc-v/src/common/espressif/esp_dedic_gpio.h eren.terzioglu@espressif.com
-arch/risc-v/src/common/espressif/esp_dma.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_dma.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_efuse.c eren.terzioglu@espressif.com huangqi3@xiaomi.com
-arch/risc-v/src/common/espressif/esp_efuse.h eren.terzioglu@espressif.com
-arch/risc-v/src/common/espressif/esp_ets_timer_legacy.c tiago.medicci@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_gpio.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com fangxinyong@xiaomi.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_gpio.h eren.terzioglu@espressif.com tiago.medicci@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_head.S eren.terzioglu@espressif.com inochiama@outlook.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_hr_timer.c eren.terzioglu@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com hujun5@xiaomi.com xiaoxiang@xiaomi.com
-arch/risc-v/src/common/espressif/esp_hr_timer.h eren.terzioglu@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com hujun5@xiaomi.com
-arch/risc-v/src/common/espressif/esp_i2c.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com xiaoxiang@xiaomi.com wangzhi16@xiaomi.com devel@sumpfralle.de
-arch/risc-v/src/common/espressif/esp_i2c.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_i2c_bitbang.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_i2c_bitbang.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_i2c_slave.c eren.terzioglu@espressif.com devel@sumpfralle.de
-arch/risc-v/src/common/espressif/esp_i2c_slave.h eren.terzioglu@espressif.com devel@sumpfralle.de
-arch/risc-v/src/common/espressif/esp_i2s.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com devel@sumpfralle.de
-arch/risc-v/src/common/espressif/esp_i2s.h eren.terzioglu@espressif.com
-arch/risc-v/src/common/espressif/esp_idle.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_irq.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com tiago.medicci@espressif.com xiaoxiang@xiaomi.com wangzhi16@xiaomi.com
-arch/risc-v/src/common/espressif/esp_irq.h eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com tiago.medicci@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_ledc.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_ledc.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_libc_stubs.c eren.terzioglu@espressif.com tiago.medicci@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_libc_stubs.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_lowputc.c eren.terzioglu@espressif.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_lowputc.h eren.terzioglu@espressif.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_mcpwm.c filipe.cavalcanti@espressif.com anchao@lixiang.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_mcpwm.h filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_memorymap.h eren.terzioglu@espressif.com inochiama@outlook.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_nxdiag.c eren.terzioglu@espressif.com devel@sumpfralle.de anchao@lixiang.com
-arch/risc-v/src/common/espressif/esp_nxdiag.h eren.terzioglu@espressif.com
-arch/risc-v/src/common/espressif/esp_oneshot.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_oneshot.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_pcnt.c eren.terzioglu@espressif.com martin.vajnar@gmail.com filipe.cavalcanti@espressif.com mich4l.matias@gmail.com hujun5@xiaomi.com
-arch/risc-v/src/common/espressif/esp_pcnt.h eren.terzioglu@espressif.com
-arch/risc-v/src/common/espressif/esp_qencoder.c martin.vajnar@gmail.com eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_qencoder.h martin.vajnar@gmail.com eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_random.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_rmt.c tiago.medicci@espressif.com filipe.cavalcanti@espressif.com hujun5@xiaomi.com petro.karashchenko@gmail.com devel@sumpfralle.de
-arch/risc-v/src/common/espressif/esp_rmt.h tiago.medicci@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_rtc.c eren.terzioglu@espressif.com hujun5@xiaomi.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_rtc.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_rtc_gpio.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_rtc_gpio.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_sdm.c eren.terzioglu@espressif.com
-arch/risc-v/src/common/espressif/esp_sdm.h eren.terzioglu@espressif.com
-arch/risc-v/src/common/espressif/esp_serial.c eren.terzioglu@espressif.com yangsong8@xiaomi.com anchao@lixiang.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_sha.c eren.terzioglu@espressif.com
-arch/risc-v/src/common/espressif/esp_sha.h eren.terzioglu@espressif.com
-arch/risc-v/src/common/espressif/esp_spi.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com tiago.medicci@espressif.com huangqi3@xiaomi.com neo.xu1990@gmail.com
-arch/risc-v/src/common/espressif/esp_spi.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_spi_bitbang.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_spi_bitbang.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_spi_slave.c eren.terzioglu@espressif.com moura.fmo@gmail.com alin.jerpelea@sony.com dongjiuzhu1@xiaomi.com
-arch/risc-v/src/common/espressif/esp_spiflash.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com devel@sumpfralle.de fangxinyong@xiaomi.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_spiflash.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_spiflash_mtd.c eren.terzioglu@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_spiflash_mtd.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_start.c eren.terzioglu@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com inochiama@outlook.com almir.okato@espressif.com
-arch/risc-v/src/common/espressif/esp_start.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_systemreset.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_systemreset.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_temperature_sensor.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com petro.karashchenko@gmail.com devel@sumpfralle.de xiaoxiang@xiaomi.com
-arch/risc-v/src/common/espressif/esp_temperature_sensor.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_tickless.c eren.terzioglu@espressif.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_tickless.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_timer.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com chenrun1@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_timer.h eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_timerisr.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_twai.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com yfliu2008@qq.com
-arch/risc-v/src/common/espressif/esp_twai.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_usbserial.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com moura.fmo@gmail.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_usbserial.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_vectors.S eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_wdt.c eren.terzioglu@espressif.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/risc-v/src/common/espressif/esp_wdt.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_wifi_api.c filipe.cavalcanti@espressif.com
-arch/risc-v/src/common/espressif/esp_wifi_api.h filipe.cavalcanti@espressif.com
-arch/risc-v/src/common/espressif/esp_wifi_event_handler.c filipe.cavalcanti@espressif.com
-arch/risc-v/src/common/espressif/esp_wifi_utils.c filipe.cavalcanti@espressif.com tiago.medicci@espressif.com eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_wifi_utils.h filipe.cavalcanti@espressif.com tiago.medicci@espressif.com eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/esp_wlan_netdev.c filipe.cavalcanti@espressif.com
-arch/risc-v/src/common/espressif/esp_wlan_netdev.h filipe.cavalcanti@espressif.com
-arch/risc-v/src/common/espressif/esp_ws2812.c tiago.medicci@espressif.com anchao@lixiang.com alin.jerpelea@sony.com huangqi3@xiaomi.com
-arch/risc-v/src/common/espressif/esp_ws2812.h tiago.medicci@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/common/espressif/platform_include/sys/lock.h tiago.medicci@espressif.com alin.jerpelea@sony.com
+
+arch/risc-v/src/common/espressif/* eren.terzioglu@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
+
 arch/risc-v/src/common/fork.S guoshichao@xiaomi.com ville.juven@unikie.com yfliu2008@qq.com alin.jerpelea@sony.com
 arch/risc-v/src/common/pgalloc.h ville.juven@unikie.com alin.jerpelea@sony.com
 arch/risc-v/src/common/riscv_addrenv.c ville.juven@unikie.com lipengfei28@xiaomi.com tiago.medicci@espressif.com masayuki.ishikawa@gmail.com yfliu2008@qq.com
@@ -8140,186 +5853,9 @@ arch/risc-v/src/eic7700x/eic7700x_start.c luppy@appkaki.com devel@sumpfralle.de
 arch/risc-v/src/eic7700x/eic7700x_timerisr.c luppy@appkaki.com
 arch/risc-v/src/eic7700x/hardware/eic7700x_memorymap.h luppy@appkaki.com
 arch/risc-v/src/eic7700x/hardware/eic7700x_plic.h luppy@appkaki.com
-arch/risc-v/src/esp32c3-legacy/.gitignore eren.terzioglu@espressif.com
-arch/risc-v/src/esp32c3-legacy/Bootloader.mk eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/Kconfig eren.terzioglu@espressif.com janouja9@fel.cvut.cz tiago.medicci@espressif.com
-arch/risc-v/src/esp32c3-legacy/Kconfig.security eren.terzioglu@espressif.com
-arch/risc-v/src/esp32c3-legacy/chip.h eren.terzioglu@espressif.com
-arch/risc-v/src/esp32c3-legacy/esp32c3.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_adc.c eren.terzioglu@espressif.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_adc.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_aes.c eren.terzioglu@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_aes.h eren.terzioglu@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_allocateheap.c eren.terzioglu@espressif.com inochiama@outlook.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_attr.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_bignum.c eren.terzioglu@espressif.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_bignum.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_ble.c eren.terzioglu@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_ble.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_ble_adapter.c eren.terzioglu@espressif.com liguiding1@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_ble_adapter.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_brownout.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_brownout.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_clockconfig.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_clockconfig.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_config.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_crypto.c eren.terzioglu@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_dma.c eren.terzioglu@espressif.com wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_dma.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_efuse.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_efuse.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_efuse_lowerhalf.c eren.terzioglu@espressif.com alin.jerpelea@sony.com ouyangxiangzhen@xiaomi.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_efuse_table.c eren.terzioglu@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_extraheaps.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_freerun.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_freerun.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_gpio.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_gpio.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_head.S eren.terzioglu@espressif.com inochiama@outlook.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_i2c.c eren.terzioglu@espressif.com xiaoxiang@xiaomi.com wangzhi16@xiaomi.com petro.karashchenko@gmail.com devel@sumpfralle.de
-arch/risc-v/src/esp32c3-legacy/esp32c3_i2c.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_ice40.c janouja9@fel.cvut.cz petro.karashchenko@gmail.com huangqi3@xiaomi.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_ice40.h janouja9@fel.cvut.cz alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_idle.c eren.terzioglu@espressif.com hujun5@xiaomi.com chenwen@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_irq.c eren.terzioglu@espressif.com xiaoxiang@xiaomi.com wangzhi16@xiaomi.com alin.jerpelea@sony.com yfliu2008@qq.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_irq.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_ledc.c eren.terzioglu@espressif.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_ledc.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_libc_stubs.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_lowputc.c eren.terzioglu@espressif.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_lowputc.h eren.terzioglu@espressif.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_memorymap.h eren.terzioglu@espressif.com inochiama@outlook.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_oneshot.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_oneshot.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_oneshot_lowerhalf.c eren.terzioglu@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_partition.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_partition.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_perf.c eren.terzioglu@espressif.com yinshengkai@xiaomi.com jukka.laitinen@tii.ae alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_pm.c eren.terzioglu@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_pm.h eren.terzioglu@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_pminitialize.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_region.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_region.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_resetcause.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_resetcause.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_rng.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_rsa.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_rsa.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_rt_timer.c eren.terzioglu@espressif.com xiaoxiang@xiaomi.com wangzhi16@xiaomi.com alin.jerpelea@sony.com yinshengkai@xiaomi.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_rt_timer.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_rtc.c eren.terzioglu@espressif.com hujun5@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_rtc.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_rtc_gpio.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_rtc_gpio.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_rtc_lowerhalf.c eren.terzioglu@espressif.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_rtc_lowerhalf.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_rtcheap.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_rtcheap.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_serial.c eren.terzioglu@espressif.com yangsong8@xiaomi.com devel@sumpfralle.de anchao@lixiang.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_sha.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_sha.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_spi.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_spi.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_spi_slave.c eren.terzioglu@espressif.com alin.jerpelea@sony.com dongjiuzhu1@xiaomi.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_spiflash.c eren.terzioglu@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_spiflash.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_spiflash_mtd.c eren.terzioglu@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_spiflash_mtd.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_start.c eren.terzioglu@espressif.com inochiama@outlook.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_start.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_systemreset.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_systemreset.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_textheap.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_tickless.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_tickless.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_tim.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_tim.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_tim_lowerhalf.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_tim_lowerhalf.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_timerisr.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_twai.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_twai.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_uid.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_uid.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_usbserial.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_usbserial.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_userspace.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_userspace.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_vectors.S eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_wdt.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_wdt.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_wdt_lowerhalf.c eren.terzioglu@espressif.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_wdt_lowerhalf.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_wifi_adapter.c eren.terzioglu@espressif.com liguiding1@xiaomi.com yamamoto@midokura.com devel@sumpfralle.de tiago.medicci@espressif.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_wifi_adapter.h eren.terzioglu@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_wifi_utils.c eren.terzioglu@espressif.com tiago.medicci@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_wifi_utils.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_wireless.c eren.terzioglu@espressif.com alin.jerpelea@sony.com huangqi3@xiaomi.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_wireless.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_wlan.c eren.terzioglu@espressif.com devel@sumpfralle.de tiago.medicci@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/esp32c3_wlan.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/apb_ctrl_reg.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/bb_reg.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_aes.h eren.terzioglu@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_cache_memory.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_dma.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_efuse.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_gpio.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_gpio_sigmap.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_i2c.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_interrupt.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_iomux.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_ledc.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_memorymap.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_pinmap.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_rom_layout.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_rsa.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_rtccntl.h eren.terzioglu@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_saradc.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_sha.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_soc.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_spi.h eren.terzioglu@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_syscon.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_system.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_systimer.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_tim.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_twai.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_uart.h eren.terzioglu@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/esp32c3_usb_serial_jtag.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/extmem_reg.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/fe_reg.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/nrx_reg.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/regi2c_bbpll.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/regi2c_brownout.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/regi2c_ctrl.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/regi2c_dig_reg.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/regi2c_lp_bias.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/regi2c_saradc.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/spi_mem_reg.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/hardware/wdev_reg.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/rom/esp32c3_libc_stubs.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3-legacy/rom/esp32c3_spiflash.h eren.terzioglu@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3/.gitignore eren.terzioglu@espressif.com dongheng@espressif.com gustavo.nihei@espressif.com
-arch/risc-v/src/esp32c3/Kconfig eren.terzioglu@espressif.com gustavo.nihei@espressif.com dongheng@espressif.com abdelatif.guettouche@espressif.com sara.souza@espressif.com
-arch/risc-v/src/esp32c3/esp_ble.c eren.terzioglu@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3/esp_ble.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3/esp_ble_adapter.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3/esp_ble_adapter.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3/esp_coex_adapter.c tiago.medicci@espressif.com filipe.cavalcanti@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com hujun5@xiaomi.com
-arch/risc-v/src/esp32c3/esp_coex_adapter.h filipe.cavalcanti@espressif.com
-arch/risc-v/src/esp32c3/esp_wifi_adapter.c tiago.medicci@espressif.com filipe.cavalcanti@espressif.com liguiding1@xiaomi.com yamamoto@midokura.com devel@sumpfralle.de
-arch/risc-v/src/esp32c3/esp_wireless.c eren.terzioglu@espressif.com huangqi3@xiaomi.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c3/esp_wireless.h eren.terzioglu@espressif.com alin.jerpelea@sony.com filipe.cavalcanti@espressif.com
-arch/risc-v/src/esp32c3/hal_esp32c3.mk tiago.medicci@espressif.com eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com gewalalb@gmail.com
-arch/risc-v/src/esp32c6/.gitignore eren.terzioglu@espressif.com
-arch/risc-v/src/esp32c6/Kconfig eren.terzioglu@espressif.com chenwen@espressif.com 101105604+simbit18@users.noreply.github.com
-arch/risc-v/src/esp32c6/esp_coex_adapter.c tiago.medicci@espressif.com filipe.cavalcanti@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com hujun5@xiaomi.com
-arch/risc-v/src/esp32c6/esp_wifi_adapter.c tiago.medicci@espressif.com filipe.cavalcanti@espressif.com liguiding1@xiaomi.com yamamoto@midokura.com devel@sumpfralle.de
-arch/risc-v/src/esp32c6/esp_wifi_adapter.h tiago.medicci@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/esp32c6/hal_esp32c6.mk tiago.medicci@espressif.com eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com gewalalb@gmail.com
-arch/risc-v/src/esp32h2/.gitignore eren.terzioglu@espressif.com
-arch/risc-v/src/esp32h2/Kconfig eren.terzioglu@espressif.com
-arch/risc-v/src/esp32h2/hal_esp32h2.mk eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com tiago.medicci@espressif.com alin.jerpelea@sony.com gewalalb@gmail.com
+
+arch/risc-v/src/esp32* eren.terzioglu@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
+
 arch/risc-v/src/fe310/Kconfig masayuki.ishikawa@gmail.com 59230071+hartmannathan@users.noreply.github.com
 arch/risc-v/src/fe310/chip.h masayuki.ishikawa@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 arch/risc-v/src/fe310/fe310.h masayuki.ishikawa@gmail.com alin.jerpelea@sony.com abdelatif.guettouche@gmail.com xiaoxiang@xiaomi.com
@@ -8615,7 +6151,6 @@ arch/risc-v/src/nuttsbi/sbi_mtimer.c ville.juven@unikie.com yfliu2008@qq.com ino
 arch/risc-v/src/nuttsbi/sbi_mtrap.S ville.juven@unikie.com inochiama@outlook.com devel@sumpfralle.de alin.jerpelea@sony.com yfliu2008@qq.com
 arch/risc-v/src/nuttsbi/sbi_start.c ville.juven@unikie.com yfliu2008@qq.com inochiama@outlook.com alin.jerpelea@sony.com
 arch/risc-v/src/nuttsbi/sbi_vectors.S ville.juven@unikie.com alin.jerpelea@sony.com
-arch/risc-v/src/opensbi/.gitignore eero.nurkkala@offcode.fi
 arch/risc-v/src/opensbi/Kconfig eero.nurkkala@offcode.fi petro.karashchenko@gmail.com jouni.ukkonen@unikie.com jukkax@ssrc.tii.ae masayuki.ishikawa@gmail.com
 arch/risc-v/src/qemu-rv/Kconfig yfliu2008@qq.com huangqi3@xiaomi.com 101105604+simbit18@users.noreply.github.com anchao@lixiang.com
 arch/risc-v/src/qemu-rv/chip.h huangqi3@xiaomi.com tiago.medicci@espressif.com ville.juven@unikie.com masayuki.ishikawa@gmail.com xiaoxiang@xiaomi.com
@@ -8637,157 +6172,12 @@ arch/risc-v/src/qemu-rv/qemu_rv_start.c masayuki.ishikawa@gmail.com inochiama@ou
 arch/risc-v/src/qemu-rv/qemu_rv_timerisr.c huangqi3@xiaomi.com masayuki.ishikawa@gmail.com inochiama@outlook.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
 arch/risc-v/src/qemu-rv/qemu_rv_userspace.c ville.juven@unikie.com alin.jerpelea@sony.com
 arch/risc-v/src/qemu-rv/qemu_rv_userspace.h ville.juven@unikie.com yfliu2008@qq.com alin.jerpelea@sony.com
-arch/risc-v/src/rp23xx-rv/Kconfig serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/chip.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_accessctrl.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_adc.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_bootram.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_busctrl.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_clocks.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_coresight_trace.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_dma.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_dreq.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_glitch_detector.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_hazard3.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_hstx_ctrl.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_hstx_fifo.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_i2c.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_intctrl.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_io_bank0.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_io_qspi.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_memorymap.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_otp.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_otp_data.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_pads_bank0.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_pads_qspi.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_pio.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_pll.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_powman.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_psm.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_pwm.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_qmi.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_resets.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_rosc.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_rp_ap.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_sha256.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_sio.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_spi.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_tbman.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_ticks.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_timer.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_trng.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_uart.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_usbctrl_dpsram.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_usbctrl_regs.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_watchdog.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_xip.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_xip_aux.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/hardware/rp23xx_xosc.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_adc.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_adc.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_clock.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_clock.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_config.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_cpuidlestack.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_cpustart.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_dmac.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_dmac.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_gpio.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_gpio.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_head.S serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_heaps.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_i2c.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_i2c.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_i2c_slave.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_i2s.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_i2s.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_i2s_pio.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_i2s_pio.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_idle.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_irq.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_irq_dispatch.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_pio.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_pio.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_pio_instructions.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_pll.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_pll.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_pwm.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_pwm.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_rom.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_serial.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_serial.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_smpcall.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_spi.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_spi.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_start.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_timerisr.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_uart.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_uart.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_usbdev.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_usbdev.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_wdt.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_wdt.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_ws2812.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_ws2812.h serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_ws2812.pio serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_xosc.c serg@podtynnyi.com
-arch/risc-v/src/rp23xx-rv/rp23xx_xosc.h serg@podtynnyi.com
-arch/risc-v/src/rv32m1/Kconfig unixjet@hotmail.com petro.karashchenko@gmail.com
-arch/risc-v/src/rv32m1/chip.h unixjet@hotmail.com alin.jerpelea@sony.com
-arch/risc-v/src/rv32m1/hardware/rv32m1_eu.h unixjet@hotmail.com alin.jerpelea@sony.com
-arch/risc-v/src/rv32m1/hardware/rv32m1_gpio.h unixjet@hotmail.com alin.jerpelea@sony.com
-arch/risc-v/src/rv32m1/hardware/rv32m1_intmux.h unixjet@hotmail.com alin.jerpelea@sony.com
-arch/risc-v/src/rv32m1/hardware/rv32m1_lpit.h unixjet@hotmail.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/rv32m1/hardware/rv32m1_lptmr.h unixjet@hotmail.com alin.jerpelea@sony.com
-arch/risc-v/src/rv32m1/hardware/rv32m1_lpuart.h unixjet@hotmail.com devel@sumpfralle.de alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/risc-v/src/rv32m1/hardware/rv32m1_memorymap.h unixjet@hotmail.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-arch/risc-v/src/rv32m1/hardware/rv32m1_pcc.h unixjet@hotmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/risc-v/src/rv32m1/hardware/rv32m1_pinmap.h unixjet@hotmail.com alin.jerpelea@sony.com
-arch/risc-v/src/rv32m1/hardware/rv32m1_port.h unixjet@hotmail.com alin.jerpelea@sony.com
-arch/risc-v/src/rv32m1/hardware/rv32m1_scg.h unixjet@hotmail.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-arch/risc-v/src/rv32m1/hardware/rv32m1_smc.h unixjet@hotmail.com alin.jerpelea@sony.com
-arch/risc-v/src/rv32m1/hardware/rv32m1_tstmr.h unixjet@hotmail.com alin.jerpelea@sony.com
-arch/risc-v/src/rv32m1/hardware/rv32m1_wdog.h unixjet@hotmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
-arch/risc-v/src/rv32m1/hardware/rv32m1ri5cy_memorymap.h unixjet@hotmail.com alin.jerpelea@sony.com
-arch/risc-v/src/rv32m1/hardware/rv32m1ri5cy_scg.h unixjet@hotmail.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/rv32m1/rv32m1.h unixjet@hotmail.com alin.jerpelea@sony.com
-arch/risc-v/src/rv32m1/rv32m1_allocateheap.c unixjet@hotmail.com alin.jerpelea@sony.com
-arch/risc-v/src/rv32m1/rv32m1_clockconfig.c unixjet@hotmail.com devel@sumpfralle.de alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/risc-v/src/rv32m1/rv32m1_clockconfig.h unixjet@hotmail.com alin.jerpelea@sony.com
-arch/risc-v/src/rv32m1/rv32m1_delay.c unixjet@hotmail.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/rv32m1/rv32m1_gpio.c unixjet@hotmail.com gustavo.nihei@espressif.com petro.karashchenko@gmail.com devel@sumpfralle.de xiaoxiang@xiaomi.com
-arch/risc-v/src/rv32m1/rv32m1_gpio.h unixjet@hotmail.com gustavo.nihei@espressif.com alin.jerpelea@sony.com
-arch/risc-v/src/rv32m1/rv32m1_head.S unixjet@hotmail.com inochiama@outlook.com yfliu2008@qq.com alin.jerpelea@sony.com huangqi3@xiaomi.com
-arch/risc-v/src/rv32m1/rv32m1_irq.c unixjet@hotmail.com huangqi3@xiaomi.com dongheng@espressif.com xiaoxiang@xiaomi.com petro.karashchenko@gmail.com
-arch/risc-v/src/rv32m1/rv32m1_irq_dispatch.c unixjet@hotmail.com huangqi3@xiaomi.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/risc-v/src/rv32m1/rv32m1_linker.h unixjet@hotmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/risc-v/src/rv32m1/rv32m1_lowputc.c unixjet@hotmail.com alin.jerpelea@sony.com
-arch/risc-v/src/rv32m1/rv32m1_lowputc.h unixjet@hotmail.com alin.jerpelea@sony.com
-arch/risc-v/src/rv32m1/rv32m1_memorymap.h unixjet@hotmail.com inochiama@outlook.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/risc-v/src/rv32m1/rv32m1_pcc.c unixjet@hotmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/risc-v/src/rv32m1/rv32m1_pcc.h unixjet@hotmail.com alin.jerpelea@sony.com
-arch/risc-v/src/rv32m1/rv32m1_serial.c unixjet@hotmail.com hujun5@xiaomi.com yangsong8@xiaomi.com 59230071+hartmannathan@users.noreply.github.com gustavo.nihei@espressif.com
-arch/risc-v/src/rv32m1/rv32m1_start.c unixjet@hotmail.com inochiama@outlook.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com huangqi3@xiaomi.com
-arch/risc-v/src/rv32m1/rv32m1_timerisr.c unixjet@hotmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/risc-v/src/rv32m1/rv32m1_timersvc.c unixjet@hotmail.com xiaoxiang@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/rv32m1/rv32m1_timersvc.h unixjet@hotmail.com alin.jerpelea@sony.com
-arch/risc-v/src/rv32m1/rv32m1_uart.h unixjet@hotmail.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-arch/risc-v/src/sg2000/Kconfig luppy@appkaki.com
-arch/risc-v/src/sg2000/chip.h luppy@appkaki.com huangqi3@xiaomi.com alin.jerpelea@sony.com
-arch/risc-v/src/sg2000/hardware/sg2000_memorymap.h luppy@appkaki.com alin.jerpelea@sony.com
-arch/risc-v/src/sg2000/hardware/sg2000_plic.h luppy@appkaki.com alin.jerpelea@sony.com
-arch/risc-v/src/sg2000/sg2000_allocateheap.c luppy@appkaki.com alin.jerpelea@sony.com
-arch/risc-v/src/sg2000/sg2000_head.S luppy@appkaki.com alin.jerpelea@sony.com
-arch/risc-v/src/sg2000/sg2000_irq.c luppy@appkaki.com alin.jerpelea@sony.com
-arch/risc-v/src/sg2000/sg2000_irq_dispatch.c luppy@appkaki.com alin.jerpelea@sony.com
-arch/risc-v/src/sg2000/sg2000_memorymap.h luppy@appkaki.com alin.jerpelea@sony.com
-arch/risc-v/src/sg2000/sg2000_mm_init.c luppy@appkaki.com alin.jerpelea@sony.com
-arch/risc-v/src/sg2000/sg2000_mm_init.h luppy@appkaki.com alin.jerpelea@sony.com
-arch/risc-v/src/sg2000/sg2000_pgalloc.c luppy@appkaki.com alin.jerpelea@sony.com
-arch/risc-v/src/sg2000/sg2000_start.c luppy@appkaki.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/risc-v/src/sg2000/sg2000_timerisr.c luppy@appkaki.com alin.jerpelea@sony.com
+
+arch/risc-v/src/rp23xx-rv/* serg@podtynnyi.com
+arch/risc-v/src/rv32m1/* unixjet@hotmail.com alin.jerpelea@sony.com
+arch/risc-v/src/sg2000/* luppy@appkaki.com alin.jerpelea@sony.com
+
 arch/sim/Kconfig xiaoxiang@xiaomi.com pettitkd@gmail.com yinshengkai@xiaomi.com
-arch/sim/include/.gitignore xiaoxiang@xiaomi.com
 arch/sim/include/arch.h masayuki.ishikawa@gmail.com alin.jerpelea@sony.com sene@apache.org
 arch/sim/include/elf.h anchao@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
 arch/sim/include/inttypes.h paul-a.patience@polymtl.ca yamamoto@midokura.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com ptka@mailbox.org
@@ -8798,7 +6188,6 @@ arch/sim/include/sim/README.txt xiaoxiang@xiaomi.com
 arch/sim/include/spinlock.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 arch/sim/include/syscall.h alin.jerpelea@sony.com anchao@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
 arch/sim/include/types.h xiaoxiang@xiaomi.com alin.jerpelea@sony.com yamamoto@midokura.com
-arch/sim/src/.gitignore xiaoxiang@xiaomi.com anchao@xiaomi.com yamamoto@midokura.com pettitkd@gmail.com
 arch/sim/src/Makefile xiaoxiang@xiaomi.com zhangyuan21@xiaomi.com anchao@xiaomi.com
 arch/sim/src/cmake/Toolchain.cmake xuxin19@xiaomi.com anchao@xiaomi.com huangqi3@xiaomi.com buxiasen@gmail.com wangmingrong1@xiaomi.com
 arch/sim/src/cmake/platform.cmake anchao@xiaomi.com alin.jerpelea@sony.com guoshichao@xiaomi.com
@@ -8904,8 +6293,8 @@ arch/sim/src/sim/win/sim_hostmisc.c zhangyuan21@xiaomi.com yinshengkai@xiaomi.co
 arch/sim/src/sim/win/sim_hosttime.c zhangyuan21@xiaomi.com anchao@xiaomi.com liguiding1@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
 arch/sim/src/sim/win/sim_hostuart.c xiaoxiang@xiaomi.com anchao@xiaomi.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com
 arch/sim/src/sim/win/sim_wpcap.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
+
 arch/sparc/Kconfig fft@feedforward.com.cn anchao@xiaomi.com xiaoxiang@xiaomi.com
-arch/sparc/include/.gitignore fft@feedforward.com.cn
 arch/sparc/include/arch.h fft@feedforward.com.cn xiaoxiang@xiaomi.com alin.jerpelea@sony.com
 arch/sparc/include/bm3803/irq.h fft@feedforward.com.cn 101105604+simbit18@users.noreply.github.com alin.jerpelea@sony.com
 arch/sparc/include/bm3823/irq.h fft@feedforward.com.cn 101105604+simbit18@users.noreply.github.com alin.jerpelea@sony.com
@@ -8918,7 +6307,6 @@ arch/sparc/include/sparc_v8/irq.h fft@feedforward.com.cn 101105604+simbit18@user
 arch/sparc/include/spinlock.h fft@feedforward.com.cn alin.jerpelea@sony.com
 arch/sparc/include/syscall.h xiaoxiang@xiaomi.com fft@feedforward.com.cn zhangyuan21@xiaomi.com alin.jerpelea@sony.com
 arch/sparc/include/types.h fft@feedforward.com.cn chenxiaoyi@xiaomi.com alin.jerpelea@sony.com
-arch/sparc/src/.gitignore fft@feedforward.com.cn
 arch/sparc/src/Makefile fft@feedforward.com.cn xiaoxiang@xiaomi.com alanrosenthal@google.com alin.jerpelea@sony.com marco.casaroli@gmail.com
 arch/sparc/src/bm3803/Kconfig fft@feedforward.com.cn xiaoxiang@xiaomi.com
 arch/sparc/src/bm3803/bm3803-config.h fft@feedforward.com.cn xiaoxiang@xiaomi.com alin.jerpelea@sony.com
@@ -9015,70 +6403,10 @@ arch/sparc/src/sparc_v8/sparc_v8_swint1.c zhangyuan21@xiaomi.com hujun5@xiaomi.c
 arch/sparc/src/sparc_v8/sparc_v8_switchcontext.c zhangyuan21@xiaomi.com hujun5@xiaomi.com alin.jerpelea@sony.com
 arch/sparc/src/sparc_v8/sparc_v8_syscall.S zhangyuan21@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
 arch/sparc/src/sparc_v8/sparc_v8_systemreset.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/tricore/Kconfig anchao@lixiang.com wangchengdong@lixiang.com “wangchengdong@lixiang.com”
-arch/tricore/include/.gitignore anchao@lixiang.com
-arch/tricore/include/arch.h anchao@lixiang.com “wangchengdong@lixiang.com” buxiasen@xiaomi.com alin.jerpelea@sony.com
-arch/tricore/include/barriers.h lipengfei28@xiaomi.com
-arch/tricore/include/inttypes.h anchao@lixiang.com alin.jerpelea@sony.com
-arch/tricore/include/irq.h anchao@lixiang.com hujun5@xiaomi.com buxiasen@xiaomi.com “wangchengdong@lixiang.com” wangchengdong@lixiang.com
-arch/tricore/include/limits.h anchao@lixiang.com alin.jerpelea@sony.com
-arch/tricore/include/spinlock.h anchao@lixiang.com lipengfei28@xiaomi.com alin.jerpelea@sony.com
-arch/tricore/include/syscall.h anchao@lixiang.com alin.jerpelea@sony.com
-arch/tricore/include/tc397/chip.h wangchengdong@lixiang.com
-arch/tricore/include/tc397/irq.h wangchengdong@lixiang.com
-arch/tricore/include/tc3xx/irq.h anchao@lixiang.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/tricore/include/types.h anchao@lixiang.com chenxiaoyi@xiaomi.com alin.jerpelea@sony.com
-arch/tricore/src/.gitignore anchao@lixiang.com
-arch/tricore/src/Makefile anchao@lixiang.com masayuki.ishikawa@gmail.com xuxin19@xiaomi.com alin.jerpelea@sony.com wangchengdong@lixiang.com
-arch/tricore/src/cmake/Toolchain.cmake anchao@lixiang.com liguiding1@xiaomi.com alin.jerpelea@sony.com
-arch/tricore/src/cmake/ToolchainGnuc.cmake anchao@lixiang.com wangmingrong1@xiaomi.com simbit18@gmail.com alin.jerpelea@sony.com yinshengkai@xiaomi.com
-arch/tricore/src/cmake/ToolchainTasking.cmake anchao@lixiang.com v-tangmeng@xiaomi.com simbit18@gmail.com alin.jerpelea@sony.com
-arch/tricore/src/cmake/platform.cmake anchao@lixiang.com wangmingrong1@xiaomi.com tiago.medicci@espressif.com alin.jerpelea@sony.com
-arch/tricore/src/cmake/tc3xx.cmake anchao@lixiang.com alin.jerpelea@sony.com
-arch/tricore/src/common/Ifx_Cfg_Trap.h anchao@lixiang.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/tricore/src/common/Toolchain.defs anchao@lixiang.com alin.jerpelea@sony.com
-arch/tricore/src/common/ToolchainGnuc.defs anchao@lixiang.com wangmingrong1@xiaomi.com alin.jerpelea@sony.com yinshengkai@xiaomi.com pressl.stepan@gmail.com
-arch/tricore/src/common/ToolchainTasking.defs anchao@lixiang.com anjiahao@xiaomi.com anchao.archer@bytedance.com v-tangmeng@xiaomi.com wangmingrong1@xiaomi.com
-arch/tricore/src/common/tricore_allocateheap.c anchao@lixiang.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_checkstack.c anchao@lixiang.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_createstack.c anchao@lixiang.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_csa.c anchao@lixiang.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_doirq.c anchao@lixiang.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_exit.c anchao@lixiang.com buxiasen@xiaomi.com hujun5@xiaomi.com alin.jerpelea@sony.com xuxingliang@xiaomi.com
-arch/tricore/src/common/tricore_getintstack.c anchao@lixiang.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_idle.c anchao@lixiang.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_initialize.c anchao@lixiang.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_initialstate.c anchao@lixiang.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_internal.h anchao@lixiang.com buxiasen@xiaomi.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_irq.c anchao@lixiang.com wangchengdong@lixiang.com “wangchengdong@lixiang.com” alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_main.c anchao@lixiang.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_mdelay.c anchao@lixiang.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_nputs.c anchao@lixiang.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_registerdump.c anchao@lixiang.com buxiasen@xiaomi.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_releasestack.c anchao@lixiang.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_saveusercontext.c anchao@lixiang.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_schedulesigaction.c anchao@lixiang.com hujun5@xiaomi.com wangzhi16@xiaomi.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_sigdeliver.c anchao@lixiang.com wangzhi16@xiaomi.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_stackframe.c anchao@lixiang.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_svcall.c anchao@lixiang.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_switchcontext.c anchao@lixiang.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_systimer.c anchao@lixiang.com wangzhi16@xiaomi.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_tcbinfo.c anchao@lixiang.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_testset.c anchao@lixiang.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_trapcall.c anchao@lixiang.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/tricore/src/common/tricore_usestack.c anchao@lixiang.com alin.jerpelea@sony.com
-arch/tricore/src/tc397/.gitignore wangchengdong@lixiang.com
-arch/tricore/src/tc397/Kconfig wangchengdong@lixiang.com
-arch/tricore/src/tc397/chip.h wangchengdong@lixiang.com
-arch/tricore/src/tc3xx/.gitignore anchao@lixiang.com
-arch/tricore/src/tc3xx/Kconfig anchao@lixiang.com
-arch/tricore/src/tc3xx/Toolchain.defs anchao@lixiang.com alin.jerpelea@sony.com
-arch/tricore/src/tc3xx/tc3xx_dummy.c alin.jerpelea@sony.com anchao@lixiang.com
-arch/tricore/src/tc3xx/tc3xx_libc.c anchao@lixiang.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/tricore/src/tc3xx/tc3xx_serial.c anchao@lixiang.com yangsong8@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/tricore/src/tc3xx/tc3xx_timerisr.c anchao@lixiang.com alin.jerpelea@sony.com
+
+arch/tricore/* anchao@lixiang.com wangchengdong@lixiang.com alin.jerpelea@sony.com
+
 arch/x86/Kconfig xiaoxiang@xiaomi.com jordi@midokura.com liuhaitao@xiaomi.com
-arch/x86/include/.gitignore xiaoxiang@xiaomi.com
 arch/x86/include/arch.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
 arch/x86/include/i486/arch.h xiaoxiang@xiaomi.com alin.jerpelea@sony.com www.desh@gmail.com
 arch/x86/include/i486/inttypes.h paul-a.patience@polymtl.ca yamamoto@midokura.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
@@ -9094,7 +6422,6 @@ arch/x86/include/qemu/arch.h alin.jerpelea@sony.com 59230071+hartmannathan@users
 arch/x86/include/qemu/irq.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com
 arch/x86/include/syscall.h xiaoxiang@xiaomi.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
 arch/x86/include/types.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
-arch/x86/src/.gitignore xiaoxiang@xiaomi.com yamamoto@midokura.com
 arch/x86/src/Makefile xiaoxiang@xiaomi.com alin.jerpelea@sony.com wangmingrong1@xiaomi.com
 arch/x86/src/common/Toolchain.defs anjiahao@xiaomi.com wangmingrong1@xiaomi.com huangqi3@xiaomi.com anchao.archer@bytedance.com alin.jerpelea@sony.com
 arch/x86/src/common/x86_allocateheap.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
@@ -9124,779 +6451,13 @@ arch/x86/src/i486/i486_stackframe.c zhangyuan21@xiaomi.com alin.jerpelea@sony.co
 arch/x86/src/i486/i486_syscall6.S zhangyuan21@xiaomi.com alin.jerpelea@sony.com
 arch/x86/src/i486/i486_usestack.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
 arch/x86/src/i486/i486_utils.S alin.jerpelea@sony.com
-arch/x86/src/qemu/Kconfig xiaoxiang@xiaomi.com
-arch/x86/src/qemu/chip.h alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com xiaoxiang@xiaomi.com petro.karashchenko@gmail.com
-arch/x86/src/qemu/qemu.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com sebastien@lorquet.fr 59230071+hartmannathan@users.noreply.github.com
-arch/x86/src/qemu/qemu_fullcontextrestore.S alin.jerpelea@sony.com zhangyuan21@xiaomi.com
-arch/x86/src/qemu/qemu_handlers.c alin.jerpelea@sony.com hujun5@xiaomi.com zhangyuan21@xiaomi.com
-arch/x86/src/qemu/qemu_head.S alin.jerpelea@sony.com xiaoxiang@xiaomi.com juha.niskanen@haltian.com  1 file changed, 1 insertion(+), 1 deletion(-)
-arch/x86/src/qemu/qemu_idle.c alin.jerpelea@sony.com zhangyuan21@xiaomi.com gustavo.nihei@espressif.com abdelatif.guettouche@gmail.com
-arch/x86/src/qemu/qemu_keypad.c alin.jerpelea@sony.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com
-arch/x86/src/qemu/qemu_keypad.h alin.jerpelea@sony.com
-arch/x86/src/qemu/qemu_lowputc.c alin.jerpelea@sony.com zhangyuan21@xiaomi.com gustavo.nihei@espressif.com
-arch/x86/src/qemu/qemu_lowsetup.c alin.jerpelea@sony.com zhangyuan21@xiaomi.com gustavo.nihei@espressif.com
-arch/x86/src/qemu/qemu_memorymap.h alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com
-arch/x86/src/qemu/qemu_saveusercontext.S alin.jerpelea@sony.com Yuuichi.A.Nakamura@sony.com zhangyuan21@xiaomi.com
-arch/x86/src/qemu/qemu_serial.c alin.jerpelea@sony.com zhangyuan21@xiaomi.com juha.niskanen@haltian.com yangsong8@xiaomi.com
-arch/x86/src/qemu/qemu_timerisr.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com mark@mjs.pw
-arch/x86/src/qemu/qemu_vectors.S alin.jerpelea@sony.com zhangyuan21@xiaomi.com xiaoxiang@xiaomi.com  1 file changed, 1 insertion(+), 1 deletion(-)
-arch/x86/src/qemu/qemu_vga.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com petro.karashchenko@gmail.com michael.jung@secore.ly
-arch/x86/src/qemu/qemu_vga.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/x86_64/Kconfig p-szafonimateusz@xiaomi.com sonic.tw.tp@gmail.com bashton@brennanashton.com liwenxiang1@xiaomi.com ouyangxiangzhen@xiaomi.com
-arch/x86_64/include/.gitignore sonic.tw.tp@gmail.com
-arch/x86_64/include/acpi.h p-szafonimateusz@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/x86_64/include/arch.h sonic.tw.tp@gmail.com p-szafonimateusz@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-arch/x86_64/include/barriers.h lipengfei28@xiaomi.com
-arch/x86_64/include/elf.h p-szafonimateusz@xiaomi.com liwenxiang1@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/include/hpet.h p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/include/intel64/arch.h p-szafonimateusz@xiaomi.com sonic.tw.tp@gmail.com xiaoxiang@xiaomi.com bashton@brennanashton.com petro.karashchenko@gmail.com
-arch/x86_64/include/intel64/inttypes.h sonic.tw.tp@gmail.com yamamoto@midokura.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/include/intel64/io.h sonic.tw.tp@gmail.com p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-arch/x86_64/include/intel64/irq.h p-szafonimateusz@xiaomi.com sonic.tw.tp@gmail.com xiaoxiang@xiaomi.com buxiasen@xiaomi.com hujun5@xiaomi.com
-arch/x86_64/include/intel64/limits.h sonic.tw.tp@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/include/intel64/types.h sonic.tw.tp@gmail.com yamamoto@midokura.com xiaoxiang@xiaomi.com chenxiaoyi@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/include/inttypes.h sonic.tw.tp@gmail.com alin.jerpelea@sony.com
-arch/x86_64/include/io.h sonic.tw.tp@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/x86_64/include/irq.h p-szafonimateusz@xiaomi.com sonic.tw.tp@gmail.com liwenxiang1@xiaomi.com anchao@xiaomi.com hujun5@xiaomi.com
-arch/x86_64/include/limits.h sonic.tw.tp@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/x86_64/include/multiboot2.h sonic.tw.tp@gmail.com alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/x86_64/include/setjmp.h liwenxiang1@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/include/spinlock.h p-szafonimateusz@xiaomi.com lipengfei28@xiaomi.com yanghuatao@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/include/syscall.h xiaoxiang@xiaomi.com p-szafonimateusz@xiaomi.com sonic.tw.tp@gmail.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-arch/x86_64/include/types.h sonic.tw.tp@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
-arch/x86_64/src/.gitignore sonic.tw.tp@gmail.com xiaoxiang@xiaomi.com yamamoto@midokura.com
-arch/x86_64/src/Makefile sonic.tw.tp@gmail.com xiaoxiang@xiaomi.com liwenxiang1@xiaomi.com matias@protobits.dev cuiziwei@xiaomi.com
-arch/x86_64/src/cmake/Toolchain.cmake p-szafonimateusz@xiaomi.com xuxin19@xiaomi.com cuiziwei@xiaomi.com liguiding1@xiaomi.com trns1997@gmail.com
-arch/x86_64/src/cmake/platform.cmake p-szafonimateusz@xiaomi.com xuxin19@xiaomi.com cuiziwei@xiaomi.com alin.jerpelea@sony.com wangmingrong1@xiaomi.com
-arch/x86_64/src/common/Kconfig p-szafonimateusz@xiaomi.com ouyangxiangzhen@xiaomi.com sonic.tw.tp@gmail.com
-arch/x86_64/src/common/Toolchain.defs p-szafonimateusz@xiaomi.com cuiziwei@xiaomi.com wangbowen6@xiaomi.com wangmingrong1@xiaomi.com liwenxiang1@xiaomi.com
-arch/x86_64/src/common/addrenv.h p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/crt0.c p-szafonimateusz@xiaomi.com anjiahao@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/fork.S liwenxiang1@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/multiboot1.S ouyangxiangzhen@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/multiboot1.ld ouyangxiangzhen@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/pgalloc.h p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/x86_64_acpi.c p-szafonimateusz@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/x86_64/src/common/x86_64_addrenv.c p-szafonimateusz@xiaomi.com lipengfei28@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/x86_64/src/common/x86_64_addrenv_kstack.c p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/x86_64_addrenv_perms.c p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/x86_64_allocateheap.c zhangyuan21@xiaomi.com p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/x86_64_copystate.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/x86_64/src/common/x86_64_exit.c zhangyuan21@xiaomi.com anchao@xiaomi.com p-szafonimateusz@xiaomi.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/x86_64_fork.c liwenxiang1@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/x86_64_fork.h liwenxiang1@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/x86_64_getintstack.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com p-szafonimateusz@xiaomi.com liguiding1@xiaomi.com
-arch/x86_64/src/common/x86_64_hwdebug.c p-szafonimateusz@xiaomi.com devel@sumpfralle.de
-arch/x86_64/src/common/x86_64_hwdebug.h p-szafonimateusz@xiaomi.com devel@sumpfralle.de
-arch/x86_64/src/common/x86_64_initialize.c zhangyuan21@xiaomi.com p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com wangbowen6@xiaomi.com xiaoxiang@xiaomi.com
-arch/x86_64/src/common/x86_64_internal.h zhangyuan21@xiaomi.com p-szafonimateusz@xiaomi.com liwenxiang1@xiaomi.com ouyangxiangzhen@xiaomi.com xiaoxiang@xiaomi.com
-arch/x86_64/src/common/x86_64_lowputs.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/x86_64_mdelay.c zhangyuan21@xiaomi.com liwenxiang1@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/x86_64_mmu.c p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/x86_64_mmu.h p-szafonimateusz@xiaomi.com anchao@lixiang.com alin.jerpelea@sony.com
-arch/x86_64/src/common/x86_64_modifyreg16.c zhangyuan21@xiaomi.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/x86_64_modifyreg32.c zhangyuan21@xiaomi.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/x86_64_modifyreg8.c zhangyuan21@xiaomi.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/x86_64_nputs.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/x86_64_pci.c p-szafonimateusz@xiaomi.com yangshuyong@xiaomi.com wangyongrong@xiaomi.com lipengfei28@xiaomi.com yezhonghui@xiaomi.com
-arch/x86_64/src/common/x86_64_pgalloc.c p-szafonimateusz@xiaomi.com lipengfei28@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/x86_64_pthread_start.c p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/x86_64_signal_dispatch.c p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/x86_64_switchcontext.c zhangyuan21@xiaomi.com p-szafonimateusz@xiaomi.com liguiding1@xiaomi.com liwenxiang1@xiaomi.com hujun5@xiaomi.com
-arch/x86_64/src/common/x86_64_syscall.c p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com huangqi3@xiaomi.com
-arch/x86_64/src/common/x86_64_task_start.c p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/x86_64_tcbinfo.c xiaoxiang@xiaomi.com liwenxiang1@xiaomi.com anjiahao@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/x86_64_tlb.c p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/x86_64_tls.c liwenxiang1@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/common/x86_64_udelay.c zhangyuan21@xiaomi.com liwenxiang1@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/Kconfig p-szafonimateusz@xiaomi.com sonic.tw.tp@gmail.com petro.karashchenko@gmail.com ouyangxiangzhen@xiaomi.com devel@sumpfralle.de
-arch/x86_64/src/intel64/Toolchain.defs wangbowen6@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/chip.h sonic.tw.tp@gmail.com 101105604+simbit18@users.noreply.github.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com zhangyuan21@xiaomi.com
-arch/x86_64/src/intel64/intel64.h p-szafonimateusz@xiaomi.com sonic.tw.tp@gmail.com 101105604+simbit18@users.noreply.github.com alin.jerpelea@sony.com zhangyuan21@xiaomi.com
-arch/x86_64/src/intel64/intel64_backtrace_fp.c liwenxiang1@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_cache.c p-szafonimateusz@xiaomi.com liguiding1@xiaomi.com liwenxiang1@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_check_capability.c p-szafonimateusz@xiaomi.com sonic.tw.tp@gmail.com liwenxiang1@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_checkstack.c liwenxiang1@xiaomi.com p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_cpu.c p-szafonimateusz@xiaomi.com anchao@lixiang.com devel@sumpfralle.de liwenxiang1@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_cpu.h p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_cpuidlestack.c p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_cpustart.c p-szafonimateusz@xiaomi.com ouyangxiangzhen@xiaomi.com hujun5@xiaomi.com liwenxiang1@xiaomi.com lipengfei28@xiaomi.com
-arch/x86_64/src/intel64/intel64_createstack.c zhangyuan21@xiaomi.com liwenxiang1@xiaomi.com p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com raiden00@railab.me
-arch/x86_64/src/intel64/intel64_fb.c p-szafonimateusz@xiaomi.com ouyangxiangzhen@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_fbterm.c p-szafonimateusz@xiaomi.com ouyangxiangzhen@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_fpucmp.c p-szafonimateusz@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_freq.c p-szafonimateusz@xiaomi.com ouyangxiangzhen@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_fullcontextrestore.S p-szafonimateusz@xiaomi.com sonic.tw.tp@gmail.com zhangyuan21@xiaomi.com liwenxiang1@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_handlers.c sonic.tw.tp@gmail.com p-szafonimateusz@xiaomi.com liwenxiang1@xiaomi.com hujun5@xiaomi.com bashton@brennanashton.com
-arch/x86_64/src/intel64/intel64_head.S p-szafonimateusz@xiaomi.com sonic.tw.tp@gmail.com ouyangxiangzhen@xiaomi.com masayuki.ishikawa@gmail.com bashton@brennanashton.com
-arch/x86_64/src/intel64/intel64_hpet.c p-szafonimateusz@xiaomi.com yezhonghui@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_hpet.h p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_hpet_alarm.c p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_idle.c sonic.tw.tp@gmail.com ouyangxiangzhen@xiaomi.com liwenxiang1@xiaomi.com alin.jerpelea@sony.com p-szafonimateusz@xiaomi.com
-arch/x86_64/src/intel64/intel64_initialstate.c zhangyuan21@xiaomi.com p-szafonimateusz@xiaomi.com liwenxiang1@xiaomi.com xiaoxiang@xiaomi.com devel@sumpfralle.de
-arch/x86_64/src/intel64/intel64_irq.c p-szafonimateusz@xiaomi.com zhangyuan21@xiaomi.com lipengfei28@xiaomi.com liwenxiang1@xiaomi.com yezhonghui@xiaomi.com
-arch/x86_64/src/intel64/intel64_lowsetup.c p-szafonimateusz@xiaomi.com sonic.tw.tp@gmail.com bashton@brennanashton.com raiden00@railab.me zhangyuan21@xiaomi.com
-arch/x86_64/src/intel64/intel64_lowsetup.h p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_map_region.c p-szafonimateusz@xiaomi.com ouyangxiangzhen@xiaomi.com zhangyuan21@xiaomi.com alin.jerpelea@sony.com liwenxiang1@xiaomi.com
-arch/x86_64/src/intel64/intel64_oneshot.c p-szafonimateusz@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com xiaoxiang@xiaomi.com wangzhi16@xiaomi.com
-arch/x86_64/src/intel64/intel64_oneshot.h p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com ouyangxiangzhen@xiaomi.com
-arch/x86_64/src/intel64/intel64_oneshot_lower.c p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_perf.c liwenxiang1@xiaomi.com jukka.laitinen@tii.ae alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_pgalloc.c p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_regdump.c zhangyuan21@xiaomi.com liwenxiang1@xiaomi.com buxiasen@xiaomi.com p-szafonimateusz@xiaomi.com devel@sumpfralle.de
-arch/x86_64/src/intel64/intel64_releasestack.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_restore_auxstate.c zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_rng.c sonic.tw.tp@gmail.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com petro.karashchenko@gmail.com bashton@brennanashton.com
-arch/x86_64/src/intel64/intel64_rtc.c zhangyuan21@xiaomi.com 101105604+simbit18@users.noreply.github.com hujun5@xiaomi.com p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_saveusercontext.S p-szafonimateusz@xiaomi.com sonic.tw.tp@gmail.com anchao@xiaomi.com alin.jerpelea@sony.com zhangyuan21@xiaomi.com
-arch/x86_64/src/intel64/intel64_schedulesigaction.c hujun5@xiaomi.com p-szafonimateusz@xiaomi.com liwenxiang1@xiaomi.com zhangyuan21@xiaomi.com xiaoxiang@xiaomi.com
-arch/x86_64/src/intel64/intel64_serial.c sonic.tw.tp@gmail.com p-szafonimateusz@xiaomi.com raiden00@railab.me zhangyuan21@xiaomi.com ouyangxiangzhen@xiaomi.com
-arch/x86_64/src/intel64/intel64_sigdeliver.c zhangyuan21@xiaomi.com p-szafonimateusz@xiaomi.com wangzhi16@xiaomi.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_smpcall.c hujun5@xiaomi.com liwenxiang1@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com p-szafonimateusz@xiaomi.com
-arch/x86_64/src/intel64/intel64_stackframe.c zhangyuan21@xiaomi.com p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_start.c p-szafonimateusz@xiaomi.com ouyangxiangzhen@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_systemreset.c p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_testset.S p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_tsc_ndelay.c liwenxiang1@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_tsc_tickless.c p-szafonimateusz@xiaomi.com ouyangxiangzhen@xiaomi.com xiaoxiang@xiaomi.com wangzhi16@xiaomi.com devel@sumpfralle.de
-arch/x86_64/src/intel64/intel64_tsc_timerisr.c p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_usestack.c zhangyuan21@xiaomi.com liwenxiang1@xiaomi.com p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/intel64/intel64_vectors.S p-szafonimateusz@xiaomi.com sonic.tw.tp@gmail.com devel@sumpfralle.de zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/x86_64/src/qemu/Kconfig sonic.tw.tp@gmail.com
-arch/xtensa/Kconfig gustavo.nihei@espressif.com abdelatif.guettouche@espressif.com zhuyanlin1@xiaomi.com acassis@gmail.com
-arch/xtensa/include/.gitignore xiaoxiang@xiaomi.com
-arch/xtensa/include/arch.h chenwen@espressif.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com abdelatif.guettouche@espressif.com
-arch/xtensa/include/elf.h yamamoto@midokura.com Feng.Gao@sony.com alin.jerpelea@sony.com
-arch/xtensa/include/esp32/chip.h alin.jerpelea@sony.com abdelatif.guettouche@espressif.com
-arch/xtensa/include/esp32/core-isa.h alin.jerpelea@sony.com zhuyanlin1@xiaomi.com tiago.medicci@espressif.com
-arch/xtensa/include/esp32/esp32_himem_chardev.h zhong.wan@sony.com alin.jerpelea@sony.com
-arch/xtensa/include/esp32/esp_efuse_table.h acassis@gmail.com alin.jerpelea@sony.com
-arch/xtensa/include/esp32/irq.h alin.jerpelea@sony.com abdelatif.guettouche@espressif.com lucas.vaz@espressif.com acassis@gmail.com
-arch/xtensa/include/esp32/memory_layout.h abdelatif.guettouche@espressif.com yamamoto@midokura.com 101105604+simbit18@users.noreply.github.com alin.jerpelea@sony.com
-arch/xtensa/include/esp32/partition.h zhaoqing.zhang@sony.com
-arch/xtensa/include/esp32/tie-asm.h alin.jerpelea@sony.com
-arch/xtensa/include/esp32/tie.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-arch/xtensa/include/esp32s2/chip.h acassis@gmail.com alin.jerpelea@sony.com
-arch/xtensa/include/esp32s2/core-isa.h acassis@gmail.com zhuyanlin1@xiaomi.com alin.jerpelea@sony.com tiago.medicci@espressif.com
-arch/xtensa/include/esp32s2/irq.h gustavo.nihei@espressif.com acassis@gmail.com lucas.vaz@espressif.com filipe.cavalcanti@espressif.com zhuyanlin1@xiaomi.com
-arch/xtensa/include/esp32s2/tie-asm.h acassis@gmail.com alin.jerpelea@sony.com
-arch/xtensa/include/esp32s2/tie.h abdelatif.guettouche@espressif.com acassis@gmail.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-arch/xtensa/include/esp32s3/.gitignore almir.okato@espressif.com
-arch/xtensa/include/esp32s3/chip.h gustavo.nihei@espressif.com alin.jerpelea@sony.com
-arch/xtensa/include/esp32s3/core-isa.h gustavo.nihei@espressif.com alin.jerpelea@sony.com zhuyanlin1@xiaomi.com tiago.medicci@espressif.com
-arch/xtensa/include/esp32s3/irq.h gustavo.nihei@espressif.com lucas.vaz@espressif.com tiago.medicci@espressif.com chenxiaoyi@xiaomi.com petro.karashchenko@gmail.com
-arch/xtensa/include/esp32s3/memory_layout.h chenwen@espressif.com alin.jerpelea@sony.com
-arch/xtensa/include/esp32s3/partition.h zhaoqing.zhang@sony.com alin.jerpelea@sony.com
-arch/xtensa/include/esp32s3/tie-asm.h gustavo.nihei@espressif.com alin.jerpelea@sony.com
-arch/xtensa/include/esp32s3/tie.h gustavo.nihei@espressif.com alin.jerpelea@sony.com
-arch/xtensa/include/inttypes.h paul-a.patience@polymtl.ca yamamoto@midokura.com alin.jerpelea@sony.com filipe.cavalcanti@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/include/irq.h hujun5@xiaomi.com chenxiaoyi@xiaomi.com anchao@xiaomi.com gustavo.nihei@espressif.com
-arch/xtensa/include/limits.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/xtensa/include/loadstore.h yamamoto@midokura.com alin.jerpelea@sony.com
-arch/xtensa/include/lx6/chip.h alin.jerpelea@sony.com
-arch/xtensa/include/lx6/irq.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-arch/xtensa/include/lx7/chip.h gustavo.nihei@espressif.com alin.jerpelea@sony.com
-arch/xtensa/include/lx7/irq.h acassis@gmail.com alin.jerpelea@sony.com
-arch/xtensa/include/setjmp.h zhuyanlin1@xiaomi.com alin.jerpelea@sony.com
-arch/xtensa/include/simcall.h yamamoto@midokura.com chenxiaoyi@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/xtensa/include/spinlock.h abdelatif.guettouche@gmail.com hujun5@xiaomi.com alin.jerpelea@sony.com yamamoto@midokura.com
-arch/xtensa/include/stdarg.h zhuyanlin1@xiaomi.com alin.jerpelea@sony.com
-arch/xtensa/include/syscall.h zhuyanlin1@xiaomi.com chenxiaoyi@xiaomi.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com
-arch/xtensa/include/types.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com yamamoto@midokura.com filipe.cavalcanti@espressif.com
-arch/xtensa/include/xtensa/core.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com zhuyanlin1@xiaomi.com gustavo.nihei@espressif.com
-arch/xtensa/include/xtensa/core_macros.h acassis@gmail.com petro.karashchenko@gmail.com chenwen@espressif.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/xtensa/include/xtensa/xtensa_abi.h zhuyanlin1@xiaomi.com abdelatif.guettouche@espressif.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-arch/xtensa/include/xtensa/xtensa_coproc.h yamamoto@midokura.com alin.jerpelea@sony.com liguiding1@xiaomi.com zhuyanlin1@xiaomi.com
-arch/xtensa/include/xtensa/xtensa_corebits.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/xtensa/include/xtensa/xtensa_specregs.h alin.jerpelea@sony.com yamamoto@midokura.com tiago.medicci@espressif.com
-arch/xtensa/src/.gitignore xiaoxiang@xiaomi.com yamamoto@midokura.com
-arch/xtensa/src/Makefile xiaoxiang@xiaomi.com anchao@xiaomi.com gustavo.nihei@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/cmake/Toolchain.cmake xuxin19@xiaomi.com wangmingrong1@xiaomi.com alin.jerpelea@sony.com
-arch/xtensa/src/cmake/platform.cmake xuxin19@xiaomi.com tiago.medicci@espressif.com alin.jerpelea@sony.com wangmingrong1@xiaomi.com
-arch/xtensa/src/common/crt0.c anjiahao@xiaomi.com
-arch/xtensa/src/common/espressif/Kconfig eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com tiago.medicci@espressif.com laczenjms@gmail.com 101105604+simbit18@users.noreply.github.com
-arch/xtensa/src/common/espressif/Wireless.mk filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/common/espressif/esp_adc.c filipe.cavalcanti@espressif.com devel@sumpfralle.de
-arch/xtensa/src/common/espressif/esp_adc.h filipe.cavalcanti@espressif.com
-arch/xtensa/src/common/espressif/esp_crypto.c eren.terzioglu@espressif.com
-arch/xtensa/src/common/espressif/esp_dedic_gpio.c eren.terzioglu@espressif.com
-arch/xtensa/src/common/espressif/esp_dedic_gpio.h eren.terzioglu@espressif.com
-arch/xtensa/src/common/espressif/esp_espnow_pktradio.c laczenjms@gmail.com filipe.cavalcanti@espressif.com
-arch/xtensa/src/common/espressif/esp_espnow_pktradio.h laczenjms@gmail.com
-arch/xtensa/src/common/espressif/esp_i2c_bitbang.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/common/espressif/esp_i2c_bitbang.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/common/espressif/esp_i2c_slave.c eren.terzioglu@espressif.com devel@sumpfralle.de
-arch/xtensa/src/common/espressif/esp_i2c_slave.h eren.terzioglu@espressif.com devel@sumpfralle.de
-arch/xtensa/src/common/espressif/esp_i2s.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com devel@sumpfralle.de
-arch/xtensa/src/common/espressif/esp_i2s.h eren.terzioglu@espressif.com
-arch/xtensa/src/common/espressif/esp_ledc.c eren.terzioglu@espressif.com
-arch/xtensa/src/common/espressif/esp_ledc.h eren.terzioglu@espressif.com
-arch/xtensa/src/common/espressif/esp_loader.c almir.okato@espressif.com filipe.cavalcanti@espressif.com tiago.medicci@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/common/espressif/esp_loader.h almir.okato@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/common/espressif/esp_mcpwm.c filipe.cavalcanti@espressif.com anchao@lixiang.com petro.karashchenko@gmail.com alin.jerpelea@sony.com fangxinyong@xiaomi.com
-arch/xtensa/src/common/espressif/esp_mcpwm.h filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/common/espressif/esp_nxdiag.c eren.terzioglu@espressif.com devel@sumpfralle.de filipe.cavalcanti@espressif.com anchao@lixiang.com
-arch/xtensa/src/common/espressif/esp_nxdiag.h eren.terzioglu@espressif.com
-arch/xtensa/src/common/espressif/esp_openeth.c marco.casaroli@gmail.com devel@sumpfralle.de filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/common/espressif/esp_pcnt.c eren.terzioglu@espressif.com martin.vajnar@gmail.com filipe.cavalcanti@espressif.com hujun5@xiaomi.com
-arch/xtensa/src/common/espressif/esp_pcnt.h eren.terzioglu@espressif.com
-arch/xtensa/src/common/espressif/esp_qencoder.c eren.terzioglu@espressif.com
-arch/xtensa/src/common/espressif/esp_qencoder.h eren.terzioglu@espressif.com
-arch/xtensa/src/common/espressif/esp_rmt.c tiago.medicci@espressif.com hujun5@xiaomi.com petro.karashchenko@gmail.com filipe.cavalcanti@espressif.com devel@sumpfralle.de
-arch/xtensa/src/common/espressif/esp_rmt.h tiago.medicci@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/common/espressif/esp_sdm.c eren.terzioglu@espressif.com
-arch/xtensa/src/common/espressif/esp_sdm.h eren.terzioglu@espressif.com
-arch/xtensa/src/common/espressif/esp_sha.c eren.terzioglu@espressif.com
-arch/xtensa/src/common/espressif/esp_sha.h eren.terzioglu@espressif.com
-arch/xtensa/src/common/espressif/esp_spi_bitbang.c eren.terzioglu@espressif.com
-arch/xtensa/src/common/espressif/esp_spi_bitbang.h eren.terzioglu@espressif.com
-arch/xtensa/src/common/espressif/esp_spiflash.c filipe.cavalcanti@espressif.com devel@sumpfralle.de hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/xtensa/src/common/espressif/esp_spiflash.h filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/common/espressif/esp_spiflash_mtd.c filipe.cavalcanti@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/xtensa/src/common/espressif/esp_spiflash_mtd.h filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/common/espressif/esp_temperature_sensor.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com petro.karashchenko@gmail.com devel@sumpfralle.de xiaoxiang@xiaomi.com
-arch/xtensa/src/common/espressif/esp_temperature_sensor.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/common/espressif/esp_wifi_utils.c filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/common/espressif/esp_wifi_utils.h filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/common/espressif/esp_wireless.c filipe.cavalcanti@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/xtensa/src/common/espressif/esp_wireless.h filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/common/espressif/esp_wlan.c filipe.cavalcanti@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/xtensa/src/common/espressif/esp_wlan.h filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/common/espressif/esp_ws2812.c tiago.medicci@espressif.com filipe.cavalcanti@espressif.com anchao@lixiang.com alin.jerpelea@sony.com huangqi3@xiaomi.com
-arch/xtensa/src/common/espressif/esp_ws2812.h tiago.medicci@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/common/espressif/platform_include/sys/lock.h tiago.medicci@espressif.com Feng.Gao@sony.com alin.jerpelea@sony.com
-arch/xtensa/src/common/espressif/utils/memory_reserve.h tiago.medicci@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/common/mpu.h zhuyanlin1@xiaomi.com chenrun1@xiaomi.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-arch/xtensa/src/common/xtensa.h xiaoxiang@xiaomi.com abdelatif.guettouche@espressif.com alin.jerpelea@sony.com zhuyanlin1@xiaomi.com
-arch/xtensa/src/common/xtensa_asm_utils.h abdelatif.guettouche@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/common/xtensa_assert.c tianxin7@xiaomi.com xiaoxiang@xiaomi.com zhangyuan21@xiaomi.com hujun5@xiaomi.com
-arch/xtensa/src/common/xtensa_attr.h alin.jerpelea@sony.com abdelatif.guettouche@espressif.com xiaoxiang@xiaomi.com yamamoto@midokura.com
-arch/xtensa/src/common/xtensa_backtrace.c zhuyanlin1@xiaomi.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com tiago.medicci@espressif.com anchao@xiaomi.com
-arch/xtensa/src/common/xtensa_cache.c zhuyanlin1@xiaomi.com liguiding1@xiaomi.com chenrun1@xiaomi.com buxiasen@xiaomi.com alin.jerpelea@sony.com
-arch/xtensa/src/common/xtensa_checkstack.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com dongjiuzhu1@xiaomi.com abdelatif.guettouche@espressif.com
-arch/xtensa/src/common/xtensa_context.S abdelatif.guettouche@espressif.com zhuyanlin1@xiaomi.com gustavo.nihei@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/common/xtensa_coproc.S zhuyanlin1@xiaomi.com abdelatif.guettouche@espressif.com gustavo.nihei@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/common/xtensa_counter.h chenwen@espressif.com zhuyanlin1@xiaomi.com alin.jerpelea@sony.com
-arch/xtensa/src/common/xtensa_cpenable.c alin.jerpelea@sony.com zhuyanlin1@xiaomi.com
-arch/xtensa/src/common/xtensa_cpuinfo.c liaoao@xiaomi.com wangming9@xiaomi.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/xtensa/src/common/xtensa_cpuint.c chenxiaoyi@xiaomi.com
-arch/xtensa/src/common/xtensa_createstack.c abdelatif.guettouche@espressif.com anchao@xiaomi.com xiaoxiang@xiaomi.com abdelatif.guettouche@gmail.com
-arch/xtensa/src/common/xtensa_debug.c chenxiaoyi@xiaomi.com filipe.cavalcanti@espressif.com
-arch/xtensa/src/common/xtensa_dispatch_syscall.S gustavo.nihei@espressif.com chenxiaoyi@xiaomi.com alin.jerpelea@sony.com
-arch/xtensa/src/common/xtensa_exit.c xiaoxiang@xiaomi.com anchao@xiaomi.com alin.jerpelea@sony.com abdelatif.guettouche@espressif.com
-arch/xtensa/src/common/xtensa_fpucmp.c zhuyanlin1@xiaomi.com gustavo.nihei@espressif.com zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/xtensa/src/common/xtensa_getintstack.c zhangyuan21@xiaomi.com xiaoxiang@xiaomi.com liguiding1@xiaomi.com alin.jerpelea@sony.com
-arch/xtensa/src/common/xtensa_hostfs.c yamamoto@midokura.com xiaoxiang@xiaomi.com zhuyanlin1@xiaomi.com chenrun1@xiaomi.com chenxiaoyi@xiaomi.com
-arch/xtensa/src/common/xtensa_idle.c alin.jerpelea@sony.com acassis@gmail.com yamamoto@midokura.com masayuki.ishikawa@gmail.com
-arch/xtensa/src/common/xtensa_initialize.c xiaoxiang@xiaomi.com abdelatif.guettouche@espressif.com alin.jerpelea@sony.com hujun5@xiaomi.com
-arch/xtensa/src/common/xtensa_initialstate.c tiago.medicci@espressif.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com zhuyanlin1@xiaomi.com
-arch/xtensa/src/common/xtensa_int_handlers.S abdelatif.guettouche@espressif.com chenxiaoyi@xiaomi.com zhuyanlin1@xiaomi.com gustavo.nihei@espressif.com
-arch/xtensa/src/common/xtensa_irqdispatch.c hujun5@xiaomi.com alin.jerpelea@sony.com yamamoto@midokura.com zhuyanlin1@xiaomi.com
-arch/xtensa/src/common/xtensa_loadstore.S yamamoto@midokura.com alin.jerpelea@sony.com zhuyanlin1@xiaomi.com
-arch/xtensa/src/common/xtensa_lowputs.c alin.jerpelea@sony.com zhangyuan21@xiaomi.com
-arch/xtensa/src/common/xtensa_macros.S abdelatif.guettouche@espressif.com tiago.medicci@espressif.com gustavo.nihei@espressif.com yamamoto@midokura.com alin.jerpelea@sony.com
-arch/xtensa/src/common/xtensa_mdelay.c alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/xtensa/src/common/xtensa_mm.h abdelatif.guettouche@espressif.com chenwen@espressif.com alin.jerpelea@sony.com acassis@gmail.com
-arch/xtensa/src/common/xtensa_modifyreg16.c alin.jerpelea@sony.com hujun5@xiaomi.com abdelatif.guettouche@espressif.com
-arch/xtensa/src/common/xtensa_modifyreg32.c alin.jerpelea@sony.com hujun5@xiaomi.com abdelatif.guettouche@espressif.com
-arch/xtensa/src/common/xtensa_modifyreg8.c alin.jerpelea@sony.com hujun5@xiaomi.com abdelatif.guettouche@espressif.com
-arch/xtensa/src/common/xtensa_mpu.c zhuyanlin1@xiaomi.com chenrun1@xiaomi.com liguiding1@xiaomi.com alin.jerpelea@sony.com f.panag@amco.gr
-arch/xtensa/src/common/xtensa_nputs.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com wangbowen6@xiaomi.com
-arch/xtensa/src/common/xtensa_oneshot.c zhuyanlin1@xiaomi.com anchao@xiaomi.com alin.jerpelea@sony.com
-arch/xtensa/src/common/xtensa_panic.S abdelatif.guettouche@espressif.com anchao@xiaomi.com alin.jerpelea@sony.com zhuyanlin1@xiaomi.com
-arch/xtensa/src/common/xtensa_perf.c zhuyanlin1@xiaomi.com wangming9@xiaomi.com yinshengkai@xiaomi.com jukka.laitinen@tii.ae alin.jerpelea@sony.com
-arch/xtensa/src/common/xtensa_pthread_start.c gustavo.nihei@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/common/xtensa_registerdump.c zhangyuan21@xiaomi.com buxiasen@xiaomi.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/xtensa/src/common/xtensa_releasestack.c alin.jerpelea@sony.com abdelatif.guettouche@espressif.com xiaoxiang@xiaomi.com xuanlin@pinecone.net
-arch/xtensa/src/common/xtensa_saveusercontext.c abdelatif.guettouche@espressif.com chenxiaoyi@xiaomi.com chenrun1@xiaomi.com anchao.archer@bytedance.com tiago.medicci@espressif.com
-arch/xtensa/src/common/xtensa_schedsigaction.c hujun5@xiaomi.com abdelatif.guettouche@espressif.com xiaoxiang@xiaomi.com yamamoto@midokura.com
-arch/xtensa/src/common/xtensa_sigdeliver.c abdelatif.guettouche@espressif.com hujun5@xiaomi.com liguiding1@xiaomi.com dongheng@espressif.com
-arch/xtensa/src/common/xtensa_signal_dispatch.c gustavo.nihei@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/common/xtensa_signal_handler.S gustavo.nihei@espressif.com chenxiaoyi@xiaomi.com alin.jerpelea@sony.com
-arch/xtensa/src/common/xtensa_simcall.S yamamoto@midokura.com alin.jerpelea@sony.com zhuyanlin1@xiaomi.com
-arch/xtensa/src/common/xtensa_smpcall.c hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/xtensa/src/common/xtensa_stackframe.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com abdelatif.guettouche@espressif.com anchao@xiaomi.com
-arch/xtensa/src/common/xtensa_swint.c gustavo.nihei@espressif.com zhuyanlin1@xiaomi.com hujun5@xiaomi.com zhangyuan21@xiaomi.com abdelatif.guettouche@espressif.com
-arch/xtensa/src/common/xtensa_task_start.c gustavo.nihei@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/common/xtensa_tcbinfo.c abdelatif.guettouche@espressif.com Feng.Gao@sony.com zhangyuan21@xiaomi.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com
-arch/xtensa/src/common/xtensa_timer.h yamamoto@midokura.com alin.jerpelea@sony.com zhuyanlin1@xiaomi.com xiaoxiang@xiaomi.com
-arch/xtensa/src/common/xtensa_tls.c tiago.medicci@espressif.com
-arch/xtensa/src/common/xtensa_udelay.c alin.jerpelea@sony.com yamamoto@midokura.com gustavo.nihei@espressif.com
-arch/xtensa/src/common/xtensa_user_handler.S abdelatif.guettouche@espressif.com yamamoto@midokura.com anchao@xiaomi.com chenxiaoyi@xiaomi.com
-arch/xtensa/src/common/xtensa_usestack.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com abdelatif.guettouche@espressif.com abdelatif.guettouche@gmail.com
-arch/xtensa/src/common/xtensa_vectors.S gustavo.nihei@espressif.com abdelatif.guettouche@espressif.com zhuyanlin1@xiaomi.com alin.jerpelea@sony.com
-arch/xtensa/src/common/xtensa_window_vector.S gustavo.nihei@espressif.com alin.jerpelea@sony.com abdelatif.guettouche@espressif.com
-arch/xtensa/src/common/xtensa_windowspill.S abdelatif.guettouche@espressif.com alin.jerpelea@sony.com zhuyanlin1@xiaomi.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32/.gitignore filipe.cavalcanti@espressif.com gustavo.nihei@espressif.com abdelatif.guettouche@espressif.com lucas.vaz@espressif.com
-arch/xtensa/src/esp32/Bootloader.mk gustavo.nihei@espressif.com lucas.vaz@espressif.com filipe.cavalcanti@espressif.com almir.okato@espressif.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32/Kconfig acassis@gmail.com gustavo.nihei@espressif.com filipe.cavalcanti@espressif.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32/Kconfig.security gustavo.nihei@espressif.com almir.okato@espressif.com
-arch/xtensa/src/esp32/bootloader/.gitignore gustavo.nihei@espressif.com filipe.cavalcanti@espressif.com lucas.vaz@espressif.com
-arch/xtensa/src/esp32/chip.h zhuyanlin1@xiaomi.com marco.casaroli@gmail.com
-arch/xtensa/src/esp32/chip_macros.h gustavo.nihei@espressif.com abdelatif.guettouche@espressif.com tiago.medicci@espressif.com masayuki.ishikawa@gmail.com
-arch/xtensa/src/esp32/chip_memory.h abdelatif.guettouche@espressif.com tiago.medicci@espressif.com zhuyanlin1@xiaomi.com
-arch/xtensa/src/esp32/esp32_aes.c dongheng@espressif.com abdelatif.guettouche@espressif.com anjiahao@xiaomi.com devel@sumpfralle.de wangbowen6@xiaomi.com
-arch/xtensa/src/esp32/esp32_aes.h dongheng@espressif.com devel@sumpfralle.de
-arch/xtensa/src/esp32/esp32_allocateheap.c gustavo.nihei@espressif.com abdelatif.guettouche@espressif.com yamamoto@midokura.com alin.jerpelea@sony.com
-arch/xtensa/src/esp32/esp32_ble.c acassis@gmail.com chengkai@xiaomi.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32/esp32_ble.h acassis@gmail.com
-arch/xtensa/src/esp32/esp32_ble_adapter.c tiago.medicci@espressif.com acassis@gmail.com filipe.cavalcanti@espressif.com xiaoxiang@xiaomi.com petro.karashchenko@gmail.com
-arch/xtensa/src/esp32/esp32_ble_adapter.h acassis@gmail.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com
-arch/xtensa/src/esp32/esp32_clockconfig.c chenwen@espressif.com acassis@gmail.com tiago.medicci@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/esp32/esp32_clockconfig.h chenwen@espressif.com alin.jerpelea@sony.com tiago.medicci@espressif.com acassis@gmail.com
-arch/xtensa/src/esp32/esp32_config.h alin.jerpelea@sony.com acassis@gmail.com yamamoto@midokura.com
-arch/xtensa/src/esp32/esp32_cpuidlestack.c abdelatif.guettouche@espressif.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com yamamoto@midokura.com
-arch/xtensa/src/esp32/esp32_cpustart.c xiaoxiang@xiaomi.com abdelatif.guettouche@espressif.com zhangyuan21@xiaomi.com yamamoto@midokura.com
-arch/xtensa/src/esp32/esp32_crypto.c pruteanuvlad1611@yahoo.com
-arch/xtensa/src/esp32/esp32_dac.c tomas.pilny@espressif.com hujun5@xiaomi.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32/esp32_dac.h tomas.pilny@espressif.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32/esp32_dma.c dongheng@espressif.com tiago.medicci@espressif.com gustavo.nihei@espressif.com wangbowen6@xiaomi.com petro.karashchenko@gmail.com
-arch/xtensa/src/esp32/esp32_dma.h dongheng@espressif.com tiago.medicci@espressif.com gustavo.nihei@espressif.com yamamoto@midokura.com
-arch/xtensa/src/esp32/esp32_efuse.c acassis@gmail.com tiago.medicci@espressif.com gustavo.nihei@espressif.com filipe.cavalcanti@espressif.com
-arch/xtensa/src/esp32/esp32_efuse.h acassis@gmail.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32/esp32_efuse_lowerhalf.c acassis@gmail.com gustavo.nihei@espressif.com ouyangxiangzhen@xiaomi.com
-arch/xtensa/src/esp32/esp32_emac.c acassis@gmail.com zhanghongyu@xiaomi.com anchao@xiaomi.com xiaoxiang@xiaomi.com abdelatif.guettouche@espressif.com
-arch/xtensa/src/esp32/esp32_emac.h acassis@gmail.com
-arch/xtensa/src/esp32/esp32_extraheaps.c abdelatif.guettouche@espressif.com
-arch/xtensa/src/esp32/esp32_freerun.c sara.souza@espressif.com abdelatif.guettouche@espressif.com filipe.cavalcanti@espressif.com
-arch/xtensa/src/esp32/esp32_freerun.h sara.souza@espressif.com gustavo.nihei@espressif.com petro.karashchenko@gmail.com
-arch/xtensa/src/esp32/esp32_gpio.c lucas.vaz@espressif.com abdelatif.guettouche@espressif.com alan.carvalho@espressif.com acassis@gmail.com
-arch/xtensa/src/esp32/esp32_gpio.h lucas.vaz@espressif.com acassis@gmail.com abdelatif.guettouche@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/esp32/esp32_himem.c acassis@gmail.com gustavo.nihei@espressif.com petro.karashchenko@gmail.com hujun5@xiaomi.com masayuki.ishikawa@gmail.com
-arch/xtensa/src/esp32/esp32_himem.h acassis@gmail.com gustavo.nihei@espressif.com abdelatif.guettouche@espressif.com
-arch/xtensa/src/esp32/esp32_himem_chardev.c zhong.wan@sony.com zhaoqing.zhang@sony.com devel@sumpfralle.de anchao@xiaomi.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32/esp32_i2c.c acassis@gmail.com sara.souza@espressif.com gustavo.nihei@espressif.com anjiahao@xiaomi.com abdelatif.guettouche@espressif.com
-arch/xtensa/src/esp32/esp32_i2c.h acassis@gmail.com lucas.vaz@espressif.com eren.terzioglu@espressif.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32/esp32_i2s.c tiago.medicci@espressif.com filipe.cavalcanti@espressif.com eren.terzioglu@espressif.com simona.alexandra2000@gmail.com anjiahao@xiaomi.com
-arch/xtensa/src/esp32/esp32_idle.c chenwen@espressif.com abdelatif.guettouche@espressif.com hujun5@xiaomi.com gustavo.nihei@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32/esp32_imm.c abdelatif.guettouche@espressif.com chenwen@espressif.com xiaoxiang@xiaomi.com yamamoto@midokura.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32/esp32_intercpu_interrupt.c masayuki.ishikawa@gmail.com alin.jerpelea@sony.com hujun5@xiaomi.com abdelatif.guettouche@espressif.com
-arch/xtensa/src/esp32/esp32_iramheap.c abdelatif.guettouche@espressif.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com
-arch/xtensa/src/esp32/esp32_iramheap.h abdelatif.guettouche@espressif.com anjiahao@xiaomi.com
-arch/xtensa/src/esp32/esp32_irq.c abdelatif.guettouche@espressif.com tiago.medicci@espressif.com xiaoxiang@xiaomi.com wangzhi16@xiaomi.com
-arch/xtensa/src/esp32/esp32_irq.h abdelatif.guettouche@espressif.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32/esp32_ledc.c acassis@gmail.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32/esp32_ledc.h acassis@gmail.com
-arch/xtensa/src/esp32/esp32_libc_stubs.c lucas.vaz@espressif.com tiago.medicci@espressif.com petro.karashchenko@gmail.com
-arch/xtensa/src/esp32/esp32_oneshot.c sara.souza@espressif.com gustavo.nihei@espressif.com filipe.cavalcanti@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32/esp32_oneshot.h sara.souza@espressif.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32/esp32_oneshot_lowerhalf.c sara.souza@espressif.com gustavo.nihei@espressif.com abdelatif.guettouche@espressif.com xiaoxiang@xiaomi.com devel@sumpfralle.de
-arch/xtensa/src/esp32/esp32_partition.c dongheng@espressif.com zhaoqing.zhang@sony.com chenwen@espressif.com gustavo.nihei@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32/esp32_partition.h dongheng@espressif.com chenwen@espressif.com
-arch/xtensa/src/esp32/esp32_pm.c chenwen@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com gustavo.nihei@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32/esp32_pm.h chenwen@espressif.com petro.karashchenko@gmail.com
-arch/xtensa/src/esp32/esp32_pminitialize.c chenwen@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32/esp32_psram.c acassis@gmail.com abdelatif.guettouche@espressif.com yamamoto@midokura.com tiago.medicci@espressif.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32/esp32_psram.h acassis@gmail.com abdelatif.guettouche@espressif.com
-arch/xtensa/src/esp32/esp32_qencoder.c acassis@gmail.com filipe.cavalcanti@espressif.com
-arch/xtensa/src/esp32/esp32_qencoder.h acassis@gmail.com
-arch/xtensa/src/esp32/esp32_region.c alin.jerpelea@sony.com yamamoto@midokura.com anchao@xiaomi.com
-arch/xtensa/src/esp32/esp32_region.h alin.jerpelea@sony.com
-arch/xtensa/src/esp32/esp32_resetcause.c abdelatif.guettouche@espressif.com
-arch/xtensa/src/esp32/esp32_resetcause.h abdelatif.guettouche@espressif.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32/esp32_rng.c acassis@gmail.com abdelatif.guettouche@espressif.com anjiahao@xiaomi.com tiago.medicci@espressif.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32/esp32_rt_timer.c dongheng@espressif.com abdelatif.guettouche@espressif.com chenwen@espressif.com gustavo.nihei@espressif.com petro.karashchenko@gmail.com
-arch/xtensa/src/esp32/esp32_rt_timer.h dongheng@espressif.com abdelatif.guettouche@espressif.com chenwen@espressif.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32/esp32_rtc.c chenwen@espressif.com sara.souza@espressif.com lucas.vaz@espressif.com gustavo.nihei@espressif.com abdelatif.guettouche@espressif.com
-arch/xtensa/src/esp32/esp32_rtc.h chenwen@espressif.com sara.souza@espressif.com lucas.vaz@espressif.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32/esp32_rtc_gpio.c lucas.vaz@espressif.com fangxinyong@xiaomi.com petro.karashchenko@gmail.com
-arch/xtensa/src/esp32/esp32_rtc_gpio.h lucas.vaz@espressif.com alan.carvalho@espressif.com
-arch/xtensa/src/esp32/esp32_rtc_lowerhalf.c chenwen@espressif.com gustavo.nihei@espressif.com hujun5@xiaomi.com xiaoxiang@xiaomi.com abdelatif.guettouche@espressif.com
-arch/xtensa/src/esp32/esp32_rtc_lowerhalf.h chenwen@espressif.com
-arch/xtensa/src/esp32/esp32_rtcheap.c abdelatif.guettouche@espressif.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com
-arch/xtensa/src/esp32/esp32_rtcheap.h abdelatif.guettouche@espressif.com anjiahao@xiaomi.com
-arch/xtensa/src/esp32/esp32_serial.c sara.souza@espressif.com petro.karashchenko@gmail.com abdelatif.guettouche@espressif.com acassis@gmail.com
-arch/xtensa/src/esp32/esp32_sha.c pruteanuvlad1611@yahoo.com
-arch/xtensa/src/esp32/esp32_sha.h pruteanuvlad1611@yahoo.com
-arch/xtensa/src/esp32/esp32_smp.h alin.jerpelea@sony.com abdelatif.guettouche@espressif.com masayuki.ishikawa@gmail.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32/esp32_spi.c acassis@gmail.com dongheng@espressif.com gustavo.nihei@espressif.com abdelatif.guettouche@espressif.com petro.karashchenko@gmail.com
-arch/xtensa/src/esp32/esp32_spi.h acassis@gmail.com gustavo.nihei@espressif.com dongheng@espressif.com sara.souza@espressif.com
-arch/xtensa/src/esp32/esp32_spi_slave.c acassis@gmail.com dongheng@espressif.com gustavo.nihei@espressif.com abdelatif.guettouche@espressif.com dongjiuzhu1@xiaomi.com
-arch/xtensa/src/esp32/esp32_spicache.c acassis@gmail.com tiago.medicci@espressif.com matias@protobits.dev
-arch/xtensa/src/esp32/esp32_spicache.h acassis@gmail.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32/esp32_spiflash.c dongheng@espressif.com acassis@gmail.com abdelatif.guettouche@espressif.com tiago.medicci@espressif.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32/esp32_spiflash.h acassis@gmail.com dongheng@espressif.com chenwen@espressif.com gustavo.nihei@espressif.com zhaoqing.zhang@sony.com
-arch/xtensa/src/esp32/esp32_spiram.c acassis@gmail.com eren.terzioglu@espressif.com abdelatif.guettouche@espressif.com filipe.cavalcanti@espressif.com yamamoto@midokura.com
-arch/xtensa/src/esp32/esp32_spiram.h acassis@gmail.com eren.terzioglu@espressif.com abdelatif.guettouche@espressif.com filipe.cavalcanti@espressif.com
-arch/xtensa/src/esp32/esp32_start.c gustavo.nihei@espressif.com almir.okato@espressif.com xiaoxiang@xiaomi.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32/esp32_start.h alin.jerpelea@sony.com
-arch/xtensa/src/esp32/esp32_systemreset.c chenwen@espressif.com abdelatif.guettouche@espressif.com
-arch/xtensa/src/esp32/esp32_systemreset.h chenwen@espressif.com
-arch/xtensa/src/esp32/esp32_textheap.c abdelatif.guettouche@espressif.com yamamoto@midokura.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32/esp32_tickless.c chenwen@espressif.com gustavo.nihei@espressif.com abdelatif.guettouche@espressif.com xiaoxiang@xiaomi.com filipe.cavalcanti@espressif.com
-arch/xtensa/src/esp32/esp32_tickless.h chenwen@espressif.com
-arch/xtensa/src/esp32/esp32_tim.c sara.souza@espressif.com gustavo.nihei@espressif.com abdelatif.guettouche@espressif.com dongheng@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32/esp32_tim.h sara.souza@espressif.com gustavo.nihei@espressif.com dongheng@espressif.com
-arch/xtensa/src/esp32/esp32_tim_lowerhalf.c sara.souza@espressif.com gustavo.nihei@espressif.com abdelatif.guettouche@espressif.com petro.karashchenko@gmail.com acassis@gmail.com
-arch/xtensa/src/esp32/esp32_tim_lowerhalf.h sara.souza@espressif.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32/esp32_timerisr.c chenwen@espressif.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com mark@mjs.pw
-arch/xtensa/src/esp32/esp32_touch.c lucas.vaz@espressif.com devel@sumpfralle.de anchao@xiaomi.com
-arch/xtensa/src/esp32/esp32_touch.h lucas.vaz@espressif.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32/esp32_touch_lowerhalf.h lucas.vaz@espressif.com
-arch/xtensa/src/esp32/esp32_twai.c acassis@gmail.com xiaoxiang@xiaomi.com vbenso@gmail.com filipe.cavalcanti@espressif.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32/esp32_twai.h acassis@gmail.com xiaoxiang@xiaomi.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32/esp32_user.c yamamoto@midokura.com tiago.medicci@espressif.com abdelatif.guettouche@espressif.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32/esp32_userspace.c gustavo.nihei@espressif.com yamamoto@midokura.com 59230071+hartmannathan@users.noreply.github.com
-arch/xtensa/src/esp32/esp32_userspace.h gustavo.nihei@espressif.com 59230071+hartmannathan@users.noreply.github.com
-arch/xtensa/src/esp32/esp32_userspace_pid.c yamamoto@midokura.com
-arch/xtensa/src/esp32/esp32_wdt.c sara.souza@espressif.com gustavo.nihei@espressif.com lucas.vaz@espressif.com abdelatif.guettouche@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32/esp32_wdt.h sara.souza@espressif.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32/esp32_wdt_lowerhalf.c sara.souza@espressif.com gustavo.nihei@espressif.com abdelatif.guettouche@espressif.com filipe.cavalcanti@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32/esp32_wdt_lowerhalf.h sara.souza@espressif.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32/esp32_wifi_adapter.c dongheng@espressif.com tiago.medicci@espressif.com chenwen@espressif.com filipe.cavalcanti@espressif.com acassis@gmail.com
-arch/xtensa/src/esp32/esp32_wifi_adapter.h dongheng@espressif.com chenwen@espressif.com filipe.cavalcanti@espressif.com gustavo.nihei@espressif.com acassis@gmail.com
-arch/xtensa/src/esp32/esp32_window_hooks.S gustavo.nihei@espressif.com
-arch/xtensa/src/esp32/hal.mk tiago.medicci@espressif.com filipe.cavalcanti@espressif.com almir.okato@espressif.com eren.terzioglu@espressif.com pruteanuvlad1611@yahoo.com
-arch/xtensa/src/esp32/hardware/esp32_aes.h dongheng@espressif.com alin.jerpelea@sony.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32/hardware/esp32_apb_ctrl.h tiago.medicci@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/esp32/hardware/esp32_dma.h dongheng@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/esp32/hardware/esp32_dport.h alin.jerpelea@sony.com dongheng@espressif.com acassis@gmail.com 101105604+simbit18@users.noreply.github.com
-arch/xtensa/src/esp32/hardware/esp32_efuse.h tiago.medicci@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/esp32/hardware/esp32_efuse_defs.h tiago.medicci@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/esp32/hardware/esp32_emac.h acassis@gmail.com gustavo.nihei@espressif.com alin.jerpelea@sony.com jbampton@gmail.com
-arch/xtensa/src/esp32/hardware/esp32_gpio.h alin.jerpelea@sony.com abdelatif.guettouche@espressif.com acassis@gmail.com
-arch/xtensa/src/esp32/hardware/esp32_gpio_sigmap.h alin.jerpelea@sony.com acassis@gmail.com dongheng@espressif.com
-arch/xtensa/src/esp32/hardware/esp32_i2c.h acassis@gmail.com alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32/hardware/esp32_i2s.h tiago.medicci@espressif.com chenwen@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32/hardware/esp32_iomux.h alin.jerpelea@sony.com lucas.vaz@espressif.com abdelatif.guettouche@espressif.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32/hardware/esp32_ledc.h acassis@gmail.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/xtensa/src/esp32/hardware/esp32_pcnt.h acassis@gmail.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/xtensa/src/esp32/hardware/esp32_pid.h gustavo.nihei@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/esp32/hardware/esp32_pinmap.h dongheng@espressif.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/xtensa/src/esp32/hardware/esp32_rtc_io.h alan.carvalho@espressif.com devel@sumpfralle.de petro.karashchenko@gmail.com alin.jerpelea@sony.com
-arch/xtensa/src/esp32/hardware/esp32_rtccntl.h alin.jerpelea@sony.com chenwen@espressif.com lucas.vaz@espressif.com sara.souza@espressif.com
-arch/xtensa/src/esp32/hardware/esp32_sens.h tomas.pilny@espressif.com lucas.vaz@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/esp32/hardware/esp32_soc.h chenwen@espressif.com tiago.medicci@espressif.com acassis@gmail.com alin.jerpelea@sony.com
-arch/xtensa/src/esp32/hardware/esp32_spi.h acassis@gmail.com abdelatif.guettouche@espressif.com zhaoqing.zhang@sony.com alin.jerpelea@sony.com
-arch/xtensa/src/esp32/hardware/esp32_tim.h sara.souza@espressif.com 101105604+simbit18@users.noreply.github.com abdelatif.guettouche@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/esp32/hardware/esp32_touch.h lucas.vaz@espressif.com alin.jerpelea@sony.com
-arch/xtensa/src/esp32/hardware/esp32_twai.h acassis@gmail.com vbenso@gmail.com alin.jerpelea@sony.com
-arch/xtensa/src/esp32/hardware/esp32_uart.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com sara.souza@espressif.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32/hardware/esp32_uhci.h sara.souza@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-arch/xtensa/src/esp32/hardware/wdev_reg.h acassis@gmail.com alin.jerpelea@sony.com
-arch/xtensa/src/esp32/rom/esp32_efuse.h acassis@gmail.com gustavo.nihei@espressif.com petro.karashchenko@gmail.com
-arch/xtensa/src/esp32/rom/esp32_libc_stubs.h lucas.vaz@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32/rom/esp32_spiflash.h acassis@gmail.com lucas.vaz@espressif.com devel@sumpfralle.de gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s2/.gitignore lucas.vaz@espressif.com filipe.cavalcanti@espressif.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s2/Bootloader.mk gustavo.nihei@espressif.com almir.okato@espressif.com filipe.cavalcanti@espressif.com lucas.vaz@espressif.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32s2/Kconfig acassis@gmail.com gustavo.nihei@espressif.com filipe.cavalcanti@espressif.com eren.terzioglu@espressif.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32s2/Kconfig.security gustavo.nihei@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s2/chip.h zhuyanlin1@xiaomi.com
-arch/xtensa/src/esp32s2/chip_macros.h acassis@gmail.com
-arch/xtensa/src/esp32s2/chip_memory.h acassis@gmail.com tiago.medicci@espressif.com zhuyanlin1@xiaomi.com
-arch/xtensa/src/esp32s2/esp32s2_allocateheap.c acassis@gmail.com xiaoxiang@xiaomi.com abdelatif.guettouche@espressif.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_clockconfig.c acassis@gmail.com tiago.medicci@espressif.com gustavo.nihei@espressif.com almir.okato@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_clockconfig.h acassis@gmail.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_config.h acassis@gmail.com eren.terzioglu@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_dma.c tiago.medicci@espressif.com wangbowen6@xiaomi.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_dma.h tiago.medicci@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_efuse.c acassis@gmail.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_efuse.h acassis@gmail.com 101105604+simbit18@users.noreply.github.com
-arch/xtensa/src/esp32s2/esp32s2_efuse_lowerhalf.c acassis@gmail.com
-arch/xtensa/src/esp32s2/esp32s2_efuse_table.c acassis@gmail.com devel@sumpfralle.de
-arch/xtensa/src/esp32s2/esp32s2_extraheaps.c eren.terzioglu@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_freerun.c sara.souza@espressif.com xiaoxiang@xiaomi.com petro.karashchenko@gmail.com
-arch/xtensa/src/esp32s2/esp32s2_freerun.h sara.souza@espressif.com petro.karashchenko@gmail.com
-arch/xtensa/src/esp32s2/esp32s2_gpio.c acassis@gmail.com gustavo.nihei@espressif.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_gpio.h acassis@gmail.com gustavo.nihei@espressif.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_i2c.c gustavo.nihei@espressif.com anjiahao@xiaomi.com xiaoxiang@xiaomi.com wangzhi16@xiaomi.com eren.terzioglu@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_i2c.h gustavo.nihei@espressif.com eren.terzioglu@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_i2s.c tiago.medicci@espressif.com filipe.cavalcanti@espressif.com eren.terzioglu@espressif.com lucas.vaz@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s2/esp32s2_idle.c acassis@gmail.com hujun5@xiaomi.com zhuyanlin1@xiaomi.com
-arch/xtensa/src/esp32s2/esp32s2_irq.c gustavo.nihei@espressif.com acassis@gmail.com xiaoxiang@xiaomi.com wangzhi16@xiaomi.com chenxiaoyi@xiaomi.com
-arch/xtensa/src/esp32s2/esp32s2_irq.h gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_libc_stubs.c lucas.vaz@espressif.com tiago.medicci@espressif.com petro.karashchenko@gmail.com
-arch/xtensa/src/esp32s2/esp32s2_lowputc.c acassis@gmail.com sara.souza@espressif.com eren.terzioglu@espressif.com gustavo.nihei@espressif.com hujun5@xiaomi.com
-arch/xtensa/src/esp32s2/esp32s2_lowputc.h acassis@gmail.com sara.souza@espressif.com eren.terzioglu@espressif.com gustavo.nihei@espressif.com hujun5@xiaomi.com
-arch/xtensa/src/esp32s2/esp32s2_oneshot.c sara.souza@espressif.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_oneshot.h sara.souza@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_oneshot_lowerhalf.c sara.souza@espressif.com gustavo.nihei@espressif.com anchao@xiaomi.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s2/esp32s2_psram.c acassis@gmail.com
-arch/xtensa/src/esp32s2/esp32s2_psram.h acassis@gmail.com devel@sumpfralle.de
-arch/xtensa/src/esp32s2/esp32s2_region.c acassis@gmail.com anchao@xiaomi.com
-arch/xtensa/src/esp32s2/esp32s2_region.h acassis@gmail.com
-arch/xtensa/src/esp32s2/esp32s2_rng.c acassis@gmail.com filipe.cavalcanti@espressif.com anjiahao@xiaomi.com gustavo.nihei@espressif.com almir.okato@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_rt_timer.c sara.souza@espressif.com xiaoxiang@xiaomi.com wangzhi16@xiaomi.com petro.karashchenko@gmail.com anjiahao@xiaomi.com
-arch/xtensa/src/esp32s2/esp32s2_rt_timer.h sara.souza@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s2/esp32s2_rtc.c eren.terzioglu@espressif.com acassis@gmail.com hujun5@xiaomi.com almir.okato@espressif.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_rtc.h eren.terzioglu@espressif.com acassis@gmail.com
-arch/xtensa/src/esp32s2/esp32s2_rtc_gpio.c lucas.vaz@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_rtc_gpio.h lucas.vaz@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_rtc_lowerhalf.c eren.terzioglu@espressif.com hujun5@xiaomi.com
-arch/xtensa/src/esp32s2/esp32s2_rtc_lowerhalf.h eren.terzioglu@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_rtcheap.c eren.terzioglu@espressif.com devel@sumpfralle.de
-arch/xtensa/src/esp32s2/esp32s2_rtcheap.h eren.terzioglu@espressif.com devel@sumpfralle.de
-arch/xtensa/src/esp32s2/esp32s2_serial.c acassis@gmail.com sara.souza@espressif.com gustavo.nihei@espressif.com eren.terzioglu@espressif.com yangsong8@xiaomi.com
-arch/xtensa/src/esp32s2/esp32s2_spi.c acassis@gmail.com lucas.vaz@espressif.com petro.karashchenko@gmail.com anjiahao@xiaomi.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_spi.h acassis@gmail.com eren.terzioglu@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_spi_slave.c eren.terzioglu@espressif.com dongjiuzhu1@xiaomi.com fangxinyong@xiaomi.com roy.feng@sony.com
-arch/xtensa/src/esp32s2/esp32s2_spiram.c acassis@gmail.com eren.terzioglu@espressif.com xiaoxiang@xiaomi.com almir.okato@espressif.com yinshengkai@xiaomi.com
-arch/xtensa/src/esp32s2/esp32s2_spiram.h acassis@gmail.com xiaoxiang@xiaomi.com eren.terzioglu@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_start.c gustavo.nihei@espressif.com acassis@gmail.com almir.okato@espressif.com filipe.cavalcanti@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s2/esp32s2_start.h acassis@gmail.com
-arch/xtensa/src/esp32s2/esp32s2_systemreset.c filipe.cavalcanti@espressif.com acassis@gmail.com
-arch/xtensa/src/esp32s2/esp32s2_systemreset.h filipe.cavalcanti@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_textheap.c eren.terzioglu@espressif.com yamamoto@midokura.com devel@sumpfralle.de
-arch/xtensa/src/esp32s2/esp32s2_tim.c sara.souza@espressif.com gustavo.nihei@espressif.com filipe.cavalcanti@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s2/esp32s2_tim.h sara.souza@espressif.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_tim_lowerhalf.c sara.souza@espressif.com gustavo.nihei@espressif.com petro.karashchenko@gmail.com acassis@gmail.com devel@sumpfralle.de
-arch/xtensa/src/esp32s2/esp32s2_tim_lowerhalf.h sara.souza@espressif.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_timerisr.c acassis@gmail.com gustavo.nihei@espressif.com zhuyanlin1@xiaomi.com
-arch/xtensa/src/esp32s2/esp32s2_touch.c lucas.vaz@espressif.com filipe.cavalcanti@espressif.com devel@sumpfralle.de anchao@xiaomi.com
-arch/xtensa/src/esp32s2/esp32s2_touch.h lucas.vaz@espressif.com filipe.cavalcanti@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_touch_lowerhalf.h lucas.vaz@espressif.com almir.okato@espressif.com devel@sumpfralle.de
-arch/xtensa/src/esp32s2/esp32s2_twai.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_twai.h eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_user.c acassis@gmail.com eren.terzioglu@espressif.com abdelatif.guettouche@espressif.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_wdt.c gustavo.nihei@espressif.com eren.terzioglu@espressif.com lucas.vaz@espressif.com sara.souza@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s2/esp32s2_wdt.h gustavo.nihei@espressif.com sara.souza@espressif.com eren.terzioglu@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s2/esp32s2_wdt_lowerhalf.c gustavo.nihei@espressif.com eren.terzioglu@espressif.com raiden00@railab.me xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s2/esp32s2_wdt_lowerhalf.h gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s2/esp32s2_wifi_adapter.c filipe.cavalcanti@espressif.com liguiding1@xiaomi.com yamamoto@midokura.com devel@sumpfralle.de hujun5@xiaomi.com
-arch/xtensa/src/esp32s2/esp32s2_wifi_adapter.h filipe.cavalcanti@espressif.com
-arch/xtensa/src/esp32s2/hal.mk tiago.medicci@espressif.com filipe.cavalcanti@espressif.com almir.okato@espressif.com eren.terzioglu@espressif.com
-arch/xtensa/src/esp32s2/hardware/esp32s2_aes.h acassis@gmail.com devel@sumpfralle.de
-arch/xtensa/src/esp32s2/hardware/esp32s2_cache_memory.h gustavo.nihei@espressif.com almir.okato@espressif.com petro.karashchenko@gmail.com
-arch/xtensa/src/esp32s2/hardware/esp32s2_dma.h tiago.medicci@espressif.com
-arch/xtensa/src/esp32s2/hardware/esp32s2_efuse.h acassis@gmail.com
-arch/xtensa/src/esp32s2/hardware/esp32s2_gpio.h acassis@gmail.com
-arch/xtensa/src/esp32s2/hardware/esp32s2_gpio_sigmap.h acassis@gmail.com 101105604+simbit18@users.noreply.github.com
-arch/xtensa/src/esp32s2/hardware/esp32s2_i2c.h gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s2/hardware/esp32s2_i2cbbpll.h acassis@gmail.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s2/hardware/esp32s2_i2s.h acassis@gmail.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32s2/hardware/esp32s2_interrupt.h acassis@gmail.com
-arch/xtensa/src/esp32s2/hardware/esp32s2_iomux.h acassis@gmail.com gustavo.nihei@espressif.com petro.karashchenko@gmail.com
-arch/xtensa/src/esp32s2/hardware/esp32s2_ledc.h acassis@gmail.com
-arch/xtensa/src/esp32s2/hardware/esp32s2_pinmap.h acassis@gmail.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s2/hardware/esp32s2_rsa.h acassis@gmail.com
-arch/xtensa/src/esp32s2/hardware/esp32s2_rtc_io.h acassis@gmail.com petro.karashchenko@gmail.com
-arch/xtensa/src/esp32s2/hardware/esp32s2_rtccntl.h acassis@gmail.com lucas.vaz@espressif.com gustavo.nihei@espressif.com eren.terzioglu@espressif.com devel@sumpfralle.de
-arch/xtensa/src/esp32s2/hardware/esp32s2_sens.h lucas.vaz@espressif.com
-arch/xtensa/src/esp32s2/hardware/esp32s2_soc.h acassis@gmail.com almir.okato@espressif.com eren.terzioglu@espressif.com gustavo.nihei@espressif.com petro.karashchenko@gmail.com
-arch/xtensa/src/esp32s2/hardware/esp32s2_spi.h acassis@gmail.com almir.okato@espressif.com lucas.vaz@espressif.com
-arch/xtensa/src/esp32s2/hardware/esp32s2_spi_mem_reg.h acassis@gmail.com devel@sumpfralle.de
-arch/xtensa/src/esp32s2/hardware/esp32s2_syscon.h eren.terzioglu@espressif.com
-arch/xtensa/src/esp32s2/hardware/esp32s2_system.h acassis@gmail.com gustavo.nihei@espressif.com eren.terzioglu@espressif.com devel@sumpfralle.de
-arch/xtensa/src/esp32s2/hardware/esp32s2_systimer.h sara.souza@espressif.com
-arch/xtensa/src/esp32s2/hardware/esp32s2_tim.h acassis@gmail.com sara.souza@espressif.com gustavo.nihei@espressif.com eren.terzioglu@espressif.com
-arch/xtensa/src/esp32s2/hardware/esp32s2_touch.h lucas.vaz@espressif.com
-arch/xtensa/src/esp32s2/hardware/esp32s2_twai.h eren.terzioglu@espressif.com
-arch/xtensa/src/esp32s2/hardware/esp32s2_uart.h acassis@gmail.com
-arch/xtensa/src/esp32s2/hardware/regi2c_bbpll.h eren.terzioglu@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s2/hardware/regi2c_ctrl.h eren.terzioglu@espressif.com
-arch/xtensa/src/esp32s2/hardware/regi2c_lp_bias.h eren.terzioglu@espressif.com
-arch/xtensa/src/esp32s2/hardware/wdev_reg.h acassis@gmail.com
-arch/xtensa/src/esp32s2/rom/esp32s2_libc_stubs.h lucas.vaz@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s2/rom/esp32s2_opi_flash.h acassis@gmail.com xiaoxiang@xiaomi.com devel@sumpfralle.de
-arch/xtensa/src/esp32s2/rom/esp32s2_spiflash.h acassis@gmail.com xiaoxiang@xiaomi.com devel@sumpfralle.de
-arch/xtensa/src/esp32s3/.gitignore lucas.vaz@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s3/Bootloader.mk gustavo.nihei@espressif.com almir.okato@espressif.com lucas.vaz@espressif.com filipe.cavalcanti@espressif.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32s3/Kconfig gustavo.nihei@espressif.com filipe.cavalcanti@espressif.com acassis@gmail.com tiago.medicci@espressif.com dongheng@espressif.com
-arch/xtensa/src/esp32s3/chip.h gustavo.nihei@espressif.com marco.casaroli@gmail.com
-arch/xtensa/src/esp32s3/chip_macros.h gustavo.nihei@espressif.com tiago.medicci@espressif.com xiaoxiang@xiaomi.com 101105604+simbit18@users.noreply.github.com
-arch/xtensa/src/esp32s3/chip_memory.h gustavo.nihei@espressif.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_aes.c chenwen@espressif.com devel@sumpfralle.de
-arch/xtensa/src/esp32s3/esp32s3_aes.h chenwen@espressif.com devel@sumpfralle.de
-arch/xtensa/src/esp32s3/esp32s3_allocateheap.c gustavo.nihei@espressif.com chenwen@espressif.com dongheng@espressif.com wangbowen6@xiaomi.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_ble.c petro.karashchenko@gmail.com chengkai@xiaomi.com devel@sumpfralle.de xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_ble.h petro.karashchenko@gmail.com
-arch/xtensa/src/esp32s3/esp32s3_ble_adapter.c tiago.medicci@espressif.com petro.karashchenko@gmail.com filipe.cavalcanti@espressif.com liguiding1@xiaomi.com anchao@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_ble_adapter.h petro.karashchenko@gmail.com filipe.cavalcanti@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_cache.c tiago.medicci@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_clockconfig.c gustavo.nihei@espressif.com tiago.medicci@espressif.com almir.okato@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_clockconfig.h gustavo.nihei@espressif.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_config.h gustavo.nihei@espressif.com petro.karashchenko@gmail.com acassis@gmail.com
-arch/xtensa/src/esp32s3/esp32s3_cpuidlestack.c gustavo.nihei@espressif.com abdelatif.guettouche@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_cpustart.c gustavo.nihei@espressif.com xiaoxiang@xiaomi.com abdelatif.guettouche@espressif.com hujun5@xiaomi.com zhuyanlin1@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_dma.c acassis@gmail.com eren.terzioglu@espressif.com tiago.medicci@espressif.com chenwen@espressif.com dongheng@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_dma.h acassis@gmail.com eren.terzioglu@espressif.com tiago.medicci@espressif.com chenwen@espressif.com dongheng@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_efuse.c acassis@gmail.com almir.okato@espressif.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_efuse.h acassis@gmail.com 101105604+simbit18@users.noreply.github.com almir.okato@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_efuse_lowerhalf.c acassis@gmail.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_efuse_table.c acassis@gmail.com devel@sumpfralle.de
-arch/xtensa/src/esp32s3/esp32s3_extraheaps.c chenwen@espressif.com eren.terzioglu@espressif.com yamamoto@midokura.com
-arch/xtensa/src/esp32s3/esp32s3_freerun.c gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_freerun.h gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_gpio.c gustavo.nihei@espressif.com omarfaruk.dc@gmail.com Feng.Gao@sony.com dongheng@espressif.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_gpio.h gustavo.nihei@espressif.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_himem.c chenwen@espressif.com hujun5@xiaomi.com almir.okato@espressif.com devel@sumpfralle.de petro.karashchenko@gmail.com
-arch/xtensa/src/esp32s3/esp32s3_himem.h chenwen@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_i2c.c gustavo.nihei@espressif.com anjiahao@xiaomi.com kevin.zhou@sony.com marco.casaroli@gmail.com eren.terzioglu@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_i2c.h gustavo.nihei@espressif.com eren.terzioglu@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_idle.c chenwen@espressif.com gustavo.nihei@espressif.com dongheng@espressif.com hujun5@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_imm.c chenwen@espressif.com eren.terzioglu@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_intercpu_interrupt.c gustavo.nihei@espressif.com hujun5@xiaomi.com fangxinyong@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_irq.c gustavo.nihei@espressif.com tiago.medicci@espressif.com xiaoxiang@xiaomi.com chenxiaoyi@xiaomi.com wangzhi16@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_irq.h tiago.medicci@espressif.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_lcd.c dongheng@espressif.com liamjmh0@gmail.com zhaoqing.zhang@sony.com devel@sumpfralle.de halysson1007@gmail.com
-arch/xtensa/src/esp32s3/esp32s3_libc_stubs.c tiago.medicci@espressif.com petro.karashchenko@gmail.com chenwen@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_lowputc.c gustavo.nihei@espressif.com petro.karashchenko@gmail.com yamamoto@midokura.com tiago.medicci@espressif.com acassis@gmail.com
-arch/xtensa/src/esp32s3/esp32s3_lowputc.h gustavo.nihei@espressif.com petro.karashchenko@gmail.com
-arch/xtensa/src/esp32s3/esp32s3_oneshot.c gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_oneshot.h gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_oneshot_lowerhalf.c gustavo.nihei@espressif.com anchao@xiaomi.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_otg.h dongheng@espressif.com almir.okato@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_otg_device.c dongheng@espressif.com devel@sumpfralle.de yangsong8@xiaomi.com xiaoxiang@xiaomi.com fangxinyong@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_partition.c chenwen@espressif.com zhaoqing.zhang@sony.com xiaoxiang@xiaomi.com Feng.Gao@sony.com yamamoto@midokura.com
-arch/xtensa/src/esp32s3/esp32s3_partition.h chenwen@espressif.com yamamoto@midokura.com
-arch/xtensa/src/esp32s3/esp32s3_pm.c chenwen@espressif.com thiago.sfinelon@gmail.com devel@sumpfralle.de
-arch/xtensa/src/esp32s3/esp32s3_pm.h chenwen@espressif.com devel@sumpfralle.de
-arch/xtensa/src/esp32s3/esp32s3_pminitialize.c chenwen@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_psram.h acassis@gmail.com devel@sumpfralle.de
-arch/xtensa/src/esp32s3/esp32s3_psram_octal.c dongheng@espressif.com chenwen@espressif.com tiago.medicci@espressif.com 101105604+simbit18@users.noreply.github.com almir.okato@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_psram_quad.c dongheng@espressif.com almir.okato@espressif.com filipe.cavalcanti@espressif.com chenwen@espressif.com yinshengkai@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_qspi.c dongheng@espressif.com zhaoqing.zhang@sony.com kevin.zhou@sony.com devel@sumpfralle.de tiago.medicci@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_qspi.h dongheng@espressif.com kevin.zhou@sony.com devel@sumpfralle.de
-arch/xtensa/src/esp32s3/esp32s3_region.c gustavo.nihei@espressif.com anchao@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_region.h gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_reset_reasons.c zhaoqing.zhang@sony.com
-arch/xtensa/src/esp32s3/esp32s3_reset_reasons.h tiago.medicci@espressif.com zhaoqing.zhang@sony.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_rng.c acassis@gmail.com tiago.medicci@espressif.com gustavo.nihei@espressif.com alan.carvalho@espressif.com almir.okato@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_rt_timer.c gustavo.nihei@espressif.com chenwen@espressif.com xiaoxiang@xiaomi.com wangzhi16@xiaomi.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_rt_timer.h gustavo.nihei@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_rtc.c acassis@gmail.com chenwen@espressif.com tiago.medicci@espressif.com hujun5@xiaomi.com thiago.sfinelon@gmail.com
-arch/xtensa/src/esp32s3/esp32s3_rtc.h acassis@gmail.com chenwen@espressif.com tiago.medicci@espressif.com thiago.sfinelon@gmail.com
-arch/xtensa/src/esp32s3/esp32s3_rtc_gpio.c lucas.vaz@espressif.com fangxinyong@xiaomi.com anchao@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_rtc_gpio.h lucas.vaz@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_rtc_lowerhalf.c acassis@gmail.com hujun5@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_rtc_lowerhalf.h acassis@gmail.com eren.terzioglu@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_rtcheap.c acassis@gmail.com eren.terzioglu@espressif.com xiaoxiang@xiaomi.com devel@sumpfralle.de
-arch/xtensa/src/esp32s3/esp32s3_rtcheap.h acassis@gmail.com eren.terzioglu@espressif.com devel@sumpfralle.de xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_sdmmc.c Yinzhe.Wu@sony.com filipe.cavalcanti@espressif.com devel@sumpfralle.de fangxinyong@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_serial.c gustavo.nihei@espressif.com petro.karashchenko@gmail.com yangsong8@xiaomi.com acassis@gmail.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_smp.h gustavo.nihei@espressif.com abdelatif.guettouche@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_spi.c acassis@gmail.com chenwen@espressif.com wangjianyu3@xiaomi.com dongheng@espressif.com 40821031+w2016561536@users.noreply.github.com
-arch/xtensa/src/esp32s3/esp32s3_spi.h acassis@gmail.com dongheng@espressif.com chenwen@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_spi_slave.c dongheng@espressif.com zhaoqing.zhang@sony.com kevin.zhou@sony.com tiago.medicci@espressif.com roy.feng@sony.com
-arch/xtensa/src/esp32s3/esp32s3_spi_timing.c chenwen@espressif.com dongheng@espressif.com filipe.cavalcanti@espressif.com almir.okato@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_spi_timing.h dongheng@espressif.com chenwen@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_spiflash.c tiago.medicci@espressif.com dongheng@espressif.com chenwen@espressif.com abdelatif.guettouche@espressif.com jukka.laitinen@tii.ae
-arch/xtensa/src/esp32s3/esp32s3_spiflash.h abdelatif.guettouche@espressif.com chenwen@espressif.com tiago.medicci@espressif.com zhaoqing.zhang@sony.com
-arch/xtensa/src/esp32s3/esp32s3_spiflash_mtd.c abdelatif.guettouche@espressif.com Feng.Gao@sony.com chenwen@espressif.com anjiahao@xiaomi.com marco.casaroli@gmail.com
-arch/xtensa/src/esp32s3/esp32s3_spiflash_mtd.h abdelatif.guettouche@espressif.com chenwen@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_spiram.c acassis@gmail.com chenwen@espressif.com dongheng@espressif.com filipe.cavalcanti@espressif.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_spiram.h acassis@gmail.com xiaoxiang@xiaomi.com chenwen@espressif.com eren.terzioglu@espressif.com dongheng@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_start.c almir.okato@espressif.com gustavo.nihei@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_start.h gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_systemreset.c tiago.medicci@espressif.com gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_systemreset.h tiago.medicci@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_textheap.c eren.terzioglu@espressif.com yamamoto@midokura.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com petro.karashchenko@gmail.com
-arch/xtensa/src/esp32s3/esp32s3_tickless.c gustavo.nihei@espressif.com kevin.zhou@sony.com
-arch/xtensa/src/esp32s3/esp32s3_tim.c gustavo.nihei@espressif.com filipe.cavalcanti@espressif.com fangxinyong@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_tim.h gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_tim_lowerhalf.c gustavo.nihei@espressif.com acassis@gmail.com petro.karashchenko@gmail.com
-arch/xtensa/src/esp32s3/esp32s3_tim_lowerhalf.h gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_timerisr.c gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_touch.c lucas.vaz@espressif.com devel@sumpfralle.de anchao@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_touch.h lucas.vaz@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_touch_lowerhalf.h lucas.vaz@espressif.com devel@sumpfralle.de
-arch/xtensa/src/esp32s3/esp32s3_twai.c eren.terzioglu@espressif.com tiago.medicci@espressif.com fangxinyong@xiaomi.com almir.okato@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_twai.h eren.terzioglu@espressif.com almir.okato@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_usbserial.c acassis@gmail.com 59230071+hartmannathan@users.noreply.github.com fangxinyong@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_usbserial.h acassis@gmail.com
-arch/xtensa/src/esp32s3/esp32s3_user.c gustavo.nihei@espressif.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_userspace.c gustavo.nihei@espressif.com wangbowen6@xiaomi.com almir.okato@espressif.com filipe.cavalcanti@espressif.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_userspace.h gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_wdt.c gustavo.nihei@espressif.com eren.terzioglu@espressif.com lucas.vaz@espressif.com xiaoxiang@xiaomi.com fangxinyong@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_wdt.h gustavo.nihei@espressif.com eren.terzioglu@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s3/esp32s3_wdt_lowerhalf.c gustavo.nihei@espressif.com eren.terzioglu@espressif.com xiaoxiang@xiaomi.com filipe.cavalcanti@espressif.com raiden00@railab.me
-arch/xtensa/src/esp32s3/esp32s3_wdt_lowerhalf.h gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_wifi_adapter.c tiago.medicci@espressif.com filipe.cavalcanti@espressif.com petro.karashchenko@gmail.com chenwen@espressif.com dongheng@espressif.com
-arch/xtensa/src/esp32s3/esp32s3_wifi_adapter.h tiago.medicci@espressif.com filipe.cavalcanti@espressif.com petro.karashchenko@gmail.com devel@sumpfralle.de
-arch/xtensa/src/esp32s3/hal.mk tiago.medicci@espressif.com filipe.cavalcanti@espressif.com almir.okato@espressif.com eren.terzioglu@espressif.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_aes.h chenwen@espressif.com devel@sumpfralle.de
-arch/xtensa/src/esp32s3/hardware/esp32s3_apb_ctrl.h gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_bb.h tiago.medicci@espressif.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_cache_memory.h gustavo.nihei@espressif.com almir.okato@espressif.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_dma.h acassis@gmail.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_efuse.h gustavo.nihei@espressif.com devel@sumpfralle.de
-arch/xtensa/src/esp32s3/hardware/esp32s3_fe.h tiago.medicci@espressif.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_gpio.h gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_gpio_sigmap.h gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_i2c.h gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_i2s.h acassis@gmail.com devel@sumpfralle.de
-arch/xtensa/src/esp32s3/hardware/esp32s3_interrupt_core0.h gustavo.nihei@espressif.com devel@sumpfralle.de
-arch/xtensa/src/esp32s3/hardware/esp32s3_interrupt_core1.h gustavo.nihei@espressif.com devel@sumpfralle.de
-arch/xtensa/src/esp32s3/hardware/esp32s3_iomux.h gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_lcd_cam.h dongheng@espressif.com devel@sumpfralle.de
-arch/xtensa/src/esp32s3/hardware/esp32s3_ledc.h acassis@gmail.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_nrx.h tiago.medicci@espressif.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_otg.h dongheng@espressif.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_pinmap.h gustavo.nihei@espressif.com acassis@gmail.com dongheng@espressif.com lucas.vaz@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_rom_layout.h gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_rtc_io.h lucas.vaz@espressif.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_rtccntl.h gustavo.nihei@espressif.com acassis@gmail.com devel@sumpfralle.de eren.terzioglu@espressif.com chenwen@espressif.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_sdmmc.h Yinzhe.Wu@sony.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_sens.h lucas.vaz@espressif.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_sensitive.h gustavo.nihei@espressif.com devel@sumpfralle.de
-arch/xtensa/src/esp32s3/hardware/esp32s3_soc.h gustavo.nihei@espressif.com almir.okato@espressif.com dongheng@espressif.com eren.terzioglu@espressif.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_spi.h acassis@gmail.com devel@sumpfralle.de
-arch/xtensa/src/esp32s3/hardware/esp32s3_syscon.h tiago.medicci@espressif.com devel@sumpfralle.de
-arch/xtensa/src/esp32s3/hardware/esp32s3_system.h gustavo.nihei@espressif.com tiago.medicci@espressif.com eren.terzioglu@espressif.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_systimer.h gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_tim.h gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_touch.h lucas.vaz@espressif.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_twai.h eren.terzioglu@espressif.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_uart.h gustavo.nihei@espressif.com chenwen@espressif.com devel@sumpfralle.de 59230071+hartmannathan@users.noreply.github.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_usb_serial_jtag.h acassis@gmail.com 101105604+simbit18@users.noreply.github.com almir.okato@espressif.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_usb_wrap.h dongheng@espressif.com
-arch/xtensa/src/esp32s3/hardware/esp32s3_wcl_core.h gustavo.nihei@espressif.com
-arch/xtensa/src/esp32s3/hardware/regi2c_bbpll.h acassis@gmail.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s3/hardware/regi2c_ctrl.h acassis@gmail.com tiago.medicci@espressif.com
-arch/xtensa/src/esp32s3/hardware/regi2c_dig_reg.h acassis@gmail.com
-arch/xtensa/src/esp32s3/hardware/regi2c_lp_bias.h acassis@gmail.com
-arch/xtensa/src/esp32s3/hardware/regi2c_saradc.h zhaoqing.zhang@sony.com
-arch/xtensa/src/esp32s3/hardware/wdev_reg.h acassis@gmail.com
-arch/xtensa/src/esp32s3/rom/esp32s3_libc_stubs.h tiago.medicci@espressif.com xiaoxiang@xiaomi.com
-arch/xtensa/src/esp32s3/rom/esp32s3_spiflash.h abdelatif.guettouche@espressif.com almir.okato@espressif.com dongheng@espressif.com xiaoxiang@xiaomi.com devel@sumpfralle.de
-arch/xtensa/src/lx6/Toolchain.defs xiaoxiang@xiaomi.com alin.jerpelea@sony.com anjiahao@xiaomi.com cuiziwei@xiaomi.com
-arch/xtensa/src/lx7/Kconfig acassis@gmail.com
-arch/xtensa/src/lx7/Toolchain.defs xiaoxiang@xiaomi.com acassis@gmail.com zhuyanlin1@xiaomi.com anjiahao@xiaomi.com cuiziwei@xiaomi.com
-arch/z16/Kconfig liuhaitao@xiaomi.com jordi@midokura.com xiaoxiang@xiaomi.com
-arch/z16/include/arch.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com
-arch/z16/include/inttypes.h paul-a.patience@polymtl.ca yamamoto@midokura.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/z16/include/irq.h anchao@xiaomi.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/z16/include/limits.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/z16/include/syscall.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com
-arch/z16/include/types.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com chenxiaoyi@xiaomi.com
-arch/z16/include/z16f/arch.h alin.jerpelea@sony.com petro.karashchenko@gmail.com 59230071+hartmannathan@users.noreply.github.com
-arch/z16/include/z16f/chip.h alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/z16/include/z16f/irq.h alin.jerpelea@sony.com hujun5@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
-arch/z16/src/.gitignore xiaoxiang@xiaomi.com yamamoto@midokura.com
-arch/z16/src/Makefile xiaoxiang@xiaomi.com matias@protobits.dev abdelatif.guettouche@espressif.com
-arch/z16/src/common/z16_allocateheap.c alin.jerpelea@sony.com
-arch/z16/src/common/z16_copystate.c alin.jerpelea@sony.com
-arch/z16/src/common/z16_createstack.c abdelatif.guettouche@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/z16/src/common/z16_doirq.c hujun5@xiaomi.com zhangyuan21@xiaomi.com alin.jerpelea@sony.com
-arch/z16/src/common/z16_exit.c anchao@xiaomi.com xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com abdelatif.guettouche@espressif.com
-arch/z16/src/common/z16_idle.c alin.jerpelea@sony.com
-arch/z16/src/common/z16_initialize.c xiaoxiang@xiaomi.com Yuuichi.A.Nakamura@sony.com alin.jerpelea@sony.com yfliu2008@qq.com
-arch/z16/src/common/z16_initialstate.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/z16/src/common/z16_internal.h xiaoxiang@xiaomi.com zhangyuan21@xiaomi.com anchao@xiaomi.com hujun5@xiaomi.com
-arch/z16/src/common/z16_mdelay.c alin.jerpelea@sony.com
-arch/z16/src/common/z16_nputs.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com wangbowen6@xiaomi.com
-arch/z16/src/common/z16_registerdump.c zhangyuan21@xiaomi.com petro.karashchenko@gmail.com buxiasen@xiaomi.com alin.jerpelea@sony.com
-arch/z16/src/common/z16_releasestack.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/z16/src/common/z16_schedulesigaction.c hujun5@xiaomi.com xiaoxiang@xiaomi.com wangzhi16@xiaomi.com gustavo.nihei@espressif.com
-arch/z16/src/common/z16_sigdeliver.c wangzhi16@xiaomi.com hujun5@xiaomi.com zhaoxiu.zeng@gmail.com alin.jerpelea@sony.com
-arch/z16/src/common/z16_stackframe.c xiaoxiang@xiaomi.com anchao@xiaomi.com alin.jerpelea@sony.com
-arch/z16/src/common/z16_switchcontext.c zhangyuan21@xiaomi.com hujun5@xiaomi.com alin.jerpelea@sony.com
-arch/z16/src/common/z16_udelay.c alin.jerpelea@sony.com
-arch/z16/src/common/z16_usestack.c xiaoxiang@xiaomi.com abdelatif.guettouche@gmail.com alin.jerpelea@sony.com gustavo.nihei@espressif.com
-arch/z16/src/z16f/Toolchain.defs anchao@xiaomi.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com anchao.archer@bytedance.com
-arch/z16/src/z16f/chip.h xiaoxiang@xiaomi.com 101105604+simbit18@users.noreply.github.com sebastien@lorquet.fr
-arch/z16/src/z16f/z16f_clkinit.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/z16/src/z16f/z16f_espi.c petro.karashchenko@gmail.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com juha.niskanen@haltian.com
-arch/z16/src/z16f/z16f_head.S alin.jerpelea@sony.com xiaoxiang@xiaomi.com  1 file changed, 2 insertions(+), 2 deletions(-)  1 file changed, 489 deletions(-)
-arch/z16/src/z16f/z16f_irq.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-arch/z16/src/z16f/z16f_lowuart.S alin.jerpelea@sony.com  1 file changed, 272 deletions(-)  1 file changed, 7 insertions(+), 5 deletions(-)  1 file changed, 1 insertion(+), 1 deletion(-)
-arch/z16/src/z16f/z16f_restoreusercontext.S juha.niskanen@haltian.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com  1 file changed, 103 deletions(-)
-arch/z16/src/z16f/z16f_saveusercontext.S zhangyuan21@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-arch/z16/src/z16f/z16f_serial.c hujun5@xiaomi.com xiaoxiang@xiaomi.com yangsong8@xiaomi.com
-arch/z16/src/z16f/z16f_sysexec.c alin.jerpelea@sony.com hujun5@xiaomi.com xiaoxiang@xiaomi.com
-arch/z16/src/z16f/z16f_timerisr.c xiaoxiang@xiaomi.com f.panag@amco.gr mark@mjs.pw
+
+arch/x86/src/qemu/* xiaoxiang@xiaomi.com alin.jerpelea@sony.com zhangyuan21@xiaomi.com gustavo.nihei@espressif.com
+arch/x86_64/* p-szafonimateusz@xiaomi.com xiaoxiang@xiaomi.com
+arch/xtensa/* filipe.cavalcanti@espressif.com tiago.medicci@espressif.com eren.terzioglu@espressif.com acassis@gmail.com
+arch/z16/* xiaoxiang@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com anchao@xiaomi.com
+
 arch/z80/Kconfig xiaoxiang@xiaomi.com liuhaitao@xiaomi.com
-arch/z80/include/.gitignore xiaoxiang@xiaomi.com
 arch/z80/include/arch.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
 arch/z80/include/ez80/arch.h alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com
 arch/z80/include/ez80/inttypes.h paul-a.patience@polymtl.ca yamamoto@midokura.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com code@bje.id.au
@@ -9929,7 +6490,6 @@ arch/z80/include/z80/io.h alin.jerpelea@sony.com petro.karashchenko@gmail.com 59
 arch/z80/include/z80/irq.h alin.jerpelea@sony.com hujun5@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
 arch/z80/include/z80/limits.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 arch/z80/include/z80/types.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com chenxiaoyi@xiaomi.com
-arch/z80/src/.gitignore xiaoxiang@xiaomi.com yamamoto@midokura.com
 arch/z80/src/Makefile alin.jerpelea@sony.com xiaoxiang@xiaomi.com code@bje.id.au abdelatif.guettouche@espressif.com
 arch/z80/src/Makefile.clang code@bje.id.au yinshengkai@xiaomi.com abdelatif.guettouche@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
 arch/z80/src/Makefile.sdccl alin.jerpelea@sony.com xiaoxiang@xiaomi.com matias@protobits.dev
@@ -10043,7 +6603,6 @@ arch/z80/src/z8/z8_serial.c alin.jerpelea@sony.com hujun5@xiaomi.com xiaoxiang@x
 arch/z80/src/z8/z8_sigdeliver.c wangzhi16@xiaomi.com hujun5@xiaomi.com zhaoxiu.zeng@gmail.com
 arch/z80/src/z8/z8_timerisr.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com mark@mjs.pw
 arch/z80/src/z8/z8_vector.S alin.jerpelea@sony.com xiaoxiang@xiaomi.com  1 file changed, 873 deletions(-)  1 file changed, 1 insertion(+), 1 deletion(-)
-arch/z80/src/z80/.gitignore xiaoxiang@xiaomi.com
 arch/z80/src/z80/Kconfig anchao@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
 arch/z80/src/z80/Toolchain.defs xiaoxiang@xiaomi.com alin.jerpelea@sony.com anjiahao@xiaomi.com
 arch/z80/src/z80/chip.h alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com xiaoxiang@xiaomi.com
@@ -10060,6 +6619,7 @@ arch/z80/src/z80/z80_rom.asm alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 arch/z80/src/z80/z80_saveusercontext.asm alin.jerpelea@sony.com zhangyuan21@xiaomi.com xiaoxiang@xiaomi.com
 arch/z80/src/z80/z80_schedulesigaction.c hujun5@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 arch/z80/src/z80/z80_sigdeliver.c wangzhi16@xiaomi.com hujun5@xiaomi.com zhaoxiu.zeng@gmail.com
+
 audio/Kconfig xiaoxiang@xiaomi.com renjianguang@xiaomi.com alin.jerpelea@sony.com acassis@gmail.com
 audio/Makefile alin.jerpelea@sony.com xiaoxiang@xiaomi.com yamamoto@midokura.com masayuki.ishikawa@gmail.com
 audio/audio.c alin.jerpelea@sony.com hanqiyuan@xiaomi.com anchao@pinecone.net yangyalei@xiaomi.com
@@ -10095,7 +6655,6 @@ binfmt/libnxflat/libnxflat_uninit.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 binfmt/libnxflat/libnxflat_unload.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 binfmt/libnxflat/libnxflat_verify.c alin.jerpelea@sony.com gustavo.nihei@espressif.com
 binfmt/nxflat.c walmis@gmail.com alin.jerpelea@sony.com ppisa@pikron.com
-boards/.gitignore xiaoxiang@xiaomi.com alin.jerpelea@sony.com yamamoto@midokura.com mnitsche@dc.uba.ar
 boards/Board.mk alin.jerpelea@sony.com xiaoxiang@xiaomi.com yamamoto@midokura.com abdelatif.guettouche@espressif.com
 boards/Kconfig alin.jerpelea@sony.com bijunda1@xiaomi.com raiden00@railab.me acassis@gmail.com
 boards/Makefile alin.jerpelea@sony.com alanrosenthal@google.com xiaoxiang@xiaomi.com matias@protobits.dev masayuki.ishikawa@gmail.com
@@ -10414,221 +6973,13 @@ boards/arm/eoss3/quickfeather/src/eoss3_autoleds.c bashton@brennanashton.com ali
 boards/arm/eoss3/quickfeather/src/eoss3_boot.c bashton@brennanashton.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 boards/arm/eoss3/quickfeather/src/eoss3_bringup.c bashton@brennanashton.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
 boards/arm/eoss3/quickfeather/src/quickfeather.h bashton@brennanashton.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com
-boards/arm/fvp-v8r-aarch32/fvp-armv8r-aarch32/Kconfig alexander.merkle@lauterbach.com
-boards/arm/fvp-v8r-aarch32/fvp-armv8r-aarch32/configs/nsh/defconfig alexander.merkle@lauterbach.com acassis@gmail.com mazhuang@xiaomi.com hujun5@xiaomi.com fangxinyong@xiaomi.com
-boards/arm/fvp-v8r-aarch32/fvp-armv8r-aarch32/include/board.h alexander.merkle@lauterbach.com alin.jerpelea@sony.com
-boards/arm/fvp-v8r-aarch32/fvp-armv8r-aarch32/include/board_memorymap.h alexander.merkle@lauterbach.com alin.jerpelea@sony.com
-boards/arm/fvp-v8r-aarch32/fvp-armv8r-aarch32/scripts/dramboot.ld alexander.merkle@lauterbach.com liguiding1@xiaomi.com cuiziwei@xiaomi.com alin.jerpelea@sony.com
-boards/arm/fvp-v8r-aarch32/fvp-armv8r-aarch32/scripts/fvp_cfg.txt alexander.merkle@lauterbach.com
-boards/arm/fvp-v8r-aarch32/fvp-armv8r-aarch32/src/Makefile alexander.merkle@lauterbach.com alin.jerpelea@sony.com
-boards/arm/fvp-v8r-aarch32/fvp-armv8r-aarch32/src/fvp-armv8r.h alexander.merkle@lauterbach.com 101105604+simbit18@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/fvp-v8r-aarch32/fvp-armv8r-aarch32/src/fvp_appinit.c alexander.merkle@lauterbach.com alin.jerpelea@sony.com
-boards/arm/fvp-v8r-aarch32/fvp-armv8r-aarch32/src/fvp_boardinit.c alexander.merkle@lauterbach.com alin.jerpelea@sony.com
-boards/arm/fvp-v8r-aarch32/fvp-armv8r-aarch32/src/fvp_bringup.c alexander.merkle@lauterbach.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-aiotbox/Kconfig wangshuai26@xiaomi.com
-boards/arm/gd32f4/gd32f450zk-aiotbox/configs/aiotboxnsh/defconfig wangshuai26@xiaomi.com wangjianyu3@xiaomi.com
-boards/arm/gd32f4/gd32f450zk-aiotbox/include/board.h wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-aiotbox/scripts/gnu-elf.ld wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-aiotbox/scripts/kernel-space.ld wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-aiotbox/scripts/ld.script wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-aiotbox/scripts/memory.ld wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-aiotbox/scripts/user-space.ld wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-aiotbox/src/Makefile wangshuai26@xiaomi.com alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com
-boards/arm/gd32f4/gd32f450zk-aiotbox/src/gd32f450z_aiotbox.h wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-aiotbox/src/gd32f4xx_appinit.c wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-aiotbox/src/gd32f4xx_autoleds.c wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-aiotbox/src/gd32f4xx_boot.c wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-aiotbox/src/gd32f4xx_bringup.c wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-aiotbox/src/gd32f4xx_buttons.c wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-aiotbox/src/gd32f4xx_gpio.c wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-aiotbox/src/gd32f4xx_i2c.c wangshuai26@xiaomi.com devel@sumpfralle.de petro.karashchenko@gmail.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-aiotbox/src/gd32f4xx_romfs.c wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-aiotbox/src/gd32f4xx_romfs.h wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-aiotbox/src/gd32f4xx_sdio.c wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-aiotbox/src/gd32f4xx_spi.c wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-aiotbox/src/gd32f4xx_userleds.c wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-eval/Kconfig jie.xu@gigadevice.com anchao@xiaomi.com
-boards/arm/gd32f4/gd32f450zk-eval/configs/btngpionsh/defconfig jie.xu@gigadevice.com wangjianyu3@xiaomi.com acassis@gmail.com tiago.medicci@espressif.com
-boards/arm/gd32f4/gd32f450zk-eval/configs/fmcfsnsh/defconfig jie.xu@gigadevice.com wangjianyu3@xiaomi.com acassis@gmail.com tiago.medicci@espressif.com
-boards/arm/gd32f4/gd32f450zk-eval/configs/fmclfsnsh/defconfig jie.xu@gigadevice.com wangjianyu3@xiaomi.com acassis@gmail.com tiago.medicci@espressif.com
-boards/arm/gd32f4/gd32f450zk-eval/configs/i2c0testnsh/defconfig jie.xu@gigadevice.com acassis@gmail.com wangjianyu3@xiaomi.com
-boards/arm/gd32f4/gd32f450zk-eval/configs/netnsh/defconfig jie.xu@gigadevice.com wangjianyu3@xiaomi.com acassis@gmail.com tiago.medicci@espressif.com
-boards/arm/gd32f4/gd32f450zk-eval/configs/nsh/defconfig jie.xu@gigadevice.com wangjianyu3@xiaomi.com
-boards/arm/gd32f4/gd32f450zk-eval/configs/sdionsh/defconfig jie.xu@gigadevice.com wangjianyu3@xiaomi.com acassis@gmail.com tiago.medicci@espressif.com
-boards/arm/gd32f4/gd32f450zk-eval/configs/spifsnsh/defconfig jie.xu@gigadevice.com wangjianyu3@xiaomi.com acassis@gmail.com tiago.medicci@espressif.com
-boards/arm/gd32f4/gd32f450zk-eval/configs/spilfsnsh/defconfig jie.xu@gigadevice.com wangjianyu3@xiaomi.com acassis@gmail.com tiago.medicci@espressif.com
-boards/arm/gd32f4/gd32f450zk-eval/include/board.h jie.xu@gigadevice.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-eval/scripts/gnu-elf.ld jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-eval/scripts/kernel-space.ld jie.xu@gigadevice.com cuiziwei@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-eval/scripts/ld.script jie.xu@gigadevice.com cuiziwei@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-eval/scripts/memory.ld jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-eval/scripts/user-space.ld jie.xu@gigadevice.com cuiziwei@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-eval/src/Makefile jie.xu@gigadevice.com gaojunchen@svehicle.cn alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com
-boards/arm/gd32f4/gd32f450zk-eval/src/gd32f450z_eval.h jie.xu@gigadevice.com gaojunchen@svehicle.cn alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_appinit.c jie.xu@gigadevice.com gaojunchen@svehicle.cn alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_at24.c jie.xu@gigadevice.com shen497@purdue.edu alin.jerpelea@sony.com anchao@xiaomi.com
-boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_autoleds.c jie.xu@gigadevice.com anchao@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_boot.c jie.xu@gigadevice.com gaojunchen@svehicle.cn alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_bringup.c gaojunchen@svehicle.cn jie.xu@gigadevice.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com anchao@xiaomi.com
-boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_buttons.c jie.xu@gigadevice.com alin.jerpelea@sony.com anchao@xiaomi.com
-boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_gd25.c jie.xu@gigadevice.com jingfei@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_gpio.c jie.xu@gigadevice.com alin.jerpelea@sony.com anchao@xiaomi.com
-boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_romfs.c jie.xu@gigadevice.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_romfs.h jie.xu@gigadevice.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_sdio.c jie.xu@gigadevice.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_spi.c jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f450zk-eval/src/gd32f4xx_userleds.c jie.xu@gigadevice.com anchao@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470ik-eval/Kconfig jie.xu@gigadevice.com
-boards/arm/gd32f4/gd32f470ik-eval/configs/fmclfsnsh/defconfig jie.xu@gigadevice.com wangjianyu3@xiaomi.com acassis@gmail.com tiago.medicci@espressif.com
-boards/arm/gd32f4/gd32f470ik-eval/configs/i2c0testnsh/defconfig jie.xu@gigadevice.com wangjianyu3@xiaomi.com
-boards/arm/gd32f4/gd32f470ik-eval/configs/netnsh/defconfig jie.xu@gigadevice.com wangjianyu3@xiaomi.com acassis@gmail.com tiago.medicci@espressif.com
-boards/arm/gd32f4/gd32f470ik-eval/configs/nsh/defconfig jie.xu@gigadevice.com wangjianyu3@xiaomi.com
-boards/arm/gd32f4/gd32f470ik-eval/include/board.h jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470ik-eval/scripts/gnu-elf.ld jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470ik-eval/scripts/kernel-space.ld jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470ik-eval/scripts/ld.script jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470ik-eval/scripts/memory.ld jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470ik-eval/scripts/user-space.ld jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470ik-eval/src/Makefile jie.xu@gigadevice.com gaojunchen@svehicle.cn 101105604+simbit18@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470ik-eval/src/gd32f470i_eval.h jie.xu@gigadevice.com gaojunchen@svehicle.cn alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470ik-eval/src/gd32f4xx_appinit.c jie.xu@gigadevice.com gaojunchen@svehicle.cn alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470ik-eval/src/gd32f4xx_at24.c jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470ik-eval/src/gd32f4xx_autoleds.c jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470ik-eval/src/gd32f4xx_boot.c jie.xu@gigadevice.com gaojunchen@svehicle.cn alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470ik-eval/src/gd32f4xx_bringup.c gaojunchen@svehicle.cn jie.xu@gigadevice.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470ik-eval/src/gd32f4xx_buttons.c jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470ik-eval/src/gd32f4xx_gd25.c jie.xu@gigadevice.com jingfei@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470ik-eval/src/gd32f4xx_gpio.c jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470ik-eval/src/gd32f4xx_romfs.c jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470ik-eval/src/gd32f4xx_romfs.h jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470ik-eval/src/gd32f4xx_sdio.c jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470ik-eval/src/gd32f4xx_spi.c jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470ik-eval/src/gd32f4xx_userleds.c jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/Kconfig wangshuai26@xiaomi.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/configs/aiotboxnsh/defconfig wangshuai26@xiaomi.com wangjianyu3@xiaomi.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/include/board.h wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/scripts/gnu-elf.ld wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/scripts/kernel-space.ld wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/scripts/ld.script wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/scripts/memory.ld wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/scripts/user-space.ld wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/src/Makefile wangshuai26@xiaomi.com alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/src/etc_romfs.c wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/src/gd32f470z_aiotbox.h wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/src/gd32f4xx_appinit.c wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/src/gd32f4xx_at24.c wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/src/gd32f4xx_autoleds.c wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/src/gd32f4xx_boot.c wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/src/gd32f4xx_bringup.c wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/src/gd32f4xx_buttons.c wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/src/gd32f4xx_gd25.c wangshuai26@xiaomi.com jingfei@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/src/gd32f4xx_gpio.c wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/src/gd32f4xx_i2c.c wangshuai26@xiaomi.com devel@sumpfralle.de petro.karashchenko@gmail.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/src/gd32f4xx_reset.c wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/src/gd32f4xx_romfs.c wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/src/gd32f4xx_romfs.h wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/src/gd32f4xx_sdio.c wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/src/gd32f4xx_spi.c wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-aiotbox/src/gd32f4xx_userleds.c wangshuai26@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-eval/Kconfig jie.xu@gigadevice.com
-boards/arm/gd32f4/gd32f470zk-eval/configs/fmclfsnsh/defconfig jie.xu@gigadevice.com wangjianyu3@xiaomi.com acassis@gmail.com tiago.medicci@espressif.com
-boards/arm/gd32f4/gd32f470zk-eval/configs/i2c0testnsh/defconfig jie.xu@gigadevice.com acassis@gmail.com wangjianyu3@xiaomi.com
-boards/arm/gd32f4/gd32f470zk-eval/configs/netnsh/defconfig jie.xu@gigadevice.com wangjianyu3@xiaomi.com acassis@gmail.com tiago.medicci@espressif.com
-boards/arm/gd32f4/gd32f470zk-eval/configs/nsh/defconfig jie.xu@gigadevice.com wangjianyu3@xiaomi.com
-boards/arm/gd32f4/gd32f470zk-eval/configs/sdionsh/defconfig jie.xu@gigadevice.com wangjianyu3@xiaomi.com acassis@gmail.com tiago.medicci@espressif.com
-boards/arm/gd32f4/gd32f470zk-eval/configs/spilfsnsh/defconfig jie.xu@gigadevice.com wangjianyu3@xiaomi.com acassis@gmail.com tiago.medicci@espressif.com
-boards/arm/gd32f4/gd32f470zk-eval/include/board.h jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-eval/scripts/gnu-elf.ld jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-eval/scripts/kernel-space.ld jie.xu@gigadevice.com alin.jerpelea@sony.com cuiziwei@xiaomi.com
-boards/arm/gd32f4/gd32f470zk-eval/scripts/ld.script jie.xu@gigadevice.com alin.jerpelea@sony.com cuiziwei@xiaomi.com
-boards/arm/gd32f4/gd32f470zk-eval/scripts/memory.ld jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-eval/scripts/user-space.ld jie.xu@gigadevice.com alin.jerpelea@sony.com cuiziwei@xiaomi.com
-boards/arm/gd32f4/gd32f470zk-eval/src/Makefile jie.xu@gigadevice.com gaojunchen@svehicle.cn fangxinyong@xiaomi.com alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com
-boards/arm/gd32f4/gd32f470zk-eval/src/etc_romfs.c fangxinyong@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-eval/src/gd32f470z_eval.h jie.xu@gigadevice.com gaojunchen@svehicle.cn alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-eval/src/gd32f4xx_appinit.c jie.xu@gigadevice.com gaojunchen@svehicle.cn alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-eval/src/gd32f4xx_at24.c jie.xu@gigadevice.com alin.jerpelea@sony.com anchao@xiaomi.com
-boards/arm/gd32f4/gd32f470zk-eval/src/gd32f4xx_autoleds.c jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-eval/src/gd32f4xx_boot.c jie.xu@gigadevice.com gaojunchen@svehicle.cn alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-eval/src/gd32f4xx_bringup.c gaojunchen@svehicle.cn jie.xu@gigadevice.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com anchao@xiaomi.com
-boards/arm/gd32f4/gd32f470zk-eval/src/gd32f4xx_buttons.c jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-eval/src/gd32f4xx_gd25.c jie.xu@gigadevice.com jingfei@xiaomi.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-eval/src/gd32f4xx_gpio.c jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-eval/src/gd32f4xx_reset.c jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-eval/src/gd32f4xx_romfs.c jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-eval/src/gd32f4xx_romfs.h jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-eval/src/gd32f4xx_sdio.c jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-eval/src/gd32f4xx_spi.c jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/gd32f4/gd32f470zk-eval/src/gd32f4xx_userleds.c jie.xu@gigadevice.com alin.jerpelea@sony.com
-boards/arm/imx6/sabre-6quad/Kconfig alin.jerpelea@sony.com
-boards/arm/imx6/sabre-6quad/configs/citest/defconfig nietingting@xiaomi.com masayuki.ishikawa@gmail.com tengshuangshuang@xiaomi.com mazhuang@xiaomi.com acassis@gmail.com
-boards/arm/imx6/sabre-6quad/configs/citest/run nietingting@xiaomi.com
-boards/arm/imx6/sabre-6quad/configs/coredump/defconfig anchao@xiaomi.com anjiahao@xiaomi.com mazhuang@xiaomi.com xiaoxiang@xiaomi.com hujun5@xiaomi.com
-boards/arm/imx6/sabre-6quad/configs/elf/defconfig masayuki.ishikawa@gmail.com xiaoxiang@xiaomi.com liguiding1@xiaomi.com anjiahao@xiaomi.com mazhuang@xiaomi.com
-boards/arm/imx6/sabre-6quad/configs/knsh/defconfig masayuki.ishikawa@gmail.com ville.juven@unikie.com mazhuang@xiaomi.com xiaoxiang@xiaomi.com hujun5@xiaomi.com
-boards/arm/imx6/sabre-6quad/configs/knsh_smp/defconfig minabe.oki@gmail.com ville.juven@unikie.com mazhuang@xiaomi.com xiaoxiang@xiaomi.com hujun5@xiaomi.com
-boards/arm/imx6/sabre-6quad/configs/libcxx/defconfig masayuki.ishikawa@gmail.com jihandong@xiaomi.com yinshengkai@xiaomi.com ville.juven@unikie.com mazhuang@xiaomi.com
-boards/arm/imx6/sabre-6quad/configs/netknsh/defconfig masayuki.ishikawa@gmail.com xiaoxiang@xiaomi.com anchao@xiaomi.com wangjianyu3@xiaomi.com mazhuang@xiaomi.com
-boards/arm/imx6/sabre-6quad/configs/netknsh_smp/defconfig masayuki.ishikawa@gmail.com xiaoxiang@xiaomi.com anchao@xiaomi.com wangjianyu3@xiaomi.com mazhuang@xiaomi.com
-boards/arm/imx6/sabre-6quad/configs/netnsh/defconfig masayuki.ishikawa@gmail.com xiaoxiang@xiaomi.com liguiding1@xiaomi.com abdelatif.guettouche@espressif.com alin.jerpelea@sony.com
-boards/arm/imx6/sabre-6quad/configs/netnsh_ar8031/defconfig masayuki.ishikawa@gmail.com wangjianyu3@xiaomi.com mazhuang@xiaomi.com acassis@gmail.com tiago.medicci@espressif.com
-boards/arm/imx6/sabre-6quad/configs/netnsh_smp/defconfig masayuki.ishikawa@gmail.com xiaoxiang@xiaomi.com liguiding1@xiaomi.com abdelatif.guettouche@espressif.com alin.jerpelea@sony.com
-boards/arm/imx6/sabre-6quad/configs/netnsh_wb/defconfig masayuki.ishikawa@gmail.com xiaoxiang@xiaomi.com wangjianyu3@xiaomi.com mazhuang@xiaomi.com acassis@gmail.com
-boards/arm/imx6/sabre-6quad/configs/nsh/defconfig alin.jerpelea@sony.com masayuki.ishikawa@gmail.com xiaoxiang@xiaomi.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com
-boards/arm/imx6/sabre-6quad/configs/posix_spawn/defconfig masayuki.ishikawa@gmail.com xiaoxiang@xiaomi.com liguiding1@xiaomi.com mazhuang@xiaomi.com hujun5@xiaomi.com
-boards/arm/imx6/sabre-6quad/configs/smp/defconfig alin.jerpelea@sony.com masayuki.ishikawa@gmail.com xiaoxiang@xiaomi.com liguiding1@xiaomi.com mazhuang@xiaomi.com
-boards/arm/imx6/sabre-6quad/include/board.h alin.jerpelea@sony.com
-boards/arm/imx6/sabre-6quad/include/board_memorymap.h alin.jerpelea@sony.com gustavo.nihei@espressif.com xiaoxiang@xiaomi.com
-boards/arm/imx6/sabre-6quad/scripts/dramboot.ld alin.jerpelea@sony.com liguiding1@xiaomi.com cuiziwei@xiaomi.com masayuki.ishikawa@gmail.com
-boards/arm/imx6/sabre-6quad/scripts/dramboot.sct anchao@xiaomi.com cuiziwei@xiaomi.com alin.jerpelea@sony.com
-boards/arm/imx6/sabre-6quad/src/Makefile alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/arm/imx6/sabre-6quad/src/imx_appinit.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com hartman.nathan@gmail.com
-boards/arm/imx6/sabre-6quad/src/imx_autoleds.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com
-boards/arm/imx6/sabre-6quad/src/imx_boardinit.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com
-boards/arm/imx6/sabre-6quad/src/imx_bringup.c alin.jerpelea@sony.com huangqi3@xiaomi.com xiaoxiang@xiaomi.com
-boards/arm/imx6/sabre-6quad/src/imx_userleds.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/arm/imx6/sabre-6quad/src/sabre-6quad.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/arm/imx9/imx95-evk/Kconfig andre.heinemans@nxp.com 101105604+simbit18@users.noreply.github.com
-boards/arm/imx9/imx95-evk/configs/can/defconfig andre.heinemans@nxp.com
-boards/arm/imx9/imx95-evk/configs/nsh/defconfig andre.heinemans@nxp.com
-boards/arm/imx9/imx95-evk/configs/rpmsg/defconfig andre.heinemans@nxp.com
-boards/arm/imx9/imx95-evk/include/board.h andre.heinemans@nxp.com
-boards/arm/imx9/imx95-evk/scripts/ddr.ld andre.heinemans@nxp.com
-boards/arm/imx9/imx95-evk/scripts/flash.ld andre.heinemans@nxp.com
-boards/arm/imx9/imx95-evk/scripts/itcm.ld andre.heinemans@nxp.com
-boards/arm/imx9/imx95-evk/src/Makefile andre.heinemans@nxp.com simbit18@gmail.com
-boards/arm/imx9/imx95-evk/src/imx95-evk.h andre.heinemans@nxp.com
-boards/arm/imx9/imx95-evk/src/imx95_appinit.c andre.heinemans@nxp.com
-boards/arm/imx9/imx95-evk/src/imx95_boardinit.c andre.heinemans@nxp.com
-boards/arm/imx9/imx95-evk/src/imx95_bringup.c andre.heinemans@nxp.com
-boards/arm/imx9/imx95-evk/src/imx95_i2c.c andre.heinemans@nxp.com
-boards/arm/imx9/imx95-evk/src/imx95_spi.c andre.heinemans@nxp.com
-boards/arm/imxrt/arcx-socket-grid/Kconfig acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/configs/nsh/defconfig acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/configs/usbdisk/defconfig acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/include/board.h acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/kernel/Makefile acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/kernel/imxrt_userspace.c acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/scripts/flash-ocram.ld acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/scripts/kernel-space.ld acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/scripts/memory.ld acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/scripts/user-space.ld acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/src/Makefile acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/src/arcx-socket-grid.h acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/src/imxrt_appinit.c acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/src/imxrt_autoleds.c acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/src/imxrt_boot.c acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/src/imxrt_bringup.c acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/src/imxrt_ethernet.c acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/src/imxrt_flexspi_nor_boot.c acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/src/imxrt_flexspi_nor_boot.h acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/src/imxrt_flexspi_nor_flash.c acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/src/imxrt_flexspi_nor_flash.h acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/src/imxrt_gpio.c acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/src/imxrt_sdram_ini_dcd.c acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/src/imxrt_spi.c acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/src/imxrt_usbhost.c acassis@gmail.com
-boards/arm/imxrt/arcx-socket-grid/src/imxrt_userleds.c acassis@gmail.com
+
+boards/arm/fvp-v8r-aarch32/* alexander.merkle@lauterbach.com alin.jerpelea@sony.com
+boards/arm/gd32f4/gd32f450zk-* wangshuai26@xiaomi.com alin.jerpelea@sony.com jie.xu@gigadevice.com anchao@xiaomi.com
+boards/arm/imx6/sabre-6quad/* anchao@xiaomi.com anjiahao@xiaomi.com mazhuang@xiaomi.com xiaoxiang@xiaomi.com hujun5@xiaomi.com
+boards/arm/imx9/* andre.heinemans@nxp.com
+boards/arm/imxrt/arcx-socket-grid/* acassis@gmail.com
+
 boards/arm/imxrt/imxrt1020-evk/Kconfig dave@marples.net petro.karashchenko@gmail.com
 boards/arm/imxrt/imxrt1020-evk/configs/netnsh/defconfig dave@marples.net xiaoxiang@xiaomi.com wangjianyu3@xiaomi.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com
 boards/arm/imxrt/imxrt1020-evk/configs/nsh/defconfig dave@marples.net xiaoxiang@xiaomi.com wangjianyu3@xiaomi.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com
@@ -10807,46 +7158,9 @@ boards/arm/imxrt/imxrt1170-evk/src/imxrt_sdram_ini_dcd.c peter.vanderperk@nxp.co
 boards/arm/imxrt/imxrt1170-evk/src/imxrt_spi.c peter.vanderperk@nxp.com alin.jerpelea@sony.com
 boards/arm/imxrt/imxrt1170-evk/src/imxrt_usbhost.c peter.vanderperk@nxp.com alin.jerpelea@sony.com
 boards/arm/imxrt/imxrt1170-evk/src/imxrt_userleds.c peter.vanderperk@nxp.com alin.jerpelea@sony.com
-boards/arm/imxrt/teensy-4.x/Kconfig lencmich@fel.cvut.cz michallenc@seznam.cz git@pbrier.nl devel@sumpfralle.de 101105604+simbit18@users.noreply.github.com
-boards/arm/imxrt/teensy-4.x/configs/can-4.1/defconfig lencmich@fel.cvut.cz michallenc@seznam.cz raiden00@railab.me wangjianyu3@xiaomi.com xiaoxiang@xiaomi.com
-boards/arm/imxrt/teensy-4.x/configs/enc-4.1/defconfig michallenc@seznam.cz wangjianyu3@xiaomi.com liguiding1@xiaomi.com hujun5@xiaomi.com dongjiuzhu1@xiaomi.com
-boards/arm/imxrt/teensy-4.x/configs/lcd-4.1/defconfig lencmich@fel.cvut.cz peter.vanderperk@nxp.com wangjianyu3@xiaomi.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com
-boards/arm/imxrt/teensy-4.x/configs/lua-4.1/defconfig michael.mogenson@gmail.com wangjianyu3@xiaomi.com hujun5@xiaomi.com xiaoxiang@xiaomi.com
-boards/arm/imxrt/teensy-4.x/configs/netnsh-4.1/defconfig lencmich@fel.cvut.cz wangjianyu3@xiaomi.com liguiding1@xiaomi.com xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com
-boards/arm/imxrt/teensy-4.x/configs/nsh-4.0/defconfig lencmich@fel.cvut.cz wangjianyu3@xiaomi.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com hujun5@xiaomi.com
-boards/arm/imxrt/teensy-4.x/configs/nsh-4.1/defconfig lencmich@fel.cvut.cz wangjianyu3@xiaomi.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com hujun5@xiaomi.com
-boards/arm/imxrt/teensy-4.x/configs/pikron-bb/defconfig ppisa@pikron.com michallenc@seznam.cz xiaoxiang@xiaomi.com liguiding1@xiaomi.com wangjianyu3@xiaomi.com
-boards/arm/imxrt/teensy-4.x/configs/pwm-4.1/defconfig michallenc@seznam.cz wangjianyu3@xiaomi.com liguiding1@xiaomi.com hujun5@xiaomi.com xiaoxiang@xiaomi.com
-boards/arm/imxrt/teensy-4.x/configs/sd-4.1/defconfig lencmich@fel.cvut.cz wangjianyu3@xiaomi.com xuxingliang@xiaomi.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com
-boards/arm/imxrt/teensy-4.x/include/board.h lencmich@fel.cvut.cz michallenc@seznam.cz petro.karashchenko@gmail.com alin.jerpelea@sony.com
-boards/arm/imxrt/teensy-4.x/kernel/Makefile lencmich@fel.cvut.cz xiaoxiang@xiaomi.com liguiding1@xiaomi.com yamamoto@midokura.com alexvasiljev@gmail.com
-boards/arm/imxrt/teensy-4.x/kernel/imxrt_userspace.c lencmich@fel.cvut.cz xiaoxiang@xiaomi.com petro.karashchenko@gmail.com liguiding1@xiaomi.com alin.jerpelea@sony.com
-boards/arm/imxrt/teensy-4.x/scripts/flash-ocram.ld lencmich@fel.cvut.cz cuiziwei@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-boards/arm/imxrt/teensy-4.x/scripts/flash.ld lencmich@fel.cvut.cz cuiziwei@xiaomi.com alin.jerpelea@sony.com
-boards/arm/imxrt/teensy-4.x/scripts/kernel-space.ld lencmich@fel.cvut.cz cuiziwei@xiaomi.com alin.jerpelea@sony.com
-boards/arm/imxrt/teensy-4.x/scripts/memory.ld lencmich@fel.cvut.cz alin.jerpelea@sony.com
-boards/arm/imxrt/teensy-4.x/scripts/user-space.ld lencmich@fel.cvut.cz cuiziwei@xiaomi.com alin.jerpelea@sony.com anjiahao@xiaomi.com
-boards/arm/imxrt/teensy-4.x/src/Makefile lencmich@fel.cvut.cz michallenc@seznam.cz git@pbrier.nl xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/imxrt/teensy-4.x/src/imxrt_adc.c lencmich@fel.cvut.cz michallenc@seznam.cz xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/imxrt/teensy-4.x/src/imxrt_appinit.c lencmich@fel.cvut.cz michael.mogenson@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/imxrt/teensy-4.x/src/imxrt_autoleds.c lencmich@fel.cvut.cz alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com
-boards/arm/imxrt/teensy-4.x/src/imxrt_boot.c lencmich@fel.cvut.cz alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com peter.vanderperk@nxp.com xiaoxiang@xiaomi.com
-boards/arm/imxrt/teensy-4.x/src/imxrt_bringup.c lencmich@fel.cvut.cz michallenc@seznam.cz xiaoxiang@xiaomi.com alin.jerpelea@sony.com huangqi3@xiaomi.com
-boards/arm/imxrt/teensy-4.x/src/imxrt_enc.c michallenc@seznam.cz alin.jerpelea@sony.com
-boards/arm/imxrt/teensy-4.x/src/imxrt_ethernet.c lencmich@fel.cvut.cz hujun5@xiaomi.com masayuki.ishikawa@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/imxrt/teensy-4.x/src/imxrt_flexcan.c lencmich@fel.cvut.cz michallenc@seznam.cz xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/imxrt/teensy-4.x/src/imxrt_flexpwm.c michallenc@seznam.cz alin.jerpelea@sony.com
-boards/arm/imxrt/teensy-4.x/src/imxrt_flexspi_nor_boot.c lencmich@fel.cvut.cz xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/imxrt/teensy-4.x/src/imxrt_flexspi_nor_boot.h lencmich@fel.cvut.cz petro.karashchenko@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/imxrt/teensy-4.x/src/imxrt_flexspi_nor_flash.c lencmich@fel.cvut.cz alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/arm/imxrt/teensy-4.x/src/imxrt_flexspi_nor_flash.h lencmich@fel.cvut.cz petro.karashchenko@gmail.com devel@sumpfralle.de alin.jerpelea@sony.com
-boards/arm/imxrt/teensy-4.x/src/imxrt_gpio.c michallenc@seznam.cz xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/imxrt/teensy-4.x/src/imxrt_i2c.c lencmich@fel.cvut.cz alin.jerpelea@sony.com xiaoxiang@xiaomi.com matias@protobits.dev
-boards/arm/imxrt/teensy-4.x/src/imxrt_reset.c git@pbrier.nl alin.jerpelea@sony.com
-boards/arm/imxrt/teensy-4.x/src/imxrt_spi.c lencmich@fel.cvut.cz xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/imxrt/teensy-4.x/src/imxrt_st7789.c lencmich@fel.cvut.cz alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/arm/imxrt/teensy-4.x/src/imxrt_userleds.c lencmich@fel.cvut.cz michael.mogenson@gmail.com alin.jerpelea@sony.com
-boards/arm/imxrt/teensy-4.x/src/teensy-4.h lencmich@fel.cvut.cz michallenc@seznam.cz petro.karashchenko@gmail.com alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com
+
+boards/arm/imxrt/teensy-4.x/* lencmich@fel.cvut.cz michallenc@seznam.cz petro.karashchenko@gmail.com
+
 boards/arm/kinetis/freedom-k28f/Kconfig johannes.schock@nivus.com alin.jerpelea@sony.com anchao@xiaomi.com
 boards/arm/kinetis/freedom-k28f/configs/nsh/defconfig alin.jerpelea@sony.com xiaoxiang@xiaomi.com wangjianyu3@xiaomi.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com
 boards/arm/kinetis/freedom-k28f/configs/nshsdusb/defconfig johannes.schock@nivus.com xiaoxiang@xiaomi.com liguiding1@xiaomi.com acassis@gmail.com wangjianyu3@xiaomi.com
@@ -11339,7 +7653,6 @@ boards/arm/lpc31xx/ea3131/configs/pgnsh/defconfig alin.jerpelea@sony.com zhangyu
 boards/arm/lpc31xx/ea3131/configs/usbserial/defconfig alin.jerpelea@sony.com xiaoxiang@xiaomi.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com
 boards/arm/lpc31xx/ea3131/include/board.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com thomas.narayana-swamy@wandercraft.eu
 boards/arm/lpc31xx/ea3131/include/board_memorymap.h alin.jerpelea@sony.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
-boards/arm/lpc31xx/ea3131/locked/.gitignore alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 boards/arm/lpc31xx/ea3131/locked/Makefile alin.jerpelea@sony.com xiaoxiang@xiaomi.com yamamoto@midokura.com liuhaitao@xiaomi.com alexvasiljev@gmail.com
 boards/arm/lpc31xx/ea3131/locked/ld-locked.script alin.jerpelea@sony.com
 boards/arm/lpc31xx/ea3131/locked/mklocked.sh alin.jerpelea@sony.com xiaoxiang@xiaomi.com manuelstuehn@freenet.de
@@ -11356,7 +7669,6 @@ boards/arm/lpc31xx/ea3131/src/lpc31_leds.c alin.jerpelea@sony.com xiaoxiang@xiao
 boards/arm/lpc31xx/ea3131/src/lpc31_mem.c alin.jerpelea@sony.com f.panag@amco.gr xiaoxiang@xiaomi.com
 boards/arm/lpc31xx/ea3131/src/lpc31_spi.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 boards/arm/lpc31xx/ea3131/src/lpc31_usbhost.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com petro.karashchenko@gmail.com devel@sumpfralle.de
-boards/arm/lpc31xx/ea3131/tools/.gitignore alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 boards/arm/lpc31xx/ea3131/tools/Makefile alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 boards/arm/lpc31xx/ea3131/tools/armusbocd.cfg alin.jerpelea@sony.com
 boards/arm/lpc31xx/ea3131/tools/crc32.c alin.jerpelea@sony.com
@@ -11380,7 +7692,6 @@ boards/arm/lpc31xx/ea3152/src/lpc31_fillpage.c alin.jerpelea@sony.com xiaoxiang@
 boards/arm/lpc31xx/ea3152/src/lpc31_leds.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 boards/arm/lpc31xx/ea3152/src/lpc31_mem.c alin.jerpelea@sony.com f.panag@amco.gr xiaoxiang@xiaomi.com
 boards/arm/lpc31xx/ea3152/src/lpc31_spi.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/arm/lpc31xx/ea3152/tools/.gitignore alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 boards/arm/lpc31xx/ea3152/tools/Makefile alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 boards/arm/lpc31xx/ea3152/tools/armusbocd.cfg alin.jerpelea@sony.com
 boards/arm/lpc31xx/ea3152/tools/crc32.c alin.jerpelea@sony.com
@@ -11407,7 +7718,6 @@ boards/arm/lpc31xx/olimex-lpc-h3131/src/lpc31_mmcsd.c alin.jerpelea@sony.com xia
 boards/arm/lpc31xx/olimex-lpc-h3131/src/lpc31_spi.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 boards/arm/lpc31xx/olimex-lpc-h3131/src/lpc31_usbhost.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com petro.karashchenko@gmail.com devel@sumpfralle.de
 boards/arm/lpc31xx/olimex-lpc-h3131/src/lpc_h3131.h alin.jerpelea@sony.com bashton@brennanashton.com devel@sumpfralle.de
-boards/arm/lpc31xx/olimex-lpc-h3131/tools/.gitignore alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 boards/arm/lpc31xx/olimex-lpc-h3131/tools/Makefile alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 boards/arm/lpc31xx/olimex-lpc-h3131/tools/armusbocd.cfg alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 boards/arm/lpc31xx/olimex-lpc-h3131/tools/crc32.c alin.jerpelea@sony.com
@@ -11966,7 +8276,6 @@ boards/arm/qemu/qemu-armv7r/configs/nsh/defconfig p-liuyanfeng9@xiaomi.com
 boards/arm/qemu/qemu-armv7r/configs/pnsh/defconfig p-liuyanfeng9@xiaomi.com
 boards/arm/qemu/qemu-armv7r/include/board.h p-liuyanfeng9@xiaomi.com
 boards/arm/qemu/qemu-armv7r/include/board_memorymap.h p-liuyanfeng9@xiaomi.com
-boards/arm/qemu/qemu-armv7r/kernel/.gitignore p-liuyanfeng9@xiaomi.com
 boards/arm/qemu/qemu-armv7r/kernel/Makefile p-liuyanfeng9@xiaomi.com
 boards/arm/qemu/qemu-armv7r/kernel/qemu_userspace.c p-liuyanfeng9@xiaomi.com
 boards/arm/qemu/qemu-armv7r/scripts/memory.ld p-liuyanfeng9@xiaomi.com
@@ -12002,379 +8311,13 @@ boards/arm/ra4/xiao-ra4m1/src/ra4m1_bringup.c rcsim10@gmail.com
 boards/arm/ra4/xiao-ra4m1/src/ra4m1_gpio.c rcsim10@gmail.com
 boards/arm/ra4/xiao-ra4m1/src/ra4m1_userleds.c rcsim10@gmail.com
 boards/arm/ra4/xiao-ra4m1/src/xiao-ra4m1.h rcsim10@gmail.com
-boards/arm/rp2040/adafruit-feather-rp2040/Kconfig 58759586+curuvar@users.noreply.github.com bijunda1@xiaomi.com
-boards/arm/rp2040/adafruit-feather-rp2040/configs/audiopack/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/adafruit-feather-rp2040/configs/composite/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/adafruit-feather-rp2040/configs/displaypack/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/adafruit-feather-rp2040/configs/enc28j60/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com mazhuang@xiaomi.com acassis@gmail.com
-boards/arm/rp2040/adafruit-feather-rp2040/configs/lcd1602/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/adafruit-feather-rp2040/configs/nsh-flash/defconfig 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/adafruit-feather-rp2040/configs/nsh/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/adafruit-feather-rp2040/configs/nshsram/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com masayuki.ishikawa@gmail.com
-boards/arm/rp2040/adafruit-feather-rp2040/configs/smp/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/adafruit-feather-rp2040/configs/spisd/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/adafruit-feather-rp2040/configs/ssd1306/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/adafruit-feather-rp2040/configs/st7735/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/adafruit-feather-rp2040/configs/usbmsc/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com wangjianyu3@xiaomi.com
-boards/arm/rp2040/adafruit-feather-rp2040/configs/usbnsh/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/adafruit-feather-rp2040/configs/waveshare-lcd-1.14/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/adafruit-feather-rp2040/configs/waveshare-lcd-1.3/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/adafruit-feather-rp2040/include/board.h 58759586+curuvar@users.noreply.github.com ian@iandouglasscott.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/adafruit-feather-rp2040/include/rp2040_i2cdev.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-feather-rp2040/include/rp2040_i2sdev.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-feather-rp2040/include/rp2040_spidev.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-feather-rp2040/include/rp2040_spisd.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-feather-rp2040/scripts/adafruit-feather-rp2040-flash.ld 58759586+curuvar@users.noreply.github.com cuiziwei@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-feather-rp2040/scripts/adafruit-feather-rp2040-sram.ld 58759586+curuvar@users.noreply.github.com cuiziwei@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-feather-rp2040/src/rp2040_appinit.c 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-feather-rp2040/src/rp2040_boardinitialize.c 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-feather-rp2040/src/rp2040_bringup.c 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-feather-rp2040/src/rp2040_gpio.c 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-feather-rp2040/src/rp2040_pico.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-kb2040/Kconfig 58759586+curuvar@users.noreply.github.com bijunda1@xiaomi.com
-boards/arm/rp2040/adafruit-kb2040/configs/audiopack/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/adafruit-kb2040/configs/composite/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/adafruit-kb2040/configs/displaypack/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/adafruit-kb2040/configs/enc28j60/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com mazhuang@xiaomi.com acassis@gmail.com
-boards/arm/rp2040/adafruit-kb2040/configs/lcd1602/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/adafruit-kb2040/configs/nsh-flash/defconfig 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/adafruit-kb2040/configs/nsh/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/adafruit-kb2040/configs/nshsram/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com masayuki.ishikawa@gmail.com
-boards/arm/rp2040/adafruit-kb2040/configs/smp/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/adafruit-kb2040/configs/spisd/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/adafruit-kb2040/configs/ssd1306/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/adafruit-kb2040/configs/st7735/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/adafruit-kb2040/configs/usbmsc/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com wangjianyu3@xiaomi.com
-boards/arm/rp2040/adafruit-kb2040/configs/usbnsh/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/adafruit-kb2040/configs/waveshare-lcd-1.14/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/adafruit-kb2040/configs/waveshare-lcd-1.3/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/adafruit-kb2040/include/board.h 58759586+curuvar@users.noreply.github.com ian@iandouglasscott.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/adafruit-kb2040/include/rp2040_i2cdev.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-kb2040/include/rp2040_i2sdev.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-kb2040/include/rp2040_spidev.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-kb2040/include/rp2040_spisd.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-kb2040/scripts/adafruit-kb2040-flash.ld 58759586+curuvar@users.noreply.github.com cuiziwei@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-kb2040/scripts/adafruit-kb2040-sram.ld 58759586+curuvar@users.noreply.github.com cuiziwei@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-kb2040/src/rp2040_appinit.c 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-kb2040/src/rp2040_boardinitialize.c 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-kb2040/src/rp2040_bringup.c 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-kb2040/src/rp2040_gpio.c 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-kb2040/src/rp2040_pico.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-qt-py-rp2040/Kconfig 58759586+curuvar@users.noreply.github.com
-boards/arm/rp2040/adafruit-qt-py-rp2040/configs/gpio/defconfig 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/adafruit-qt-py-rp2040/configs/nsh-flash/defconfig 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/adafruit-qt-py-rp2040/configs/nsh/defconfig 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/adafruit-qt-py-rp2040/configs/nshsram/defconfig 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/adafruit-qt-py-rp2040/configs/smp/defconfig 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/adafruit-qt-py-rp2040/configs/usbnsh/defconfig 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/adafruit-qt-py-rp2040/include/board.h 58759586+curuvar@users.noreply.github.com ian@iandouglasscott.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/adafruit-qt-py-rp2040/include/rp2040_i2cdev.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-qt-py-rp2040/include/rp2040_i2sdev.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-qt-py-rp2040/include/rp2040_spidev.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-qt-py-rp2040/include/rp2040_spisd.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-qt-py-rp2040/scripts/adafruit-qt-py-rp2040-flash.ld 58759586+curuvar@users.noreply.github.com cuiziwei@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-qt-py-rp2040/scripts/adafruit-qt-py-rp2040-sram.ld 58759586+curuvar@users.noreply.github.com cuiziwei@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-qt-py-rp2040/src/rp2040_appinit.c 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-qt-py-rp2040/src/rp2040_boardinitialize.c 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-qt-py-rp2040/src/rp2040_bringup.c 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-qt-py-rp2040/src/rp2040_gpio.c 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/adafruit-qt-py-rp2040/src/rp2040_pico.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/common/Kconfig petro.karashchenko@gmail.com 58759586+curuvar@users.noreply.github.com bijunda1@xiaomi.com michael.jung@secore.ly zhongjiezhu1@gmail.com
-boards/arm/rp2040/common/Makefile y.512.nakamura@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com petro.karashchenko@gmail.com
-boards/arm/rp2040/common/include/rp2040_ads7046.h nicco.maggioni@gmail.com
-boards/arm/rp2040/common/include/rp2040_bmp180.h phfbertoleti@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/common/include/rp2040_bmp280.h acassis@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/common/include/rp2040_common_bringup.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/common/include/rp2040_common_initialize.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/common/include/rp2040_ina219.h phfbertoleti@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/common/include/rp2040_lcd_backpack.h transistorretorcido@gmail.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/common/include/rp2040_max6675.h acassis@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/common/include/rp2040_pwmdev.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/common/include/rp2040_tmp112.h nicco.maggioni@gmail.com
-boards/arm/rp2040/common/include/rp2040_uniqueid.h adam@novators.net alin.jerpelea@sony.com
-boards/arm/rp2040/common/src/.gitignore 58759586+curuvar@users.noreply.github.com
-boards/arm/rp2040/common/src/rp2040_ads7046.c nicco.maggioni@gmail.com
-boards/arm/rp2040/common/src/rp2040_bmp180.c phfbertoleti@gmail.com alin.jerpelea@sony.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/common/src/rp2040_bmp280.c acassis@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/common/src/rp2040_common_bringup.c 58759586+curuvar@users.noreply.github.com matteo.golin@gmail.com nicco.maggioni@gmail.com xiaoxiang@xiaomi.com acassis@gmail.com
-boards/arm/rp2040/common/src/rp2040_common_initialize.c 58759586+curuvar@users.noreply.github.com adam@novators.net michael.jung@secore.ly alin.jerpelea@sony.com
-boards/arm/rp2040/common/src/rp2040_composite.c y.512.nakamura@gmail.com xiaoxiang@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com zhangyuan21@xiaomi.com
-boards/arm/rp2040/common/src/rp2040_enc28j60.c y.512.nakamura@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/common/src/rp2040_firmware.c 58759586+curuvar@users.noreply.github.com devel@sumpfralle.de alin.jerpelea@sony.com
-boards/arm/rp2040/common/src/rp2040_gc9a01.c bijunda1@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/common/src/rp2040_i2cdev.c y.512.nakamura@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/common/src/rp2040_i2sdev.c y.512.nakamura@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-boards/arm/rp2040/common/src/rp2040_ina219.c phfbertoleti@gmail.com alin.jerpelea@sony.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com 101105604+simbit18@users.noreply.github.com
-boards/arm/rp2040/common/src/rp2040_lcd_backpack.c transistorretorcido@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com 59230071+hartmannathan@users.noreply.github.com
-boards/arm/rp2040/common/src/rp2040_max6675.c acassis@gmail.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-boards/arm/rp2040/common/src/rp2040_pwmdev.c 58759586+curuvar@users.noreply.github.com t-ando@advaly.co.jp alin.jerpelea@sony.com
-boards/arm/rp2040/common/src/rp2040_reset.c 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/common/src/rp2040_spi.c 58759586+curuvar@users.noreply.github.com kevinwit1999@gmail.com alin.jerpelea@sony.com bijunda1@xiaomi.com
-boards/arm/rp2040/common/src/rp2040_spidev.c y.512.nakamura@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/common/src/rp2040_spisd.c y.512.nakamura@gmail.com 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-boards/arm/rp2040/common/src/rp2040_ssd1306.c y.512.nakamura@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/common/src/rp2040_st7735.c transistorretorcido@gmail.com 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/common/src/rp2040_st7789.c y.512.nakamura@gmail.com bijunda1@xiaomi.com 58759586+curuvar@users.noreply.github.com zhongjiezhu1@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/common/src/rp2040_tmp112.c nicco.maggioni@gmail.com
-boards/arm/rp2040/common/src/rp2040_uniqueid.c adam@novators.net devel@sumpfralle.de alin.jerpelea@sony.com petro.karashchenko@gmail.com
-boards/arm/rp2040/common/src/rp2040_usbmsc.c y.512.nakamura@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/common/src/rp2040_w5500.c michael.jung@secore.ly alin.jerpelea@sony.com
-boards/arm/rp2040/pimoroni-tiny2040/Kconfig 58759586+curuvar@users.noreply.github.com ptka@mailbox.org
-boards/arm/rp2040/pimoroni-tiny2040/configs/composite/defconfig ptka@mailbox.org 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com petro.karashchenko@gmail.com
-boards/arm/rp2040/pimoroni-tiny2040/configs/gpio/defconfig ptka@mailbox.org xiaoxiang@xiaomi.com 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com petro.karashchenko@gmail.com
-boards/arm/rp2040/pimoroni-tiny2040/configs/nsh-flash/defconfig 58759586+curuvar@users.noreply.github.com anchao@xiaomi.com serg@podtynnyi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/pimoroni-tiny2040/configs/nsh/defconfig ptka@mailbox.org xiaoxiang@xiaomi.com 58759586+curuvar@users.noreply.github.com anchao@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/pimoroni-tiny2040/configs/nshsram/defconfig ptka@mailbox.org xiaoxiang@xiaomi.com 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com masayuki.ishikawa@gmail.com
-boards/arm/rp2040/pimoroni-tiny2040/configs/smp/defconfig ptka@mailbox.org xiaoxiang@xiaomi.com 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com petro.karashchenko@gmail.com
-boards/arm/rp2040/pimoroni-tiny2040/configs/spisd/defconfig ptka@mailbox.org 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com petro.karashchenko@gmail.com
-boards/arm/rp2040/pimoroni-tiny2040/configs/usbmsc/defconfig ptka@mailbox.org 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com wangjianyu3@xiaomi.com
-boards/arm/rp2040/pimoroni-tiny2040/configs/usbnsh/defconfig ptka@mailbox.org xiaoxiang@xiaomi.com 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com petro.karashchenko@gmail.com
-boards/arm/rp2040/pimoroni-tiny2040/include/board.h ptka@mailbox.org alin.jerpelea@sony.com xiaoxiang@xiaomi.com ian@iandouglasscott.com
-boards/arm/rp2040/pimoroni-tiny2040/include/rp2040_i2cdev.h ptka@mailbox.org alin.jerpelea@sony.com
-boards/arm/rp2040/pimoroni-tiny2040/include/rp2040_i2sdev.h ptka@mailbox.org alin.jerpelea@sony.com
-boards/arm/rp2040/pimoroni-tiny2040/include/rp2040_spidev.h ptka@mailbox.org alin.jerpelea@sony.com
-boards/arm/rp2040/pimoroni-tiny2040/include/rp2040_spisd.h ptka@mailbox.org alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/pimoroni-tiny2040/scripts/pimoroni-tiny2040-flash.ld ptka@mailbox.org cuiziwei@xiaomi.com 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/pimoroni-tiny2040/scripts/pimoroni-tiny2040-sram.ld ptka@mailbox.org cuiziwei@xiaomi.com 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/pimoroni-tiny2040/src/rp2040_appinit.c ptka@mailbox.org xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/pimoroni-tiny2040/src/rp2040_boardinitialize.c ptka@mailbox.org 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/pimoroni-tiny2040/src/rp2040_bringup.c 58759586+curuvar@users.noreply.github.com ptka@mailbox.org alin.jerpelea@sony.com
-boards/arm/rp2040/pimoroni-tiny2040/src/rp2040_gpio.c ptka@mailbox.org xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/pimoroni-tiny2040/src/rp2040_pico.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/pimoroni-tiny2040/src/rp2040_tiny2040.h ptka@mailbox.org alin.jerpelea@sony.com
-boards/arm/rp2040/raspberrypi-pico-w/Kconfig 58759586+curuvar@users.noreply.github.com 101105604+simbit18@users.noreply.github.com bijunda1@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico-w/configs/audiopack/defconfig 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico-w/configs/composite/defconfig 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico-w/configs/displaypack/defconfig 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico-w/configs/enc28j60/defconfig 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com serg@podtynnyi.com mazhuang@xiaomi.com acassis@gmail.com
-boards/arm/rp2040/raspberrypi-pico-w/configs/lcd1602/defconfig 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico-w/configs/nsh-flash/defconfig 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico-w/configs/nsh/defconfig 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico-w/configs/nshsram/defconfig 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com masayuki.ishikawa@gmail.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico-w/configs/smp/defconfig 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico-w/configs/spisd/defconfig 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico-w/configs/ssd1306/defconfig 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico-w/configs/st7735/defconfig 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico-w/configs/telnet/defconfig 58759586+curuvar@users.noreply.github.com anchao@xiaomi.com acassis@gmail.com xiaoxiang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/raspberrypi-pico-w/configs/usbmsc/defconfig 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com wangjianyu3@xiaomi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico-w/configs/usbnsh/defconfig 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico-w/configs/waveshare-lcd-1.14/defconfig 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico-w/configs/waveshare-lcd-1.3/defconfig 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico-w/include/board.h 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com ian@iandouglasscott.com
-boards/arm/rp2040/raspberrypi-pico-w/include/rp2040_extra_gpio.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/raspberrypi-pico-w/include/rp2040_i2cdev.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/raspberrypi-pico-w/include/rp2040_i2sdev.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/raspberrypi-pico-w/include/rp2040_spidev.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/raspberrypi-pico-w/include/rp2040_spisd.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/raspberrypi-pico-w/scripts/raspberrypi-pico-flash.ld 58759586+curuvar@users.noreply.github.com cuiziwei@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/raspberrypi-pico-w/scripts/raspberrypi-pico-sram.ld 58759586+curuvar@users.noreply.github.com cuiziwei@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/raspberrypi-pico-w/src/rp2040_appinit.c 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/raspberrypi-pico-w/src/rp2040_boardinitialize.c 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/raspberrypi-pico-w/src/rp2040_bringup.c 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/raspberrypi-pico-w/src/rp2040_gpio.c 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/raspberrypi-pico-w/src/rp2040_pico.h 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/raspberrypi-pico/Kconfig 58759586+curuvar@users.noreply.github.com y.512.nakamura@gmail.com bijunda1@xiaomi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico/configs/ads7046/defconfig nicco.maggioni@gmail.com
-boards/arm/rp2040/raspberrypi-pico/configs/audiopack/defconfig y.512.nakamura@gmail.com xiaoxiang@xiaomi.com 58759586+curuvar@users.noreply.github.com liguiding1@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/raspberrypi-pico/configs/bmp280/defconfig acassis@gmail.com serg@podtynnyi.com
-boards/arm/rp2040/raspberrypi-pico/configs/composite/defconfig y.512.nakamura@gmail.com xiaoxiang@xiaomi.com 58759586+curuvar@users.noreply.github.com liguiding1@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/raspberrypi-pico/configs/displaypack/defconfig y.512.nakamura@gmail.com xiaoxiang@xiaomi.com 58759586+curuvar@users.noreply.github.com dongjiuzhu1@xiaomi.com liguiding1@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico/configs/enc28j60/defconfig y.512.nakamura@gmail.com 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com liguiding1@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico/configs/lcd1602/defconfig transistorretorcido@gmail.com 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com liguiding1@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/raspberrypi-pico/configs/nsh-flash/defconfig 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico/configs/nsh/defconfig y.512.nakamura@gmail.com masayuki.ishikawa@gmail.com xiaoxiang@xiaomi.com 58759586+curuvar@users.noreply.github.com dongjiuzhu1@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico/configs/nshsram/defconfig y.512.nakamura@gmail.com xiaoxiang@xiaomi.com masayuki.ishikawa@gmail.com 58759586+curuvar@users.noreply.github.com dongjiuzhu1@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico/configs/pico-restouch-lcd-2.8/defconfig zhongjiezhu1@gmail.com serg@podtynnyi.com
-boards/arm/rp2040/raspberrypi-pico/configs/smp/defconfig y.512.nakamura@gmail.com masayuki.ishikawa@gmail.com xiaoxiang@xiaomi.com 58759586+curuvar@users.noreply.github.com dongjiuzhu1@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico/configs/spisd/defconfig y.512.nakamura@gmail.com xiaoxiang@xiaomi.com 58759586+curuvar@users.noreply.github.com dongjiuzhu1@xiaomi.com liguiding1@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico/configs/ssd1306/defconfig y.512.nakamura@gmail.com xiaoxiang@xiaomi.com 58759586+curuvar@users.noreply.github.com dongjiuzhu1@xiaomi.com liguiding1@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico/configs/st7735/defconfig transistorretorcido@gmail.com 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com liguiding1@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/raspberrypi-pico/configs/tmp112/defconfig nicco.maggioni@gmail.com
-boards/arm/rp2040/raspberrypi-pico/configs/usbmsc/defconfig y.512.nakamura@gmail.com xiaoxiang@xiaomi.com 58759586+curuvar@users.noreply.github.com liguiding1@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/raspberrypi-pico/configs/usbnsh/defconfig y.512.nakamura@gmail.com xiaoxiang@xiaomi.com 58759586+curuvar@users.noreply.github.com liguiding1@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/raspberrypi-pico/configs/waveshare-lcd-1.14/defconfig bijunda1@xiaomi.com xiaoxiang@xiaomi.com 58759586+curuvar@users.noreply.github.com liguiding1@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/raspberrypi-pico/configs/waveshare-lcd-1.3/defconfig bijunda1@xiaomi.com xiaoxiang@xiaomi.com 58759586+curuvar@users.noreply.github.com liguiding1@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/raspberrypi-pico/include/board.h y.512.nakamura@gmail.com acassis@gmail.com matheus@castello.eng.br alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico/include/rp2040_i2cdev.h y.512.nakamura@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/raspberrypi-pico/include/rp2040_i2sdev.h y.512.nakamura@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/raspberrypi-pico/include/rp2040_spidev.h y.512.nakamura@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/raspberrypi-pico/include/rp2040_spisd.h y.512.nakamura@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico/scripts/raspberrypi-pico-flash.ld y.512.nakamura@gmail.com cuiziwei@xiaomi.com 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/raspberrypi-pico/scripts/raspberrypi-pico-sram.ld y.512.nakamura@gmail.com cuiziwei@xiaomi.com 58759586+curuvar@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm/rp2040/raspberrypi-pico/src/rp2040_appinit.c y.512.nakamura@gmail.com masayuki.ishikawa@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/raspberrypi-pico/src/rp2040_autoleds.c acassis@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/raspberrypi-pico/src/rp2040_boardinitialize.c y.512.nakamura@gmail.com 58759586+curuvar@users.noreply.github.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/raspberrypi-pico/src/rp2040_bringup.c 58759586+curuvar@users.noreply.github.com y.512.nakamura@gmail.com masayuki.ishikawa@gmail.com phfbertoleti@gmail.com bijunda1@xiaomi.com
-boards/arm/rp2040/raspberrypi-pico/src/rp2040_buttons.c acassis@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/raspberrypi-pico/src/rp2040_gpio.c matheus@castello.eng.br xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/raspberrypi-pico/src/rp2040_pico.h masayuki.ishikawa@gmail.com acassis@gmail.com matheus@castello.eng.br alin.jerpelea@sony.com
-boards/arm/rp2040/raspberrypi-pico/src/rp2040_userleds.c acassis@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/seeed-xiao-rp2040/Kconfig rcsim10@gmail.com
-boards/arm/rp2040/seeed-xiao-rp2040/configs/gpio/defconfig halysson1007@gmail.com serg@podtynnyi.com
-boards/arm/rp2040/seeed-xiao-rp2040/configs/nsh/defconfig rcsim10@gmail.com serg@podtynnyi.com
-boards/arm/rp2040/seeed-xiao-rp2040/configs/usbnsh/defconfig halysson1007@gmail.com serg@podtynnyi.com
-boards/arm/rp2040/seeed-xiao-rp2040/configs/userleds/defconfig halysson1007@gmail.com serg@podtynnyi.com
-boards/arm/rp2040/seeed-xiao-rp2040/configs/ws2812/defconfig halysson1007@gmail.com serg@podtynnyi.com
-boards/arm/rp2040/seeed-xiao-rp2040/include/board.h rcsim10@gmail.com halysson1007@gmail.com ian@iandouglasscott.com alin.jerpelea@sony.com
-boards/arm/rp2040/seeed-xiao-rp2040/include/rp2040_i2cdev.h rcsim10@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/seeed-xiao-rp2040/include/rp2040_i2sdev.h rcsim10@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/seeed-xiao-rp2040/include/rp2040_spidev.h rcsim10@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/seeed-xiao-rp2040/include/rp2040_spisd.h rcsim10@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/seeed-xiao-rp2040/scripts/seeed-xiao-rp2040-flash.ld rcsim10@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/seeed-xiao-rp2040/scripts/seeed-xiao-rp2040-sram.ld rcsim10@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/seeed-xiao-rp2040/src/rp2040_appinit.c rcsim10@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/seeed-xiao-rp2040/src/rp2040_autoleds.c halysson1007@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/seeed-xiao-rp2040/src/rp2040_boardinitialize.c rcsim10@gmail.com halysson1007@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/seeed-xiao-rp2040/src/rp2040_bringup.c rcsim10@gmail.com halysson1007@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/seeed-xiao-rp2040/src/rp2040_gpio.c rcsim10@gmail.com halysson1007@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/seeed-xiao-rp2040/src/rp2040_pico.h rcsim10@gmail.com halysson1007@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/seeed-xiao-rp2040/src/rp2040_userleds.c halysson1007@gmail.com alin.jerpelea@sony.com
-boards/arm/rp2040/w5500-evb-pico/Kconfig michael.jung@secore.ly
-boards/arm/rp2040/w5500-evb-pico/configs/usbnsh/defconfig michael.jung@secore.ly serg@podtynnyi.com acassis@gmail.com
-boards/arm/rp2040/w5500-evb-pico/include/board.h michael.jung@secore.ly devel@sumpfralle.de alin.jerpelea@sony.com ian@iandouglasscott.com
-boards/arm/rp2040/w5500-evb-pico/include/rp2040_i2cdev.h michael.jung@secore.ly alin.jerpelea@sony.com
-boards/arm/rp2040/w5500-evb-pico/include/rp2040_i2sdev.h michael.jung@secore.ly alin.jerpelea@sony.com
-boards/arm/rp2040/w5500-evb-pico/include/rp2040_spidev.h michael.jung@secore.ly alin.jerpelea@sony.com
-boards/arm/rp2040/w5500-evb-pico/include/rp2040_spisd.h michael.jung@secore.ly alin.jerpelea@sony.com
-boards/arm/rp2040/w5500-evb-pico/scripts/w5500-evb-pico-flash.ld michael.jung@secore.ly alin.jerpelea@sony.com
-boards/arm/rp2040/w5500-evb-pico/scripts/w5500-evb-pico-sram.ld michael.jung@secore.ly alin.jerpelea@sony.com
-boards/arm/rp2040/w5500-evb-pico/src/rp2040_appinit.c michael.jung@secore.ly alin.jerpelea@sony.com
-boards/arm/rp2040/w5500-evb-pico/src/rp2040_autoleds.c michael.jung@secore.ly alin.jerpelea@sony.com
-boards/arm/rp2040/w5500-evb-pico/src/rp2040_boardinitialize.c michael.jung@secore.ly alin.jerpelea@sony.com
-boards/arm/rp2040/w5500-evb-pico/src/rp2040_bringup.c michael.jung@secore.ly alin.jerpelea@sony.com
-boards/arm/rp2040/w5500-evb-pico/src/rp2040_buttons.c michael.jung@secore.ly alin.jerpelea@sony.com
-boards/arm/rp2040/w5500-evb-pico/src/rp2040_gpio.c michael.jung@secore.ly alin.jerpelea@sony.com
-boards/arm/rp2040/w5500-evb-pico/src/rp2040_pico.h michael.jung@secore.ly alin.jerpelea@sony.com
-boards/arm/rp2040/w5500-evb-pico/src/rp2040_userleds.c michael.jung@secore.ly alin.jerpelea@sony.com
-boards/arm/rp2040/waveshare-rp2040-lcd-1.28/Kconfig bijunda1@xiaomi.com
-boards/arm/rp2040/waveshare-rp2040-lcd-1.28/configs/composite/defconfig bijunda1@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/waveshare-rp2040-lcd-1.28/configs/fb/defconfig bijunda1@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/waveshare-rp2040-lcd-1.28/configs/lvgl/defconfig bijunda1@xiaomi.com xuxingliang@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/waveshare-rp2040-lcd-1.28/configs/nsh-flash/defconfig bijunda1@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/waveshare-rp2040-lcd-1.28/configs/nsh/defconfig bijunda1@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/waveshare-rp2040-lcd-1.28/configs/nshsram/defconfig bijunda1@xiaomi.com serg@podtynnyi.com masayuki.ishikawa@gmail.com
-boards/arm/rp2040/waveshare-rp2040-lcd-1.28/configs/smp/defconfig bijunda1@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/waveshare-rp2040-lcd-1.28/configs/spisd/defconfig bijunda1@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/waveshare-rp2040-lcd-1.28/configs/usbmsc/defconfig bijunda1@xiaomi.com serg@podtynnyi.com wangjianyu3@xiaomi.com
-boards/arm/rp2040/waveshare-rp2040-lcd-1.28/configs/usbnsh/defconfig bijunda1@xiaomi.com serg@podtynnyi.com
-boards/arm/rp2040/waveshare-rp2040-lcd-1.28/include/board.h bijunda1@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com ian@iandouglasscott.com
-boards/arm/rp2040/waveshare-rp2040-lcd-1.28/include/rp2040_i2cdev.h bijunda1@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/waveshare-rp2040-lcd-1.28/include/rp2040_i2sdev.h bijunda1@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/waveshare-rp2040-lcd-1.28/include/rp2040_spidev.h bijunda1@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/waveshare-rp2040-lcd-1.28/include/rp2040_spisd.h bijunda1@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/waveshare-rp2040-lcd-1.28/scripts/waveshare-rp2040-lcd-1-28-flash.ld bijunda1@xiaomi.com cuiziwei@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/waveshare-rp2040-lcd-1.28/scripts/waveshare-rp2040-lcd-1-28-sram.ld bijunda1@xiaomi.com cuiziwei@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/waveshare-rp2040-lcd-1.28/src/rp2040_appinit.c bijunda1@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/waveshare-rp2040-lcd-1.28/src/rp2040_boardinitialize.c bijunda1@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/waveshare-rp2040-lcd-1.28/src/rp2040_bringup.c bijunda1@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/waveshare-rp2040-lcd-1.28/src/rp2040_gpio.c bijunda1@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/waveshare-rp2040-lcd-1.28/src/rp2040_pico.h bijunda1@xiaomi.com alin.jerpelea@sony.com
-boards/arm/rp2040/waveshare-rp2040-zero/Kconfig rovnerhenry@gmail.com
-boards/arm/rp2040/waveshare-rp2040-zero/configs/gpio/defconfig rovnerhenry@gmail.com serg@podtynnyi.com
-boards/arm/rp2040/waveshare-rp2040-zero/configs/nsh/defconfig rovnerhenry@gmail.com serg@podtynnyi.com
-boards/arm/rp2040/waveshare-rp2040-zero/configs/usbnsh/defconfig rovnerhenry@gmail.com serg@podtynnyi.com
-boards/arm/rp2040/waveshare-rp2040-zero/configs/ws2812/defconfig rovnerhenry@gmail.com serg@podtynnyi.com
-boards/arm/rp2040/waveshare-rp2040-zero/include/board.h rovnerhenry@gmail.com ian@iandouglasscott.com
-boards/arm/rp2040/waveshare-rp2040-zero/include/rp2040_i2cdev.h rovnerhenry@gmail.com
-boards/arm/rp2040/waveshare-rp2040-zero/include/rp2040_i2sdev.h rovnerhenry@gmail.com
-boards/arm/rp2040/waveshare-rp2040-zero/include/rp2040_spidev.h rovnerhenry@gmail.com
-boards/arm/rp2040/waveshare-rp2040-zero/include/rp2040_spisd.h rovnerhenry@gmail.com
-boards/arm/rp2040/waveshare-rp2040-zero/scripts/waveshare-rp2040-zero-flash.ld rovnerhenry@gmail.com
-boards/arm/rp2040/waveshare-rp2040-zero/scripts/waveshare-rp2040-zero-sram.ld rovnerhenry@gmail.com
-boards/arm/rp2040/waveshare-rp2040-zero/src/rp2040_appinit.c rovnerhenry@gmail.com
-boards/arm/rp2040/waveshare-rp2040-zero/src/rp2040_boardinitialize.c rovnerhenry@gmail.com
-boards/arm/rp2040/waveshare-rp2040-zero/src/rp2040_bringup.c rovnerhenry@gmail.com
-boards/arm/rp2040/waveshare-rp2040-zero/src/rp2040_gpio.c rovnerhenry@gmail.com
-boards/arm/rp2040/waveshare-rp2040-zero/src/rp2040_pico.h rovnerhenry@gmail.com
-boards/arm/rp23xx/common/.gitignore pbjd97@gmail.com
-boards/arm/rp23xx/common/Kconfig marco.casaroli@gmail.com bijunda@dreame.tech
-boards/arm/rp23xx/common/Makefile marco.casaroli@gmail.com
-boards/arm/rp23xx/common/include/rp23xx_common_bringup.h marco.casaroli@gmail.com
-boards/arm/rp23xx/common/include/rp23xx_common_initialize.h marco.casaroli@gmail.com
-boards/arm/rp23xx/common/include/rp23xx_pwmdev.h marco.casaroli@gmail.com
-boards/arm/rp23xx/common/include/rp23xx_uniqueid.h marco.casaroli@gmail.com
-boards/arm/rp23xx/common/src/.gitignore marco.casaroli@gmail.com
-boards/arm/rp23xx/common/src/rp23xx_common_bringup.c marco.casaroli@gmail.com bijunda@dreame.tech pbjd97@gmail.com
-boards/arm/rp23xx/common/src/rp23xx_common_initialize.c marco.casaroli@gmail.com bijunda@dreame.tech
-boards/arm/rp23xx/common/src/rp23xx_composite.c marco.casaroli@gmail.com devel@sumpfralle.de
-boards/arm/rp23xx/common/src/rp23xx_i2cdev.c marco.casaroli@gmail.com
-boards/arm/rp23xx/common/src/rp23xx_i2sdev.c marco.casaroli@gmail.com
-boards/arm/rp23xx/common/src/rp23xx_pwmdev.c marco.casaroli@gmail.com
-boards/arm/rp23xx/common/src/rp23xx_reset.c marco.casaroli@gmail.com serg@podtynnyi.com
-boards/arm/rp23xx/common/src/rp23xx_spi.c marco.casaroli@gmail.com
-boards/arm/rp23xx/common/src/rp23xx_spidev.c marco.casaroli@gmail.com
-boards/arm/rp23xx/common/src/rp23xx_spisd.c bijunda@dreame.tech
-boards/arm/rp23xx/common/src/rp23xx_uniqueid.c marco.casaroli@gmail.com pbjd97@gmail.com devel@sumpfralle.de xiaoxiang@xiaomi.com
-boards/arm/rp23xx/common/src/rp23xx_usbmsc.c marco.casaroli@gmail.com
-boards/arm/rp23xx/pimoroni-pico-2-plus/Kconfig marco.casaroli@gmail.com
-boards/arm/rp23xx/pimoroni-pico-2-plus/configs/audiopack/defconfig marco.casaroli@gmail.com serg@podtynnyi.com
-boards/arm/rp23xx/pimoroni-pico-2-plus/configs/composite/defconfig marco.casaroli@gmail.com serg@podtynnyi.com
-boards/arm/rp23xx/pimoroni-pico-2-plus/configs/nsh/defconfig marco.casaroli@gmail.com serg@podtynnyi.com
-boards/arm/rp23xx/pimoroni-pico-2-plus/configs/nshsram/defconfig marco.casaroli@gmail.com serg@podtynnyi.com pbjd97@gmail.com
-boards/arm/rp23xx/pimoroni-pico-2-plus/configs/smp/defconfig marco.casaroli@gmail.com serg@podtynnyi.com
-boards/arm/rp23xx/pimoroni-pico-2-plus/configs/usbmsc/defconfig marco.casaroli@gmail.com serg@podtynnyi.com wangjianyu3@xiaomi.com
-boards/arm/rp23xx/pimoroni-pico-2-plus/configs/usbnsh/defconfig marco.casaroli@gmail.com serg@podtynnyi.com
-boards/arm/rp23xx/pimoroni-pico-2-plus/configs/userled/defconfig marco.casaroli@gmail.com serg@podtynnyi.com
-boards/arm/rp23xx/pimoroni-pico-2-plus/include/board.h marco.casaroli@gmail.com bijunda@dreame.tech pbjd97@gmail.com ian@iandouglasscott.com
-boards/arm/rp23xx/pimoroni-pico-2-plus/include/rp23xx_i2cdev.h marco.casaroli@gmail.com pbjd97@gmail.com
-boards/arm/rp23xx/pimoroni-pico-2-plus/include/rp23xx_i2sdev.h marco.casaroli@gmail.com pbjd97@gmail.com
-boards/arm/rp23xx/pimoroni-pico-2-plus/include/rp23xx_spidev.h marco.casaroli@gmail.com pbjd97@gmail.com
-boards/arm/rp23xx/pimoroni-pico-2-plus/scripts/memmap_copy_to_ram.ld marco.casaroli@gmail.com rcsim10@gmail.com
-boards/arm/rp23xx/pimoroni-pico-2-plus/scripts/memmap_default.ld marco.casaroli@gmail.com rcsim10@gmail.com
-boards/arm/rp23xx/pimoroni-pico-2-plus/scripts/memmap_no_flash.ld marco.casaroli@gmail.com rcsim10@gmail.com
-boards/arm/rp23xx/pimoroni-pico-2-plus/src/rp23xx_appinit.c marco.casaroli@gmail.com pbjd97@gmail.com
-boards/arm/rp23xx/pimoroni-pico-2-plus/src/rp23xx_autoleds.c marco.casaroli@gmail.com pbjd97@gmail.com
-boards/arm/rp23xx/pimoroni-pico-2-plus/src/rp23xx_boardinitialize.c marco.casaroli@gmail.com pbjd97@gmail.com
-boards/arm/rp23xx/pimoroni-pico-2-plus/src/rp23xx_bringup.c marco.casaroli@gmail.com pbjd97@gmail.com
-boards/arm/rp23xx/pimoroni-pico-2-plus/src/rp23xx_buttons.c marco.casaroli@gmail.com pbjd97@gmail.com
-boards/arm/rp23xx/pimoroni-pico-2-plus/src/rp23xx_gpio.c marco.casaroli@gmail.com pbjd97@gmail.com
-boards/arm/rp23xx/pimoroni-pico-2-plus/src/rp23xx_pico.h marco.casaroli@gmail.com pbjd97@gmail.com
-boards/arm/rp23xx/pimoroni-pico-2-plus/src/rp23xx_userleds.c marco.casaroli@gmail.com pbjd97@gmail.com
-boards/arm/rp23xx/raspberrypi-pico-2/Kconfig marco.casaroli@gmail.com
-boards/arm/rp23xx/raspberrypi-pico-2/configs/nsh/defconfig marco.casaroli@gmail.com serg@podtynnyi.com
-boards/arm/rp23xx/raspberrypi-pico-2/configs/smp/defconfig serg@podtynnyi.com
-boards/arm/rp23xx/raspberrypi-pico-2/configs/spisd/defconfig pbjd97@gmail.com serg@podtynnyi.com
-boards/arm/rp23xx/raspberrypi-pico-2/configs/usbnsh/defconfig marco.casaroli@gmail.com serg@podtynnyi.com
-boards/arm/rp23xx/raspberrypi-pico-2/configs/userled/defconfig marco.casaroli@gmail.com serg@podtynnyi.com
-boards/arm/rp23xx/raspberrypi-pico-2/include/board.h marco.casaroli@gmail.com bijunda@dreame.tech ian@iandouglasscott.com
-boards/arm/rp23xx/raspberrypi-pico-2/include/rp23xx_i2cdev.h marco.casaroli@gmail.com
-boards/arm/rp23xx/raspberrypi-pico-2/include/rp23xx_i2sdev.h marco.casaroli@gmail.com
-boards/arm/rp23xx/raspberrypi-pico-2/include/rp23xx_spidev.h marco.casaroli@gmail.com
-boards/arm/rp23xx/raspberrypi-pico-2/include/rp23xx_spisd.h bijunda@dreame.tech
-boards/arm/rp23xx/raspberrypi-pico-2/scripts/memmap_copy_to_ram.ld marco.casaroli@gmail.com rcsim10@gmail.com serg@podtynnyi.com
-boards/arm/rp23xx/raspberrypi-pico-2/scripts/memmap_default.ld marco.casaroli@gmail.com rcsim10@gmail.com serg@podtynnyi.com
-boards/arm/rp23xx/raspberrypi-pico-2/scripts/memmap_no_flash.ld marco.casaroli@gmail.com rcsim10@gmail.com serg@podtynnyi.com
-boards/arm/rp23xx/raspberrypi-pico-2/src/etc/init.d/rc.sysinit pbjd97@gmail.com
-boards/arm/rp23xx/raspberrypi-pico-2/src/etc/init.d/rcS pbjd97@gmail.com
-boards/arm/rp23xx/raspberrypi-pico-2/src/rp23xx_appinit.c marco.casaroli@gmail.com
-boards/arm/rp23xx/raspberrypi-pico-2/src/rp23xx_autoleds.c marco.casaroli@gmail.com
-boards/arm/rp23xx/raspberrypi-pico-2/src/rp23xx_boardinitialize.c marco.casaroli@gmail.com
-boards/arm/rp23xx/raspberrypi-pico-2/src/rp23xx_bringup.c marco.casaroli@gmail.com
-boards/arm/rp23xx/raspberrypi-pico-2/src/rp23xx_buttons.c marco.casaroli@gmail.com
-boards/arm/rp23xx/raspberrypi-pico-2/src/rp23xx_gpio.c marco.casaroli@gmail.com
-boards/arm/rp23xx/raspberrypi-pico-2/src/rp23xx_pico.h marco.casaroli@gmail.com
-boards/arm/rp23xx/raspberrypi-pico-2/src/rp23xx_userleds.c marco.casaroli@gmail.com
-boards/arm/rp23xx/xiao-rp2350/Kconfig rcsim10@gmail.com
-boards/arm/rp23xx/xiao-rp2350/configs/combo/defconfig rcsim10@gmail.com serg@podtynnyi.com
-boards/arm/rp23xx/xiao-rp2350/configs/nsh/defconfig rcsim10@gmail.com serg@podtynnyi.com
-boards/arm/rp23xx/xiao-rp2350/configs/usbnsh/defconfig rcsim10@gmail.com serg@podtynnyi.com
-boards/arm/rp23xx/xiao-rp2350/include/board.h rcsim10@gmail.com
-boards/arm/rp23xx/xiao-rp2350/include/rp23xx_i2cdev.h rcsim10@gmail.com
-boards/arm/rp23xx/xiao-rp2350/include/rp23xx_i2sdev.h rcsim10@gmail.com
-boards/arm/rp23xx/xiao-rp2350/include/rp23xx_spidev.h rcsim10@gmail.com
-boards/arm/rp23xx/xiao-rp2350/include/rp23xx_spisd.h rcsim10@gmail.com
-boards/arm/rp23xx/xiao-rp2350/scripts/memmap_copy_to_ram.ld rcsim10@gmail.com
-boards/arm/rp23xx/xiao-rp2350/scripts/memmap_default.ld rcsim10@gmail.com
-boards/arm/rp23xx/xiao-rp2350/scripts/memmap_no_flash.ld rcsim10@gmail.com
-boards/arm/rp23xx/xiao-rp2350/src/etc/init.d/rc.sysinit rcsim10@gmail.com
-boards/arm/rp23xx/xiao-rp2350/src/etc/init.d/rcS rcsim10@gmail.com
-boards/arm/rp23xx/xiao-rp2350/src/rp23xx_appinit.c rcsim10@gmail.com
-boards/arm/rp23xx/xiao-rp2350/src/rp23xx_autoleds.c rcsim10@gmail.com
-boards/arm/rp23xx/xiao-rp2350/src/rp23xx_boardinitialize.c rcsim10@gmail.com
-boards/arm/rp23xx/xiao-rp2350/src/rp23xx_bringup.c rcsim10@gmail.com
-boards/arm/rp23xx/xiao-rp2350/src/rp23xx_gpio.c rcsim10@gmail.com
-boards/arm/rp23xx/xiao-rp2350/src/rp23xx_pico.h rcsim10@gmail.com
-boards/arm/rp23xx/xiao-rp2350/src/rp23xx_userleds.c rcsim10@gmail.com
+
+boards/arm/rp2040/* 58759586+curuvar@users.noreply.github.com serg@podtynnyi.com acassis@gmail.com alin.jerpelea@sony.com y.512.nakamura@gmail.com xiaoxiang@xiaomi.com
+boards/arm/rp2040/w5500-evb-pico/* michael.jung@secore.ly serg@podtynnyi.com
+boards/arm/rp2040/waveshare-rp2040-lcd-1.28/* bijunda1@xiaomi.com serg@podtynnyi.com
+boards/arm/rp2040/waveshare-rp2040-zero/* rovnerhenry@gmail.com serg@podtynnyi.com
+boards/arm/rp23xx/* marco.casaroli@gmail.com serg@podtynnyi.com
+
 boards/arm/s32k1xx/rddrone-bms772/Kconfig jari.vanewijk@nxp.com
 boards/arm/s32k1xx/rddrone-bms772/configs/nsh/defconfig jari.vanewijk@nxp.com acassis@gmail.com
 boards/arm/s32k1xx/rddrone-bms772/include/board.h jari.vanewijk@nxp.com alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com
@@ -15694,54 +11637,9 @@ boards/arm/xmc4/xmc4800-relax/src/xmc4_bringup.c thomas.narayana-swamy@wandercra
 boards/arm/xmc4/xmc4800-relax/src/xmc4_buttons.c thomas.narayana-swamy@wandercraft.eu alin.jerpelea@sony.com
 boards/arm/xmc4/xmc4800-relax/src/xmc4_spi.c thomas.narayana-swamy@wandercraft.eu alin.jerpelea@sony.com
 boards/arm/xmc4/xmc4800-relax/src/xmc4_userleds.c thomas.narayana-swamy@wandercraft.eu alin.jerpelea@sony.com
-boards/arm64/a527/avaota-a1/Kconfig luppy@appkaki.com
-boards/arm64/a527/avaota-a1/configs/nsh/defconfig luppy@appkaki.com
-boards/arm64/a527/avaota-a1/include/board.h luppy@appkaki.com
-boards/arm64/a527/avaota-a1/include/board_memorymap.h luppy@appkaki.com
-boards/arm64/a527/avaota-a1/scripts/gnu-elf.ld luppy@appkaki.com
-boards/arm64/a527/avaota-a1/scripts/ld.script luppy@appkaki.com
-boards/arm64/a527/avaota-a1/src/Makefile luppy@appkaki.com
-boards/arm64/a527/avaota-a1/src/a527_appinit.c luppy@appkaki.com
-boards/arm64/a527/avaota-a1/src/a527_boardinit.c luppy@appkaki.com
-boards/arm64/a527/avaota-a1/src/a527_bringup.c luppy@appkaki.com
-boards/arm64/a527/avaota-a1/src/a527_power.c luppy@appkaki.com
-boards/arm64/a527/avaota-a1/src/avaota-a1.h luppy@appkaki.com
-boards/arm64/a64/pinephone/Kconfig luppy@appkaki.com
-boards/arm64/a64/pinephone/configs/lcd/defconfig luppy@appkaki.com acassis@gmail.com mazhuang@xiaomi.com fangxinyong@xiaomi.com qinwei1@xiaomi.com
-boards/arm64/a64/pinephone/configs/lvgl/defconfig luppy@appkaki.com xuxingliang@xiaomi.com acassis@gmail.com mazhuang@xiaomi.com fangxinyong@xiaomi.com
-boards/arm64/a64/pinephone/configs/nsh/defconfig luppy@appkaki.com acassis@gmail.com mazhuang@xiaomi.com fangxinyong@xiaomi.com qinwei1@xiaomi.com
-boards/arm64/a64/pinephone/configs/sensor/defconfig fft@feedforward.com.cn acassis@gmail.com luppy@appkaki.com mazhuang@xiaomi.com fangxinyong@xiaomi.com
-boards/arm64/a64/pinephone/include/board.h luppy@appkaki.com alin.jerpelea@sony.com
-boards/arm64/a64/pinephone/include/board_memorymap.h luppy@appkaki.com alin.jerpelea@sony.com
-boards/arm64/a64/pinephone/scripts/dramboot.ld luppy@appkaki.com cuiziwei@xiaomi.com zhangyuan21@xiaomi.com alin.jerpelea@sony.com ville.juven@unikie.com
-boards/arm64/a64/pinephone/src/Makefile luppy@appkaki.com fft@feedforward.com.cn alin.jerpelea@sony.com
-boards/arm64/a64/pinephone/src/pinephone.h luppy@appkaki.com alin.jerpelea@sony.com
-boards/arm64/a64/pinephone/src/pinephone_appinit.c luppy@appkaki.com alin.jerpelea@sony.com
-boards/arm64/a64/pinephone/src/pinephone_autoleds.c luppy@appkaki.com anchao@xiaomi.com alin.jerpelea@sony.com
-boards/arm64/a64/pinephone/src/pinephone_boardinit.c luppy@appkaki.com alin.jerpelea@sony.com
-boards/arm64/a64/pinephone/src/pinephone_bringup.c luppy@appkaki.com fft@feedforward.com.cn alin.jerpelea@sony.com
-boards/arm64/a64/pinephone/src/pinephone_display.c luppy@appkaki.com lipengfei28@xiaomi.com alin.jerpelea@sony.com
-boards/arm64/a64/pinephone/src/pinephone_display.h luppy@appkaki.com alin.jerpelea@sony.com
-boards/arm64/a64/pinephone/src/pinephone_lcd.c luppy@appkaki.com alin.jerpelea@sony.com
-boards/arm64/a64/pinephone/src/pinephone_lcd.h luppy@appkaki.com alin.jerpelea@sony.com
-boards/arm64/a64/pinephone/src/pinephone_pmic.c luppy@appkaki.com alin.jerpelea@sony.com
-boards/arm64/a64/pinephone/src/pinephone_pmic.h luppy@appkaki.com alin.jerpelea@sony.com
-boards/arm64/a64/pinephone/src/pinephone_reset.c fft@feedforward.com.cn alin.jerpelea@sony.com
-boards/arm64/a64/pinephone/src/pinephone_touch.c luppy@appkaki.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/arm64/a64/pinephone/src/pinephone_touch.h luppy@appkaki.com alin.jerpelea@sony.com
-boards/arm64/a64/pinephone/src/pinephone_userleds.c luppy@appkaki.com anchao@xiaomi.com alin.jerpelea@sony.com
-boards/arm64/bcm2711/raspberrypi-4b/Kconfig 101105604+simbit18@users.noreply.github.com matteo.golin@gmail.com
-boards/arm64/bcm2711/raspberrypi-4b/configs/nsh/defconfig matteo.golin@gmail.com mazhuang@xiaomi.com
-boards/arm64/bcm2711/raspberrypi-4b/include/board.h matteo.golin@gmail.com
-boards/arm64/bcm2711/raspberrypi-4b/scripts/dramboot.ld matteo.golin@gmail.com
-boards/arm64/bcm2711/raspberrypi-4b/src/Makefile matteo.golin@gmail.com
-boards/arm64/bcm2711/raspberrypi-4b/src/bcm2711_i2cdev.c matteo.golin@gmail.com
-boards/arm64/bcm2711/raspberrypi-4b/src/bcm2711_i2cdev.h matteo.golin@gmail.com
-boards/arm64/bcm2711/raspberrypi-4b/src/rpi4b.h matteo.golin@gmail.com
-boards/arm64/bcm2711/raspberrypi-4b/src/rpi4b_appinit.c matteo.golin@gmail.com
-boards/arm64/bcm2711/raspberrypi-4b/src/rpi4b_boardinitialize.c matteo.golin@gmail.com
-boards/arm64/bcm2711/raspberrypi-4b/src/rpi4b_bringup.c matteo.golin@gmail.com
-boards/arm64/bcm2711/raspberrypi-4b/src/rpi4b_gpio.c matteo.golin@gmail.com
+boards/arm64/a527/avaota-a1/* luppy@appkaki.com
+boards/arm64/a64/pinephone/* luppy@appkaki.com
+boards/arm64/bcm2711/* matteo.golin@gmail.com
 boards/arm64/fvp-v8r/fvp-armv8r/Kconfig qinwei1@xiaomi.com
 boards/arm64/fvp-v8r/fvp-armv8r/configs/citest/defconfig nietingting@xiaomi.com acassis@gmail.com mazhuang@xiaomi.com liguiding1@xiaomi.com fangxinyong@xiaomi.com
 boards/arm64/fvp-v8r/fvp-armv8r/configs/citest_smp/defconfig nietingting@xiaomi.com acassis@gmail.com mazhuang@xiaomi.com liguiding1@xiaomi.com fangxinyong@xiaomi.com
@@ -15757,16 +11655,7 @@ boards/arm64/fvp-v8r/fvp-armv8r/src/fvp-armv8r.h qinwei1@xiaomi.com 101105604+si
 boards/arm64/fvp-v8r/fvp-armv8r/src/fvp_appinit.c qinwei1@xiaomi.com alin.jerpelea@sony.com
 boards/arm64/fvp-v8r/fvp-armv8r/src/fvp_boardinit.c qinwei1@xiaomi.com alin.jerpelea@sony.com
 boards/arm64/fvp-v8r/fvp-armv8r/src/fvp_bringup.c qinwei1@xiaomi.com alin.jerpelea@sony.com
-boards/arm64/imx8/imx8qm-mek/Kconfig qinwei1@xiaomi.com
-boards/arm64/imx8/imx8qm-mek/configs/nsh/defconfig qinwei1@xiaomi.com acassis@gmail.com mazhuang@xiaomi.com liguiding1@xiaomi.com fangxinyong@xiaomi.com
-boards/arm64/imx8/imx8qm-mek/include/board.h thomas.narayana-swamy@wandercraft.eu alin.jerpelea@sony.com
-boards/arm64/imx8/imx8qm-mek/include/board_memorymap.h qinwei1@xiaomi.com 101105604+simbit18@users.noreply.github.com alin.jerpelea@sony.com
-boards/arm64/imx8/imx8qm-mek/scripts/dramboot.ld qinwei1@xiaomi.com cuiziwei@xiaomi.com alin.jerpelea@sony.com ville.juven@unikie.com
-boards/arm64/imx8/imx8qm-mek/src/Makefile qinwei1@xiaomi.com alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com
-boards/arm64/imx8/imx8qm-mek/src/imx8_appinit.c qinwei1@xiaomi.com alin.jerpelea@sony.com
-boards/arm64/imx8/imx8qm-mek/src/imx8_boardinit.c qinwei1@xiaomi.com alin.jerpelea@sony.com
-boards/arm64/imx8/imx8qm-mek/src/imx8_bringup.c qinwei1@xiaomi.com alin.jerpelea@sony.com
-boards/arm64/imx8/imx8qm-mek/src/imx8qm-mek.h qinwei1@xiaomi.com 101105604+simbit18@users.noreply.github.com alin.jerpelea@sony.com
+boards/arm64/imx8/imx8qm-mek/* qinwei1@xiaomi.com
 boards/arm64/imx9/imx93-evk/Kconfig ville.juven@unikie.com 101105604+simbit18@users.noreply.github.com
 boards/arm64/imx9/imx93-evk/configs/bootloader/defconfig eero.nurkkala@offcode.fi wangjianyu3@xiaomi.com mazhuang@xiaomi.com anchao@lixiang.com jukkax@ssrc.tii.ae
 boards/arm64/imx9/imx93-evk/configs/knsh/defconfig gpoulios@census-labs.com
@@ -16282,400 +12171,12 @@ boards/risc-v/eic7700x/starpro64/src/Makefile luppy@appkaki.com
 boards/risc-v/eic7700x/starpro64/src/eic7700x_appinit.c luppy@appkaki.com
 boards/risc-v/eic7700x/starpro64/src/etc/init.d/rc.sysinit luppy@appkaki.com
 boards/risc-v/eic7700x/starpro64/src/etc/init.d/rcS luppy@appkaki.com
-boards/risc-v/esp32c3-legacy/common/.gitignore eren.terzioglu@espressif.com
-boards/risc-v/esp32c3-legacy/common/Kconfig eren.terzioglu@espressif.com
-boards/risc-v/esp32c3-legacy/common/Makefile eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/include/esp32c3_board_adc.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/include/esp32c3_board_apds9960.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/include/esp32c3_board_bmp180.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/include/esp32c3_board_i2c.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/include/esp32c3_board_ice40.h janouja9@fel.cvut.cz alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/include/esp32c3_board_ledc.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/include/esp32c3_board_mpu60x0_i2c.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/include/esp32c3_board_oneshot.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/include/esp32c3_board_spidev.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/include/esp32c3_board_spiflash.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/include/esp32c3_board_spislavedev.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/include/esp32c3_board_twai.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/include/esp32c3_board_wdt.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/include/esp32c3_board_wlan.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/kernel/Makefile eren.terzioglu@espressif.com alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com
-boards/risc-v/esp32c3-legacy/common/kernel/esp32c3_userspace.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/scripts/.gitignore eren.terzioglu@espressif.com
-boards/risc-v/esp32c3-legacy/common/scripts/esp32c3_aliases.ld eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/scripts/esp32c3_rom.ld eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/scripts/flat_memory.ld eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/scripts/kernel-space.ld eren.terzioglu@espressif.com inochiama@outlook.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/scripts/legacy_sections.ld eren.terzioglu@espressif.com inochiama@outlook.com alin.jerpelea@sony.com tiago.medicci@espressif.com
-boards/risc-v/esp32c3-legacy/common/scripts/mcuboot_sections.ld eren.terzioglu@espressif.com inochiama@outlook.com alin.jerpelea@sony.com tiago.medicci@espressif.com
-boards/risc-v/esp32c3-legacy/common/scripts/protected_memory.ld eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/scripts/user-space.ld eren.terzioglu@espressif.com inochiama@outlook.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/src/esp32c3_board_adc.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/src/esp32c3_board_apa102.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/src/esp32c3_board_apds9960.c eren.terzioglu@espressif.com alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com
-boards/risc-v/esp32c3-legacy/common/src/esp32c3_board_bmp180.c eren.terzioglu@espressif.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-boards/risc-v/esp32c3-legacy/common/src/esp32c3_board_gc9a01.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/src/esp32c3_board_i2c.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/src/esp32c3_board_ice40.c janouja9@fel.cvut.cz alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/src/esp32c3_board_ledc.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/src/esp32c3_board_mpu60x0_i2c.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/src/esp32c3_board_oneshot.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/src/esp32c3_board_spi.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/src/esp32c3_board_spidev.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/src/esp32c3_board_spiflash.c eren.terzioglu@espressif.com jingfei@xiaomi.com  alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/src/esp32c3_board_spislavedev.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/src/esp32c3_board_st7735.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/src/esp32c3_board_st7789.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/src/esp32c3_board_twai.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/src/esp32c3_board_wdt.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/common/src/esp32c3_board_wlan.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit-rust-1/Kconfig eren.terzioglu@espressif.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit-rust-1/configs/brickmatch/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit-rust-1/configs/nsh/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit-rust-1/include/board.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit-rust-1/include/board_memorymap.h eren.terzioglu@espressif.com alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit-rust-1/src/esp32c3-devkit-rust-1.h eren.terzioglu@espressif.com alin.jerpelea@sony.com huangqi3@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit-rust-1/src/esp32c3_appinit.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit-rust-1/src/esp32c3_autoleds.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit-rust-1/src/esp32c3_boot.c eren.terzioglu@espressif.com huangqi3@xiaomi.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit-rust-1/src/esp32c3_bringup.c eren.terzioglu@espressif.com huangqi3@xiaomi.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit-rust-1/src/esp32c3_ioctl.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit-rust-1/src/esp32c3_reset.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/Kconfig eren.terzioglu@espressif.com 101105604+simbit18@users.noreply.github.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/adc/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/autopm/defconfig eren.terzioglu@espressif.com wangjianyu3@xiaomi.com acassis@gmail.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/ble/defconfig eren.terzioglu@espressif.com wangjianyu3@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/bmp180/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/coremark/defconfig eren.terzioglu@espressif.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/crypto/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/cxx/defconfig eren.terzioglu@espressif.com jihandong@xiaomi.com yinshengkai@xiaomi.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/efuse/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/elf/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/gdbstub/defconfig eren.terzioglu@espressif.com wangjianyu3@xiaomi.com acassis@gmail.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/gpio/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/knsh/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/lvgl/defconfig eren.terzioglu@espressif.com xuxingliang@xiaomi.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/mcuboot_slot_confirm/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/module/defconfig eren.terzioglu@espressif.com wangjianyu3@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/nsh/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/nvcfgdata/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/oneshot/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/ostest/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/pm/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/pwm/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/random/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/romfs/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/rtc/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/sotest/defconfig eren.terzioglu@espressif.com wangjianyu3@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/spiflash/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/sta_softap/defconfig eren.terzioglu@espressif.com tiago.medicci@espressif.com wangjianyu3@xiaomi.com acassis@gmail.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/tickless/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/timer/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/twai/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/uid/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/usbconsole/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/watchdog/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/watcher/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/configs/wifi/defconfig eren.terzioglu@espressif.com wangjianyu3@xiaomi.com acassis@gmail.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/include/board.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/include/board_memorymap.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/src/esp32c3-devkit.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/src/esp32c3_appinit.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/src/esp32c3_boot.c eren.terzioglu@espressif.com huangqi3@xiaomi.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/src/esp32c3_bringup.c eren.terzioglu@espressif.com janouja9@fel.cvut.cz huangqi3@xiaomi.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/src/esp32c3_gpio.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/src/esp32c3_ioctl.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/src/esp32c3_reset.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/src/esp32c3_uid.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/src/etc/group eren.terzioglu@espressif.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/src/etc/init.d/rc.sysinit eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/src/etc/init.d/rcS eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3-legacy/esp32c3-devkit/src/etc/passwd eren.terzioglu@espressif.com
-boards/risc-v/esp32c3/common/.gitignore huangqi3@xiaomi.com eren.terzioglu@espressif.com xiaoxiang@xiaomi.com
-boards/risc-v/esp32c3/common/Kconfig eren.terzioglu@espressif.com gustavo.nihei@espressif.com 101105604+simbit18@users.noreply.github.com
-boards/risc-v/esp32c3/common/Makefile eren.terzioglu@espressif.com gustavo.nihei@espressif.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/risc-v/esp32c3/common/include/esp_board_adc.h filipe.cavalcanti@espressif.com
-boards/risc-v/esp32c3/common/include/esp_board_bmp180.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/common/include/esp_board_i2c.h eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/common/include/esp_board_i2s.h eren.terzioglu@espressif.com
-boards/risc-v/esp32c3/common/include/esp_board_ledc.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/common/include/esp_board_mmcsd.h filipe.cavalcanti@espressif.com
-boards/risc-v/esp32c3/common/include/esp_board_rmt.h tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/common/include/esp_board_spidev.h eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/common/include/esp_board_spiflash.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/common/include/esp_board_spislavedev.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/common/include/esp_board_wlan.h tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/common/scripts/.gitignore eren.terzioglu@espressif.com gustavo.nihei@espressif.com
-boards/risc-v/esp32c3/common/scripts/common.ld eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/common/scripts/esp32c3_aliases.ld eren.terzioglu@espressif.com gustavo.nihei@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com tiago.medicci@espressif.com
-boards/risc-v/esp32c3/common/scripts/esp32c3_flat_memory.ld eren.terzioglu@espressif.com tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/common/scripts/esp32c3_legacy_sections.ld eren.terzioglu@espressif.com inochiama@outlook.com tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/common/scripts/esp32c3_sections.ld eren.terzioglu@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com gewalalb@gmail.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/common/src/esp_board_adc.c filipe.cavalcanti@espressif.com
-boards/risc-v/esp32c3/common/src/esp_board_bmp180.c eren.terzioglu@espressif.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-boards/risc-v/esp32c3/common/src/esp_board_i2c.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/common/src/esp_board_i2s.c eren.terzioglu@espressif.com
-boards/risc-v/esp32c3/common/src/esp_board_ledc.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/common/src/esp_board_mmcsd.c filipe.cavalcanti@espressif.com
-boards/risc-v/esp32c3/common/src/esp_board_rmt.c tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/common/src/esp_board_spi.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/common/src/esp_board_spidev.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/common/src/esp_board_spiflash.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com  jingfei@xiaomi.com tiago.medicci@espressif.com
-boards/risc-v/esp32c3/common/src/esp_board_spislavedev.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/common/src/esp_board_twai.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/common/src/esp_board_wlan.c tiago.medicci@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/esp32c3-generic/Kconfig eren.terzioglu@espressif.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/adc/defconfig filipe.cavalcanti@espressif.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/ble/defconfig eren.terzioglu@espressif.com wangjianyu3@xiaomi.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/bmp180/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/buttons/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/crypto/defconfig eren.terzioglu@espressif.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/efuse/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/gpio/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/i2c/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/i2schar/defconfig eren.terzioglu@espressif.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/mcuboot_nsh/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/mcuboot_update_agent/defconfig filipe.cavalcanti@espressif.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/nimble/defconfig laczenjms@gmail.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/nsh/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/ostest/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/pwm/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/random/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/rmt/defconfig tiago.medicci@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/rtc/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/sdm/defconfig eren.terzioglu@espressif.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/sdmmc_spi/defconfig filipe.cavalcanti@espressif.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/spi/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/spiflash/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/sta_softap/defconfig tiago.medicci@espressif.com filipe.cavalcanti@espressif.com mazhuang@xiaomi.com acassis@gmail.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/temperature_sensor/defconfig eren.terzioglu@espressif.com anchao.archer@bytedance.com xiaoxiang@xiaomi.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/tickless/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/timers/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/twai/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/usbconsole/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/watchdog/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c3/esp32c3-generic/configs/wifi/defconfig tiago.medicci@espressif.com filipe.cavalcanti@espressif.com mazhuang@xiaomi.com acassis@gmail.com
-boards/risc-v/esp32c3/esp32c3-generic/include/board.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/esp32c3-generic/src/esp32c3-generic.h eren.terzioglu@espressif.com tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/esp32c3-generic/src/esp32c3_appinit.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/esp32c3-generic/src/esp32c3_boot.c eren.terzioglu@espressif.com alin.jerpelea@sony.com huangqi3@xiaomi.com
-boards/risc-v/esp32c3/esp32c3-generic/src/esp32c3_bringup.c eren.terzioglu@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/esp32c3-generic/src/esp32c3_buttons.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/esp32c3-generic/src/esp32c3_gpio.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/esp32c3-generic/src/esp32c3_reset.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c3/esp32c3-xiao/Kconfig rcsim10@gmail.com
-boards/risc-v/esp32c3/esp32c3-xiao/configs/ble/defconfig rcsim10@gmail.com
-boards/risc-v/esp32c3/esp32c3-xiao/configs/gpio/defconfig rcsim10@gmail.com
-boards/risc-v/esp32c3/esp32c3-xiao/configs/nsh/defconfig rcsim10@gmail.com
-boards/risc-v/esp32c3/esp32c3-xiao/configs/usbnsh/defconfig rcsim10@gmail.com
-boards/risc-v/esp32c3/esp32c3-xiao/configs/wifi/defconfig rcsim10@gmail.com
-boards/risc-v/esp32c3/esp32c3-xiao/include/board.h rcsim10@gmail.com
-boards/risc-v/esp32c3/esp32c3-xiao/src/esp32c3-xiao.h rcsim10@gmail.com
-boards/risc-v/esp32c3/esp32c3-xiao/src/esp32c3_appinit.c rcsim10@gmail.com
-boards/risc-v/esp32c3/esp32c3-xiao/src/esp32c3_boot.c rcsim10@gmail.com
-boards/risc-v/esp32c3/esp32c3-xiao/src/esp32c3_bringup.c rcsim10@gmail.com
-boards/risc-v/esp32c3/esp32c3-xiao/src/esp32c3_gpio.c rcsim10@gmail.com
-boards/risc-v/esp32c3/esp32c3-xiao/src/esp32c3_reset.c rcsim10@gmail.com
-boards/risc-v/esp32c6/common/.gitignore huangqi3@xiaomi.com
-boards/risc-v/esp32c6/common/Kconfig eren.terzioglu@espressif.com
-boards/risc-v/esp32c6/common/Makefile eren.terzioglu@espressif.com chenwen@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/common/include/esp_board_adc.h filipe.cavalcanti@espressif.com
-boards/risc-v/esp32c6/common/include/esp_board_bmp180.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/common/include/esp_board_i2c.h eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/common/include/esp_board_i2s.h eren.terzioglu@espressif.com
-boards/risc-v/esp32c6/common/include/esp_board_ledc.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/common/include/esp_board_mcpwm.h filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/common/include/esp_board_mfrc522.h moura.fmo@gmail.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/common/include/esp_board_mmcsd.h filipe.cavalcanti@espressif.com
-boards/risc-v/esp32c6/common/include/esp_board_mpu60x0.h filipe.cavalcanti@espressif.com
-boards/risc-v/esp32c6/common/include/esp_board_pcnt.h eren.terzioglu@espressif.com
-boards/risc-v/esp32c6/common/include/esp_board_rmt.h tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/common/include/esp_board_spidev.h eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/common/include/esp_board_spiflash.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/common/include/esp_board_spislavedev.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/common/include/esp_board_wlan.h tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/common/scripts/.gitignore eren.terzioglu@espressif.com chenwen@espressif.com
-boards/risc-v/esp32c6/common/scripts/common.ld eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/common/scripts/esp32c6_aliases.ld eren.terzioglu@espressif.com alin.jerpelea@sony.com tiago.medicci@espressif.com
-boards/risc-v/esp32c6/common/scripts/esp32c6_flat_memory.ld eren.terzioglu@espressif.com tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/common/scripts/esp32c6_legacy_sections.ld eren.terzioglu@espressif.com inochiama@outlook.com tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/common/scripts/esp32c6_sections.ld eren.terzioglu@espressif.com tiago.medicci@espressif.com almir.okato@espressif.com filipe.cavalcanti@espressif.com gewalalb@gmail.com
-boards/risc-v/esp32c6/common/src/esp_board_adc.c filipe.cavalcanti@espressif.com
-boards/risc-v/esp32c6/common/src/esp_board_bmp180.c eren.terzioglu@espressif.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-boards/risc-v/esp32c6/common/src/esp_board_i2c.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/common/src/esp_board_i2s.c eren.terzioglu@espressif.com
-boards/risc-v/esp32c6/common/src/esp_board_ledc.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/common/src/esp_board_mcpwm.c filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/common/src/esp_board_mfrc522.c moura.fmo@gmail.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/common/src/esp_board_mmcsd.c filipe.cavalcanti@espressif.com
-boards/risc-v/esp32c6/common/src/esp_board_mpu60x0.c filipe.cavalcanti@espressif.com
-boards/risc-v/esp32c6/common/src/esp_board_pcnt.c eren.terzioglu@espressif.com martin.vajnar@gmail.com
-boards/risc-v/esp32c6/common/src/esp_board_rmt.c tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/common/src/esp_board_spi.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/common/src/esp_board_spidev.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/common/src/esp_board_spiflash.c eren.terzioglu@espressif.com davi.silva@agrosystem.com.br filipe.cavalcanti@espressif.com jingfei@xiaomi.com
-boards/risc-v/esp32c6/common/src/esp_board_spislavedev.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/common/src/esp_board_twai.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/common/src/esp_board_wlan.c tiago.medicci@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/esp32c6-devkitc/Kconfig eren.terzioglu@espressif.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/adc/defconfig filipe.cavalcanti@espressif.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/bmp180/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/buttons/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/capture/defconfig filipe.cavalcanti@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/crypto/defconfig eren.terzioglu@espressif.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/efuse/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/gpio/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/i2c/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/i2schar/defconfig eren.terzioglu@espressif.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/mcuboot_nsh/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/mcuboot_update_agent/defconfig filipe.cavalcanti@espressif.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/motor/defconfig filipe.cavalcanti@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/mpu60x0/defconfig filipe.cavalcanti@espressif.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/nsh/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/ostest/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/pwm/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/qencoder/defconfig martin.vajnar@gmail.com mazhuang@xiaomi.com eren.terzioglu@espressif.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/random/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/rmt/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/rtc/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/sdm/defconfig eren.terzioglu@espressif.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/sdmmc_spi/defconfig filipe.cavalcanti@espressif.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/spi/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com tiago.medicci@espressif.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/spiflash/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/spislv/defconfig moura.fmo@gmail.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/sta_softap/defconfig tiago.medicci@espressif.com filipe.cavalcanti@espressif.com mazhuang@xiaomi.com acassis@gmail.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/temperature_sensor/defconfig eren.terzioglu@espressif.com anchao.archer@bytedance.com xiaoxiang@xiaomi.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/tickless/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/timers/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/twai/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/usbconsole/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/watchdog/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitc/configs/wifi/defconfig tiago.medicci@espressif.com filipe.cavalcanti@espressif.com mazhuang@xiaomi.com acassis@gmail.com
-boards/risc-v/esp32c6/esp32c6-devkitc/include/board.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/esp32c6-devkitc/src/esp32c6-devkitc.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/esp32c6-devkitc/src/esp32c6_appinit.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/esp32c6-devkitc/src/esp32c6_boot.c eren.terzioglu@espressif.com alin.jerpelea@sony.com huangqi3@xiaomi.com moura.fmo@gmail.com
-boards/risc-v/esp32c6/esp32c6-devkitc/src/esp32c6_bringup.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com mich4l.matias@gmail.com tiago.medicci@espressif.com martin.vajnar@gmail.com
-boards/risc-v/esp32c6/esp32c6-devkitc/src/esp32c6_buttons.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/esp32c6-devkitc/src/esp32c6_gpio.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/esp32c6-devkitc/src/esp32c6_reset.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/esp32c6-devkitm/Kconfig eren.terzioglu@espressif.com
-boards/risc-v/esp32c6/esp32c6-devkitm/configs/bmp180/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitm/configs/buttons/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitm/configs/efuse/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitm/configs/gpio/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitm/configs/i2c/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitm/configs/i2schar/defconfig eren.terzioglu@espressif.com
-boards/risc-v/esp32c6/esp32c6-devkitm/configs/mcuboot_nsh/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitm/configs/nsh/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitm/configs/ostest/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitm/configs/pwm/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitm/configs/random/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitm/configs/rmt/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitm/configs/rtc/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitm/configs/sdmmc_spi/defconfig filipe.cavalcanti@espressif.com
-boards/risc-v/esp32c6/esp32c6-devkitm/configs/spi/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com tiago.medicci@espressif.com
-boards/risc-v/esp32c6/esp32c6-devkitm/configs/spiflash/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitm/configs/spislv/defconfig moura.fmo@gmail.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitm/configs/sta_softap/defconfig tiago.medicci@espressif.com filipe.cavalcanti@espressif.com mazhuang@xiaomi.com acassis@gmail.com
-boards/risc-v/esp32c6/esp32c6-devkitm/configs/tickless/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitm/configs/timers/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitm/configs/twai/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitm/configs/usbconsole/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitm/configs/watchdog/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32c6/esp32c6-devkitm/configs/wifi/defconfig tiago.medicci@espressif.com filipe.cavalcanti@espressif.com mazhuang@xiaomi.com acassis@gmail.com
-boards/risc-v/esp32c6/esp32c6-devkitm/include/board.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/esp32c6-devkitm/src/esp32c6-devkitm.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/esp32c6-devkitm/src/esp32c6_appinit.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/esp32c6-devkitm/src/esp32c6_boot.c eren.terzioglu@espressif.com alin.jerpelea@sony.com huangqi3@xiaomi.com moura.fmo@gmail.com
-boards/risc-v/esp32c6/esp32c6-devkitm/src/esp32c6_bringup.c eren.terzioglu@espressif.com mich4l.matias@gmail.com tiago.medicci@espressif.com moura.fmo@gmail.com filipe.cavalcanti@espressif.com
-boards/risc-v/esp32c6/esp32c6-devkitm/src/esp32c6_buttons.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/esp32c6-devkitm/src/esp32c6_gpio.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/esp32c6-devkitm/src/esp32c6_reset.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32c6/esp32c6-xiao/Kconfig rcsim10@gmail.com
-boards/risc-v/esp32c6/esp32c6-xiao/configs/gpio/defconfig rcsim10@gmail.com
-boards/risc-v/esp32c6/esp32c6-xiao/configs/nsh/defconfig rcsim10@gmail.com
-boards/risc-v/esp32c6/esp32c6-xiao/configs/usbnsh/defconfig rcsim10@gmail.com
-boards/risc-v/esp32c6/esp32c6-xiao/configs/wifi/defconfig rcsim10@gmail.com
-boards/risc-v/esp32c6/esp32c6-xiao/include/board.h rcsim10@gmail.com
-boards/risc-v/esp32c6/esp32c6-xiao/src/esp32c6-xiao.h rcsim10@gmail.com
-boards/risc-v/esp32c6/esp32c6-xiao/src/esp32c6_appinit.c rcsim10@gmail.com
-boards/risc-v/esp32c6/esp32c6-xiao/src/esp32c6_boot.c rcsim10@gmail.com
-boards/risc-v/esp32c6/esp32c6-xiao/src/esp32c6_bringup.c rcsim10@gmail.com filipe.cavalcanti@espressif.com
-boards/risc-v/esp32c6/esp32c6-xiao/src/esp32c6_gpio.c rcsim10@gmail.com
-boards/risc-v/esp32c6/esp32c6-xiao/src/esp32c6_reset.c rcsim10@gmail.com
-boards/risc-v/esp32h2/common/.gitignore huangqi3@xiaomi.com
-boards/risc-v/esp32h2/common/Kconfig eren.terzioglu@espressif.com
-boards/risc-v/esp32h2/common/Makefile eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/common/include/esp_board_adc.h filipe.cavalcanti@espressif.com
-boards/risc-v/esp32h2/common/include/esp_board_bmp180.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/common/include/esp_board_i2c.h eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/common/include/esp_board_i2s.h eren.terzioglu@espressif.com
-boards/risc-v/esp32h2/common/include/esp_board_ledc.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/common/include/esp_board_mcpwm.h filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/common/include/esp_board_mmcsd.h filipe.cavalcanti@espressif.com
-boards/risc-v/esp32h2/common/include/esp_board_pcnt.h eren.terzioglu@espressif.com
-boards/risc-v/esp32h2/common/include/esp_board_rmt.h tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/common/include/esp_board_spidev.h eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/common/include/esp_board_spiflash.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/common/include/esp_board_spislavedev.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/common/scripts/.gitignore eren.terzioglu@espressif.com
-boards/risc-v/esp32h2/common/scripts/common.ld eren.terzioglu@espressif.com tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/common/scripts/esp32h2_aliases.ld eren.terzioglu@espressif.com alin.jerpelea@sony.com tiago.medicci@espressif.com
-boards/risc-v/esp32h2/common/scripts/esp32h2_flat_memory.ld eren.terzioglu@espressif.com tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/common/scripts/esp32h2_legacy_sections.ld eren.terzioglu@espressif.com inochiama@outlook.com tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/common/scripts/esp32h2_sections.ld eren.terzioglu@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com gewalalb@gmail.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/common/src/esp_board_adc.c filipe.cavalcanti@espressif.com
-boards/risc-v/esp32h2/common/src/esp_board_bmp180.c eren.terzioglu@espressif.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-boards/risc-v/esp32h2/common/src/esp_board_i2c.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/common/src/esp_board_i2s.c eren.terzioglu@espressif.com
-boards/risc-v/esp32h2/common/src/esp_board_ledc.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/common/src/esp_board_mcpwm.c filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/common/src/esp_board_mmcsd.c filipe.cavalcanti@espressif.com
-boards/risc-v/esp32h2/common/src/esp_board_pcnt.c eren.terzioglu@espressif.com martin.vajnar@gmail.com
-boards/risc-v/esp32h2/common/src/esp_board_rmt.c tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/common/src/esp_board_spi.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/common/src/esp_board_spidev.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/common/src/esp_board_spiflash.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com  jingfei@xiaomi.com tiago.medicci@espressif.com
-boards/risc-v/esp32h2/common/src/esp_board_spislavedev.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/common/src/esp_board_twai.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/esp32h2-devkit/Kconfig eren.terzioglu@espressif.com 101105604+simbit18@users.noreply.github.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/adc/defconfig filipe.cavalcanti@espressif.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/bmp180/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/buttons/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/capture/defconfig filipe.cavalcanti@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/crypto/defconfig eren.terzioglu@espressif.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/efuse/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/gpio/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/i2c/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/i2schar/defconfig eren.terzioglu@espressif.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/mcuboot_nsh/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/motor/defconfig filipe.cavalcanti@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/nsh/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/ostest/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/pwm/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/qencoder/defconfig eren.terzioglu@espressif.com martin.vajnar@gmail.com mazhuang@xiaomi.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/random/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/rmt/defconfig tiago.medicci@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/rtc/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/sdm/defconfig eren.terzioglu@espressif.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/sdmmc_spi/defconfig filipe.cavalcanti@espressif.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/spi/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/spiflash/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/temperature_sensor/defconfig eren.terzioglu@espressif.com anchao.archer@bytedance.com xiaoxiang@xiaomi.com mazhuang@xiaomi.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/tickless/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/timers/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/twai/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/usbconsole/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32h2/esp32h2-devkit/configs/watchdog/defconfig eren.terzioglu@espressif.com mazhuang@xiaomi.com
-boards/risc-v/esp32h2/esp32h2-devkit/include/board.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/esp32h2-devkit/src/esp32h2-devkit.h eren.terzioglu@espressif.com tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/esp32h2-devkit/src/esp32h2_appinit.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/esp32h2-devkit/src/esp32h2_boot.c eren.terzioglu@espressif.com alin.jerpelea@sony.com huangqi3@xiaomi.com
-boards/risc-v/esp32h2/esp32h2-devkit/src/esp32h2_bringup.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/esp32h2-devkit/src/esp32h2_buttons.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/esp32h2-devkit/src/esp32h2_gpio.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/risc-v/esp32h2/esp32h2-devkit/src/esp32h2_reset.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
+
+boards/risc-v/esp32c3-legacy/* filipe.cavalcanti@espressif.com tiago.medicci@espressif.com eren.terzioglu@espressif.com
+boards/risc-v/esp32c3/* filipe.cavalcanti@espressif.com tiago.medicci@espressif.com eren.terzioglu@espressif.com
+boards/risc-v/esp32c6/* filipe.cavalcanti@espressif.com tiago.medicci@espressif.com eren.terzioglu@espressif.com
+boards/risc-v/esp32h2/* filipe.cavalcanti@espressif.com tiago.medicci@espressif.com eren.terzioglu@espressif.com
+
 boards/risc-v/fe310/hifive1-revb/Kconfig masayuki.ishikawa@gmail.com
 boards/risc-v/fe310/hifive1-revb/configs/nsh/defconfig masayuki.ishikawa@gmail.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com
 boards/risc-v/fe310/hifive1-revb/include/board.h masayuki.ishikawa@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
@@ -16899,47 +12400,9 @@ boards/risc-v/qemu-rv/rv-virt/src/qemu_rv_autoleds.c 88271018+rushabhvg@users.no
 boards/risc-v/qemu-rv/rv-virt/src/qemu_rv_userleds.c 88271018+rushabhvg@users.noreply.github.com alin.jerpelea@sony.com
 boards/risc-v/qemu-rv/rv-virt/src/romfs.h tiago.medicci@espressif.com alin.jerpelea@sony.com
 boards/risc-v/qemu-rv/rv-virt/src/romfs_stub.c tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/risc-v/rp23xx-rv/common/.gitignore serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/common/Kconfig serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/common/Makefile serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/common/include/rp23xx_common_bringup.h serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/common/include/rp23xx_common_initialize.h serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/common/include/rp23xx_pwmdev.h serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/common/include/rp23xx_uniqueid.h serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/common/src/.gitignore serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/common/src/rp23xx_common_bringup.c serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/common/src/rp23xx_common_initialize.c serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/common/src/rp23xx_composite.c serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/common/src/rp23xx_i2cdev.c serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/common/src/rp23xx_i2sdev.c serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/common/src/rp23xx_pwmdev.c serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/common/src/rp23xx_reset.c serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/common/src/rp23xx_spi.c serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/common/src/rp23xx_spidev.c serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/common/src/rp23xx_spisd.c serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/common/src/rp23xx_uniqueid.c serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/common/src/rp23xx_usbmsc.c serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/raspberrypi-pico-2-rv/Kconfig serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/raspberrypi-pico-2-rv/configs/nsh/defconfig serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/raspberrypi-pico-2-rv/configs/usbnsh/defconfig serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/raspberrypi-pico-2-rv/include/board.h serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/raspberrypi-pico-2-rv/include/rp23xx_i2cdev.h serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/raspberrypi-pico-2-rv/include/rp23xx_i2sdev.h serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/raspberrypi-pico-2-rv/include/rp23xx_spidev.h serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/raspberrypi-pico-2-rv/include/rp23xx_spisd.h serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/raspberrypi-pico-2-rv/scripts/memmap_copy_to_ram.ld serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/raspberrypi-pico-2-rv/scripts/memmap_default.ld serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/raspberrypi-pico-2-rv/scripts/memmap_no_flash.ld serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/raspberrypi-pico-2-rv/src/etc/init.d/rc.sysinit serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/raspberrypi-pico-2-rv/src/etc/init.d/rcS serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/raspberrypi-pico-2-rv/src/rp23xx_appinit.c serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/raspberrypi-pico-2-rv/src/rp23xx_autoleds.c serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/raspberrypi-pico-2-rv/src/rp23xx_boardinitialize.c serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/raspberrypi-pico-2-rv/src/rp23xx_bringup.c serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/raspberrypi-pico-2-rv/src/rp23xx_buttons.c serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/raspberrypi-pico-2-rv/src/rp23xx_gpio.c serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/raspberrypi-pico-2-rv/src/rp23xx_pico.h serg@podtynnyi.com
-boards/risc-v/rp23xx-rv/raspberrypi-pico-2-rv/src/rp23xx_userleds.c serg@podtynnyi.com
+
+boards/risc-v/rp23xx-rv/* serg@podtynnyi.com
+
 boards/risc-v/rv32m1/rv32m1-vega/Kconfig unixjet@hotmail.com petro.karashchenko@gmail.com
 boards/risc-v/rv32m1/rv32m1-vega/configs/buttons/defconfig unixjet@hotmail.com xiaoxiang@xiaomi.com liguiding1@xiaomi.com huangqi3@xiaomi.com dongjiuzhu1@xiaomi.com
 boards/risc-v/rv32m1/rv32m1-vega/configs/nsh-itcm/defconfig unixjet@hotmail.com xiaoxiang@xiaomi.com liguiding1@xiaomi.com huangqi3@xiaomi.com dongjiuzhu1@xiaomi.com
@@ -17122,761 +12585,11 @@ boards/tricore/tc397/a2g-tc397-5v-tft/src/tc397.h wangchengdong@lixiang.com
 boards/tricore/tc397/a2g-tc397-5v-tft/src/tc397_appinit.c wangchengdong@lixiang.com
 boards/tricore/tc397/a2g-tc397-5v-tft/src/tc397_boardinit.c wangchengdong@lixiang.com
 boards/tricore/tc397/a2g-tc397-5v-tft/src/tc397_bringup.c wangchengdong@lixiang.com
-boards/x86/qemu/qemu-i486/Kconfig alin.jerpelea@sony.com
-boards/x86/qemu/qemu-i486/configs/nsh/defconfig alin.jerpelea@sony.com masayuki.ishikawa@gmail.com xiaoxiang@xiaomi.com wangjianyu3@xiaomi.com liguiding1@xiaomi.com
-boards/x86/qemu/qemu-i486/configs/ostest/defconfig alin.jerpelea@sony.com xiaoxiang@xiaomi.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com liuhaitao@xiaomi.com
-boards/x86/qemu/qemu-i486/include/board.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/x86/qemu/qemu-i486/scripts/qemu.ld alin.jerpelea@sony.com cuiziwei@xiaomi.com
-boards/x86/qemu/qemu-i486/src/Makefile alin.jerpelea@sony.com xiaoxiang@xiaomi.com liuhaitao@xiaomi.com
-boards/x86/qemu/qemu-i486/src/qemu_appinit.c liuhaitao@xiaomi.com alin.jerpelea@sony.com masayuki.ishikawa@gmail.com xiaoxiang@xiaomi.com zhangyuan21@xiaomi.com
-boards/x86/qemu/qemu-i486/src/qemu_boot.c alin.jerpelea@sony.com zhangyuan21@xiaomi.com xiaoxiang@xiaomi.com
-boards/x86/qemu/qemu-i486/src/qemu_i486.h alin.jerpelea@sony.com gustavo.nihei@espressif.com
-boards/x86_64/intel64/qemu-intel64/Kconfig sonic.tw.tp@gmail.com bashton@brennanashton.com p-szafonimateusz@xiaomi.com 101105604+simbit18@users.noreply.github.com
-boards/x86_64/intel64/qemu-intel64/configs/earlyfb/defconfig bashton@brennanashton.com raiden00@railab.me p-szafonimateusz@xiaomi.com lipengfei28@xiaomi.com ouyangxiangzhen@xiaomi.com
-boards/x86_64/intel64/qemu-intel64/configs/fb/defconfig p-szafonimateusz@xiaomi.com jukka.laitinen@tii.ae
-boards/x86_64/intel64/qemu-intel64/configs/jumbo/defconfig raiden00@railab.me p-szafonimateusz@xiaomi.com xiaoxiang@xiaomi.com yezhonghui@xiaomi.com
-boards/x86_64/intel64/qemu-intel64/configs/knsh_romfs/defconfig p-szafonimateusz@xiaomi.com
-boards/x86_64/intel64/qemu-intel64/configs/knsh_romfs_pci/defconfig p-szafonimateusz@xiaomi.com
-boards/x86_64/intel64/qemu-intel64/configs/lvgl/defconfig p-szafonimateusz@xiaomi.com jukka.laitinen@tii.ae
-boards/x86_64/intel64/qemu-intel64/configs/nsh/defconfig bashton@brennanashton.com p-szafonimateusz@xiaomi.com liguiding1@xiaomi.com masayuki.ishikawa@gmail.com xiaoxiang@xiaomi.com
-boards/x86_64/intel64/qemu-intel64/configs/nsh_pci/defconfig p-szafonimateusz@xiaomi.com jukka.laitinen@tii.ae xiaoxiang@xiaomi.com
-boards/x86_64/intel64/qemu-intel64/configs/nsh_pci_smp/defconfig p-szafonimateusz@xiaomi.com jukka.laitinen@tii.ae xiaoxiang@xiaomi.com
-boards/x86_64/intel64/qemu-intel64/configs/ostest/defconfig xiaoxiang@xiaomi.com sonic.tw.tp@gmail.com p-szafonimateusz@xiaomi.com liguiding1@xiaomi.com masayuki.ishikawa@gmail.com
-boards/x86_64/intel64/qemu-intel64/include/board.h sonic.tw.tp@gmail.com petro.karashchenko@gmail.com alin.jerpelea@sony.com bashton@brennanashton.com gustavo.nihei@espressif.com
-boards/x86_64/intel64/qemu-intel64/scripts/qemu-kernel.ld p-szafonimateusz@xiaomi.com
-boards/x86_64/intel64/qemu-intel64/scripts/qemu.ld sonic.tw.tp@gmail.com liwenxiang1@xiaomi.com p-szafonimateusz@xiaomi.com cuiziwei@xiaomi.com ouyangxiangzhen@xiaomi.com
-boards/x86_64/intel64/qemu-intel64/src/Makefile sonic.tw.tp@gmail.com p-szafonimateusz@xiaomi.com bashton@brennanashton.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/x86_64/intel64/qemu-intel64/src/qemu_appinit.c p-szafonimateusz@xiaomi.com sonic.tw.tp@gmail.com bashton@brennanashton.com alin.jerpelea@sony.com zhangyuan21@xiaomi.com
-boards/x86_64/intel64/qemu-intel64/src/qemu_boot.c sonic.tw.tp@gmail.com p-szafonimateusz@xiaomi.com bashton@brennanashton.com alin.jerpelea@sony.com zhangyuan21@xiaomi.com
-boards/x86_64/intel64/qemu-intel64/src/qemu_bringup.c p-szafonimateusz@xiaomi.com bashton@brennanashton.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/x86_64/intel64/qemu-intel64/src/qemu_intel64.h sonic.tw.tp@gmail.com petro.karashchenko@gmail.com alin.jerpelea@sony.com bashton@brennanashton.com p-szafonimateusz@xiaomi.com
-boards/x86_64/intel64/qemu-intel64/src/qemu_net.c sonic.tw.tp@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com wangbowen6@xiaomi.com zhangyuan21@xiaomi.com
-boards/x86_64/intel64/qemu-intel64/src/qemu_reset.c p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-boards/x86_64/intel64/qemu-intel64/src/romfs.h p-szafonimateusz@xiaomi.com
-boards/x86_64/intel64/qemu-intel64/src/romfs_stub.c p-szafonimateusz@xiaomi.com
-boards/xtensa/esp32/common/.gitignore huangqi3@xiaomi.com
-boards/xtensa/esp32/common/Kconfig gustavo.nihei@espressif.com akaliszan@altimetrik.com 101105604+simbit18@users.noreply.github.com yamamoto@midokura.com abdelatif.guettouche@espressif.com
-boards/xtensa/esp32/common/Makefile abdelatif.guettouche@espressif.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/xtensa/esp32/common/include/board_qencoder.h acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/include/esp32_backlight.h halysson1007@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/include/esp32_bme680.h simona.alexandra2000@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/include/esp32_bmp180.h phfbertoleti@gmail.com petro.karashchenko@gmail.com alin.jerpelea@sony.com gustavo.nihei@espressif.com
-boards/xtensa/esp32/common/include/esp32_bmp280.h andreykvak.g3@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/include/esp32_board_adc.h filipe.cavalcanti@espressif.com devel@sumpfralle.de
-boards/xtensa/esp32/common/include/esp32_board_apds9960.h acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/include/esp32_board_dac.h tomas.pilny@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-boards/xtensa/esp32/common/include/esp32_board_i2c.h phfbertoleti@gmail.com petro.karashchenko@gmail.com alin.jerpelea@sony.com lucas.vaz@espressif.com
-boards/xtensa/esp32/common/include/esp32_board_mcpwm.h filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/include/esp32_board_oneshot.h sara.souza@espressif.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/include/esp32_board_pcnt.h eren.terzioglu@espressif.com
-boards/xtensa/esp32/common/include/esp32_board_rmt.h tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/include/esp32_board_sdmmc.h filipe.cavalcanti@espressif.com
-boards/xtensa/esp32/common/include/esp32_board_spiflash.h gustavo.nihei@espressif.com petro.karashchenko@gmail.com tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/include/esp32_board_spislavedev.h moura.fmo@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/include/esp32_board_wdt.h abdelatif.guettouche@espressif.com petro.karashchenko@gmail.com alin.jerpelea@sony.com gustavo.nihei@espressif.com
-boards/xtensa/esp32/common/include/esp32_board_wlan.h abdelatif.guettouche@espressif.com petro.karashchenko@gmail.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/include/esp32_es8388.h lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/include/esp32_ht16k33.h acassis@gmail.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/include/esp32_lcd_backpack.h acassis@gmail.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/include/esp32_ltr308.h robertalexa2000@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/include/esp32_max6675.h acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/include/esp32_mcp2515.h acassis@gmail.com petro.karashchenko@gmail.com alin.jerpelea@sony.com gustavo.nihei@espressif.com
-boards/xtensa/esp32/common/include/esp32_ms5611.h acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/include/esp32_rgbled.h simona.alexandra2000@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/include/esp32_sht3x.h acassis@gmail.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/include/esp32_ssd1680.h akaliszan@altimetrik.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/include/esp32_tca9548a.h acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/include/esp32_zerocross.h halysson1007@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/kernel/Makefile gustavo.nihei@espressif.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-boards/xtensa/esp32/common/kernel/esp32_userspace.c gustavo.nihei@espressif.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-boards/xtensa/esp32/common/scripts/.gitignore gustavo.nihei@espressif.com
-boards/xtensa/esp32/common/scripts/esp32_aliases.ld acassis@gmail.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/scripts/esp32_sections.ld filipe.cavalcanti@espressif.com tiago.medicci@espressif.com
-boards/xtensa/esp32/common/scripts/flat_memory.ld gustavo.nihei@espressif.com almir.okato@espressif.com tiago.medicci@espressif.com alin.jerpelea@sony.com yamamoto@midokura.com
-boards/xtensa/esp32/common/scripts/kernel-space.ld gustavo.nihei@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-boards/xtensa/esp32/common/scripts/legacy_sections.ld gustavo.nihei@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/scripts/mcuboot_sections.ld gustavo.nihei@espressif.com almir.okato@espressif.com tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/scripts/protected_memory.ld gustavo.nihei@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/scripts/user-space.ld gustavo.nihei@espressif.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-boards/xtensa/esp32/common/src/esp32_backlight.c halysson1007@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/src/esp32_bme680.c simona.alexandra2000@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/src/esp32_bmp180.c phfbertoleti@gmail.com alin.jerpelea@sony.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
-boards/xtensa/esp32/common/src/esp32_bmp280.c andreykvak.g3@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/src/esp32_board_adc.c filipe.cavalcanti@espressif.com devel@sumpfralle.de
-boards/xtensa/esp32/common/src/esp32_board_apa102_lcd.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/src/esp32_board_apds9960.c acassis@gmail.com alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com
-boards/xtensa/esp32/common/src/esp32_board_dac.c tomas.pilny@espressif.com eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/src/esp32_board_i2c.c phfbertoleti@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/xtensa/esp32/common/src/esp32_board_i2sdev.c tiago.medicci@espressif.com eren.terzioglu@espressif.com lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/src/esp32_board_mcpwm.c filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/src/esp32_board_pcnt.c eren.terzioglu@espressif.com martin.vajnar@gmail.com
-boards/xtensa/esp32/common/src/esp32_board_rmt.c tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/src/esp32_board_sdmmc.c filipe.cavalcanti@espressif.com
-boards/xtensa/esp32/common/src/esp32_board_spi.c gustavo.nihei@espressif.com xiaoxiang@xiaomi.com akaliszan@altimetrik.com aungkhantmaw64@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/src/esp32_board_spidev.c eren.terzioglu@espressif.com sara.souza@espressif.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/xtensa/esp32/common/src/esp32_board_spiflash.c gustavo.nihei@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com jingfei@xiaomi.com xiaoxiang@xiaomi.com
-boards/xtensa/esp32/common/src/esp32_board_spislavedev.c moura.fmo@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/src/esp32_board_wdt.c abdelatif.guettouche@espressif.com sara.souza@espressif.com alin.jerpelea@sony.com gustavo.nihei@espressif.com
-boards/xtensa/esp32/common/src/esp32_board_wlan.c abdelatif.guettouche@espressif.com sara.souza@espressif.com filipe.cavalcanti@espressif.com gustavo.nihei@espressif.com tiago.medicci@espressif.com
-boards/xtensa/esp32/common/src/esp32_cs4344.c tiago.medicci@espressif.com eren.terzioglu@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com petro.karashchenko@gmail.com
-boards/xtensa/esp32/common/src/esp32_es8388.c lucas.vaz@espressif.com eren.terzioglu@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/xtensa/esp32/common/src/esp32_gc9a01.c aungkhantmaw64@gmail.com
-boards/xtensa/esp32/common/src/esp32_ht16k33.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/src/esp32_ili9341.c gustavo.nihei@espressif.com xiaoxiang@xiaomi.com lucas.vaz@espressif.com raiden00@railab.me alin.jerpelea@sony.com
-boards/xtensa/esp32/common/src/esp32_lcd_backpack.c acassis@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-boards/xtensa/esp32/common/src/esp32_ltr308.c robertalexa2000@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/src/esp32_max6675.c acassis@gmail.com alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com
-boards/xtensa/esp32/common/src/esp32_mcp2515.c acassis@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com
-boards/xtensa/esp32/common/src/esp32_ms5611.c acassis@gmail.com t-ando@advaly.co.jp alin.jerpelea@sony.com
-boards/xtensa/esp32/common/src/esp32_oneshot.c sara.souza@espressif.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/xtensa/esp32/common/src/esp32_qencoder.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/src/esp32_rgbled.c simona.alexandra2000@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/src/esp32_sht3x.c acassis@gmail.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-boards/xtensa/esp32/common/src/esp32_ssd1306.c acassis@gmail.com robertalexa2000@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/src/esp32_ssd1680.c akaliszan@altimetrik.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/src/esp32_st7789.c tiago.medicci@espressif.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/xtensa/esp32/common/src/esp32_tca9548a.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/common/src/esp32_zerocross.c halysson1007@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-2432S028/Kconfig halysson1007@gmail.com
-boards/xtensa/esp32/esp32-2432S028/configs/lvgl/defconfig halysson1007@gmail.com xuxingliang@xiaomi.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32/esp32-2432S028/configs/nsh/defconfig halysson1007@gmail.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32/esp32-2432S028/include/board.h halysson1007@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-2432S028/include/board_memorymap.h halysson1007@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-2432S028/src/esp32-2432S028.h halysson1007@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-2432S028/src/esp32_appinit.c halysson1007@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-2432S028/src/esp32_boot.c halysson1007@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-2432S028/src/esp32_bringup.c halysson1007@gmail.com eren.terzioglu@espressif.com laczenjms@gmail.com filipe.cavalcanti@espressif.com huangqi3@xiaomi.com
-boards/xtensa/esp32/esp32-2432S028/src/esp32_reset.c halysson1007@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-audio-kit/Kconfig acassis@gmail.com
-boards/xtensa/esp32/esp32-audio-kit/configs/audio/defconfig acassis@gmail.com eren.terzioglu@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32/esp32-audio-kit/configs/nsh/defconfig acassis@gmail.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32/esp32-audio-kit/configs/wifi/defconfig acassis@gmail.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com huangqi3@xiaomi.com
-boards/xtensa/esp32/esp32-audio-kit/include/board.h acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-audio-kit/include/board_memorymap.h acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-audio-kit/src/esp32-audio-kit.h acassis@gmail.com filipe.cavalcanti@espressif.com eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-audio-kit/src/esp32_appinit.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-audio-kit/src/esp32_boot.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-audio-kit/src/esp32_bringup.c acassis@gmail.com eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com laczenjms@gmail.com huangqi3@xiaomi.com
-boards/xtensa/esp32/esp32-audio-kit/src/esp32_buttons.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-audio-kit/src/esp32_gpio.c acassis@gmail.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-audio-kit/src/esp32_reset.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-audio-kit/src/esp32_userleds.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-devkitc/Kconfig abdelatif.guettouche@espressif.com petro.karashchenko@gmail.com yamamoto@midokura.com matias@protobits.dev gustavo.nihei@espressif.com
-boards/xtensa/esp32/esp32-devkitc/configs/adc/defconfig filipe.cavalcanti@espressif.com
-boards/xtensa/esp32/esp32-devkitc/configs/audio/defconfig tiago.medicci@espressif.com eren.terzioglu@espressif.com xiaoxiang@xiaomi.com acassis@gmail.com filipe.cavalcanti@espressif.com
-boards/xtensa/esp32/esp32-devkitc/configs/autopm/defconfig chenwen@espressif.com gustavo.nihei@espressif.com alin.jerpelea@sony.com tiago.medicci@espressif.com liguiding1@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/ble/defconfig acassis@gmail.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com liguiding1@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/blewifi/defconfig acassis@gmail.com tiago.medicci@espressif.com lucas.vaz@espressif.com filipe.cavalcanti@espressif.com xiaoxiang@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/bmp280/defconfig andreykvak.g3@gmail.com acassis@gmail.com xiaoxiang@xiaomi.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32/esp32-devkitc/configs/brickmatch/defconfig acassis@gmail.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/buttons/defconfig gustavo.nihei@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32/esp32-devkitc/configs/capture/defconfig filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/coremark/defconfig lucas.vaz@espressif.com tiago.medicci@espressif.com xiaoxiang@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/crypto/defconfig pruteanuvlad1611@yahoo.com
-boards/xtensa/esp32/esp32-devkitc/configs/cxx/defconfig gustavo.nihei@espressif.com jihandong@xiaomi.com wangjianyu3@xiaomi.com yinshengkai@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32/esp32-devkitc/configs/dac/defconfig tomas.pilny@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32/esp32-devkitc/configs/efuse/defconfig yamamoto@midokura.com tiago.medicci@espressif.com acassis@gmail.com xiaoxiang@xiaomi.com filipe.cavalcanti@espressif.com
-boards/xtensa/esp32/esp32-devkitc/configs/elf/defconfig abdelatif.guettouche@espressif.com masayuki.ishikawa@gmail.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com dongjiuzhu1@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/espnow/defconfig laczenjms@gmail.com filipe.cavalcanti@espressif.com
-boards/xtensa/esp32/esp32-devkitc/configs/i2schar/defconfig tiago.medicci@espressif.com eren.terzioglu@espressif.com wangjianyu3@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32/esp32-devkitc/configs/knsh/defconfig gustavo.nihei@espressif.com acassis@gmail.com tiago.medicci@espressif.com wangjianyu3@xiaomi.com almir.okato@espressif.com
-boards/xtensa/esp32/esp32-devkitc/configs/leds/defconfig abdelatif.guettouche@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/match4/defconfig eren.terzioglu@espressif.com
-boards/xtensa/esp32/esp32-devkitc/configs/max6675/defconfig acassis@gmail.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32/esp32-devkitc/configs/mcp2515/defconfig acassis@gmail.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/mcuboot_nsh/defconfig lucas.vaz@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32/esp32-devkitc/configs/mcuboot_slot_confirm/defconfig gerson.budke@ossystems.com.br wangjianyu3@xiaomi.com tiago.medicci@espressif.com gustavo.nihei@espressif.com acassis@gmail.com
-boards/xtensa/esp32/esp32-devkitc/configs/mcuboot_update_agent/defconfig gerson.budke@ossystems.com.br filipe.cavalcanti@espressif.com acassis@gmail.com tiago.medicci@espressif.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/modbus/defconfig acassis@gmail.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com yamamoto@midokura.com petro.karashchenko@gmail.com
-boards/xtensa/esp32/esp32-devkitc/configs/module/defconfig yamamoto@midokura.com acassis@gmail.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com xiaoxiang@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/motor/defconfig filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/mqttc/defconfig abdelatif.guettouche@espressif.com gustavo.nihei@espressif.com alin.jerpelea@sony.com wangjianyu3@xiaomi.com filipe.cavalcanti@espressif.com
-boards/xtensa/esp32/esp32-devkitc/configs/ms5611/defconfig acassis@gmail.com xiaoxiang@xiaomi.com t-ando@advaly.co.jp filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/nsh/defconfig abdelatif.guettouche@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/nvblk/defconfig laczenjms@gmail.com
-boards/xtensa/esp32/esp32-devkitc/configs/nxdiag/defconfig lucas.vaz@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32/esp32-devkitc/configs/nxlooper/defconfig tiago.medicci@espressif.com eren.terzioglu@espressif.com acassis@gmail.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/oneshot/defconfig sara.souza@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32/esp32-devkitc/configs/ostest/defconfig abdelatif.guettouche@espressif.com tiago.medicci@espressif.com wangjianyu3@xiaomi.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/pm/defconfig abdelatif.guettouche@espressif.com liguiding1@xiaomi.com wangjianyu3@xiaomi.com chenwen@espressif.com tiago.medicci@espressif.com
-boards/xtensa/esp32/esp32-devkitc/configs/psram/defconfig abdelatif.guettouche@espressif.com yamamoto@midokura.com gustavo.nihei@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com
-boards/xtensa/esp32/esp32-devkitc/configs/psram_usrheap/defconfig gustavo.nihei@espressif.com yamamoto@midokura.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com tengshuangshuang@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/pwm/defconfig acassis@gmail.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com yamamoto@midokura.com petro.karashchenko@gmail.com
-boards/xtensa/esp32/esp32-devkitc/configs/qemu_openeth/defconfig marco.casaroli@gmail.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/qencoder/defconfig eren.terzioglu@espressif.com martin.vajnar@gmail.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/random/defconfig abdelatif.guettouche@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/rmt/defconfig tiago.medicci@espressif.com tomas.pilny@espressif.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/rtc/defconfig chenwen@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32/esp32-devkitc/configs/sdm/defconfig eren.terzioglu@espressif.com
-boards/xtensa/esp32/esp32-devkitc/configs/sdmmc_spi/defconfig filipe.cavalcanti@espressif.com
-boards/xtensa/esp32/esp32-devkitc/configs/smp/defconfig abdelatif.guettouche@espressif.com masayuki.ishikawa@gmail.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/snake/defconfig eren.terzioglu@espressif.com
-boards/xtensa/esp32/esp32-devkitc/configs/softap/defconfig roy.feng@sony.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32/esp32-devkitc/configs/sotest/defconfig yamamoto@midokura.com acassis@gmail.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com xiaoxiang@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/spiflash/defconfig abdelatif.guettouche@espressif.com gustavo.nihei@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/sta_softap/defconfig dongheng@espressif.com tiago.medicci@espressif.com gustavo.nihei@espressif.com alin.jerpelea@sony.com filipe.cavalcanti@espressif.com
-boards/xtensa/esp32/esp32-devkitc/configs/tickless/defconfig chenwen@espressif.com gustavo.nihei@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/timer/defconfig abdelatif.guettouche@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/twai/defconfig eren.terzioglu@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32/esp32-devkitc/configs/wamr_wasi_debug/defconfig yamamoto@midokura.com acassis@gmail.com xiaoxiang@xiaomi.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/watchdog/defconfig abdelatif.guettouche@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/watcher/defconfig sara.souza@espressif.com xiaoxiang@xiaomi.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/wifi/defconfig lucas.vaz@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32/esp32-devkitc/configs/wifi_smp/defconfig lucas.vaz@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32/esp32-devkitc/configs/wifinsh/defconfig acassis@gmail.com gustavo.nihei@espressif.com alin.jerpelea@sony.com tiago.medicci@espressif.com liguiding1@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/configs/wifishare/defconfig acassis@gmail.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/include/board.h abdelatif.guettouche@espressif.com alin.jerpelea@sony.com acassis@gmail.com matias@protobits.dev
-boards/xtensa/esp32/esp32-devkitc/include/board_memorymap.h gustavo.nihei@espressif.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-devkitc/src/esp32-devkitc.h abdelatif.guettouche@espressif.com tiago.medicci@espressif.com alin.jerpelea@sony.com vbenso@gmail.com acassis@gmail.com
-boards/xtensa/esp32/esp32-devkitc/src/esp32_appinit.c abdelatif.guettouche@espressif.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/src/esp32_boot.c abdelatif.guettouche@espressif.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/src/esp32_bringup.c abdelatif.guettouche@espressif.com acassis@gmail.com tiago.medicci@espressif.com eren.terzioglu@espressif.com sara.souza@espressif.com
-boards/xtensa/esp32/esp32-devkitc/src/esp32_buttons.c gustavo.nihei@espressif.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com lucas.vaz@espressif.com petro.karashchenko@gmail.com
-boards/xtensa/esp32/esp32-devkitc/src/esp32_gpio.c acassis@gmail.com xiaoxiang@xiaomi.com sara.souza@espressif.com jari.vanewijk@nxp.com filipe.cavalcanti@espressif.com
-boards/xtensa/esp32/esp32-devkitc/src/esp32_ledc.c acassis@gmail.com alin.jerpelea@sony.com tiago.medicci@espressif.com
-boards/xtensa/esp32/esp32-devkitc/src/esp32_reset.c abdelatif.guettouche@espressif.com chenwen@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-devkitc/src/esp32_twai.c acassis@gmail.com alin.jerpelea@sony.com tiago.medicci@espressif.com xiaoxiang@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/src/esp32_userleds.c abdelatif.guettouche@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-devkitc/src/esp32_w5500.c acassis@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/xtensa/esp32/esp32-devkitc/src/esp32_ws2812.c vbenso@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-ethernet-kit/Kconfig abdelatif.guettouche@espressif.com matias@protobits.dev gustavo.nihei@espressif.com
-boards/xtensa/esp32/esp32-ethernet-kit/configs/autopm/defconfig chenwen@espressif.com gustavo.nihei@espressif.com alin.jerpelea@sony.com tiago.medicci@espressif.com liguiding1@xiaomi.com
-boards/xtensa/esp32/esp32-ethernet-kit/configs/buttons/defconfig gustavo.nihei@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32/esp32-ethernet-kit/configs/ethernet/defconfig abdelatif.guettouche@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com xiaoxiang@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32/esp32-ethernet-kit/configs/nsh/defconfig abdelatif.guettouche@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com
-boards/xtensa/esp32/esp32-ethernet-kit/configs/oneshot/defconfig sara.souza@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32/esp32-ethernet-kit/configs/rtc/defconfig chenwen@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32/esp32-ethernet-kit/configs/wifi/defconfig lucas.vaz@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32/esp32-ethernet-kit/include/board.h abdelatif.guettouche@espressif.com matias@protobits.dev alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-ethernet-kit/include/board_memorymap.h gustavo.nihei@espressif.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-ethernet-kit/src/esp32-ethernet-kit.h abdelatif.guettouche@espressif.com gustavo.nihei@espressif.com sara.souza@espressif.com filipe.cavalcanti@espressif.com petro.karashchenko@gmail.com
-boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_appinit.c abdelatif.guettouche@espressif.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_boot.c abdelatif.guettouche@espressif.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_bringup.c abdelatif.guettouche@espressif.com sara.souza@espressif.com gustavo.nihei@espressif.com chenwen@espressif.com acassis@gmail.com
-boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_buttons.c gustavo.nihei@espressif.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com lucas.vaz@espressif.com petro.karashchenko@gmail.com
-boards/xtensa/esp32/esp32-ethernet-kit/src/esp32_reset.c abdelatif.guettouche@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-lyrat/Kconfig lucas.vaz@espressif.com
-boards/xtensa/esp32/esp32-lyrat/configs/audio/defconfig lucas.vaz@espressif.com eren.terzioglu@espressif.com tiago.medicci@espressif.com acassis@gmail.com filipe.cavalcanti@espressif.com
-boards/xtensa/esp32/esp32-lyrat/configs/buttons/defconfig lucas.vaz@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com acassis@gmail.com
-boards/xtensa/esp32/esp32-lyrat/configs/nsh/defconfig lucas.vaz@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com acassis@gmail.com
-boards/xtensa/esp32/esp32-lyrat/configs/nxrecorder/defconfig lucas.vaz@espressif.com eren.terzioglu@espressif.com tiago.medicci@espressif.com wangjianyu3@xiaomi.com mazhuang@xiaomi.com
-boards/xtensa/esp32/esp32-lyrat/configs/rtptools/defconfig tiago.medicci@gmail.com eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32/esp32-lyrat/configs/sdmmc_spi/defconfig filipe.cavalcanti@espressif.com
-boards/xtensa/esp32/esp32-lyrat/configs/wifi/defconfig lucas.vaz@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32/esp32-lyrat/include/board.h lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-lyrat/include/board_memorymap.h lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-lyrat/src/esp32-lyrat.h lucas.vaz@espressif.com filipe.cavalcanti@espressif.com eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-lyrat/src/esp32_appinit.c lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-lyrat/src/esp32_boot.c lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-lyrat/src/esp32_bringup.c lucas.vaz@espressif.com eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com laczenjms@gmail.com huangqi3@xiaomi.com
-boards/xtensa/esp32/esp32-lyrat/src/esp32_buttons.c lucas.vaz@espressif.com anchao@xiaomi.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-lyrat/src/esp32_gpio.c lucas.vaz@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-lyrat/src/esp32_reset.c lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-lyrat/src/esp32_userleds.c lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-pico-kit/Kconfig lucas.vaz@espressif.com 101105604+simbit18@users.noreply.github.com
-boards/xtensa/esp32/esp32-pico-kit/configs/nsh/defconfig lucas.vaz@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32/esp32-pico-kit/include/board.h lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-pico-kit/include/board_memorymap.h lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-pico-kit/src/esp32-pico-kit.h lucas.vaz@espressif.com eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-pico-kit/src/esp32_appinit.c lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-pico-kit/src/esp32_boot.c lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-pico-kit/src/esp32_bringup.c lucas.vaz@espressif.com eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com laczenjms@gmail.com 101105604+simbit18@users.noreply.github.com
-boards/xtensa/esp32/esp32-pico-kit/src/esp32_buttons.c lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-pico-kit/src/esp32_gpio.c lucas.vaz@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-pico-kit/src/esp32_ledc.c lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-pico-kit/src/esp32_reset.c lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-pico-kit/src/esp32_twai.c lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-sparrow-kit/Kconfig robertalexa2000@gmail.com
-boards/xtensa/esp32/esp32-sparrow-kit/configs/ble/defconfig you@example.com
-boards/xtensa/esp32/esp32-sparrow-kit/configs/mqttc/defconfig luca12andreea@gmail.com eren.terzioglu@espressif.com wangjianyu3@xiaomi.com filipe.cavalcanti@espressif.com
-boards/xtensa/esp32/esp32-sparrow-kit/configs/nsh/defconfig robertalexa2000@gmail.com simona.alexandra2000@gmail.com eren.terzioglu@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32/esp32-sparrow-kit/configs/wifi/defconfig luca12andreea@gmail.com eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32/esp32-sparrow-kit/include/board.h robertalexa2000@gmail.com alin.jerpelea@sony.com fangxinyong@xiaomi.com
-boards/xtensa/esp32/esp32-sparrow-kit/include/board_memorymap.h robertalexa2000@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-sparrow-kit/src/esp32-sparrow-kit.h robertalexa2000@gmail.com simona.alexandra2000@gmail.com filipe.cavalcanti@espressif.com eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-sparrow-kit/src/esp32_appinit.c robertalexa2000@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-sparrow-kit/src/esp32_autoleds.c robertalexa2000@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-sparrow-kit/src/esp32_boot.c robertalexa2000@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-sparrow-kit/src/esp32_bringup.c robertalexa2000@gmail.com simona.alexandra2000@gmail.com filipe.cavalcanti@espressif.com eren.terzioglu@espressif.com laczenjms@gmail.com
-boards/xtensa/esp32/esp32-sparrow-kit/src/esp32_buttons.c robertalexa2000@gmail.com alin.jerpelea@sony.com lucas.vaz@espressif.com
-boards/xtensa/esp32/esp32-sparrow-kit/src/esp32_gpio.c robertalexa2000@gmail.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-sparrow-kit/src/esp32_reset.c robertalexa2000@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-sparrow-kit/src/esp32_userleds.c robertalexa2000@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-wrover-kit/Kconfig abdelatif.guettouche@espressif.com matias@protobits.dev gustavo.nihei@espressif.com
-boards/xtensa/esp32/esp32-wrover-kit/configs/autopm/defconfig chenwen@espressif.com gustavo.nihei@espressif.com alin.jerpelea@sony.com tiago.medicci@espressif.com liguiding1@xiaomi.com
-boards/xtensa/esp32/esp32-wrover-kit/configs/bmp180/defconfig gustavo.nihei@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com
-boards/xtensa/esp32/esp32-wrover-kit/configs/buttons/defconfig gustavo.nihei@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32/esp32-wrover-kit/configs/gpio/defconfig abdelatif.guettouche@espressif.com tiago.medicci@espressif.com wangjianyu3@xiaomi.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com
-boards/xtensa/esp32/esp32-wrover-kit/configs/lcd1602/defconfig acassis@gmail.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com yamamoto@midokura.com
-boards/xtensa/esp32/esp32-wrover-kit/configs/leds/defconfig abdelatif.guettouche@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com
-boards/xtensa/esp32/esp32-wrover-kit/configs/lua/defconfig rpgarc77@gmail.com acassis@gmail.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32/esp32-wrover-kit/configs/lvgl/defconfig gustavo.nihei@espressif.com xuxingliang@xiaomi.com pengyiqiang@xiaomi.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32/esp32-wrover-kit/configs/nsh/defconfig abdelatif.guettouche@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com
-boards/xtensa/esp32/esp32-wrover-kit/configs/nx/defconfig gustavo.nihei@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32/esp32-wrover-kit/configs/oneshot/defconfig sara.souza@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32/esp32-wrover-kit/configs/rtc/defconfig chenwen@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32/esp32-wrover-kit/configs/sdmmc_spi/defconfig filipe.cavalcanti@espressif.com
-boards/xtensa/esp32/esp32-wrover-kit/configs/wifi/defconfig lucas.vaz@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32/esp32-wrover-kit/include/board.h abdelatif.guettouche@espressif.com rpgarc77@gmail.com gustavo.nihei@espressif.com matias@protobits.dev acassis@gmail.com
-boards/xtensa/esp32/esp32-wrover-kit/include/board_memorymap.h gustavo.nihei@espressif.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-wrover-kit/src/esp32-wrover-kit.h abdelatif.guettouche@espressif.com gustavo.nihei@espressif.com sara.souza@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-wrover-kit/src/esp32_appinit.c abdelatif.guettouche@espressif.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-wrover-kit/src/esp32_autoleds.c abdelatif.guettouche@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-wrover-kit/src/esp32_boot.c abdelatif.guettouche@espressif.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/xtensa/esp32/esp32-wrover-kit/src/esp32_bringup.c abdelatif.guettouche@espressif.com gustavo.nihei@espressif.com sara.souza@espressif.com phfbertoleti@gmail.com acassis@gmail.com
-boards/xtensa/esp32/esp32-wrover-kit/src/esp32_buttons.c gustavo.nihei@espressif.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com lucas.vaz@espressif.com petro.karashchenko@gmail.com
-boards/xtensa/esp32/esp32-wrover-kit/src/esp32_gpio.c abdelatif.guettouche@espressif.com acassis@gmail.com xiaoxiang@xiaomi.com sara.souza@espressif.com jari.vanewijk@nxp.com
-boards/xtensa/esp32/esp32-wrover-kit/src/esp32_reset.c abdelatif.guettouche@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/esp32-wrover-kit/src/esp32_userleds.c abdelatif.guettouche@espressif.com rpgarc77@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/lilygo_tbeam_lora_gps/Kconfig acassis@gmail.com
-boards/xtensa/esp32/lilygo_tbeam_lora_gps/configs/gps/defconfig acassis@gmail.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32/lilygo_tbeam_lora_gps/configs/nsh/defconfig acassis@gmail.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32/lilygo_tbeam_lora_gps/configs/sx127x/defconfig acassis@gmail.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32/lilygo_tbeam_lora_gps/include/board.h acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/lilygo_tbeam_lora_gps/include/board_memorymap.h acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/lilygo_tbeam_lora_gps/src/esp32_appinit.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/lilygo_tbeam_lora_gps/src/esp32_boot.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/lilygo_tbeam_lora_gps/src/esp32_bringup.c acassis@gmail.com filipe.cavalcanti@espressif.com laczenjms@gmail.com huangqi3@xiaomi.com alin.jerpelea@sony.com
-boards/xtensa/esp32/lilygo_tbeam_lora_gps/src/esp32_buttons.c acassis@gmail.com alin.jerpelea@sony.com lucas.vaz@espressif.com
-boards/xtensa/esp32/lilygo_tbeam_lora_gps/src/esp32_gpio.c acassis@gmail.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/lilygo_tbeam_lora_gps/src/esp32_reset.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/lilygo_tbeam_lora_gps/src/esp32_sx127x.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/lilygo_tbeam_lora_gps/src/esp32_userleds.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/lilygo_tbeam_lora_gps/src/lilygo_tbeam_lora_gps.h acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_eink5_v2/Kconfig akaliszan@altimetrik.com 101105604+simbit18@users.noreply.github.com
-boards/xtensa/esp32/ttgo_eink5_v2/configs/fb/defconfig akaliszan@altimetrik.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com acassis@gmail.com
-boards/xtensa/esp32/ttgo_eink5_v2/include/board.h akaliszan@altimetrik.com abdelatif.guettouche@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_eink5_v2/include/board_memorymap.h gustavo.nihei@espressif.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_eink5_v2/src/esp32_appinit.c akaliszan@altimetrik.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_eink5_v2/src/esp32_boot.c akaliszan@altimetrik.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_eink5_v2/src/esp32_bringup.c akaliszan@altimetrik.com filipe.cavalcanti@espressif.com laczenjms@gmail.com t-ando@advaly.co.jp huangqi3@xiaomi.com
-boards/xtensa/esp32/ttgo_eink5_v2/src/esp32_buttons.c akaliszan@altimetrik.com alin.jerpelea@sony.com lucas.vaz@espressif.com
-boards/xtensa/esp32/ttgo_eink5_v2/src/esp32_gpio.c akaliszan@altimetrik.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_eink5_v2/src/esp32_ledc.c akaliszan@altimetrik.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_eink5_v2/src/esp32_reset.c akaliszan@altimetrik.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_eink5_v2/src/esp32_twai.c akaliszan@altimetrik.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_eink5_v2/src/esp32_userleds.c akaliszan@altimetrik.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_eink5_v2/src/ttgo_eink5_v2.h akaliszan@altimetrik.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_lora_esp32/Kconfig acassis@gmail.com
-boards/xtensa/esp32/ttgo_lora_esp32/configs/nsh/defconfig acassis@gmail.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com yamamoto@midokura.com
-boards/xtensa/esp32/ttgo_lora_esp32/configs/sx127x/defconfig acassis@gmail.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32/ttgo_lora_esp32/include/board.h acassis@gmail.com abdelatif.guettouche@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_lora_esp32/include/board_memorymap.h gustavo.nihei@espressif.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_lora_esp32/src/esp32_appinit.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_lora_esp32/src/esp32_boot.c acassis@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/xtensa/esp32/ttgo_lora_esp32/src/esp32_bringup.c acassis@gmail.com gustavo.nihei@espressif.com filipe.cavalcanti@espressif.com laczenjms@gmail.com yamamoto@midokura.com
-boards/xtensa/esp32/ttgo_lora_esp32/src/esp32_buttons.c acassis@gmail.com alin.jerpelea@sony.com lucas.vaz@espressif.com xiaoxiang@xiaomi.com petro.karashchenko@gmail.com
-boards/xtensa/esp32/ttgo_lora_esp32/src/esp32_gpio.c acassis@gmail.com xiaoxiang@xiaomi.com jari.vanewijk@nxp.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_lora_esp32/src/esp32_reset.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_lora_esp32/src/esp32_sx127x.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_lora_esp32/src/esp32_userleds.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_lora_esp32/src/ttgo_lora_esp32.h acassis@gmail.com gustavo.nihei@espressif.com robertalexa2000@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_t_display_esp32/Kconfig tiago.medicci@espressif.com 101105604+simbit18@users.noreply.github.com
-boards/xtensa/esp32/ttgo_t_display_esp32/configs/lvgl_fb/defconfig tiago.medicci@espressif.com xuxingliang@xiaomi.com pengyiqiang@xiaomi.com wangjianyu3@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32/ttgo_t_display_esp32/configs/lvgl_lcd/defconfig tiago.medicci@espressif.com xuxingliang@xiaomi.com pengyiqiang@xiaomi.com wangjianyu3@xiaomi.com lucas.vaz@espressif.com
-boards/xtensa/esp32/ttgo_t_display_esp32/configs/nsh/defconfig tiago.medicci@espressif.com wangjianyu3@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32/ttgo_t_display_esp32/include/board.h tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_t_display_esp32/include/board_memorymap.h tiago.medicci@espressif.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_t_display_esp32/src/esp32_appinit.c tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_t_display_esp32/src/esp32_boot.c tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_t_display_esp32/src/esp32_bringup.c tiago.medicci@espressif.com filipe.cavalcanti@espressif.com laczenjms@gmail.com t-ando@advaly.co.jp huangqi3@xiaomi.com
-boards/xtensa/esp32/ttgo_t_display_esp32/src/esp32_buttons.c tiago.medicci@espressif.com alin.jerpelea@sony.com lucas.vaz@espressif.com
-boards/xtensa/esp32/ttgo_t_display_esp32/src/esp32_gpio.c tiago.medicci@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_t_display_esp32/src/esp32_ledc.c tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_t_display_esp32/src/esp32_reset.c tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_t_display_esp32/src/esp32_twai.c tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_t_display_esp32/src/esp32_userleds.c tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32/ttgo_t_display_esp32/src/ttgo_t_display_esp32.h tiago.medicci@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/common/.gitignore huangqi3@xiaomi.com
-boards/xtensa/esp32s2/common/Kconfig acassis@gmail.com 101105604+simbit18@users.noreply.github.com lucas.vaz@espressif.com gustavo.nihei@espressif.com abdelatif.guettouche@espressif.com
-boards/xtensa/esp32s2/common/Makefile acassis@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/xtensa/esp32s2/common/include/esp32s2_board_adc.h filipe.cavalcanti@espressif.com devel@sumpfralle.de
-boards/xtensa/esp32s2/common/include/esp32s2_board_pcnt.h eren.terzioglu@espressif.com
-boards/xtensa/esp32s2/common/include/esp32s2_board_rmt.h tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/common/include/esp32s2_board_sdmmc.h filipe.cavalcanti@espressif.com
-boards/xtensa/esp32s2/common/include/esp32s2_board_spidev.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/common/include/esp32s2_board_spislavedev.h eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/common/include/esp32s2_board_wdt.h gustavo.nihei@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/common/include/esp32s2_board_wlan.h filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/common/include/esp32s2_es8311.h lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/common/include/esp32s2_max6675.h acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/common/scripts/.gitignore lucas.vaz@espressif.com
-boards/xtensa/esp32s2/common/scripts/esp32s2_aliases.ld tiago.medicci@espressif.com eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/common/scripts/esp32s2_peripherals.ld lucas.vaz@espressif.com gustavo.nihei@espressif.com alin.jerpelea@sony.com eren.terzioglu@espressif.com
-boards/xtensa/esp32s2/common/scripts/esp32s2_sections.ld filipe.cavalcanti@espressif.com gustavo.nihei@espressif.com lucas.vaz@espressif.com tiago.medicci@espressif.com
-boards/xtensa/esp32s2/common/scripts/flat_memory.ld gustavo.nihei@espressif.com almir.okato@espressif.com halysson.junior@iponia.com.br eren.terzioglu@espressif.com tiago.medicci@espressif.com
-boards/xtensa/esp32s2/common/scripts/mcuboot_sections.ld gustavo.nihei@espressif.com almir.okato@espressif.com eren.terzioglu@espressif.com tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/common/src/esp32s2_board_adc.c filipe.cavalcanti@espressif.com devel@sumpfralle.de
-boards/xtensa/esp32s2/common/src/esp32s2_board_i2sdev.c tiago.medicci@espressif.com eren.terzioglu@espressif.com lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/common/src/esp32s2_board_pcnt.c eren.terzioglu@espressif.com martin.vajnar@gmail.com
-boards/xtensa/esp32s2/common/src/esp32s2_board_rmt.c tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/common/src/esp32s2_board_sdmmc.c filipe.cavalcanti@espressif.com
-boards/xtensa/esp32s2/common/src/esp32s2_board_spi.c eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/common/src/esp32s2_board_spidev.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/common/src/esp32s2_board_spiflash.c acassis@gmail.com filipe.cavalcanti@espressif.com tiago.medicci@espressif.com jingfei@xiaomi.com eren.terzioglu@espressif.com
-boards/xtensa/esp32s2/common/src/esp32s2_board_spislavedev.c eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/common/src/esp32s2_board_twai.c eren.terzioglu@espressif.com alin.jerpelea@sony.com almir.okato@espressif.com
-boards/xtensa/esp32s2/common/src/esp32s2_board_wdt.c gustavo.nihei@espressif.com eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/common/src/esp32s2_board_wlan.c filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/common/src/esp32s2_cs4344.c tiago.medicci@espressif.com eren.terzioglu@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com petro.karashchenko@gmail.com
-boards/xtensa/esp32s2/common/src/esp32s2_es8311.c lucas.vaz@espressif.com eren.terzioglu@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-boards/xtensa/esp32s2/common/src/esp32s2_ili9341.c lucas.vaz@espressif.com raiden00@railab.me alin.jerpelea@sony.com
-boards/xtensa/esp32s2/common/src/esp32s2_max6675.c acassis@gmail.com alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com
-boards/xtensa/esp32s2/common/src/esp32s2_st7789.c lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/esp32s2-kaluga-1/Kconfig lucas.vaz@espressif.com
-boards/xtensa/esp32s2/esp32s2-kaluga-1/configs/audio/defconfig lucas.vaz@espressif.com eren.terzioglu@espressif.com tiago.medicci@espressif.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32s2/esp32s2-kaluga-1/configs/buttons/defconfig lucas.vaz@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32s2/esp32s2-kaluga-1/configs/i2c/defconfig lucas.vaz@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32s2/esp32s2-kaluga-1/configs/lvgl_ili9341/defconfig lucas.vaz@espressif.com xuxingliang@xiaomi.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32s2/esp32s2-kaluga-1/configs/lvgl_st7789/defconfig lucas.vaz@espressif.com xuxingliang@xiaomi.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32s2/esp32s2-kaluga-1/configs/nsh/defconfig lucas.vaz@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com acassis@gmail.com
-boards/xtensa/esp32s2/esp32s2-kaluga-1/configs/nxlooper/defconfig lucas.vaz@espressif.com eren.terzioglu@espressif.com tiago.medicci@espressif.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32s2/esp32s2-kaluga-1/configs/rtc/defconfig eren.terzioglu@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32s2/esp32s2-kaluga-1/configs/twai/defconfig eren.terzioglu@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32s2/esp32s2-kaluga-1/configs/watchdog/defconfig eren.terzioglu@espressif.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32s2/esp32s2-kaluga-1/include/board.h lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/esp32s2-kaluga-1/src/esp32s2-kaluga-1.h lucas.vaz@espressif.com eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/esp32s2-kaluga-1/src/esp32s2_appinit.c lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/esp32s2-kaluga-1/src/esp32s2_board_i2c.c lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/esp32s2-kaluga-1/src/esp32s2_boot.c lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/esp32s2-kaluga-1/src/esp32s2_bringup.c lucas.vaz@espressif.com eren.terzioglu@espressif.com huangqi3@xiaomi.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/esp32s2-kaluga-1/src/esp32s2_buttons.c lucas.vaz@espressif.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com
-boards/xtensa/esp32s2/esp32s2-kaluga-1/src/esp32s2_gpio.c lucas.vaz@espressif.com alin.jerpelea@sony.com tiago.medicci@espressif.com
-boards/xtensa/esp32s2/esp32s2-kaluga-1/src/esp32s2_oneshot.c lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/esp32s2-kaluga-1/src/esp32s2_reset.c lucas.vaz@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/esp32s2-saola-1/Kconfig acassis@gmail.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/adc/defconfig filipe.cavalcanti@espressif.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/audio/defconfig tiago.medicci@espressif.com eren.terzioglu@espressif.com wangjianyu3@xiaomi.com xiaoxiang@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/buttons/defconfig lucas.vaz@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com acassis@gmail.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/coremark/defconfig lucas.vaz@espressif.com tiago.medicci@espressif.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/crypto/defconfig eren.terzioglu@espressif.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/cxx/defconfig gustavo.nihei@espressif.com jihandong@xiaomi.com wangjianyu3@xiaomi.com yinshengkai@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/gpio/defconfig sara.souza@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/i2c/defconfig gustavo.nihei@espressif.com acassis@gmail.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/i2schar/defconfig tiago.medicci@espressif.com eren.terzioglu@espressif.com wangjianyu3@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/mcuboot_nsh/defconfig gustavo.nihei@espressif.com tiago.medicci@espressif.com wangjianyu3@xiaomi.com liguiding1@xiaomi.com filipe.cavalcanti@espressif.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/mcuboot_update_agent/defconfig filipe.cavalcanti@espressif.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/nsh/defconfig acassis@gmail.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com yamamoto@midokura.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/nxlooper/defconfig tiago.medicci@espressif.com eren.terzioglu@espressif.com wangjianyu3@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/oneshot/defconfig sara.souza@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com acassis@gmail.com liguiding1@xiaomi.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/ostest/defconfig tiago.medicci@espressif.com wangjianyu3@xiaomi.com acassis@gmail.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/pwm/defconfig lucas.vaz@espressif.com eren.terzioglu@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/qencoder/defconfig eren.terzioglu@espressif.com martin.vajnar@gmail.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/random/defconfig acassis@gmail.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com liguiding1@xiaomi.com yamamoto@midokura.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/rmt/defconfig tiago.medicci@espressif.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/rtc/defconfig eren.terzioglu@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/sdm/defconfig eren.terzioglu@espressif.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/sdmmc_spi/defconfig filipe.cavalcanti@espressif.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/sotest/defconfig eren.terzioglu@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/spiflash/defconfig acassis@gmail.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/sta_softap/defconfig filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/temperature_sensor/defconfig eren.terzioglu@espressif.com xiaoxiang@xiaomi.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/timer/defconfig sara.souza@espressif.com gustavo.nihei@espressif.com liguiding1@xiaomi.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/twai/defconfig eren.terzioglu@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/watchdog/defconfig gustavo.nihei@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com eren.terzioglu@espressif.com acassis@gmail.com
-boards/xtensa/esp32s2/esp32s2-saola-1/configs/wifi/defconfig filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32s2/esp32s2-saola-1/include/board.h acassis@gmail.com abdelatif.guettouche@espressif.com gustavo.nihei@espressif.com lucas.vaz@espressif.com petro.karashchenko@gmail.com
-boards/xtensa/esp32s2/esp32s2-saola-1/src/esp32s2-saola-1.h acassis@gmail.com abdelatif.guettouche@espressif.com tiago.medicci@espressif.com sara.souza@espressif.com gustavo.nihei@espressif.com
-boards/xtensa/esp32s2/esp32s2-saola-1/src/esp32s2_appinit.c acassis@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/esp32s2-saola-1/src/esp32s2_bmp180.c gustavo.nihei@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/esp32s2-saola-1/src/esp32s2_board_i2c.c gustavo.nihei@espressif.com eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/esp32s2-saola-1/src/esp32s2_boot.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/esp32s2-saola-1/src/esp32s2_bringup.c eren.terzioglu@espressif.com acassis@gmail.com sara.souza@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com
-boards/xtensa/esp32s2/esp32s2-saola-1/src/esp32s2_buttons.c lucas.vaz@espressif.com alin.jerpelea@sony.com tiago.medicci@espressif.com
-boards/xtensa/esp32s2/esp32s2-saola-1/src/esp32s2_gpio.c sara.souza@espressif.com abdelatif.guettouche@espressif.com acassis@gmail.com xiaoxiang@xiaomi.com eren.terzioglu@espressif.com
-boards/xtensa/esp32s2/esp32s2-saola-1/src/esp32s2_ledc.c acassis@gmail.com eren.terzioglu@espressif.com alin.jerpelea@sony.com almir.okato@espressif.com
-boards/xtensa/esp32s2/esp32s2-saola-1/src/esp32s2_oneshot.c sara.souza@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/esp32s2-saola-1/src/esp32s2_reset.c gustavo.nihei@espressif.com abdelatif.guettouche@espressif.com acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/franzininho-wifi/Kconfig halysson.junior@iponia.com.br
-boards/xtensa/esp32s2/franzininho-wifi/configs/nsh/defconfig halysson.junior@iponia.com.br wangjianyu3@xiaomi.com tiago.medicci@espressif.com acassis@gmail.com
-boards/xtensa/esp32s2/franzininho-wifi/include/board.h halysson.junior@iponia.com.br alin.jerpelea@sony.com
-boards/xtensa/esp32s2/franzininho-wifi/src/esp32s2_appinit.c halysson.junior@iponia.com.br alin.jerpelea@sony.com
-boards/xtensa/esp32s2/franzininho-wifi/src/esp32s2_boot.c halysson.junior@iponia.com.br alin.jerpelea@sony.com
-boards/xtensa/esp32s2/franzininho-wifi/src/esp32s2_bringup.c halysson.junior@iponia.com.br huangqi3@xiaomi.com alin.jerpelea@sony.com
-boards/xtensa/esp32s2/franzininho-wifi/src/esp32s2_oneshot.c halysson.junior@iponia.com.br alin.jerpelea@sony.com
-boards/xtensa/esp32s2/franzininho-wifi/src/esp32s2_reset.c halysson.junior@iponia.com.br alin.jerpelea@sony.com
-boards/xtensa/esp32s2/franzininho-wifi/src/franzininho-wifi.h halysson.junior@iponia.com.br alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/.gitignore huangqi3@xiaomi.com
-boards/xtensa/esp32s3/common/Kconfig thiago.sfinelon@gmail.com wangjianyu3@xiaomi.com gustavo.nihei@espressif.com dongheng@espressif.com marco.casaroli@gmail.com
-boards/xtensa/esp32s3/common/Makefile gustavo.nihei@espressif.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-boards/xtensa/esp32s3/common/include/esp32s3_board_adc.h zhaoqing.zhang@sony.com filipe.cavalcanti@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/include/esp32s3_board_ledc.h wangjianyu3@xiaomi.com eren.terzioglu@espressif.com
-boards/xtensa/esp32s3/common/include/esp32s3_board_mcpwm.h filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/include/esp32s3_board_pcnt.h eren.terzioglu@espressif.com
-boards/xtensa/esp32s3/common/include/esp32s3_board_rmt.h tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/include/esp32s3_board_sdmmc.h Yinzhe.Wu@sony.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/include/esp32s3_board_spidev.h 40821031+w2016561536@users.noreply.github.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/include/esp32s3_board_spislavedev.h thiago.pereira@agrosystem.com.br
-boards/xtensa/esp32s3/common/include/esp32s3_board_tim.h gustavo.nihei@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/include/esp32s3_board_wdt.h gustavo.nihei@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/include/esp32s3_board_wlan.h tiago.medicci@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/kernel/Makefile gustavo.nihei@espressif.com alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com
-boards/xtensa/esp32s3/common/kernel/esp32s3_user_vectors.S gustavo.nihei@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/kernel/esp32s3_userspace.c gustavo.nihei@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/scripts/.gitignore gustavo.nihei@espressif.com
-boards/xtensa/esp32s3/common/scripts/esp32s3_aliases.ld petro.karashchenko@gmail.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com dongheng@espressif.com
-boards/xtensa/esp32s3/common/scripts/esp32s3_peripherals.ld gustavo.nihei@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/scripts/esp32s3_rom_aliases.ld petro.karashchenko@gmail.com tiago.medicci@espressif.com eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/scripts/esp32s3_sections.ld tiago.medicci@espressif.com almir.okato@espressif.com gustavo.nihei@espressif.com filipe.cavalcanti@espressif.com hujun5@xiaomi.com
-boards/xtensa/esp32s3/common/scripts/flat_memory.ld gustavo.nihei@espressif.com almir.okato@espressif.com tiago.medicci@espressif.com lucas.vaz@espressif.com eren.terzioglu@espressif.com
-boards/xtensa/esp32s3/common/scripts/kernel-space.ld gustavo.nihei@espressif.com tiago.medicci@espressif.com almir.okato@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/scripts/legacy_sections.ld almir.okato@espressif.com tiago.medicci@espressif.com dongheng@espressif.com gustavo.nihei@espressif.com eren.terzioglu@espressif.com
-boards/xtensa/esp32s3/common/scripts/mcuboot_sections.ld almir.okato@espressif.com eren.terzioglu@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com hujun5@xiaomi.com
-boards/xtensa/esp32s3/common/scripts/protected_memory.ld gustavo.nihei@espressif.com tiago.medicci@espressif.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-boards/xtensa/esp32s3/common/scripts/user-space.ld gustavo.nihei@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/src/esp32s3_board_adc.c filipe.cavalcanti@espressif.com zhaoqing.zhang@sony.com petro.karashchenko@gmail.com devel@sumpfralle.de alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/src/esp32s3_board_bmp180.c gustavo.nihei@espressif.com alin.jerpelea@sony.com roy.feng@sony.com
-boards/xtensa/esp32s3/common/src/esp32s3_board_i2c.c gustavo.nihei@espressif.com eren.terzioglu@espressif.com marco.casaroli@gmail.com alin.jerpelea@sony.com roy.feng@sony.com
-boards/xtensa/esp32s3/common/src/esp32s3_board_i2s.c tiago.medicci@espressif.com eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/src/esp32s3_board_ledc.c wangjianyu3@xiaomi.com eren.terzioglu@espressif.com
-boards/xtensa/esp32s3/common/src/esp32s3_board_mcpwm.c filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/src/esp32s3_board_pcnt.c eren.terzioglu@espressif.com martin.vajnar@gmail.com
-boards/xtensa/esp32s3/common/src/esp32s3_board_rmt.c tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/src/esp32s3_board_sdmmc.c Yinzhe.Wu@sony.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/src/esp32s3_board_spidev.c eren.terzioglu@espressif.com 40821031+w2016561536@users.noreply.github.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/src/esp32s3_board_spiflash.c abdelatif.guettouche@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com xiaoxiang@xiaomi.com
-boards/xtensa/esp32s3/common/src/esp32s3_board_spislavedev.c thiago.pereira@agrosystem.com.br
-boards/xtensa/esp32s3/common/src/esp32s3_board_tim.c gustavo.nihei@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/src/esp32s3_board_usb.c dongheng@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/src/esp32s3_board_wdt.c gustavo.nihei@espressif.com eren.terzioglu@espressif.com alin.jerpelea@sony.com roy.feng@sony.com
-boards/xtensa/esp32s3/common/src/esp32s3_board_wlan.c tiago.medicci@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/src/esp32s3_cs4344.c tiago.medicci@espressif.com eren.terzioglu@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/src/esp32s3_es8311.c tiago.medicci@espressif.com eren.terzioglu@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com
-boards/xtensa/esp32s3/common/src/esp32s3_lan9250.c dongheng@espressif.com zhaoqing.zhang@sony.com almir.okato@espressif.com alin.jerpelea@sony.com tiago.medicci@espressif.com
-boards/xtensa/esp32s3/common/src/esp32s3_usbmsc.c wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-8048S043/Kconfig halysson1007@gmail.com
-boards/xtensa/esp32s3/esp32s3-8048S043/configs/gpio/defconfig halysson1007@gmail.com
-boards/xtensa/esp32s3/esp32s3-8048S043/configs/i2c/defconfig halysson1007@gmail.com
-boards/xtensa/esp32s3/esp32s3-8048S043/configs/lcd/defconfig halysson1007@gmail.com
-boards/xtensa/esp32s3/esp32s3-8048S043/configs/nsh/defconfig halysson1007@gmail.com
-boards/xtensa/esp32s3/esp32s3-8048S043/configs/sdmmc/defconfig halysson1007@gmail.com
-boards/xtensa/esp32s3/esp32s3-8048S043/configs/spi/defconfig halysson1007@gmail.com
-boards/xtensa/esp32s3/esp32s3-8048S043/configs/touchscreen/defconfig halysson1007@gmail.com
-boards/xtensa/esp32s3/esp32s3-8048S043/include/board.h halysson1007@gmail.com
-boards/xtensa/esp32s3/esp32s3-8048S043/include/board_memorymap.h halysson1007@gmail.com
-boards/xtensa/esp32s3/esp32s3-8048S043/src/esp32s3-8048S043.h halysson1007@gmail.com
-boards/xtensa/esp32s3/esp32s3-8048S043/src/esp32s3_appinit.c halysson1007@gmail.com
-boards/xtensa/esp32s3/esp32s3-8048S043/src/esp32s3_board_spi.c halysson1007@gmail.com
-boards/xtensa/esp32s3/esp32s3-8048S043/src/esp32s3_board_touchsceen.c halysson1007@gmail.com
-boards/xtensa/esp32s3/esp32s3-8048S043/src/esp32s3_boot.c halysson1007@gmail.com
-boards/xtensa/esp32s3/esp32s3-8048S043/src/esp32s3_bringup.c halysson1007@gmail.com
-boards/xtensa/esp32s3/esp32s3-8048S043/src/esp32s3_buttons.c halysson1007@gmail.com
-boards/xtensa/esp32s3/esp32s3-8048S043/src/esp32s3_gpio.c halysson1007@gmail.com
-boards/xtensa/esp32s3/esp32s3-8048S043/src/esp32s3_lcd.c halysson1007@gmail.com
-boards/xtensa/esp32s3/esp32s3-8048S043/src/esp32s3_reset.c halysson1007@gmail.com
-boards/xtensa/esp32s3/esp32s3-8048S043/src/etc/init.d/rc.sysinit halysson1007@gmail.com
-boards/xtensa/esp32s3/esp32s3-8048S043/src/etc/init.d/rcS halysson1007@gmail.com
-boards/xtensa/esp32s3/esp32s3-8048S043/src/etc/txtable.txt halysson1007@gmail.com
-boards/xtensa/esp32s3/esp32s3-box/Kconfig dongheng@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-box/configs/buttons/defconfig dongheng@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me
-boards/xtensa/esp32s3/esp32s3-box/configs/lvgl-3/defconfig dongheng@espressif.com xuxingliang@xiaomi.com eren.terzioglu@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me
-boards/xtensa/esp32s3/esp32s3-box/configs/lvgl/defconfig dongheng@espressif.com xuxingliang@xiaomi.com eren.terzioglu@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me
-boards/xtensa/esp32s3/esp32s3-box/configs/nsh/defconfig dongheng@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-box/configs/touchscreen/defconfig dongheng@espressif.com eren.terzioglu@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-box/include/board.h dongheng@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-box/include/board_memorymap.h dongheng@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-box/src/esp32s3-box.h dongheng@espressif.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_appinit.c dongheng@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_board_lcd_ili9342c.c dongheng@espressif.com jiayadong@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_board_lcd_st7789.c dongheng@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com
-boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_board_spi.c dongheng@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_board_touchsceen_gt911.c dongheng@espressif.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_board_touchsceen_tt21100.c dongheng@espressif.com xiaoxiang@xiaomi.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_boot.c dongheng@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_bringup.c dongheng@espressif.com filipe.cavalcanti@espressif.com laczenjms@gmail.com huangqi3@xiaomi.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_buttons.c dongheng@espressif.com alin.jerpelea@sony.com tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_reset.c dongheng@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-devkit/Kconfig wangjianyu3@xiaomi.com abdelatif.guettouche@espressif.com 101105604+simbit18@users.noreply.github.com chenwen@espressif.com tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/adb/defconfig wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/adc/defconfig zhaoqing.zhang@sony.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com devansh.purohit@proton.me
-boards/xtensa/esp32s3/esp32s3-devkit/configs/audio/defconfig tiago.medicci@espressif.com eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me
-boards/xtensa/esp32s3/esp32s3-devkit/configs/ble/defconfig petro.karashchenko@gmail.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me
-boards/xtensa/esp32s3/esp32s3-devkit/configs/blewifi/defconfig tiago.medicci@espressif.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me acassis@gmail.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/buttons/defconfig gustavo.nihei@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me tiago.medicci@espressif.com filipe.cavalcanti@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/capture/defconfig filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/coremark/defconfig lucas.vaz@espressif.com devansh.purohit@proton.me tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/crypto/defconfig eren.terzioglu@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/cxx/defconfig gustavo.nihei@espressif.com tiago.medicci@espressif.com jihandong@xiaomi.com wangjianyu3@xiaomi.com yinshengkai@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/elf/defconfig tiago.medicci@espressif.com wangjianyu3@xiaomi.com anjiahao@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/eth_lan9250/defconfig dongheng@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me acassis@gmail.com tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/fastboot/defconfig wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/fastboot_tcp/defconfig wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/fastboot_usb/defconfig wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/gpio/defconfig tiago.medicci@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me
-boards/xtensa/esp32s3/esp32s3-devkit/configs/i2c/defconfig gustavo.nihei@espressif.com acassis@gmail.com tiago.medicci@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me
-boards/xtensa/esp32s3/esp32s3-devkit/configs/i2schar/defconfig eren.terzioglu@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/knsh/defconfig gustavo.nihei@espressif.com tiago.medicci@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me acassis@gmail.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/ksta_softap/defconfig tiago.medicci@espressif.com filipe.cavalcanti@espressif.com devansh.purohit@proton.me acassis@gmail.com tjwu1217@gmail.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/mbedtls/defconfig yamamoto@midokura.com tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/mcuboot_nsh/defconfig almir.okato@espressif.com tiago.medicci@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me lucas.vaz@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/mcuboot_update_agent/defconfig filipe.cavalcanti@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/motor/defconfig filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/nsh/defconfig gustavo.nihei@espressif.com lucas.vaz@espressif.com dongheng@espressif.com tiago.medicci@espressif.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/nxlooper/defconfig tiago.medicci@espressif.com eren.terzioglu@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me
-boards/xtensa/esp32s3/esp32s3-devkit/configs/oneshot/defconfig gustavo.nihei@espressif.com tiago.medicci@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me acassis@gmail.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/pm/defconfig chenwen@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/psram_octal/defconfig dongheng@espressif.com tiago.medicci@espressif.com tengshuangshuang@xiaomi.com wangjianyu3@xiaomi.com devansh.purohit@proton.me
-boards/xtensa/esp32s3/esp32s3-devkit/configs/psram_quad/defconfig dongheng@espressif.com tiago.medicci@espressif.com tengshuangshuang@xiaomi.com wangjianyu3@xiaomi.com devansh.purohit@proton.me
-boards/xtensa/esp32s3/esp32s3-devkit/configs/psram_usrheap/defconfig chenwen@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com tengshuangshuang@xiaomi.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/pwm/defconfig lucas.vaz@espressif.com eren.terzioglu@espressif.com 40821031+w2016561536@users.noreply.github.com tiago.medicci@espressif.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/python/defconfig tiago.medicci@espressif.com anchao.archer@bytedance.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/qemu_debug/defconfig yamamoto@midokura.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/qemu_openeth/defconfig marco.casaroli@gmail.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/qemu_toywasm/defconfig filipe.cavalcanti@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/qencoder/defconfig eren.terzioglu@espressif.com martin.vajnar@gmail.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/random/defconfig acassis@gmail.com tiago.medicci@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me
-boards/xtensa/esp32s3/esp32s3-devkit/configs/rmt/defconfig tiago.medicci@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me
-boards/xtensa/esp32s3/esp32s3-devkit/configs/rtc/defconfig eren.terzioglu@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/sdm/defconfig eren.terzioglu@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/sdmmc/defconfig Yinzhe.Wu@sony.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/sdmmc_spi/defconfig filipe.cavalcanti@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/smp/defconfig gustavo.nihei@espressif.com tiago.medicci@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me acassis@gmail.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/sotest/defconfig eren.terzioglu@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/spi/defconfig 40821031+w2016561536@users.noreply.github.com wangjianyu3@xiaomi.com devansh.purohit@proton.me tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/spiflash/defconfig abdelatif.guettouche@espressif.com tiago.medicci@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me acassis@gmail.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/spislv/defconfig thiago.pereira@agrosystem.com.br
-boards/xtensa/esp32s3/esp32s3-devkit/configs/sta_softap/defconfig tiago.medicci@espressif.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me acassis@gmail.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/stack/defconfig anjiahao@xiaomi.com wangjianyu3@xiaomi.com devansh.purohit@proton.me tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/temperature_sensor/defconfig eren.terzioglu@espressif.com xiaoxiang@xiaomi.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/tickless/defconfig gustavo.nihei@espressif.com tiago.medicci@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me acassis@gmail.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/timer/defconfig gustavo.nihei@espressif.com tiago.medicci@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me acassis@gmail.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/toywasm/defconfig yamamoto@midokura.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me
-boards/xtensa/esp32s3/esp32s3-devkit/configs/twai/defconfig eren.terzioglu@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/txtable/defconfig wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/usb_device/defconfig dongheng@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me huangqi3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/usbmsc/defconfig wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/usbnsh/defconfig acassis@gmail.com wangjianyu3@xiaomi.com devansh.purohit@proton.me filipe.cavalcanti@espressif.com huangqi3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/watchdog/defconfig gustavo.nihei@espressif.com tiago.medicci@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me eren.terzioglu@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/configs/wifi/defconfig lucas.vaz@espressif.com tiago.medicci@espressif.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me
-boards/xtensa/esp32s3/esp32s3-devkit/include/board.h gustavo.nihei@espressif.com abdelatif.guettouche@espressif.com dongheng@espressif.com tiago.medicci@espressif.com 101105604+simbit18@users.noreply.github.com
-boards/xtensa/esp32s3/esp32s3-devkit/include/board_memorymap.h gustavo.nihei@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3-devkit.h gustavo.nihei@espressif.com tiago.medicci@espressif.com acassis@gmail.com dongheng@espressif.com zhaoqing.zhang@sony.com
-boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_appinit.c gustavo.nihei@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_board_spi.c acassis@gmail.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_boot.c gustavo.nihei@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_bringup.c gustavo.nihei@espressif.com eren.terzioglu@espressif.com tiago.medicci@espressif.com acassis@gmail.com chenwen@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_buttons.c gustavo.nihei@espressif.com alin.jerpelea@sony.com tiago.medicci@espressif.com lucas.vaz@espressif.com xiaoxiang@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_djoystick.c acassis@gmail.com tiago.medicci@espressif.com alin.jerpelea@sony.com anchao@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_gpio.c tiago.medicci@espressif.com eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_reset.c gustavo.nihei@espressif.com tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_st7735.c acassis@gmail.com anchao@xiaomi.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-devkit/src/esp32s3_twai.c eren.terzioglu@espressif.com alin.jerpelea@sony.com almir.okato@espressif.com
-boards/xtensa/esp32s3/esp32s3-devkit/src/etc/init.d/rc.sysinit wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-devkit/src/etc/init.d/rcS wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-devkit/src/etc/txtable.txt wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-eye/Kconfig acassis@gmail.com wangjianyu3@xiaomi.com 101105604+simbit18@users.noreply.github.com marco.casaroli@gmail.com tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-eye/configs/gpio/defconfig marco.casaroli@gmail.com wangjianyu3@xiaomi.com devansh.purohit@proton.me luppy@appkaki.com
-boards/xtensa/esp32s3/esp32s3-eye/configs/i2c/defconfig marco.casaroli@gmail.com wangjianyu3@xiaomi.com devansh.purohit@proton.me luppy@appkaki.com tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-eye/configs/lcd/defconfig marco.casaroli@gmail.com wangjianyu3@xiaomi.com devansh.purohit@proton.me luppy@appkaki.com tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-eye/configs/nsh/defconfig acassis@gmail.com tiago.medicci@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me mazhuang@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-eye/configs/usbnsh/defconfig acassis@gmail.com wangjianyu3@xiaomi.com devansh.purohit@proton.me filipe.cavalcanti@espressif.com mazhuang@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-eye/configs/wifi/defconfig marco.casaroli@gmail.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me acassis@gmail.com
-boards/xtensa/esp32s3/esp32s3-eye/include/board.h acassis@gmail.com abdelatif.guettouche@espressif.com marco.casaroli@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-eye/include/board_memorymap.h tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-eye/src/esp32s3-eye.h marco.casaroli@gmail.com acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-eye/src/esp32s3_appinit.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-eye/src/esp32s3_board_lcd.c marco.casaroli@gmail.com devel@sumpfralle.de alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-eye/src/esp32s3_board_spi.c marco.casaroli@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-eye/src/esp32s3_boot.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-eye/src/esp32s3_bringup.c acassis@gmail.com marco.casaroli@gmail.com filipe.cavalcanti@espressif.com Yinzhe.Wu@sony.com laczenjms@gmail.com
-boards/xtensa/esp32s3/esp32s3-eye/src/esp32s3_buttons.c marco.casaroli@gmail.com alin.jerpelea@sony.com tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-eye/src/esp32s3_gpio.c marco.casaroli@gmail.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-eye/src/esp32s3_reset.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-korvo-2/Kconfig tiago.medicci@espressif.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-korvo-2/configs/audio/defconfig tiago.medicci@espressif.com eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-korvo-2/configs/nsh/defconfig tiago.medicci@espressif.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-korvo-2/configs/rtptools/defconfig tiago.medicci@espressif.com eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-korvo-2/configs/sdmmc/defconfig Yinzhe.Wu@sony.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-korvo-2/include/board.h tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-korvo-2/include/board_memorymap.h tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3-korvo-2.h tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3_appinit.c tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3_board_spi.c tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3_boot.c tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3_bringup.c tiago.medicci@espressif.com eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com Yinzhe.Wu@sony.com laczenjms@gmail.com
-boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3_buttons.c tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3_reset.c tiago.medicci@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-lcd-ev/Kconfig dongheng@espressif.com wangjianyu3@xiaomi.com eren.terzioglu@espressif.com 101105604+simbit18@users.noreply.github.com tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-lcd-ev/configs/audio/defconfig eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com
-boards/xtensa/esp32s3/esp32s3-lcd-ev/configs/buttons/defconfig dongheng@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me
-boards/xtensa/esp32s3/esp32s3-lcd-ev/configs/lcd/defconfig dongheng@espressif.com eren.terzioglu@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me
-boards/xtensa/esp32s3/esp32s3-lcd-ev/configs/lvgl/defconfig dongheng@espressif.com xuxingliang@xiaomi.com eren.terzioglu@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me
-boards/xtensa/esp32s3/esp32s3-lcd-ev/configs/nsh/defconfig dongheng@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-lcd-ev/configs/ws2812/defconfig dongheng@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-lcd-ev/include/board.h dongheng@espressif.com eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-lcd-ev/include/board_memorymap.h dongheng@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-lcd-ev/src/esp32s3-lcd-ev.h dongheng@espressif.com eren.terzioglu@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-lcd-ev/src/esp32s3_appinit.c dongheng@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-lcd-ev/src/esp32s3_board_spi.c dongheng@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-lcd-ev/src/esp32s3_boot.c dongheng@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-lcd-ev/src/esp32s3_bringup.c dongheng@espressif.com eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com laczenjms@gmail.com huangqi3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-lcd-ev/src/esp32s3_buttons.c dongheng@espressif.com alin.jerpelea@sony.com tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-lcd-ev/src/esp32s3_ioexpander.c dongheng@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-lcd-ev/src/esp32s3_lcd.c dongheng@espressif.com devel@sumpfralle.de alin.jerpelea@sony.com huangqi3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-lcd-ev/src/esp32s3_reset.c dongheng@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-lcd-ev/src/esp32s3_touchscreen.c dongheng@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-lcd-ev/src/esp32s3_ws2812.c dongheng@espressif.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-lhcbit/Kconfig jorge.gzm@gmail.com wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-lhcbit/configs/usbnsh/defconfig jorge.gzm@gmail.com wangjianyu3@xiaomi.com filipe.cavalcanti@espressif.com
-boards/xtensa/esp32s3/esp32s3-lhcbit/include/board.h jorge.gzm@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-lhcbit/include/board_memorymap.h jorge.gzm@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-lhcbit/src/esp32s3-lhcbit.h jorge.gzm@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-lhcbit/src/esp32s3_appinit.c jorge.gzm@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-lhcbit/src/esp32s3_boot.c jorge.gzm@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-lhcbit/src/esp32s3_bringup.c jorge.gzm@gmail.com huangqi3@xiaomi.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-lhcbit/src/esp32s3_reset.c jorge.gzm@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-meadow/Kconfig acassis@gmail.com wangjianyu3@xiaomi.com tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-meadow/configs/nsh/defconfig acassis@gmail.com tiago.medicci@espressif.com wangjianyu3@xiaomi.com devansh.purohit@proton.me mazhuang@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-meadow/configs/usbnsh/defconfig acassis@gmail.com wangjianyu3@xiaomi.com devansh.purohit@proton.me filipe.cavalcanti@espressif.com mazhuang@xiaomi.com
-boards/xtensa/esp32s3/esp32s3-meadow/include/board.h acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-meadow/include/board_memorymap.h tiago.medicci@espressif.com
-boards/xtensa/esp32s3/esp32s3-meadow/src/esp32s3-meadow.h acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-meadow/src/esp32s3_appinit.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-meadow/src/esp32s3_boot.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-meadow/src/esp32s3_bringup.c acassis@gmail.com huangqi3@xiaomi.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-meadow/src/esp32s3_reset.c acassis@gmail.com alin.jerpelea@sony.com
-boards/xtensa/esp32s3/esp32s3-xiao/Kconfig rcsim10@gmail.com
-boards/xtensa/esp32s3/esp32s3-xiao/configs/combo/defconfig rcsim10@gmail.com
-boards/xtensa/esp32s3/esp32s3-xiao/configs/usbnsh/defconfig rcsim10@gmail.com
-boards/xtensa/esp32s3/esp32s3-xiao/include/board.h rcsim10@gmail.com
-boards/xtensa/esp32s3/esp32s3-xiao/include/board_memorymap.h rcsim10@gmail.com
-boards/xtensa/esp32s3/esp32s3-xiao/src/esp32s3-xiao.h rcsim10@gmail.com
-boards/xtensa/esp32s3/esp32s3-xiao/src/esp32s3_appinit.c rcsim10@gmail.com
-boards/xtensa/esp32s3/esp32s3-xiao/src/esp32s3_autoleds.c rcsim10@gmail.com
-boards/xtensa/esp32s3/esp32s3-xiao/src/esp32s3_boot.c rcsim10@gmail.com
-boards/xtensa/esp32s3/esp32s3-xiao/src/esp32s3_bringup.c rcsim10@gmail.com
-boards/xtensa/esp32s3/esp32s3-xiao/src/esp32s3_gpio.c rcsim10@gmail.com filipe.cavalcanti@espressif.com
-boards/xtensa/esp32s3/esp32s3-xiao/src/esp32s3_reset.c rcsim10@gmail.com
-boards/xtensa/esp32s3/esp32s3-xiao/src/esp32s3_userleds.c rcsim10@gmail.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/Kconfig wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/configs/adb/defconfig wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/configs/fastboot/defconfig wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/configs/fastboot_tcp/defconfig wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/configs/fastboot_usb/defconfig wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/configs/gpio/defconfig wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/configs/lcd/defconfig wangjianyu3@xiaomi.com eren.terzioglu@espressif.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/configs/lvgl/defconfig wangjianyu3@xiaomi.com eren.terzioglu@espressif.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/configs/nsh/defconfig wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/configs/pca9557/defconfig wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/configs/psram/defconfig wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/configs/pwm/defconfig wangjianyu3@xiaomi.com eren.terzioglu@espressif.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/configs/txtable/defconfig wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/configs/usb_device/defconfig wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/include/board.h wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/include/board_memorymap.h wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3-szpi.h wangjianyu3@xiaomi.com eren.terzioglu@espressif.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_appinit.c wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_board_lcd.c wangjianyu3@xiaomi.com devel@sumpfralle.de
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_board_spi.c wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_boot.c wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_bringup.c wangjianyu3@xiaomi.com eren.terzioglu@espressif.com laczenjms@gmail.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_ft5x06.c wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_gpio.c wangjianyu3@xiaomi.com filipe.cavalcanti@espressif.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_pca9557.c wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_reset.c wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/etc/init.d/rc.sysinit wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/etc/init.d/rcS wangjianyu3@xiaomi.com
-boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/etc/txtable.txt wangjianyu3@xiaomi.com
+
+boards/x86/qemu/* alin.jerpelea@sony.com xiaoxiang@xiaomi.com
+boards/x86_64/* bashton@brennanashton.com p-szafonimateusz@xiaomi.com
+boards/xtensa/* eren.terzioglu@espressif.com filipe.cavalcanti@espressif.com alin.jerpelea@sony.com tiago.medicci@espressif.com gustavo.nihei@espressif.com lucas.vaz@espressif.com rcsim10@gmail.com
+
 boards/z16/z16f/z16f2800100zcog/Kconfig xiaoxiang@xiaomi.com
 boards/z16/z16f/z16f2800100zcog/configs/nsh/defconfig xiaoxiang@xiaomi.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com acassis@gmail.com
 boards/z16/z16f/z16f2800100zcog/configs/nsh/nsh.zfpproj xiaoxiang@xiaomi.com
@@ -17998,80 +12711,13 @@ boards/z80/z80/z80sim/src/z80_irq.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 boards/z80/z80/z80sim/src/z80_lowputc.c alin.jerpelea@sony.com
 boards/z80/z80/z80sim/src/z80_serial.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com anchao@lixiang.com anchao@xiaomi.com
 boards/z80/z80/z80sim/src/z80_timerisr.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-cmake/menuconfig.cmake anchao@xiaomi.com 101105604+simbit18@users.noreply.github.com xuxin19@xiaomi.com anchao@lixiang.com alin.jerpelea@sony.com
-cmake/nuttx_add_application.cmake anchao@xiaomi.com xuxin19@xiaomi.com raiden00@railab.me anjiahao@xiaomi.com alin.jerpelea@sony.com
-cmake/nuttx_add_dependencies.cmake xuxin19@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-cmake/nuttx_add_library.cmake anchao@xiaomi.com xuxin19@xiaomi.com raiden00@railab.me anchao@lixiang.com guoshichao@xiaomi.com
-cmake/nuttx_add_module.cmake anchao@xiaomi.com alin.jerpelea@sony.com
-cmake/nuttx_add_romfs.cmake xuxin19@xiaomi.com anchao@xiaomi.com raiden00@railab.me guoshichao@xiaomi.com anchao@lixiang.com
-cmake/nuttx_add_subdirectory.cmake anchao@xiaomi.com alin.jerpelea@sony.com
-cmake/nuttx_add_symtab.cmake anchao@xiaomi.com raiden00@railab.me devel@sumpfralle.de alin.jerpelea@sony.com
-cmake/nuttx_create_symlink.cmake anchao@xiaomi.com 101105604+simbit18@users.noreply.github.com alin.jerpelea@sony.com
-cmake/nuttx_export_header.cmake xuxin19@xiaomi.com alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com
-cmake/nuttx_extensions.cmake xuxin19@xiaomi.com zhengjunbo1@xiaomi.com
-cmake/nuttx_generate_headers.cmake anchao@xiaomi.com xuxin19@xiaomi.com alin.jerpelea@sony.com
-cmake/nuttx_generate_outputs.cmake anchao@xiaomi.com fanjiangang@lixiang.com xuxin19@xiaomi.com alin.jerpelea@sony.com
-cmake/nuttx_generate_sim_ld.cmake xuxin19@xiaomi.com
-cmake/nuttx_kconfig.cmake anchao@xiaomi.com xuxin19@xiaomi.com 101105604+simbit18@users.noreply.github.com alin.jerpelea@sony.com
-cmake/nuttx_mkconfig.cmake anchao@xiaomi.com anchao.archer@bytedance.com yfliu2008@qq.com xuxin19@xiaomi.com alin.jerpelea@sony.com
-cmake/nuttx_mkversion.cmake anchao@xiaomi.com pietro.albini@ferrous-systems.com alin.jerpelea@sony.com xuxin19@xiaomi.com
-cmake/nuttx_multiple_link.cmake wangmingrong1@xiaomi.com
-cmake/nuttx_parse_function_args.cmake anchao@xiaomi.com raiden00@railab.me alin.jerpelea@sony.com
-cmake/nuttx_process_config.cmake wangchengdong@lixiang.com
-cmake/nuttx_redefine_symbols.cmake anchao@xiaomi.com xuxin19@xiaomi.com alin.jerpelea@sony.com
-cmake/nuttx_remove_compile_options.cmake xuxin19@xiaomi.com devel@sumpfralle.de
-cmake/nuttx_sethost.cmake 101105604+simbit18@users.noreply.github.com alin.jerpelea@sony.com xuxin19@xiaomi.com
-cmake/nuttx_source_file_properties.cmake xuxin19@xiaomi.com alin.jerpelea@sony.com
-cmake/nuttx_toolchain.cmake guoshichao@xiaomi.com anchao@lixiang.com xuxin19@xiaomi.com
-cmake/savedefconfig.cmake xuxin19@xiaomi.com 101105604+simbit18@users.noreply.github.com alin.jerpelea@sony.com serg@podtynnyi.com
-cmake/symtab.c.in anchao@xiaomi.com alin.jerpelea@sony.com
-crypto/Kconfig jussi.kivilinna@haltian.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com makejian@xiaomi.com
-crypto/Makefile xiaoxiang@xiaomi.com alin.jerpelea@sony.com anjiahao@xiaomi.com jussi.kivilinna@haltian.com
-crypto/aes.c anjiahao@xiaomi.com alin.jerpelea@sony.com sebastien@lorquet.fr acassis@gmail.com
-crypto/blake2s.c jussi.kivilinna@haltian.com alin.jerpelea@sony.com anjiahao@xiaomi.com xiaoxiang@xiaomi.com
-crypto/blf.c anjiahao@xiaomi.com alin.jerpelea@sony.com
-crypto/bn.c makejian@xiaomi.com alin.jerpelea@sony.com yinshengkai@xiaomi.com
-crypto/cast.c anjiahao@xiaomi.com alin.jerpelea@sony.com
-crypto/castsb.h anjiahao@xiaomi.com alin.jerpelea@sony.com
-crypto/chacha_private.h anjiahao@xiaomi.com alin.jerpelea@sony.com
-crypto/chachapoly.c anjiahao@xiaomi.com makejian@xiaomi.com alin.jerpelea@sony.com
-crypto/cmac.c anjiahao@xiaomi.com alin.jerpelea@sony.com gustavo.nihei@espressif.com
-crypto/crypto.c anjiahao@xiaomi.com alin.jerpelea@sony.com sebastien@lorquet.fr makejian@xiaomi.com
-crypto/cryptodev.c anjiahao@xiaomi.com makejian@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-crypto/cryptosoft.c anjiahao@xiaomi.com makejian@xiaomi.com alin.jerpelea@sony.com gustavo.nihei@espressif.com devel@sumpfralle.de
-crypto/curve25519.c makejian@xiaomi.com alin.jerpelea@sony.com raiden00@railab.me
-crypto/des_locl.h anjiahao@xiaomi.com alin.jerpelea@sony.com
-crypto/ecb3_enc.c anjiahao@xiaomi.com alin.jerpelea@sony.com f.panag@amco.gr
-crypto/ecb_enc.c anjiahao@xiaomi.com alin.jerpelea@sony.com f.panag@amco.gr
-crypto/gmac.c anjiahao@xiaomi.com alin.jerpelea@sony.com makejian@xiaomi.com
-crypto/hmac.c anjiahao@xiaomi.com nicco.maggioni@gmail.com alin.jerpelea@sony.com
-crypto/hmac_buff.c anjiahao@xiaomi.com alin.jerpelea@sony.com
-crypto/idgen.c anjiahao@xiaomi.com alin.jerpelea@sony.com
-crypto/key_wrap.c anjiahao@xiaomi.com alin.jerpelea@sony.com
-crypto/md5.c anjiahao@xiaomi.com alin.jerpelea@sony.com
-crypto/podd.h anjiahao@xiaomi.com alin.jerpelea@sony.com
-crypto/poly1305.c anjiahao@xiaomi.com alin.jerpelea@sony.com makejian@xiaomi.com
-crypto/random_pool.c jussi.kivilinna@haltian.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com alin.jerpelea@sony.com
-crypto/rijndael.c anjiahao@xiaomi.com alin.jerpelea@sony.com
-crypto/rmd160.c anjiahao@xiaomi.com alin.jerpelea@sony.com
-crypto/set_key.c anjiahao@xiaomi.com alin.jerpelea@sony.com
-crypto/sha1.c anjiahao@xiaomi.com alin.jerpelea@sony.com
-crypto/sha2.c anjiahao@xiaomi.com makejian@xiaomi.com alin.jerpelea@sony.com
-crypto/siphash.c anjiahao@xiaomi.com alin.jerpelea@sony.com 101105604+simbit18@users.noreply.github.com
-crypto/sk.h anjiahao@xiaomi.com alin.jerpelea@sony.com
-crypto/spr.h anjiahao@xiaomi.com alin.jerpelea@sony.com
-crypto/testmngr.c alin.jerpelea@sony.com anchao@xiaomi.com
-crypto/testmngr.h alin.jerpelea@sony.com gustavo.nihei@espressif.com
-crypto/xform.c anjiahao@xiaomi.com makejian@xiaomi.com alin.jerpelea@sony.com
-drivers/.gitignore xiaoxiang@xiaomi.com yamamoto@midokura.com
-drivers/1wire/1wire.c juha.niskanen@haltian.com anjiahao@xiaomi.com abdelatif.guettouche@gmail.com alin.jerpelea@sony.com ocram.lhark@gmail.com
-drivers/1wire/1wire_crc.c juha.niskanen@haltian.com alin.jerpelea@sony.com ocram.lhark@gmail.com
-drivers/1wire/1wire_internal.h juha.niskanen@haltian.com alin.jerpelea@sony.com ocram.lhark@gmail.com anjiahao@xiaomi.com abdelatif.guettouche@gmail.com
-drivers/1wire/1wire_read.c ocram.lhark@gmail.com anjiahao@xiaomi.com alin.jerpelea@sony.com
-drivers/1wire/1wire_write.c ocram.lhark@gmail.com anjiahao@xiaomi.com alin.jerpelea@sony.com
-drivers/1wire/1wire_writeread.c ocram.lhark@gmail.com anjiahao@xiaomi.com alin.jerpelea@sony.com
-drivers/1wire/Kconfig juha.niskanen@haltian.com xiaoxiang@xiaomi.com
-drivers/1wire/ds28e17.c juha.niskanen@haltian.com abdelatif.guettouche@gmail.com anjiahao@xiaomi.com alin.jerpelea@sony.com ocram.lhark@gmail.com
+
+cmake/* 101105604+simbit18@users.noreply.github.com anchao@xiaomi.com alin.jerpelea@sony.com anchao.archer@bytedance.com
+
+crypto/* jussi.kivilinna@haltian.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com alin.jerpelea@sony.com
+
+drivers/1wire/* juha.niskanen@haltian.com anjiahao@xiaomi.com alin.jerpelea@sony.com
+
 drivers/Kconfig xiaoxiang@xiaomi.com acassis@gmail.com jordi@midokura.com augustofg96@gmail.com
 drivers/Makefile xiaoxiang@xiaomi.com alin.jerpelea@sony.com anchao@xiaomi.com
 drivers/aie/Kconfig renzhiyuan1@xiaomi.com
@@ -19083,7 +13729,7 @@ drivers/wireless/ieee802154/xbee/xbee_mac.c anthony@vergeaero.com xiaoxiang@xiao
 drivers/wireless/ieee802154/xbee/xbee_mac.h anthony@vergeaero.com alin.jerpelea@sony.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
 drivers/wireless/ieee802154/xbee/xbee_netdev.c anthony@vergeaero.com zhanghongyu@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
 drivers/wireless/lpwan/Kconfig raiden00pl@gmail.com matteo.golin@gmail.com kevinwit1999@gmail.com simbit18@gmail.com xiaoxiang@xiaomi.com
-drivers/wireless/lpwan/rn2xx3/rn2xx3.c matteo.golin@gmail.com
+drivers/wireless/lpwan/rn2xx3/* matteo.golin@gmail.com
 drivers/wireless/lpwan/sx126x/Kconfig kevinwit1999@gmail.com
 drivers/wireless/lpwan/sx126x/sx126x.c kevinwit1999@gmail.com
 drivers/wireless/lpwan/sx126x/sx126x.h kevinwit1999@gmail.com
@@ -19132,10 +13778,7 @@ drivers/wireless/spirit/lib/spirit_qi.c alin.jerpelea@sony.com xiaoxiang@xiaomi.
 drivers/wireless/spirit/lib/spirit_radio.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com huangqi3@xiaomi.com petro.karashchenko@gmail.com
 drivers/wireless/spirit/lib/spirit_spi.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com juha.niskanen@haltian.com
 drivers/wireless/spirit/lib/spirit_timer.c alin.jerpelea@sony.com devel@sumpfralle.de xiaoxiang@xiaomi.com
-dummy/Kconfig xiaoxiang@xiaomi.com
-dummy/README.md xiaoxiang@xiaomi.com
-fs/Kconfig petro.karashchenko@gmail.com xiaoxiang@xiaomi.com jordi@midokura.com
-fs/Makefile alin.jerpelea@sony.com xiaoxiang@xiaomi.com yamamoto@midokura.com
+
 fs/aio/Kconfig devel@sumpfralle.de xiaoxiang@xiaomi.com
 fs/aio/aio.h dongjiuzhu1@xiaomi.com xiaoxiang@xiaomi.com pelle.windestam@tagmaster.com
 fs/aio/aio_cancel.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com guoshichao@xiaomi.com pelle.windestam@tagmaster.com
@@ -19146,9 +13789,12 @@ fs/aio/aio_read.c alin.jerpelea@sony.com dongjiuzhu1@xiaomi.com guoshichao@xiaom
 fs/aio/aio_signal.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
 fs/aio/aio_write.c dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com guoshichao@xiaomi.com xiaoxiang@xiaomi.com
 fs/aio/aioc_contain.c dongjiuzhu1@xiaomi.com zhangshoukui@xiaomi.com anchao@xiaomi.com alin.jerpelea@sony.com
-fs/binfs/fs_binfs.c dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
+
+fs/binfs/* dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
+
 fs/cromfs/cromfs.h alin.jerpelea@sony.com vatsalasitkumar.joshi@mavs.uta.edu xiaoxiang@xiaomi.com
 fs/cromfs/fs_cromfs.c xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com petro.karashchenko@gmail.com David.Sidrane@NscDg.com
+
 fs/driver/driver.h xiaoxiang@xiaomi.com alin.jerpelea@sony.com juha.niskanen@haltian.com liaoao@xiaomi.com
 fs/driver/fs_blockmerge.c wanggang26@xiaomi.com
 fs/driver/fs_blockpartition.c xiaoxiang@xiaomi.com petro.karashchenko@gmail.com code@bje.id.au bashton@brennanashton.com
@@ -19168,22 +13814,28 @@ fs/driver/fs_unregisterblockdriver.c dongjiuzhu1@xiaomi.com guohao15@xiaomi.com 
 fs/driver/fs_unregisterdriver.c dongjiuzhu1@xiaomi.com guohao15@xiaomi.com anjiahao@xiaomi.com xiaoxiang@xiaomi.com
 fs/driver/fs_unregistermtddriver.c dongjiuzhu1@xiaomi.com guohao15@xiaomi.com anjiahao@xiaomi.com xiaoxiang@xiaomi.com
 fs/driver/fs_unregisterpipedriver.c yinshengkai@xiaomi.com dongjiuzhu1@xiaomi.com guohao15@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
+
 fs/event/Kconfig fangxinyong@xiaomi.com
 fs/event/event.h fangxinyong@xiaomi.com alin.jerpelea@sony.com
 fs/event/event_close.c fangxinyong@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
 fs/event/event_open.c fangxinyong@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
+
 fs/fat/Kconfig xiaoxiang@xiaomi.com jpa@bitbucket.mail.kapsi.fi reto.gaehwiler@hexagon.com
 fs/fat/fs_fat32.c Yinzhe.Wu@sony.com anjiahao@xiaomi.com acassis@gmail.com
 fs/fat/fs_fat32.h xiaoxiang@xiaomi.com anjiahao@xiaomi.com abdelatif.guettouche@gmail.com
 fs/fat/fs_fat32attrib.c anjiahao@xiaomi.com xiaoxiang@xiaomi.com abdelatif.guettouche@gmail.com
 fs/fat/fs_fat32dirent.c johannes.schock@nivus.com jpa@bitbucket.mail.kapsi.fi dongjiuzhu1@xiaomi.com
 fs/fat/fs_fat32util.c reto.gaehwiler@hexagon.com abdelatif.guettouche@gmail.com xiaoxiang@xiaomi.com
+
 fs/fs_heap.c buxiasen@xiaomi.com chenrun1@xiaomi.com yinshengkai@xiaomi.com xuxingliang@xiaomi.com alin.jerpelea@sony.com
 fs/fs_heap.h buxiasen@xiaomi.com chenrun1@xiaomi.com alin.jerpelea@sony.com xuxingliang@xiaomi.com yinshengkai@xiaomi.com
+
 fs/fs_initialize.c alin.jerpelea@sony.com chenrun1@xiaomi.com xiaoxiang@xiaomi.com guohao15@xiaomi.com
+
 fs/hostfs/Kconfig pettitkd@gmail.com yamamoto@midokura.com liguiding1@xiaomi.com liguiding@pinecone.net devel@sumpfralle.de
 fs/hostfs/hostfs.c pettitkd@gmail.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com abdelatif.guettouche@gmail.com
 fs/hostfs/hostfs.h pettitkd@gmail.com alin.jerpelea@sony.com anjiahao@xiaomi.com juha.niskanen@haltian.com
+
 fs/inode/fs_files.c dongjiuzhu1@xiaomi.com ville.juven@unikie.com anchao@xiaomi.com xiaoxiang@xiaomi.com
 fs/inode/fs_foreachinode.c dongjiuzhu1@xiaomi.com cuiziwei@xiaomi.com xiaoxiang@xiaomi.com anchao@lixiang.com
 fs/inode/fs_inode.c anjiahao@xiaomi.com dongjiuzhu1@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
@@ -19197,6 +13849,7 @@ fs/inode/fs_inoderemove.c alin.jerpelea@sony.com cuiziwei@xiaomi.com xiaoxiang@x
 fs/inode/fs_inodereserve.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com cuiziwei@xiaomi.com zhouliang3@xiaomi.com
 fs/inode/fs_inodesearch.c xiaoxiang@xiaomi.com cuiziwei@xiaomi.com alin.jerpelea@sony.com chenrun1@xiaomi.com
 fs/inode/inode.h xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com xuxingliang@xiaomi.com petro.karashchenko@gmail.com
+
 fs/littlefs/.gitignore liuhaitao@xiaomi.com xiaoxiang@xiaomi.com
 fs/littlefs/Kconfig yamamoto@midokura.com igy1000mb@gmail.com you@example.com li8303@163.com chenrun1@xiaomi.com
 fs/littlefs/lfs_getpath.patch chenrun1@xiaomi.com
@@ -19205,6 +13858,7 @@ fs/littlefs/lfs_nuttx_defines.h yamamoto@midokura.com
 fs/littlefs/lfs_util.patch radek.pesina@motec.com.au chenrun1@xiaomi.com
 fs/littlefs/lfs_vfs.c xiaoxiang@xiaomi.com li8303@163.com zhouliang3@xiaomi.com dongjiuzhu1@xiaomi.com abdelatif.guettouche@gmail.com
 fs/littlefs/lfs_vfs.h xiaoxiang@xiaomi.com alin.jerpelea@sony.com
+
 fs/mmap/Kconfig jukkax@ssrc.tii.ae xiaoxiang@xiaomi.com acassis@gmail.com
 fs/mmap/fs_anonmap.c jukkax@ssrc.tii.ae xiaoxiang@xiaomi.com chenrun1@xiaomi.com ville.juven@unikie.com tkaratapanis@census-labs.com
 fs/mmap/fs_mmap.c xiaoxiang@xiaomi.com jukkax@ssrc.tii.ae gustavo.nihei@espressif.com
@@ -19213,17 +13867,9 @@ fs/mmap/fs_msync.c chenrun1@xiaomi.com alin.jerpelea@sony.com
 fs/mmap/fs_munmap.c xiaoxiang@xiaomi.com jukkax@ssrc.tii.ae alin.jerpelea@sony.com
 fs/mmap/fs_rammap.c jukkax@ssrc.tii.ae xiaoxiang@xiaomi.com chenrun1@xiaomi.com
 fs/mmap/fs_rammap.h jukkax@ssrc.tii.ae alin.jerpelea@sony.com xiaoxiang@xiaomi.com wanggang26@xiaomi.com
-fs/mnemofs/Kconfig resyfer.dev@gmail.com
-fs/mnemofs/mnemofs.c resyfer.dev@gmail.com chenrun1@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com yamamoto@midokura.com
-fs/mnemofs/mnemofs.h resyfer.dev@gmail.com devel@sumpfralle.de petro.karashchenko@gmail.com alin.jerpelea@sony.com
-fs/mnemofs/mnemofs_blkalloc.c resyfer.dev@gmail.com chenrun1@xiaomi.com alin.jerpelea@sony.com
-fs/mnemofs/mnemofs_ctz.c resyfer.dev@gmail.com chenrun1@xiaomi.com petro.karashchenko@gmail.com devel@sumpfralle.de 101105604+simbit18@users.noreply.github.com
-fs/mnemofs/mnemofs_fsobj.c resyfer.dev@gmail.com chenrun1@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-fs/mnemofs/mnemofs_journal.c resyfer.dev@gmail.com chenrun1@xiaomi.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-fs/mnemofs/mnemofs_lru.c resyfer.dev@gmail.com chenrun1@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-fs/mnemofs/mnemofs_master.c resyfer.dev@gmail.com alin.jerpelea@sony.com devel@sumpfralle.de
-fs/mnemofs/mnemofs_rw.c resyfer.dev@gmail.com alin.jerpelea@sony.com
-fs/mnemofs/mnemofs_util.c resyfer.dev@gmail.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
+
+fs/mnemofs/* resyfer.dev@gmail.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
+
 fs/mount/fs_automount.c petro.karashchenko@gmail.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com chenrun1@xiaomi.com
 fs/mount/fs_foreachmountpoint.c alin.jerpelea@sony.com liguiding1@xiaomi.com xiaoxiang@xiaomi.com anchao@xiaomi.com
 fs/mount/fs_gettype.c alin.jerpelea@sony.com chenrun1@xiaomi.com anjiahao@xiaomi.com liguiding1@xiaomi.com
@@ -20347,17 +14993,9 @@ include/uuid.h xiaoxiang@xiaomi.com petro.karashchenko@gmail.com alin.jerpelea@s
 include/wait.h guoshichao@xiaomi.com
 include/wchar.h 1090959677@qq.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com devel@sumpfralle.de
 include/wctype.h acassis@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libbuiltin/.gitignore wangmingrong1@xiaomi.com
-libs/libbuiltin/Kconfig wangmingrong1@xiaomi.com
-libs/libbuiltin/Makefile wangmingrong1@xiaomi.com
-libs/libbuiltin/compiler-rt/.gitignore wangmingrong1@xiaomi.com
-libs/libbuiltin/compiler-rt/InstrProfilingPlatform.c wangmingrong1@xiaomi.com
-libs/libbuiltin/compiler-rt/coverage.c wangmingrong1@xiaomi.com chenxiaoyi@xiaomi.com
-libs/libbuiltin/libgcc/gcov.c wangmingrong1@xiaomi.com yinshengkai@xiaomi.com buxiasen@xiaomi.com
-libs/libbuiltin/libgcc/profile.c wangmingrong1@xiaomi.com
-libs/libc/.gitignore xiaoxiang@xiaomi.com anchao.archer@bytedance.com liaoao@xiaomi.com p-liuyanfeng9@xiaomi.com
-libs/libc/Kconfig jordi@midokura.com anchao@xiaomi.com anchao.archer@bytedance.com wangjianyu3@xiaomi.com
-libs/libc/Makefile xiaoxiang@xiaomi.com matias@protobits.dev anchao@xiaomi.com anchao.archer@bytedance.com
+
+libs/libbuiltin/* wangmingrong1@xiaomi.com
+
 libs/libc/aio/aio.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
 libs/libc/aio/aio_error.c alin.jerpelea@sony.com guoshichao@xiaomi.com devel@sumpfralle.de
 libs/libc/aio/aio_return.c alin.jerpelea@sony.com guoshichao@xiaomi.com xiaoxiang@xiaomi.com
@@ -20377,22 +15015,7 @@ libs/libc/builtin/lib_builtin_getname.c alin.jerpelea@sony.com xiaoxiang@xiaomi.
 libs/libc/builtin/lib_builtin_getuid.c fangxinyong@xiaomi.com alin.jerpelea@sony.com
 libs/libc/builtin/lib_builtin_isavail.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com
 libs/libc/builtin/lib_builtin_setlist.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com gustavo.nihei@espressif.com
-libs/libc/ctype/lib_ctype.c philippe.leduc@wandercraft.eu xuxin19@xiaomi.com liguiding1@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-libs/libc/ctype/lib_isalnum.c xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com
-libs/libc/ctype/lib_isalpha.c xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com
-libs/libc/ctype/lib_isascii.c xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com
-libs/libc/ctype/lib_isblank.c xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com
-libs/libc/ctype/lib_iscntrl.c xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com anchao@xiaomi.com
-libs/libc/ctype/lib_isdigit.c xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com
-libs/libc/ctype/lib_isgraph.c xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com
-libs/libc/ctype/lib_islower.c xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com
-libs/libc/ctype/lib_isprint.c xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com
-libs/libc/ctype/lib_ispunct.c xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com
-libs/libc/ctype/lib_isspace.c xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com
-libs/libc/ctype/lib_isupper.c xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com
-libs/libc/ctype/lib_isxdigit.c xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com
-libs/libc/ctype/lib_tolower.c xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com
-libs/libc/ctype/lib_toupper.c xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com
+libs/libc/ctype/* xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com
 libs/libc/dirent/lib_alphasort.c mijung@gmx.net alin.jerpelea@sony.com
 libs/libc/dirent/lib_closedir.c dongjiuzhu1@xiaomi.com hujun5@xiaomi.com alin.jerpelea@sony.com
 libs/libc/dirent/lib_dirfd.c dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com
@@ -20415,34 +15038,11 @@ libs/libc/dlfcn/lib_dlfind_object.c cuiziwei@xiaomi.com raiden00@railab.me
 libs/libc/dlfcn/lib_dlopen.c anjiahao@xiaomi.com neale@sinenomine.net xiaoxiang@xiaomi.com alin.jerpelea@sony.com
 libs/libc/dlfcn/lib_dlsym.c anjiahao@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com anchao.archer@bytedance.com
 libs/libc/dlfcn/lib_dlsymtab.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com anchao.archer@bytedance.com gustavo.nihei@espressif.com
-libs/libc/elf/Kconfig anchao.archer@bytedance.com
-libs/libc/elf/Makefile anchao.archer@bytedance.com
-libs/libc/elf/elf.h anchao.archer@bytedance.com
-libs/libc/elf/elf_addrenv.c anchao.archer@bytedance.com
-libs/libc/elf/elf_bind.c anchao.archer@bytedance.com tiago.medicci@espressif.com
-libs/libc/elf/elf_depend.c anchao.archer@bytedance.com devel@sumpfralle.de
-libs/libc/elf/elf_gethandle.c anchao.archer@bytedance.com
-libs/libc/elf/elf_getsymbol.c anchao.archer@bytedance.com
-libs/libc/elf/elf_globals.S anchao.archer@bytedance.com
-libs/libc/elf/elf_init.c anchao.archer@bytedance.com
-libs/libc/elf/elf_insert.c anchao.archer@bytedance.com
-libs/libc/elf/elf_iobuffer.c anchao.archer@bytedance.com
-libs/libc/elf/elf_load.c anchao.archer@bytedance.com
-libs/libc/elf/elf_loadhdrs.c anchao.archer@bytedance.com devel@sumpfralle.de
-libs/libc/elf/elf_read.c anchao.archer@bytedance.com
-libs/libc/elf/elf_registry.c anchao.archer@bytedance.com
-libs/libc/elf/elf_remove.c anchao.archer@bytedance.com
-libs/libc/elf/elf_sections.c anchao.archer@bytedance.com
-libs/libc/elf/elf_symbols.c anchao.archer@bytedance.com
-libs/libc/elf/elf_symtab.c anchao.archer@bytedance.com
-libs/libc/elf/elf_uninit.c anchao.archer@bytedance.com
-libs/libc/elf/elf_unload.c anchao.archer@bytedance.com
-libs/libc/elf/elf_verify.c anchao.archer@bytedance.com
-libs/libc/elf/gnu-elf.ld.in anchao.archer@bytedance.com
+
+libs/libc/elf/* anchao.archer@bytedance.com
 libs/libc/errno/lib_errno.c xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
 libs/libc/eventfd/lib_eventfd.c simon.piriou@korys.io xiaoxiang@xiaomi.com alin.jerpelea@sony.com gustavo.nihei@espressif.com
-libs/libc/fdt/.gitignore liaoao@xiaomi.com
-libs/libc/fdt/Kconfig liaoao@xiaomi.com
+
 libs/libc/fdt/version_gen.h liaoao@xiaomi.com alin.jerpelea@sony.com
 libs/libc/fixedmath/lib_b16atan2.c alin.jerpelea@sony.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com
 libs/libc/fixedmath/lib_b16cos.c alin.jerpelea@sony.com
@@ -20451,7 +15051,6 @@ libs/libc/fixedmath/lib_fixedmath.c alin.jerpelea@sony.com raiden00@railab.me gu
 libs/libc/fixedmath/lib_ubsqrt.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 libs/libc/gdbstub/Kconfig anjiahao@xiaomi.com 101105604+simbit18@users.noreply.github.com xiaoxiang@xiaomi.com
 libs/libc/gdbstub/lib_gdbstub.c anjiahao@xiaomi.com xuxingliang@xiaomi.com xiaoxiang@xiaomi.com devel@sumpfralle.de neo.xu1990@gmail.com
-libs/libc/gnssutils/.gitignore wangjianyu3@xiaomi.com
 libs/libc/gnssutils/Kconfig wangjianyu3@xiaomi.com
 libs/libc/grp/lib_find_grpfile.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 libs/libc/grp/lib_getgrbuf.c mijung@gmx.net xiaoxiang@xiaomi.com alin.jerpelea@sony.com
@@ -20498,83 +15097,13 @@ libs/libc/locale/revjis.h dongjiuzhu1@xiaomi.com
 libs/libc/lzf/lzf.h alin.jerpelea@sony.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
 libs/libc/lzf/lzf_c.c alin.jerpelea@sony.com petro.karashchenko@gmail.com
 libs/libc/lzf/lzf_d.c alin.jerpelea@sony.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com
+
 libs/libc/machine/Kconfig yangdongdong@xiaomi.com xiaoxiang@xiaomi.com tiago.medicci@espressif.com anchao@xiaomi.com
 libs/libc/machine/arch_atomic.c Takuya.Miyashita@sony.com masayuki.ishikawa@gmail.com hujun5@xiaomi.com chenrun1@xiaomi.com zhuyanlin1@xiaomi.com
 libs/libc/machine/arch_libc.c anjiahao@xiaomi.com wangmingrong1@xiaomi.com
-libs/libc/machine/arm/Kconfig xiaoxiang@xiaomi.com jordi@midokura.com lijinliang1@lixiang.com
-libs/libc/machine/arm/arch_atexit.c xiaoxiang@xiaomi.com
-libs/libc/machine/arm/arch_crc32.c lijinliang1@lixiang.com
-libs/libc/machine/arm/arch_dummy.c xiaoxiang@xiaomi.com
-libs/libc/machine/arm/arch_mcount.S xiaoxiang@xiaomi.com yinshengkai@xiaomi.com
-libs/libc/machine/arm/arch_setjmp.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/arch_unwind_find_exidx.c xiaoxiang@xiaomi.com
-libs/libc/machine/arm/arm/arch_elf.c anchao@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com ville.juven@unikie.com
-libs/libc/machine/arm/armv6-m/arch_elf.c anchao@xiaomi.com alin.jerpelea@sony.com yamamoto@midokura.com xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv7-a/Kconfig zhangyuan21@xiaomi.com chenrun1@xiaomi.com wangming9@xiaomi.com
-libs/libc/machine/arm/armv7-a/acle-compat.h xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv7-a/arch_elf.c masayuki.ishikawa@gmail.com yamamoto@midokura.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv7-a/arch_memchr.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv7-a/arch_memcpy.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv7-a/arch_memmove.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv7-a/arch_memset.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv7-a/arch_strcmp.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv7-a/arch_strlen.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv7-m/Kconfig zhangyuan21@xiaomi.com David@DSA.Consulting xiaoxiang@xiaomi.com chenrun1@xiaomi.com
-libs/libc/machine/arm/armv7-m/acle-compat.h xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv7-m/arch_elf.c yamamoto@midokura.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com anchao@xiaomi.com
-libs/libc/machine/arm/armv7-m/arch_memchr.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv7-m/arch_memcpy.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv7-m/arch_memmove.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv7-m/arch_memset.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv7-m/arch_strcmp.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv7-m/arch_strcpy.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv7-m/arch_strlen.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv7-r/Kconfig zhangyuan21@xiaomi.com chenrun1@xiaomi.com
-libs/libc/machine/arm/armv7-r/acle-compat.h xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv7-r/arch_elf.c anchao@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com ville.juven@unikie.com
-libs/libc/machine/arm/armv7-r/arch_memchr.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv7-r/arch_memcpy.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv7-r/arch_memmove.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv7-r/arch_memset.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv7-r/arch_strcmp.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv7-r/arch_strlen.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv8-m/Kconfig xiaoxiang@xiaomi.com zhangyuan21@xiaomi.com anchao@xiaomi.com chenrun1@xiaomi.com wangyongrong@xiaomi.com
-libs/libc/machine/arm/armv8-m/acle-compat.h xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv8-m/arch_elf.c xiaoxiang@xiaomi.com anchao@xiaomi.com ville.juven@unikie.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-libs/libc/machine/arm/armv8-m/arch_memchr.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv8-m/arch_memcpy.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv8-m/arch_memmove.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv8-m/arch_memset.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv8-m/arch_strcmp.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv8-m/arch_strcpy.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv8-m/arch_strlen.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv8-r/Kconfig lijinliang1@lixiang.com
-libs/libc/machine/arm/armv8-r/acle-compat.h xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv8-r/arch_elf.c lijinliang1@lixiang.com
-libs/libc/machine/arm/armv8-r/arch_memchr.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv8-r/arch_memcpy.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv8-r/arch_memmove.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv8-r/arch_memset.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv8-r/arch_strcmp.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/armv8-r/arch_strlen.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm/tc32_setjmp.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm64/Kconfig zhangyuan21@xiaomi.com chenrun1@xiaomi.com
-libs/libc/machine/arm64/arch_elf.c dongjiuzhu1@xiaomi.com wangmingrong1@xiaomi.com ville.juven@unikie.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libc/machine/arm64/arch_mcount.c xiaoxiang@xiaomi.com
-libs/libc/machine/arm64/arch_memchr.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm64/arch_memcmp.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm64/arch_memcpy.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm64/arch_memmove.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm64/arch_memset.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm64/arch_setjmp.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm64/arch_strchr.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm64/arch_strchrnul.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm64/arch_strcmp.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm64/arch_strcpy.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm64/arch_strlen.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm64/arch_strncmp.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm64/arch_strnlen.S xiaoxiang@xiaomi.com
-libs/libc/machine/arm64/arch_strrchr.S xiaoxiang@xiaomi.com
+libs/libc/machine/arm/* xiaoxiang@xiaomi.com
+libs/libc/machine/arm64/* xiaoxiang@xiaomi.com
+
 libs/libc/machine/renesas/Kconfig mransom@campbellsci.com xiaoxiang@xiaomi.com jordi@midokura.com
 libs/libc/machine/renesas/rx/Kconfig mransom@campbellsci.com xiaoxiang@xiaomi.com
 libs/libc/machine/renesas/rx/arch_setjmp.S xiaoxiang@xiaomi.com
@@ -20596,22 +15125,9 @@ libs/libc/machine/sim/arch_setjmp_x86_64.asm chenxiaoyi@xiaomi.com
 libs/libc/machine/sparc/Kconfig fft@feedforward.com.cn
 libs/libc/machine/sparc/arch_elf.c fft@feedforward.com.cn xiaoxiang@xiaomi.com ville.juven@unikie.com alin.jerpelea@sony.com
 libs/libc/machine/x86/arch_elf.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com ville.juven@unikie.com abdelatif.guettouche@espressif.com
-libs/libc/machine/x86_64/Kconfig p-szafonimateusz@xiaomi.com
-libs/libc/machine/x86_64/arch_elf64.c p-szafonimateusz@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-libs/libc/machine/x86_64/arch_memcmp.S xiaoxiang@xiaomi.com
-libs/libc/machine/x86_64/arch_memmove.S xiaoxiang@xiaomi.com
-libs/libc/machine/x86_64/arch_memset_avx2.S xiaoxiang@xiaomi.com
-libs/libc/machine/x86_64/arch_memset_sse2.S xiaoxiang@xiaomi.com
-libs/libc/machine/x86_64/arch_setjmp_x86_64.S liwenxiang1@xiaomi.com
-libs/libc/machine/x86_64/arch_stpcpy.S xiaoxiang@xiaomi.com
-libs/libc/machine/x86_64/arch_stpncpy.S xiaoxiang@xiaomi.com
-libs/libc/machine/x86_64/arch_strcat.S xiaoxiang@xiaomi.com
-libs/libc/machine/x86_64/arch_strcmp.S xiaoxiang@xiaomi.com
-libs/libc/machine/x86_64/arch_strcpy.S xiaoxiang@xiaomi.com
-libs/libc/machine/x86_64/arch_strlen.S xiaoxiang@xiaomi.com
-libs/libc/machine/x86_64/arch_strncmp.S xiaoxiang@xiaomi.com
-libs/libc/machine/x86_64/arch_strncpy.S xiaoxiang@xiaomi.com
-libs/libc/machine/x86_64/cache.h xiaoxiang@xiaomi.com
+
+libs/libc/machine/x86_64/* p-szafonimateusz@xiaomi.com xiaoxiang@xiaomi.com
+
 libs/libc/machine/xtensa/Kconfig petro.karashchenko@gmail.com zhuyanlin1@xiaomi.com chenrun1@xiaomi.com yamamoto@midokura.com
 libs/libc/machine/xtensa/arch_elf.c yamamoto@midokura.com xiaoxiang@xiaomi.com tiago.medicci@espressif.com ville.juven@unikie.com alin.jerpelea@sony.com
 libs/libc/machine/xtensa/arch_memcpy.S zhuyanlin1@xiaomi.com anjiahao@xiaomi.com tiago.medicci@espressif.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
@@ -21054,120 +15570,11 @@ libs/libc/stdlib/lib_unlockpt.c alin.jerpelea@sony.com
 libs/libc/stdlib/lib_valloc.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com mage1@xiaomi.com
 libs/libc/stdlib/lib_wcstombs.c xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com
 libs/libc/stdlib/lib_wctomb.c dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com
-libs/libc/stream/Kconfig anchao@xiaomi.com xuxingliang@xiaomi.com huangqi3@xiaomi.com
-libs/libc/stream/lib_base64outstream.c xuxingliang@xiaomi.com buxiasen@xiaomi.com
-libs/libc/stream/lib_blkoutstream.c anchao@xiaomi.com buxiasen@xiaomi.com xiaoxiang@xiaomi.com daniel.appiagyei@braincorp.com devel@sumpfralle.de
-libs/libc/stream/lib_bufferedoutstream.c huangqi3@xiaomi.com daniel.appiagyei@braincorp.com buxiasen@xiaomi.com alin.jerpelea@sony.com
-libs/libc/stream/lib_dtoa_data.c xiaoxiang@xiaomi.com
-libs/libc/stream/lib_dtoa_engine.c xiaoxiang@xiaomi.com
-libs/libc/stream/lib_dtoa_engine.h xiaoxiang@xiaomi.com
-libs/libc/stream/lib_fileinstream.c yangao1@xiaomi.com
-libs/libc/stream/lib_fileoutstream.c yinshengkai@xiaomi.com yangao1@xiaomi.com buxiasen@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libc/stream/lib_hexdumpstream.c anchao@xiaomi.com daniel.appiagyei@braincorp.com buxiasen@xiaomi.com xuxingliang@xiaomi.com alin.jerpelea@sony.com
-libs/libc/stream/lib_libbsprintf.c xiaoxiang@xiaomi.com
-libs/libc/stream/lib_libnoflush.c xiaoxiang@xiaomi.com dongjiuzhu1@xiaomi.com daniel.appiagyei@braincorp.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-libs/libc/stream/lib_libsnoflush.c xiaoxiang@xiaomi.com daniel.appiagyei@braincorp.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-libs/libc/stream/lib_libvscanf.c xiaoxiang@xiaomi.com
-libs/libc/stream/lib_libvsprintf.c xiaoxiang@xiaomi.com
-libs/libc/stream/lib_lowoutstream.c xiaoxiang@xiaomi.com yinshengkai@xiaomi.com ouyangxiangzhen@xiaomi.com daniel.appiagyei@braincorp.com buxiasen@xiaomi.com
-libs/libc/stream/lib_lzfcompress.c anchao@xiaomi.com devel@sumpfralle.de daniel.appiagyei@braincorp.com buxiasen@xiaomi.com xiaoxiang@xiaomi.com
-libs/libc/stream/lib_meminstream.c xiaoxiang@xiaomi.com daniel.appiagyei@braincorp.com yinshengkai@xiaomi.com buxiasen@xiaomi.com alin.jerpelea@sony.com
-libs/libc/stream/lib_memoutstream.c xiaoxiang@xiaomi.com daniel.appiagyei@braincorp.com buxiasen@xiaomi.com alin.jerpelea@sony.com
-libs/libc/stream/lib_memsistream.c xiaoxiang@xiaomi.com daniel.appiagyei@braincorp.com buxiasen@xiaomi.com yinshengkai@xiaomi.com alin.jerpelea@sony.com
-libs/libc/stream/lib_memsostream.c xiaoxiang@xiaomi.com daniel.appiagyei@braincorp.com yinshengkai@xiaomi.com buxiasen@xiaomi.com alin.jerpelea@sony.com
-libs/libc/stream/lib_mtdoutstream.c buxiasen@xiaomi.com tianxin7@xiaomi.com xiaoxiang@xiaomi.com daniel.appiagyei@braincorp.com devel@sumpfralle.de
-libs/libc/stream/lib_mtdsostream.c buxiasen@xiaomi.com
-libs/libc/stream/lib_nullinstream.c xiaoxiang@xiaomi.com daniel.appiagyei@braincorp.com yinshengkai@xiaomi.com buxiasen@xiaomi.com alin.jerpelea@sony.com
-libs/libc/stream/lib_nulloutstream.c xiaoxiang@xiaomi.com daniel.appiagyei@braincorp.com yinshengkai@xiaomi.com buxiasen@xiaomi.com alin.jerpelea@sony.com
-libs/libc/stream/lib_rawinstream.c xiaoxiang@xiaomi.com daniel.appiagyei@braincorp.com yinshengkai@xiaomi.com buxiasen@xiaomi.com alin.jerpelea@sony.com
-libs/libc/stream/lib_rawoutstream.c xiaoxiang@xiaomi.com huangqi3@xiaomi.com daniel.appiagyei@braincorp.com yinshengkai@xiaomi.com buxiasen@xiaomi.com
-libs/libc/stream/lib_rawsistream.c xiaoxiang@xiaomi.com daniel.appiagyei@braincorp.com yinshengkai@xiaomi.com buxiasen@xiaomi.com alin.jerpelea@sony.com
-libs/libc/stream/lib_rawsostream.c xiaoxiang@xiaomi.com huangqi3@xiaomi.com daniel.appiagyei@braincorp.com yinshengkai@xiaomi.com buxiasen@xiaomi.com
-libs/libc/stream/lib_stdinstream.c xiaoxiang@xiaomi.com daniel.appiagyei@braincorp.com yinshengkai@xiaomi.com buxiasen@xiaomi.com alin.jerpelea@sony.com
-libs/libc/stream/lib_stdoutstream.c xiaoxiang@xiaomi.com daniel.appiagyei@braincorp.com yinshengkai@xiaomi.com buxiasen@xiaomi.com anjiahao@xiaomi.com
-libs/libc/stream/lib_stdsistream.c xiaoxiang@xiaomi.com daniel.appiagyei@braincorp.com yinshengkai@xiaomi.com buxiasen@xiaomi.com alin.jerpelea@sony.com
-libs/libc/stream/lib_stdsostream.c xiaoxiang@xiaomi.com daniel.appiagyei@braincorp.com yinshengkai@xiaomi.com buxiasen@xiaomi.com alin.jerpelea@sony.com
-libs/libc/stream/lib_syslograwstream.c xiaoxiang@xiaomi.com anchao@lixiang.com daniel.appiagyei@braincorp.com buxiasen@xiaomi.com wangbowen6@xiaomi.com
-libs/libc/stream/lib_syslogstream.c xiaoxiang@xiaomi.com yinshengkai@xiaomi.com anchao@xiaomi.com dongjiuzhu1@xiaomi.com daniel.appiagyei@braincorp.com
-libs/libc/stream/lib_ultoa_invert.c xiaoxiang@xiaomi.com
-libs/libc/stream/lib_ultoa_invert.h xiaoxiang@xiaomi.com
-libs/libc/stream/lib_zeroinstream.c xiaoxiang@xiaomi.com daniel.appiagyei@braincorp.com yinshengkai@xiaomi.com buxiasen@xiaomi.com alin.jerpelea@sony.com
-libs/libc/string/Kconfig xiaoxiang@xiaomi.com petro.karashchenko@gmail.com juha.niskanen@haltian.com wengzhe@xiaomi.com
-libs/libc/string/lib_bsdmemccpy.c yangguangcai@xiaomi.com devel@sumpfralle.de
-libs/libc/string/lib_bsdmemchr.c yangguangcai@xiaomi.com devel@sumpfralle.de
-libs/libc/string/lib_bsdmemcmp.c yangguangcai@xiaomi.com devel@sumpfralle.de
-libs/libc/string/lib_bsdmemcpy.c yangguangcai@xiaomi.com devel@sumpfralle.de
-libs/libc/string/lib_bsdmemrchr.c yangguangcai@xiaomi.com devel@sumpfralle.de
-libs/libc/string/lib_bsdstpcpy.c yangguangcai@xiaomi.com
-libs/libc/string/lib_bsdstpncpy.c yangguangcai@xiaomi.com
-libs/libc/string/lib_bsdstrcat.c yangguangcai@xiaomi.com
-libs/libc/string/lib_bsdstrchr.c yangguangcai@xiaomi.com
-libs/libc/string/lib_bsdstrchrnul.c yangguangcai@xiaomi.com
-libs/libc/string/lib_bsdstrcmp.c yangguangcai@xiaomi.com
-libs/libc/string/lib_bsdstrcpy.c yangguangcai@xiaomi.com
-libs/libc/string/lib_bsdstrlen.c yangguangcai@xiaomi.com
-libs/libc/string/lib_bsdstrncmp.c yangguangcai@xiaomi.com
-libs/libc/string/lib_bsdstrncpy.c yangguangcai@xiaomi.com
-libs/libc/string/lib_bsdstrrchr.c yangguangcai@xiaomi.com
-libs/libc/string/lib_explicit_bzero.c alin.jerpelea@sony.com
-libs/libc/string/lib_ffs.c alin.jerpelea@sony.com yinshengkai@xiaomi.com nimish@users.noreply.github.com
-libs/libc/string/lib_ffsl.c alin.jerpelea@sony.com yinshengkai@xiaomi.com nimish@users.noreply.github.com
-libs/libc/string/lib_ffsll.c alin.jerpelea@sony.com yinshengkai@xiaomi.com nimish@users.noreply.github.com
-libs/libc/string/lib_fls.c alin.jerpelea@sony.com yinshengkai@xiaomi.com
-libs/libc/string/lib_flsl.c alin.jerpelea@sony.com yinshengkai@xiaomi.com gustavo.nihei@espressif.com
-libs/libc/string/lib_flsll.c alin.jerpelea@sony.com yinshengkai@xiaomi.com gustavo.nihei@espressif.com xiaoxiang@xiaomi.com
-libs/libc/string/lib_index.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com gustavo.nihei@espressif.com mage1@xiaomi.com
-libs/libc/string/lib_isbasedigit.c alin.jerpelea@sony.com wangjianyu3@xiaomi.com 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com
-libs/libc/string/lib_memccpy.c yangguangcai@xiaomi.com alin.jerpelea@sony.com mage1@xiaomi.com
-libs/libc/string/lib_memchr.c yangguangcai@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com tiago.medicci@espressif.com
-libs/libc/string/lib_memcmp.c yangguangcai@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com tiago.medicci@espressif.com
-libs/libc/string/lib_memcpy.c yangguangcai@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com tiago.medicci@espressif.com
-libs/libc/string/lib_memmem.c yangguangcai@xiaomi.com cynerd@email.cz juha.niskanen@haltian.com petro.karashchenko@gmail.com devel@sumpfralle.de
-libs/libc/string/lib_memmove.c alin.jerpelea@sony.com yangguangcai@xiaomi.com tiago.medicci@espressif.com yangdongdong@xiaomi.com
-libs/libc/string/lib_mempcpy.c chenrun1@xiaomi.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-libs/libc/string/lib_memrchr.c yangguangcai@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com gustavo.nihei@espressif.com petro.karashchenko@gmail.com
-libs/libc/string/lib_memset.c alin.jerpelea@sony.com yangguangcai@xiaomi.com xiaoxiang@xiaomi.com tiago.medicci@espressif.com
-libs/libc/string/lib_popcount.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libc/string/lib_popcountl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libc/string/lib_popcountll.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libc/string/lib_rawmemchr.c chenrun1@xiaomi.com alin.jerpelea@sony.com
-libs/libc/string/lib_rindex.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com gustavo.nihei@espressif.com mage1@xiaomi.com
-libs/libc/string/lib_skipspace.c alin.jerpelea@sony.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
-libs/libc/string/lib_stpcpy.c yangguangcai@xiaomi.com alin.jerpelea@sony.com p-szafonimateusz@xiaomi.com gustavo.nihei@espressif.com
-libs/libc/string/lib_stpncpy.c yangguangcai@xiaomi.com alin.jerpelea@sony.com lokeshbv333@gmail.com petro.karashchenko@gmail.com
-libs/libc/string/lib_strcasecmp.c alin.jerpelea@sony.com petro.karashchenko@gmail.com tiago.medicci@espressif.com yangdongdong@xiaomi.com
-libs/libc/string/lib_strcasestr.c alin.jerpelea@sony.com petro.karashchenko@gmail.com anchao@lixiang.com xiaoxiang@xiaomi.com
-libs/libc/string/lib_strcat.c yangguangcai@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com tiago.medicci@espressif.com
-libs/libc/string/lib_strchr.c yangguangcai@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com tiago.medicci@espressif.com
-libs/libc/string/lib_strchrnul.c vifextech@foxmail.com yangguangcai@xiaomi.com tiago.medicci@espressif.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-libs/libc/string/lib_strcmp.c yangguangcai@xiaomi.com alin.jerpelea@sony.com minabe.oki@gmail.com tiago.medicci@espressif.com
-libs/libc/string/lib_strcoll.c alin.jerpelea@sony.com yangguangcai@xiaomi.com
-libs/libc/string/lib_strcpy.c yangguangcai@xiaomi.com alin.jerpelea@sony.com tiago.medicci@espressif.com yangdongdong@xiaomi.com
-libs/libc/string/lib_strcspn.c alin.jerpelea@sony.com juha.niskanen@haltian.com mage1@xiaomi.com xiaoxiang@xiaomi.com
-libs/libc/string/lib_strdup.c alin.jerpelea@sony.com liguiding1@xiaomi.com xiaoxiang@xiaomi.com lilei19@xiaomi.com
-libs/libc/string/lib_strerror.c nmn35175@outlook.com alin.jerpelea@sony.com wengzhe@xiaomi.com xiaoxiang@xiaomi.com
-libs/libc/string/lib_strerrorr.c alin.jerpelea@sony.com huangqi3@xiaomi.com xiaoxiang@xiaomi.com
-libs/libc/string/lib_strlcat.c anjiahao@xiaomi.com tiago.medicci@espressif.com alin.jerpelea@sony.com yangdongdong@xiaomi.com petro.karashchenko@gmail.com
-libs/libc/string/lib_strlcpy.c anchao@xiaomi.com petro.karashchenko@gmail.com tiago.medicci@espressif.com alin.jerpelea@sony.com yangdongdong@xiaomi.com
-libs/libc/string/lib_strlen.c yangguangcai@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com tiago.medicci@espressif.com
-libs/libc/string/lib_strncasecmp.c alin.jerpelea@sony.com petro.karashchenko@gmail.com tiago.medicci@espressif.com yangdongdong@xiaomi.com
-libs/libc/string/lib_strncat.c alin.jerpelea@sony.com petro.karashchenko@gmail.com tiago.medicci@espressif.com yangdongdong@xiaomi.com
-libs/libc/string/lib_strncmp.c yangguangcai@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com tiago.medicci@espressif.com
-libs/libc/string/lib_strncpy.c yangguangcai@xiaomi.com alin.jerpelea@sony.com tiago.medicci@espressif.com yangdongdong@xiaomi.com
-libs/libc/string/lib_strndup.c alin.jerpelea@sony.com liguiding1@xiaomi.com xiaoxiang@xiaomi.com mage1@xiaomi.com
-libs/libc/string/lib_strnlen.c alin.jerpelea@sony.com petro.karashchenko@gmail.com tiago.medicci@espressif.com yangdongdong@xiaomi.com
-libs/libc/string/lib_strpbrk.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com mage1@xiaomi.com
-libs/libc/string/lib_strrchr.c alin.jerpelea@sony.com yangguangcai@xiaomi.com xiaoxiang@xiaomi.com juha.niskanen@haltian.com
-libs/libc/string/lib_strsep.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libc/string/lib_strsignal.c petro.karashchenko@gmail.com alin.jerpelea@sony.com liguiding1@xiaomi.com ysgn0101@gmail.com
-libs/libc/string/lib_strspn.c alin.jerpelea@sony.com mage1@xiaomi.com
-libs/libc/string/lib_strstr.c anchao@xiaomi.com yangguangcai@xiaomi.com alin.jerpelea@sony.com anjiahao@xiaomi.com
-libs/libc/string/lib_strtok.c alin.jerpelea@sony.com petro.karashchenko@gmail.com mage1@xiaomi.com
-libs/libc/string/lib_strtokr.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com petro.karashchenko@gmail.com
-libs/libc/string/lib_strverscmp.c dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com
-libs/libc/string/lib_strxfrm.c alin.jerpelea@sony.com petro.karashchenko@gmail.com 59230071+hartmannathan@users.noreply.github.com
-libs/libc/string/lib_timingsafe_bcmp.c anjiahao@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libc/string/lib_vikmemcpy.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com tiago.medicci@espressif.com yangdongdong@xiaomi.com
+
+libs/libc/stream/* anchao@xiaomi.com xiaoxiang@xiaomi.com
+libs/libc/string/* alin.jerpelea@sony.com xiaoxiang@xiaomi.com petro.karashchenko@gmail.com tiago.medicci@espressif.com
+libs/libc/string/lib_bsd* yangguangcai@xiaomi.com devel@sumpfralle.de
+
 libs/libc/symtab/Kconfig xiaoxiang@xiaomi.com anchao@xiaomi.com petro.karashchenko@gmail.com likun17@xiaomi.com
 libs/libc/symtab/symtab_allsyms.c anchao@xiaomi.com alin.jerpelea@sony.com huangqi3@xiaomi.com xiaoxiang@xiaomi.com
 libs/libc/symtab/symtab_findbyname.c code@bje.id.au alin.jerpelea@sony.com yamamoto@midokura.com
@@ -21351,369 +15758,22 @@ libs/libc/wqueue/work_cancel.c dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com ouy
 libs/libc/wqueue/work_queue.c ouyangxiangzhen@xiaomi.com dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
 libs/libc/wqueue/work_usrthread.c dongjiuzhu1@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com xuanlin@pinecone.net
 libs/libc/wqueue/wqueue.h dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com ouyangxiangzhen@xiaomi.com petro.karashchenko@gmail.com
-libs/libc/zoneinfo/.gitignore xiaoxiang@xiaomi.com
 libs/libc/zoneinfo/Makefile alin.jerpelea@sony.com xiaoxiang@xiaomi.com matias@protobits.dev yamamoto@midokura.com
 libs/libc/zoneinfo/tzromfs.c alin.jerpelea@sony.com
-libs/libdsp/Kconfig raiden00pl@gmail.com raiden00@railab.me xiaoxiang@xiaomi.com
-libs/libdsp/Makefile raiden00pl@gmail.com raiden00@railab.me xiaoxiang@xiaomi.com yamamoto@midokura.com masayuki.ishikawa@gmail.com
-libs/libdsp/lib_avg.c acassis@gmail.com alin.jerpelea@sony.com raiden00@railab.me
-libs/libdsp/lib_foc.c raiden00@railab.me raiden00pl@gmail.com 59230071+hartmannathan@users.noreply.github.com devel@sumpfralle.de alin.jerpelea@sony.com
-libs/libdsp/lib_foc_b16.c raiden00@railab.me 59230071+hartmannathan@users.noreply.github.com devel@sumpfralle.de alin.jerpelea@sony.com
-libs/libdsp/lib_misc.c raiden00pl@gmail.com raiden00@railab.me alin.jerpelea@sony.com gustavo.nihei@espressif.com
-libs/libdsp/lib_misc_b16.c raiden00@railab.me alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libdsp/lib_motor.c raiden00pl@gmail.com raiden00@railab.me juha.niskanen@haltian.com devel@sumpfralle.de alin.jerpelea@sony.com
-libs/libdsp/lib_motor_b16.c raiden00@railab.me devel@sumpfralle.de alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libdsp/lib_observer.c raiden00pl@gmail.com raiden00@railab.me fft@feedforward.com.cn 59230071+hartmannathan@users.noreply.github.com
-libs/libdsp/lib_observer_b16.c raiden00@railab.me 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com
-libs/libdsp/lib_pid.c raiden00pl@gmail.com raiden00@railab.me devel@sumpfralle.de alin.jerpelea@sony.com gustavo.nihei@espressif.com
-libs/libdsp/lib_pid_b16.c raiden00@railab.me devel@sumpfralle.de alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libdsp/lib_pmsm_model.c raiden00@railab.me devel@sumpfralle.de alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libdsp/lib_pmsm_model_b16.c raiden00@railab.me devel@sumpfralle.de alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libdsp/lib_svm.c raiden00pl@gmail.com raiden00@railab.me alin.jerpelea@sony.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
-libs/libdsp/lib_svm_b16.c raiden00@railab.me alin.jerpelea@sony.com xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
-libs/libdsp/lib_transform.c raiden00pl@gmail.com raiden00@railab.me alin.jerpelea@sony.com gustavo.nihei@espressif.com
-libs/libdsp/lib_transform_b16.c raiden00@railab.me alin.jerpelea@sony.com
-libs/libm/.gitignore roy.feng@sony.com
-libs/libm/Kconfig xiaoxiang@xiaomi.com yanghuatao@xiaomi.com
-libs/libm/Makefile xiaoxiang@xiaomi.com wangmingrong1@xiaomi.com masayuki.ishikawa@gmail.com xuxin19@xiaomi.com yanghuatao@xiaomi.com
-libs/libm/libm.csv anchao@xiaomi.com petro.karashchenko@gmail.com
-libs/libm/libm/Kconfig xiaoxiang@xiaomi.com
-libs/libm/libm/__cos.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/__sin.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/arm/Kconfig xiaoxiang@xiaomi.com
-libs/libm/libm/arm/armv7-m/Kconfig xiaoxiang@xiaomi.com
-libs/libm/libm/arm/armv7-m/arch_fabsf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/arm/armv7-m/arch_sqrtf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/arm/armv8-m/Kconfig xiaoxiang@xiaomi.com
-libs/libm/libm/arm/armv8-m/arch_ceil.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/arm/armv8-m/arch_ceilf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/arm/armv8-m/arch_floor.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/arm/armv8-m/arch_floorf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/arm/armv8-m/arch_nearbyint.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/arm/armv8-m/arch_nearbyintf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/arm/armv8-m/arch_rint.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/arm/armv8-m/arch_rintf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/arm/armv8-m/arch_round.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/arm/armv8-m/arch_roundf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/arm/armv8-m/arch_trunc.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/arm/armv8-m/arch_truncf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_acos.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_acosf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_acosh.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_acoshf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_acoshl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_acosl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_asin.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_asinf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_asinh.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_asinhf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_asinhl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_asinl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_atan.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_atan2.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_atan2f.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_atan2l.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_atanf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_atanh.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_atanhf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_atanhl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_atanl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_cbrt.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_ceil.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_ceilf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_ceill.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_copysign.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com dtcxzyw2333@gmail.com
-libs/libm/libm/lib_copysignf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_copysignl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com dtcxzyw2333@gmail.com
-libs/libm/libm/lib_cos.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_cosf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_cosh.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_coshf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_coshl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_cosl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_erf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_erfc.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_erfcf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_erfcl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_erff.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_erfl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_exp.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_expf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_expl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_expm1.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_expm1f.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_expm1l.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_fabs.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_fabsf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_fabsl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_floor.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_floorf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_floorl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_fmax.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_fmaxf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_fmaxl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_fmin.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_fminf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_fminl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_fmod.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_fmodf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_fmodl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_frexp.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_frexpf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libm/libm/lib_frexpl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_gamma.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_ldexp.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_ldexpf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_ldexpl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_lgamma.c xiaoxiang@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-libs/libm/libm/lib_libexpi.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_libexpif.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com anchao@xiaomi.com
-libs/libm/libm/lib_libsqrtapprox.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_llround.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_llroundf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_llroundl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_log.c xiaoxiang@xiaomi.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-libs/libm/libm/lib_log10.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_log10f.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_log10l.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_log2.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_log2f.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_log2l.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_logf.c xiaoxiang@xiaomi.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-libs/libm/libm/lib_logl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_lround.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_lroundf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_lroundl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_modf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libm/libm/lib_modff.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libm/libm/lib_modfl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libm/libm/lib_nan.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libm/libm/lib_nanf.c xiaoxiang@xiaomi.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-libs/libm/libm/lib_nanl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libm/libm/lib_pow.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libm/libm/lib_powf.c xiaoxiang@xiaomi.com yanghuatao@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libm/libm/lib_powl.c xiaoxiang@xiaomi.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-libs/libm/libm/lib_rint.c xiaoxiang@xiaomi.com raiden00@railab.me alin.jerpelea@sony.com
-libs/libm/libm/lib_rintf.c xiaoxiang@xiaomi.com raiden00@railab.me alin.jerpelea@sony.com
-libs/libm/libm/lib_rintl.c xiaoxiang@xiaomi.com raiden00@railab.me alin.jerpelea@sony.com
-libs/libm/libm/lib_round.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_roundf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_roundl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_scalbn.c xiaoxiang@xiaomi.com
-libs/libm/libm/lib_scalbnf.c xiaoxiang@xiaomi.com
-libs/libm/libm/lib_scalbnl.c xiaoxiang@xiaomi.com
-libs/libm/libm/lib_sin.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_sincos.c xiaoxiang@xiaomi.com p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libm/libm/lib_sincosf.c xiaoxiang@xiaomi.com p-szafonimateusz@xiaomi.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
-libs/libm/libm/lib_sincosl.c xiaoxiang@xiaomi.com p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libm/libm/lib_sinf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_sinh.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_sinhf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_sinhl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_sinl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_sqrt.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_sqrtf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_sqrtl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_tan.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_tanf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_tanh.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_tanhf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_tanhl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_tanl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_trunc.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_truncf.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/lib_truncl.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libm/libm.h xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/libmcs/.gitignore yinshengkai@xiaomi.com
-libs/libm/libmcs/0001-fix-build-error-remove-unused-file-fenv.h.patch yanghuatao@xiaomi.com devel@sumpfralle.de wangmingrong1@xiaomi.com
-libs/libm/libmcs/0002-fix-build-error-do-not-include-config.h.patch yanghuatao@xiaomi.com devel@sumpfralle.de wangmingrong1@xiaomi.com
-libs/libm/libmcs/0003-fix-build-error-INFINITY-error-in-quickjs.c.patch yanghuatao@xiaomi.com wangmingrong1@xiaomi.com devel@sumpfralle.de
-libs/libm/libmcs/0004-Fix-warning-function-declaration-isn-t-a-prototype-W.patch yanghuatao@xiaomi.com wangmingrong1@xiaomi.com
-libs/libm/libmcs/0005-libm-libmcs-Fix-clang-build-libmcs-warning.patch yanghuatao@xiaomi.com wangmingrong1@xiaomi.com
-libs/libm/libmcs/Kconfig yanghuatao@xiaomi.com petro.karashchenko@gmail.com
-libs/libm/newlib/.gitignore 31881278+xuxin930@users.noreply.github.com yinshengkai@xiaomi.com xuxin19@xiaomi.com
-libs/libm/newlib/0001-newlib-libm-fix-__RCSID-build-error.patch yanghuatao@xiaomi.com wangmingrong1@xiaomi.com
-libs/libm/newlib/0002-newlib-libm-remove-include-reent.h.patch yanghuatao@xiaomi.com wangmingrong1@xiaomi.com
-libs/libm/newlib/0003-newlib-fix-compilation-for-x86.patch p-szafonimateusz@xiaomi.com wangmingrong1@xiaomi.com
-libs/libm/newlib/0004-newlib-disable-optmisation-for-sincos.patch p-szafonimateusz@xiaomi.com devel@sumpfralle.de wangmingrong1@xiaomi.com
-libs/libm/newlib/Kconfig yanghuatao@xiaomi.com
-libs/libm/newlib/include/complex.h yanghuatao@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/newlib/include/ieeefp.h yanghuatao@xiaomi.com alin.jerpelea@sony.com
-libs/libm/newlib/include/machine/ieeefp.h yanghuatao@xiaomi.com xiaoxiang@xiaomi.com devel@sumpfralle.de alin.jerpelea@sony.com
-libs/libm/newlib/include/math.h yanghuatao@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libm/newlib/include/tgmath.h yanghuatao@xiaomi.com alin.jerpelea@sony.com
-libs/libm/newlib/sincosl.c p-szafonimateusz@xiaomi.com alin.jerpelea@sony.com
-libs/libm/openlibm/.gitignore yinshengkai@xiaomi.com
-libs/libm/openlibm/0001-fix-build-float_t-error-float_t-has-not-been-declare.patch yanghuatao@xiaomi.com wangmingrong1@xiaomi.com devel@sumpfralle.de
-libs/libm/openlibm/0002-add-math.h-and-complex.h-to-openlibm.patch yanghuatao@xiaomi.com wangmingrong1@xiaomi.com devel@sumpfralle.de
-libs/libm/openlibm/0003-nuttx-openlibm-Fix-openlibm-M_PI-undeclared-error.patch yanghuatao@xiaomi.com wangmingrong1@xiaomi.com
-libs/libnx/Kconfig jordi@midokura.com
-libs/libnx/Makefile matias@protobits.dev liuhaitao@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libnx/nx/nx_drawcircle.c alin.jerpelea@sony.com
-libs/libnx/nx/nx_drawline.c alin.jerpelea@sony.com
-libs/libnx/nx/nx_fillcircle.c alin.jerpelea@sony.com
-libs/libnx/nx/nx_ishidden.c alin.jerpelea@sony.com
-libs/libnx/nxcontext.h xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-libs/libnx/nxfonts/.gitignore xiaoxiang@xiaomi.com
-libs/libnx/nxfonts/Kconfig xiaoxiang@xiaomi.com
-libs/libnx/nxfonts/Makefile.sources alin.jerpelea@sony.com 41312067+SPRESENSE@users.noreply.github.com xiaoxiang@xiaomi.com liuhaitao@xiaomi.com
-libs/libnx/nxfonts/nxfonts.h alin.jerpelea@sony.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
-libs/libnx/nxfonts/nxfonts_bitmaps.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libnx/nxfonts/nxfonts_cache.c anjiahao@xiaomi.com yamamoto@midokura.com xiaoxiang@xiaomi.com devel@sumpfralle.de
-libs/libnx/nxfonts/nxfonts_convert.c alin.jerpelea@sony.com
-libs/libnx/nxfonts/nxfonts_getfont.c alin.jerpelea@sony.com jpa@bitbucket.mail.kapsi.fi
-libs/libnx/nxfonts/nxfonts_mono5x8.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_pixel-lcd-machine.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_pixel-unicode.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_sans17x22.h alin.jerpelea@sony.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com jpa@bitbucket.mail.kapsi.fi
-libs/libnx/nxfonts/nxfonts_sans17x23b.h alin.jerpelea@sony.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com
-libs/libnx/nxfonts/nxfonts_sans20x26.h alin.jerpelea@sony.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com
-libs/libnx/nxfonts/nxfonts_sans20x27b.h alin.jerpelea@sony.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com
-libs/libnx/nxfonts/nxfonts_sans22x29.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_sans22x29b.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_sans23x27.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_sans28x37.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_sans28x37b.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_sans39x48.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_sans40x49b.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_serif22x28b.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_serif22x29.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_serif27x38b.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_serif29x37.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_serif38x48.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_serif38x49b.h alin.jerpelea@sony.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com
-libs/libnx/nxfonts/nxfonts_tom-thumb-4x6.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_x11-misc-fixed-10x20.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_x11-misc-fixed-4x6.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_x11-misc-fixed-5x7.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_x11-misc-fixed-5x8.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_x11-misc-fixed-6x10.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_x11-misc-fixed-6x12.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_x11-misc-fixed-6x13.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_x11-misc-fixed-6x13b.h alin.jerpelea@sony.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com
-libs/libnx/nxfonts/nxfonts_x11-misc-fixed-6x13o.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_x11-misc-fixed-6x9.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_x11-misc-fixed-7x13.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_x11-misc-fixed-7x13b.h alin.jerpelea@sony.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com
-libs/libnx/nxfonts/nxfonts_x11-misc-fixed-7x13o.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_x11-misc-fixed-7x14.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_x11-misc-fixed-7x14b.h alin.jerpelea@sony.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com
-libs/libnx/nxfonts/nxfonts_x11-misc-fixed-8x13.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_x11-misc-fixed-8x13b.h alin.jerpelea@sony.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com
-libs/libnx/nxfonts/nxfonts_x11-misc-fixed-8x13o.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_x11-misc-fixed-9x15.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_x11-misc-fixed-9x15b.h alin.jerpelea@sony.com petro.karashchenko@gmail.com gustavo.nihei@espressif.com
-libs/libnx/nxfonts/nxfonts_x11-misc-fixed-9x18.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxfonts/nxfonts_x11-misc-fixed-9x18b.h alin.jerpelea@sony.com petro.karashchenko@gmail.com
-libs/libnx/nxglib/nxgl_area2rect.c huangqi3@xiaomi.com alin.jerpelea@sony.com
-libs/libnx/nxglib/nxgl_rect2area.c huangqi3@xiaomi.com alin.jerpelea@sony.com
-libs/libnx/nxglib/nxglib_circlepts.c alin.jerpelea@sony.com gustavo.nihei@espressif.com
-libs/libnx/nxglib/nxglib_circletraps.c alin.jerpelea@sony.com gustavo.nihei@espressif.com
-libs/libnx/nxglib/nxglib_colorcmp.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libnx/nxglib/nxglib_colorcopy.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libnx/nxglib/nxglib_intersecting.c alin.jerpelea@sony.com
-libs/libnx/nxglib/nxglib_nonintersecting.c alin.jerpelea@sony.com gustavo.nihei@espressif.com xiaoxiang@xiaomi.com
-libs/libnx/nxglib/nxglib_nullrect.c alin.jerpelea@sony.com devel@sumpfralle.de xiaoxiang@xiaomi.com
-libs/libnx/nxglib/nxglib_rectadd.c alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com
-libs/libnx/nxglib/nxglib_rectcopy.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libnx/nxglib/nxglib_rectinside.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libnx/nxglib/nxglib_rectintersect.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libnx/nxglib/nxglib_rectoffset.c alin.jerpelea@sony.com gustavo.nihei@espressif.com xiaoxiang@xiaomi.com
-libs/libnx/nxglib/nxglib_rectoverlap.c alin.jerpelea@sony.com gustavo.nihei@espressif.com xiaoxiang@xiaomi.com
-libs/libnx/nxglib/nxglib_rectsize.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libnx/nxglib/nxglib_rectunion.c alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com
-libs/libnx/nxglib/nxglib_rgb2yuv.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libnx/nxglib/nxglib_rgbblend.c alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com gustavo.nihei@espressif.com
-libs/libnx/nxglib/nxglib_runcopy.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libnx/nxglib/nxglib_runoffset.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libnx/nxglib/nxglib_splitline.c yamamoto@midokura.com alin.jerpelea@sony.com devel@sumpfralle.de 59230071+hartmannathan@users.noreply.github.com
-libs/libnx/nxglib/nxglib_trapcopy.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libnx/nxglib/nxglib_trapoffset.c alin.jerpelea@sony.com
-libs/libnx/nxglib/nxglib_vectoradd.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libnx/nxglib/nxglib_vectsubtract.c alin.jerpelea@sony.com gustavo.nihei@espressif.com xiaoxiang@xiaomi.com
-libs/libnx/nxglib/nxglib_yuv2rgb.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libnx/nxmu/nx_bitmap.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com ville.juven@unikie.com
-libs/libnx/nxmu/nx_block.c alin.jerpelea@sony.com
-libs/libnx/nxmu/nx_closewindow.c alin.jerpelea@sony.com
-libs/libnx/nxmu/nx_connect.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com
-libs/libnx/nxmu/nx_constructwindow.c alin.jerpelea@sony.com gustavo.nihei@espressif.com
-libs/libnx/nxmu/nx_cursor.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com 59230071+hartmannathan@users.noreply.github.com
-libs/libnx/nxmu/nx_disconnect.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libnx/nxmu/nx_eventhandler.c alin.jerpelea@sony.com yamamoto@midokura.com xiaoxiang@xiaomi.com anchao@xiaomi.com
-libs/libnx/nxmu/nx_eventnotify.c alin.jerpelea@sony.com
-libs/libnx/nxmu/nx_fill.c alin.jerpelea@sony.com
-libs/libnx/nxmu/nx_filltrapezoid.c alin.jerpelea@sony.com
-libs/libnx/nxmu/nx_getposition.c alin.jerpelea@sony.com
-libs/libnx/nxmu/nx_getrectangle.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com ville.juven@unikie.com
-libs/libnx/nxmu/nx_kbdchin.c alin.jerpelea@sony.com
-libs/libnx/nxmu/nx_kbdin.c alin.jerpelea@sony.com
-libs/libnx/nxmu/nx_lower.c alin.jerpelea@sony.com
-libs/libnx/nxmu/nx_modal.c alin.jerpelea@sony.com
-libs/libnx/nxmu/nx_mousein.c alin.jerpelea@sony.com
-libs/libnx/nxmu/nx_move.c alin.jerpelea@sony.com
-libs/libnx/nxmu/nx_openwindow.c alin.jerpelea@sony.com
-libs/libnx/nxmu/nx_raise.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libnx/nxmu/nx_redrawreq.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libnx/nxmu/nx_releasebkgd.c alin.jerpelea@sony.com
-libs/libnx/nxmu/nx_requestbkgd.c alin.jerpelea@sony.com
-libs/libnx/nxmu/nx_setbgcolor.c alin.jerpelea@sony.com
-libs/libnx/nxmu/nx_setpixel.c alin.jerpelea@sony.com
-libs/libnx/nxmu/nx_setposition.c alin.jerpelea@sony.com
-libs/libnx/nxmu/nx_setsize.c alin.jerpelea@sony.com
-libs/libnx/nxmu/nx_setvisibility.c alin.jerpelea@sony.com
-libs/libnx/nxmu/nx_synch.c alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com devel@sumpfralle.de
-libs/libnx/nxmu/nxmu_sendserver.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libnx/nxmu/nxmu_sendwindow.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk.h alin.jerpelea@sony.com petro.karashchenko@gmail.com xiaoxiang@xiaomi.com
-libs/libnx/nxtk/nxtk_bitmaptoolbar.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_bitmapwindow.c alin.jerpelea@sony.com jpa@bitbucket.mail.kapsi.fi
-libs/libnx/nxtk/nxtk_block.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_closetoolbar.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libnx/nxtk/nxtk_closewindow.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_containerclip.c alin.jerpelea@sony.com devel@sumpfralle.de
-libs/libnx/nxtk/nxtk_drawcircletoolbar.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_drawcirclewindow.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_drawframe.c alin.jerpelea@sony.com huangqi3@xiaomi.com
-libs/libnx/nxtk/nxtk_drawlinetoolbar.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_drawlinewindow.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_events.c alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com
-libs/libnx/nxtk/nxtk_fillcircletoolbar.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_fillcirclewindow.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_filltoolbar.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_filltraptoolbar.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_filltrapwindow.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_fillwindow.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_getposition.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_gettoolbar.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_getwindow.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_ishidden.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_lower.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_modal.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_movetoolbar.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_movewindow.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_opentoolbar.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libnx/nxtk/nxtk_openwindow.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_raise.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_setposition.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_setsize.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libnx/nxtk/nxtk_setsubwindows.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libnx/nxtk/nxtk_setvisibility.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_subwindowclip.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_subwindowmove.c alin.jerpelea@sony.com
-libs/libnx/nxtk/nxtk_synch.c alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-libs/libnx/nxtk/nxtk_toolbarbounds.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-libs/libxx/.gitignore xiaoxiang@xiaomi.com wangmingrong1@xiaomi.com haopengxiang@xiaomi.com anchao@xiaomi.com
+
+libs/libdsp/* acassis@gmail.com alin.jerpelea@sony.com raiden00@railab.me
+libs/libm/libm/* xiaoxiang@xiaomi.com alin.jerpelea@sony.com
+libs/libnx/* xiaoxiang@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
+
 libs/libxx/Kconfig xiaoxiang@xiaomi.com yamamoto@midokura.com zhuyanlin1@xiaomi.com cuiziwei@xiaomi.com
 libs/libxx/Makefile xiaoxiang@xiaomi.com alin.jerpelea@sony.com wangmingrong1@xiaomi.com zhangyuan7@pinecone.net
 libs/libxx/__config_site stuart.ianna@motec.com.au thomas.narayana-swamy@wandercraft.eu jihandong@xiaomi.com cuiziwei@xiaomi.com
-libs/libxx/libcxx/.gitignore wangmingrong1@xiaomi.com
 libs/libxx/libcxx/0001-Fix-build-error-about-__GLIBC__.patch wangmingrong1@xiaomi.com
 libs/libxx/libcxx/0001-libc-Fix-failures-with-GCC-14-92663.patch anchao.archer@bytedance.com
 libs/libxx/libcxx/0001-libcxx-fix-ld-errors.patch wangmingrong1@xiaomi.com
 libs/libxx/libcxx/0001-libcxx-remove-mach-time-h.patch wangmingrong1@xiaomi.com
 libs/libxx/libcxx/0001_fix_stdatomic_h_miss_typedef.patch wangmingrong1@xiaomi.com
 libs/libxx/libcxx/mbstate_t.patch wangmingrong1@xiaomi.com
-libs/libxx/libcxxabi/.gitignore wangmingrong1@xiaomi.com
 libs/libxx/libcxxabi/0001-libcxxabi-Fix-build-warnings-generated-by-CMake-comp.patch wangmingrong1@xiaomi.com
 libs/libxx/libcxxabi/0002-libcxxabi-fix-compilation-errors.patch wangmingrong1@xiaomi.com
 libs/libxx/libcxxmini/libxx_cxa_guard.cxx xiaoxiang@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
@@ -21725,7 +15785,6 @@ libs/libxx/libcxxmini/libxx_new.cxx xiaoxiang@xiaomi.com dingddding@163.com fang
 libs/libxx/libcxxmini/libxx_newa.cxx xiaoxiang@xiaomi.com dingddding@163.com fangxinyong@xiaomi.com alin.jerpelea@sony.com
 libs/libxx/libcxxmini/libxx_typeinfo.cxx cuiziwei@xiaomi.com
 libs/libxx/libcxxmini/libxx_typeinfo.h cuiziwei@xiaomi.com
-libs/libxx/uClibc++/.gitignore wangmingrong1@xiaomi.com
 libs/libxx/uClibc++/0001-uClibcxx-basic_definitions-fix-GCC-specific-definiti.patch wangmingrong1@xiaomi.com
 libs/libxx/uClibc++/0001-uclibxx-use-overload-constructor-of-filebuf-ostream.patch wangmingrong1@xiaomi.com devel@sumpfralle.de
 libs/libxx/uClibc++/system_configuration.h wangmingrong1@xiaomi.com simbit18@gmail.com
@@ -21824,7 +15883,6 @@ mm/shm/shmat.c jukkax@ssrc.tii.ae alin.jerpelea@sony.com ville.juven@unikie.com 
 mm/shm/shmctl.c alin.jerpelea@sony.com anjiahao@xiaomi.com zhangshoukui@xiaomi.com anchao@xiaomi.com
 mm/shm/shmdt.c jukkax@ssrc.tii.ae ville.juven@unikie.com anjiahao@xiaomi.com zhangshoukui@xiaomi.com
 mm/shm/shmget.c alin.jerpelea@sony.com anjiahao@xiaomi.com jukkax@ssrc.tii.ae xiaoxiang@xiaomi.com
-mm/tlsf/.gitignore xiaoxiang@xiaomi.com
 mm/tlsf/0001-Add-TLSF_API-and-tlsf_printf.patch xiaoxiang@xiaomi.com
 mm/tlsf/0002-Define-_DEBUG-to-0-if-not-done-yet.patch xiaoxiang@xiaomi.com
 mm/tlsf/0003-Support-customize-FL_INDEX_MAX-to-reduce-the-memory-.patch xiaoxiang@xiaomi.com
@@ -22156,80 +16214,10 @@ net/socket/shutdown.c wengzhe@xiaomi.com zhangshoukui@xiaomi.com dongjiuzhu1@xia
 net/socket/socket.c dongjiuzhu1@xiaomi.com jussi.kivilinna@haltian.com xiaoxiang@xiaomi.com anchao@xiaomi.com
 net/socket/socket.h xiaoxiang@xiaomi.com anchao@xiaomi.com dongjiuzhu1@xiaomi.com alin.jerpelea@sony.com
 net/socket/socketpair.c anchao@xiaomi.com wangchen41@xiaomi.com zhanghongyu@xiaomi.com alin.jerpelea@sony.com ouyangxiangzhen@xiaomi.com
-net/tcp/Kconfig anchao@xiaomi.com xiaoxiang@xiaomi.com wengzhe@xiaomi.com f.panag@amco.gr
-net/tcp/tcp.h anchao@xiaomi.com xiaoxiang@xiaomi.com zhanghongyu@xiaomi.com yamamoto@midokura.com
-net/tcp/tcp_accept.c alin.jerpelea@sony.com anchao@xiaomi.com seanshpark@yahoo.com jussi.kivilinna@haltian.com
-net/tcp/tcp_appsend.c anchao@xiaomi.com alexanderlunev@mail.ru yamamoto@midokura.com zhangyuan7@pinecone.net
-net/tcp/tcp_backlog.c alin.jerpelea@sony.com zhanghongyu@xiaomi.com zhangyuan7@pinecone.net xiaoxiang@xiaomi.com
-net/tcp/tcp_callback.c anchao@xiaomi.com yamamoto@midokura.com meijian@xiaomi.com wengzhe@xiaomi.com
-net/tcp/tcp_cc.c liqinhui@xiaomi.com alin.jerpelea@sony.com devel@sumpfralle.de
-net/tcp/tcp_close.c xiaoxiang@xiaomi.com anchao@xiaomi.com yamamoto@midokura.com alin.jerpelea@sony.com peter.vanderperk@nxp.com
-net/tcp/tcp_conn.c wengzhe@xiaomi.com anchao@xiaomi.com zhanghongyu@xiaomi.com wangchen41@xiaomi.com
-net/tcp/tcp_connect.c anchao@xiaomi.com zhanghongyu@xiaomi.com meijian@xiaomi.com xiaoxiang@xiaomi.com
-net/tcp/tcp_devpoll.c alexanderlunev@mail.ru anchao@xiaomi.com info@iktek.de zhanghongyu@xiaomi.com
-net/tcp/tcp_dump.c alexanderlunev@mail.ru sebastien@lorquet.fr anchao@xiaomi.com alin.jerpelea@sony.com
-net/tcp/tcp_finddev.c alin.jerpelea@sony.com zhanghongyu@xiaomi.com anchao@xiaomi.com juha.niskanen@haltian.com
-net/tcp/tcp_getsockopt.c anchao@xiaomi.com zhanghongyu@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-net/tcp/tcp_input.c anchao@xiaomi.com yamamoto@midokura.com zhanghongyu@xiaomi.com xiaoxiang@xiaomi.com
-net/tcp/tcp_ioctl.c anchao@xiaomi.com wengzhe@xiaomi.com zhanghongyu@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-net/tcp/tcp_ipselect.c alin.jerpelea@sony.com anchao@xiaomi.com
-net/tcp/tcp_listen.c anchao@xiaomi.com xiaoxiang@xiaomi.com masayuki.ishikawa@gmail.com alin.jerpelea@sony.com
-net/tcp/tcp_monitor.c anchao@xiaomi.com alin.jerpelea@sony.com zhanghongyu@xiaomi.com alexanderlunev@mail.ru
-net/tcp/tcp_netpoll.c xiaoxiang@xiaomi.com anchao@xiaomi.com alin.jerpelea@sony.com wangbowen6@xiaomi.com
-net/tcp/tcp_notifier.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com f.panag@amco.gr anchao@xiaomi.com
-net/tcp/tcp_recvfrom.c xiaoxiang@xiaomi.com anchao@xiaomi.com chenrun1@xiaomi.com yamamoto@midokura.com
-net/tcp/tcp_recvwindow.c yamamoto@midokura.com anchao@xiaomi.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-net/tcp/tcp_send.c anchao@xiaomi.com liyi25@xiaomi.com yamamoto@midokura.com biantao@pinecone.net
-net/tcp/tcp_send_buffered.c anchao@xiaomi.com yamamoto@midokura.com xiaoxiang@xiaomi.com alexanderlunev@mail.ru
-net/tcp/tcp_send_unbuffered.c xiaoxiang@xiaomi.com alexanderlunev@mail.ru yamamoto@midokura.com anchao@xiaomi.com
-net/tcp/tcp_sendfile.c alexanderlunev@mail.ru xiaoxiang@xiaomi.com anchao@xiaomi.com alin.jerpelea@sony.com
-net/tcp/tcp_seqno.c wengzhe@xiaomi.com acassis@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-net/tcp/tcp_setsockopt.c anchao@xiaomi.com zhanghongyu@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-net/tcp/tcp_shutdown.c wengzhe@xiaomi.com alin.jerpelea@sony.com zhanghongyu@xiaomi.com
-net/tcp/tcp_timer.c alexanderlunev@mail.ru zhanghongyu@xiaomi.com wangyingdong@xiaomi.com anchao@xiaomi.com
-net/tcp/tcp_txdrain.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com zhanghongyu@xiaomi.com dongjiuzhu1@xiaomi.com
-net/tcp/tcp_wrbuffer.c wengzhe@xiaomi.com anchao@xiaomi.com pelle.windestam@tagmaster.com alin.jerpelea@sony.com
-net/udp/Kconfig f.panag@amco.gr xiaoxiang@xiaomi.com wengzhe@xiaomi.com masayuki.ishikawa@gmail.com
-net/udp/udp.h xiaoxiang@xiaomi.com anchao@xiaomi.com zhanghongyu@xiaomi.com alin.jerpelea@sony.com
-net/udp/udp_callback.c anchao@xiaomi.com wengzhe@xiaomi.com macscomp@gmail.com alin.jerpelea@sony.com
-net/udp/udp_close.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com anchao@xiaomi.com zhanghongyu@xiaomi.com
-net/udp/udp_conn.c anchao@xiaomi.com wengzhe@xiaomi.com zhanghongyu@xiaomi.com wangchen41@xiaomi.com
-net/udp/udp_devpoll.c anchao@xiaomi.com alexanderlunev@mail.ru alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-net/udp/udp_finddev.c zhanghongyu@xiaomi.com wangchen41@xiaomi.com anchao@xiaomi.com sebastien@lorquet.fr
-net/udp/udp_input.c wengzhe@xiaomi.com anchao@xiaomi.com laczenjms@gmail.com zhangshuai39@xiaomi.com
-net/udp/udp_ioctl.c anchao@xiaomi.com wengzhe@xiaomi.com zhanghongyu@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-net/udp/udp_ipselect.c alin.jerpelea@sony.com anchao@xiaomi.com
-net/udp/udp_netpoll.c xiaoxiang@xiaomi.com anchao@xiaomi.com alin.jerpelea@sony.com wangbowen6@xiaomi.com
-net/udp/udp_notifier.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com wangchen41@xiaomi.com anchao@xiaomi.com
-net/udp/udp_recvfrom.c xiaoxiang@xiaomi.com zhanghongyu@xiaomi.com anchao@xiaomi.com wengzhe@xiaomi.com daichuan@xiaomi.com
-net/udp/udp_send.c wengzhe@xiaomi.com liyi25@xiaomi.com anchao@xiaomi.com zhanghongyu@xiaomi.com
-net/udp/udp_sendto_buffered.c xiaoxiang@xiaomi.com anchao@xiaomi.com zhanghongyu@xiaomi.com alin.jerpelea@sony.com wengzhe@xiaomi.com
-net/udp/udp_sendto_unbuffered.c xiaoxiang@xiaomi.com anchao@xiaomi.com wengzhe@xiaomi.com f.j.panag@gmail.com
-net/udp/udp_setsockopt.c anchao@xiaomi.com alin.jerpelea@sony.com sebastien@lorquet.fr xiaoxiang@xiaomi.com
-net/udp/udp_txdrain.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com wangchen41@xiaomi.com zhanghongyu@xiaomi.com
-net/udp/udp_wrbuffer.c zhanghongyu@xiaomi.com wengzhe@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-net/udp/udp_wrbuffer_dump.c alin.jerpelea@sony.com
-net/usrsock/Kconfig jussi.kivilinna@haltian.com f.panag@amco.gr xiaoxiang@xiaomi.com Kazuya.Hioki@sony.com jordi@midokura.com
-net/usrsock/usrsock.h jussi.kivilinna@haltian.com juha.niskanen@haltian.com dongjianli@pinecone.net xiaoxiang@xiaomi.com alin.jerpelea@sony.com
-net/usrsock/usrsock_accept.c dongjianli@pinecone.net xiaoxiang@xiaomi.com anchao@xiaomi.com juha.niskanen@haltian.com
-net/usrsock/usrsock_bind.c jussi.kivilinna@haltian.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com juha.niskanen@haltian.com
-net/usrsock/usrsock_close.c jussi.kivilinna@haltian.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com anchao@xiaomi.com
-net/usrsock/usrsock_conn.c jussi.kivilinna@haltian.com wengzhe@xiaomi.com anchao@xiaomi.com xiaoxiang@xiaomi.com f.panag@amco.gr
-net/usrsock/usrsock_connect.c jussi.kivilinna@haltian.com alin.jerpelea@sony.com zhanghongyu@xiaomi.com xiaoxiang@xiaomi.com
-net/usrsock/usrsock_devif.c liangchaozhong@xiaomi.com xiaoxiang@xiaomi.com wengzhe@xiaomi.com anjiahao@xiaomi.com zhanghongyu@xiaomi.com
-net/usrsock/usrsock_event.c jussi.kivilinna@haltian.com alin.jerpelea@sony.com anchao@xiaomi.com zhanghongyu@xiaomi.com liangchaozhong@xiaomi.com
-net/usrsock/usrsock_getpeername.c dongjianli@pinecone.net xiaoxiang@xiaomi.com anchao@xiaomi.com juha.niskanen@haltian.com
-net/usrsock/usrsock_getsockname.c jussi.kivilinna@haltian.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com juha.niskanen@haltian.com
-net/usrsock/usrsock_getsockopt.c jussi.kivilinna@haltian.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com dongjiuzhu1@xiaomi.com
-net/usrsock/usrsock_ioctl.c dongjianli@pinecone.net xiaoxiang@xiaomi.com zhanghongyu@xiaomi.com anchao@xiaomi.com
-net/usrsock/usrsock_listen.c dongjianli@pinecone.net xiaoxiang@xiaomi.com anchao@xiaomi.com alin.jerpelea@sony.com
-net/usrsock/usrsock_poll.c jussi.kivilinna@haltian.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com wangbowen6@xiaomi.com
-net/usrsock/usrsock_recvmsg.c bijunda1@xiaomi.com xiaoxiang@xiaomi.com anchao@xiaomi.com alin.jerpelea@sony.com masayuki.ishikawa@gmail.com
-net/usrsock/usrsock_sendmsg.c bijunda1@xiaomi.com anchao@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com zhanghongyu@xiaomi.com
-net/usrsock/usrsock_setsockopt.c jussi.kivilinna@haltian.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com dongjiuzhu1@xiaomi.com
-net/usrsock/usrsock_shutdown.c wengzhe@xiaomi.com alin.jerpelea@sony.com anchao@xiaomi.com
-net/usrsock/usrsock_socket.c jussi.kivilinna@haltian.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com anchao@xiaomi.com
-net/usrsock/usrsock_sockif.c jussi.kivilinna@haltian.com dongjianli@pinecone.net xiaoxiang@xiaomi.com alin.jerpelea@sony.com bijunda1@xiaomi.com
+
+net/tcp/* anchao@xiaomi.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
+net/usrsock/* jussi.kivilinna@haltian.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com anchao@xiaomi.com juha.niskanen@haltian.com
+
 net/utils/Kconfig wengzhe@xiaomi.com xiaoxiang@xiaomi.com chengkai@xiaomi.com liyi25@xiaomi.com
 net/utils/net_bufpool.c wengzhe@xiaomi.com
 net/utils/net_chksum.c anchao@xiaomi.com wengzhe@xiaomi.com wangchen41@xiaomi.com alin.jerpelea@sony.com
@@ -22250,7 +16238,6 @@ net/utils/net_tcpchksum.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 net/utils/net_timeval2dsec.c alin.jerpelea@sony.com
 net/utils/net_udpchksum.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 net/utils/utils.h wengzhe@xiaomi.com anchao@xiaomi.com zhanghongyu@xiaomi.com xiaoxiang@xiaomi.com
-openamp/.gitignore xiaoxiang@xiaomi.com liguiding@pinecone.net xuxin19@xiaomi.com anchao@xiaomi.com
 openamp/0001-lib-errno.h-fix-compile-error.patch wangbowen6@xiaomi.com wangmingrong1@xiaomi.com
 openamp/0001-ns-acknowledge-the-received-creation-message.patch xiaoxiang@xiaomi.com liguiding1@xiaomi.com wangbowen6@xiaomi.com devel@sumpfralle.de wangmingrong1@xiaomi.com
 openamp/0002-Negotiate-individual-buffer-size-dynamically.patch xiaoxiang@xiaomi.com liguiding1@xiaomi.com wangbowen6@xiaomi.com wangmingrong1@xiaomi.com
@@ -22277,7 +16264,6 @@ openamp/libmetal.cmake anchao@xiaomi.com xuxin19@xiaomi.com anchao@lixiang.com w
 openamp/libmetal.defs chao.an@gm.com xiaoxiang@xiaomi.com wangbowen6@xiaomi.com anchao@lixiang.com xuxin19@xiaomi.com
 openamp/open-amp.cmake anchao@xiaomi.com xuxin19@xiaomi.com wangbowen6@xiaomi.com wangyongrong@xiaomi.com xiaoxiang@xiaomi.com
 openamp/open-amp.defs xiaoxiang@xiaomi.com chao.an@gm.com wangbowen6@xiaomi.com liguiding1@xiaomi.com wangyongrong@xiaomi.com
-pass1/.gitignore xiaoxiang@xiaomi.com yamamoto@midokura.com
 pass1/Makefile alin.jerpelea@sony.com xiaoxiang@xiaomi.com yamamoto@midokura.com masayuki.ishikawa@gmail.com
 pass1/README.txt koch.matthew@gmail.com
 sched/Kconfig xiaoxiang@xiaomi.com yinshengkai@xiaomi.com chenrun1@xiaomi.com
@@ -22307,12 +16293,9 @@ sched/environ/env_removevar.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com wangbo
 sched/environ/env_setenv.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com anchao@lixiang.com wangbowen6@xiaomi.com
 sched/environ/env_unsetenv.c xiaoxiang@xiaomi.com alin.jerpelea@sony.com ville.juven@unikie.com hujun5@xiaomi.com
 sched/environ/environ.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com ville.juven@unikie.com wangbowen6@xiaomi.com
-sched/event/event.h anchao@lixiang.com alin.jerpelea@sony.com
-sched/event/event_destroy.c anchao@lixiang.com alin.jerpelea@sony.com
-sched/event/event_init.c anchao@lixiang.com alin.jerpelea@sony.com
-sched/event/event_post.c anchao@lixiang.com alin.jerpelea@sony.com
-sched/event/event_reset.c anchao@lixiang.com alin.jerpelea@sony.com
-sched/event/event_wait.c anchao@lixiang.com alin.jerpelea@sony.com
+
+sched/event/* anchao@lixiang.com alin.jerpelea@sony.com
+
 sched/group/group.h xiaoxiang@xiaomi.com ville.juven@unikie.com anchao@lixiang.com minabe.oki@gmail.com
 sched/group/group_childstatus.c dongjiuzhu1@xiaomi.com arjun@zglue.com devel@sumpfralle.de alin.jerpelea@sony.com
 sched/group/group_continue.c zhangyuan21@xiaomi.com hujun5@xiaomi.com liguiding1@xiaomi.com jukka.laitinen@tii.ae
@@ -22570,15 +16553,12 @@ sched/wqueue/kwork_notifier.c xiaoxiang@xiaomi.com anchao@xiaomi.com hujun5@xiao
 sched/wqueue/kwork_queue.c ouyangxiangzhen@xiaomi.com dongjiuzhu1@xiaomi.com liguiding1@xiaomi.com dulibo1@xiaomi.com
 sched/wqueue/kwork_thread.c dongjiuzhu1@xiaomi.com liguiding1@xiaomi.com ouyangxiangzhen@xiaomi.com hujun5@xiaomi.com xiaoxiang@xiaomi.com
 sched/wqueue/wqueue.h ouyangxiangzhen@xiaomi.com liguiding1@xiaomi.com dongjiuzhu1@xiaomi.com liguiding@pinecone.net
-syscall/.gitignore xiaoxiang@xiaomi.com Yuuichi.A.Nakamura@sony.com yamamoto@midokura.com
 syscall/Kconfig xiaoxiang@xiaomi.com
 syscall/Makefile alin.jerpelea@sony.com Yuuichi.A.Nakamura@sony.com xiaoxiang@xiaomi.com masayuki.ishikawa@gmail.com
 syscall/syscall.csv xiaoxiang@xiaomi.com ville.juven@unikie.com anchao@xiaomi.com huangqi3@xiaomi.com
 syscall/syscall_names.c Yuuichi.A.Nakamura@sony.com alin.jerpelea@sony.com
 syscall/syscall_stublookup.c xiaoxiang@xiaomi.com dongjianli@pinecone.net jussi.kivilinna@haltian.com Yuuichi.A.Nakamura@sony.com
 syscall/syscall_wraps.h Yuuichi.A.Nakamura@sony.com alin.jerpelea@sony.com
-syscall/wraps/.gitignore Yuuichi.A.Nakamura@sony.com
-tools/.gitignore david_s5@usa.net acassis@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
 tools/Config.mk xiaoxiang@xiaomi.com yinshengkai@xiaomi.com anchao@xiaomi.com
 tools/D.defs matheus-catarino@hotmail.com luppy@appkaki.com huangqi3@xiaomi.com wangmingrong1@xiaomi.com alin.jerpelea@sony.com
 tools/Directories.mk xiaoxiang@xiaomi.com alin.jerpelea@sony.com wangmingrong1@xiaomi.com anthony@vergeaero.com
@@ -22590,13 +16570,13 @@ tools/Makefile.host xiaoxiang@xiaomi.com zhuyanlin1@xiaomi.com yamamoto@midokura
 tools/ProtectedLibs.mk alin.jerpelea@sony.com xiaoxiang@xiaomi.com wangmingrong1@xiaomi.com ppisa@pikron.com
 tools/Rust.defs huangqi3@xiaomi.com luppy@appkaki.com wangmingrong1@xiaomi.com alin.jerpelea@sony.com
 tools/Swift.defs matheus-catarino@hotmail.com alin.jerpelea@sony.com wangmingrong1@xiaomi.com
-tools/Unix.mk alanrosenthal@google.com anchao@xiaomi.com xuxin19@xiaomi.com eren.terzioglu@espressif.com lucas.vaz@espressif.com
+tools/Unix.mk alanrosenthal@google.com anchao@xiaomi.com xuxin19@xiaomi.com lucas.vaz@espressif.com
 tools/Win.mk alanrosenthal@google.com fft@feedforward.com.cn xuxin19@xiaomi.com anchao@xiaomi.com lucas.vaz@espressif.com
 tools/Zig.defs huangqi3@xiaomi.com alin.jerpelea@sony.com yfliu2008@qq.com
 tools/b16.c alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com
-tools/bcm2711/.gitignore matteo.golin@gmail.com
-tools/bcm2711/Config.mk matteo.golin@gmail.com
-tools/bcm2711/bootfiles.sh matteo.golin@gmail.com
+
+tools/bcm2711/* matteo.golin@gmail.com
+
 tools/bdf-converter.c alin.jerpelea@sony.com spudarnia@yahoo.com tomek@cedro.info
 tools/bl602/partition_cfg_2M_nuttx.toml jsun@bouffalolab.com
 tools/btdecode.sh tiago.medicci@espressif.com neo.xu1990@gmail.com yamamoto@midokura.com
@@ -22608,62 +16588,9 @@ tools/cfgparser.c alin.jerpelea@sony.com anchao@xiaomi.com gustavo.nihei@espress
 tools/cfgparser.h alin.jerpelea@sony.com gustavo.nihei@espressif.com
 tools/checkpatch.sh xiaoxiang@xiaomi.com liuguo09@users.noreply.github.com simbit18@gmail.com liuhaitao@xiaomi.com raiden00@railab.me
 tools/checkrelease.sh adam@starcat.io adam@adamfeuer.com xiaoxiang@xiaomi.com bashton@brennanashton.com alin.jerpelea@sony.com
-tools/ci/README.md bashton@brennanashton.com
-tools/ci/cibuild.ps1 simbit18@gmail.com
-tools/ci/cibuild.sh xiaoxiang@xiaomi.com 101105604+simbit18@users.noreply.github.com bashton@brennanashton.com gustavo.nihei@espressif.com anchao@xiaomi.com
-tools/ci/cirun.sh nietingting@xiaomi.com alin.jerpelea@sony.com vela-mib@xiaomi.com
-tools/ci/docker/linux/Dockerfile bashton@brennanashton.com xiaoxiang@xiaomi.com 101105604+simbit18@users.noreply.github.com anchao@xiaomi.com zhanghongyu@xiaomi.com
-tools/ci/platforms/darwin.sh 101105604+simbit18@users.noreply.github.com yamamoto@midokura.com matheus-catarino@hotmail.com alin.jerpelea@sony.com almir.okato@espressif.com
-tools/ci/platforms/darwin_arm64.sh 101105604+simbit18@users.noreply.github.com
-tools/ci/platforms/linux.sh 101105604+simbit18@users.noreply.github.com nicco.maggioni@gmail.com alin.jerpelea@sony.com almir.okato@espressif.com wangmingrong1@xiaomi.com
-tools/ci/platforms/msys2.sh 101105604+simbit18@users.noreply.github.com wangmingrong1@xiaomi.com alin.jerpelea@sony.com luppy@appkaki.com
-tools/ci/platforms/ubuntu.sh 101105604+simbit18@users.noreply.github.com nicco.maggioni@gmail.com matheus-catarino@hotmail.com almir.okato@espressif.com alin.jerpelea@sony.com
-tools/ci/platforms/windows.ps1 simbit18@gmail.com 101105604+simbit18@users.noreply.github.com
-tools/ci/testlist/arm-01.dat anchao@xiaomi.com petro.karashchenko@gmail.com bashton@brennanashton.com
-tools/ci/testlist/arm-02.dat anchao@xiaomi.com xiaoxiang@xiaomi.com bashton@brennanashton.com masayuki.ishikawa@gmail.com jernej.turnsek@gmail.com
-tools/ci/testlist/arm-03.dat bashton@brennanashton.com anchao@xiaomi.com
-tools/ci/testlist/arm-04.dat anchao@xiaomi.com bashton@brennanashton.com xiaoxiang@xiaomi.com
-tools/ci/testlist/arm-05.dat raiden00@railab.me wangmingrong1@xiaomi.com anchao@xiaomi.com simbit18@gmail.com luppy@appkaki.com
-tools/ci/testlist/arm-06.dat anchao@xiaomi.com luppy@appkaki.com bashton@brennanashton.com xiaoxiang@xiaomi.com
-tools/ci/testlist/arm-07.dat luppy@appkaki.com raiden00@railab.me anchao@xiaomi.com bashton@brennanashton.com xiaoxiang@xiaomi.com
-tools/ci/testlist/arm-08.dat luppy@appkaki.com raiden00@railab.me anchao@xiaomi.com bashton@brennanashton.com xiaoxiang@xiaomi.com
-tools/ci/testlist/arm-09.dat luppy@appkaki.com anchao@xiaomi.com bashton@brennanashton.com raiden00@railab.me xiaoxiang@xiaomi.com
-tools/ci/testlist/arm-10.dat luppy@appkaki.com raiden00@railab.me anchao@xiaomi.com bashton@brennanashton.com xiaoxiang@xiaomi.com
-tools/ci/testlist/arm-11.dat luppy@appkaki.com anchao@xiaomi.com bashton@brennanashton.com xiaoxiang@xiaomi.com
-tools/ci/testlist/arm-12.dat raiden00@railab.me luppy@appkaki.com anchao@xiaomi.com xiaoxiang@xiaomi.com bashton@brennanashton.com
-tools/ci/testlist/arm-13.dat luppy@appkaki.com raiden00@railab.me anchao@xiaomi.com bashton@brennanashton.com xiaoxiang@xiaomi.com
-tools/ci/testlist/arm-14.dat luppy@appkaki.com
-tools/ci/testlist/arm64-01.dat luppy@appkaki.com wangmingrong1@xiaomi.com
-tools/ci/testlist/codechecker.dat xinbingnan@xiaomi.com
-tools/ci/testlist/macos.dat bashton@brennanashton.com xiaoxiang@xiaomi.com anchao@xiaomi.com qinwei1@xiaomi.com 101105604+simbit18@users.noreply.github.com
-tools/ci/testlist/msys2.dat 101105604+simbit18@users.noreply.github.com raiden00@railab.me
-tools/ci/testlist/other.dat bashton@brennanashton.com luppy@appkaki.com xuxin19@xiaomi.com fft@feedforward.com.cn acassis@gmail.com
-tools/ci/testlist/risc-v-01.dat luppy@appkaki.com 101105604+simbit18@users.noreply.github.com
-tools/ci/testlist/risc-v-02.dat luppy@appkaki.com 101105604+simbit18@users.noreply.github.com
-tools/ci/testlist/risc-v-03.dat luppy@appkaki.com
-tools/ci/testlist/risc-v-04.dat luppy@appkaki.com
-tools/ci/testlist/risc-v-05.dat luppy@appkaki.com
-tools/ci/testlist/risc-v-06.dat luppy@appkaki.com
-tools/ci/testlist/risc-v-07.dat luppy@appkaki.com
-tools/ci/testlist/sim-01.dat luppy@appkaki.com xiaoxiang@xiaomi.com anchao@xiaomi.com xuxin19@xiaomi.com zhanghongyu@xiaomi.com
-tools/ci/testlist/sim-02.dat luppy@appkaki.com anchao@xiaomi.com xiaoxiang@xiaomi.com zhangyuan21@xiaomi.com f.j.panag@gmail.com
-tools/ci/testlist/sim-03.dat luppy@appkaki.com anchao@lixiang.com
-tools/ci/testlist/windows.dat simbit18@gmail.com
-tools/ci/testlist/x86_64-01.dat luppy@appkaki.com
-tools/ci/testlist/xtensa-01.dat 101105604+simbit18@users.noreply.github.com filipe.cavalcanti@espressif.com marco.casaroli@gmail.com
-tools/ci/testlist/xtensa-02.dat tiago.medicci@espressif.com marco.casaroli@gmail.com 101105604+simbit18@users.noreply.github.com
-tools/ci/testlist/xtensa-03.dat tiago.medicci@espressif.com
-tools/ci/testrun/README.md nietingting@xiaomi.com devel@sumpfralle.de
-tools/ci/testrun/env/requirements.txt nietingting@xiaomi.com
-tools/ci/testrun/pytest.ini nietingting@xiaomi.com vela-mib@xiaomi.com
-tools/ci/testrun/script/conftest.py nietingting@xiaomi.com alin.jerpelea@sony.com tomek@cedro.info
-tools/ci/testrun/script/test_example/test_example.py nietingting@xiaomi.com alin.jerpelea@sony.com vela-mib@xiaomi.com michallenc@seznam.cz tomek@cedro.info
-tools/ci/testrun/script/test_framework/test_cmocka.py vela-mib@xiaomi.com alin.jerpelea@sony.com zhangshoukui@xiaomi.com
-tools/ci/testrun/script/test_libuv/test_libuv.py vela-mib@xiaomi.com alin.jerpelea@sony.com
-tools/ci/testrun/script/test_open_posix/test_openposix_.py vela-mib@xiaomi.com alin.jerpelea@sony.com zhangyuan29@xiaomi.com liguiding1@xiaomi.com yfliu2008@qq.com
-tools/ci/testrun/script/test_os/test_os.py nietingting@xiaomi.com alin.jerpelea@sony.com michallenc@seznam.cz vela-mib@xiaomi.com fangxinyong@xiaomi.com
-tools/ci/testrun/utils/common.py nietingting@xiaomi.com vela-mib@xiaomi.com alin.jerpelea@sony.com devel@sumpfralle.de tomek@cedro.info
-tools/ci/testrun/utils/data_model.py vela-mib@xiaomi.com alin.jerpelea@sony.com
+
+tools/ci/* simbit18@gmail.com luppy@appkaki.com raiden00@railab.me anchao@xiaomi.com bashton@brennanashton.com xiaoxiang@xiaomi.com
+
 tools/cmpconfig.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 tools/cnvwindeps.c alin.jerpelea@sony.com
 tools/configure.bat alin.jerpelea@sony.com spudarnia@yahoo.com xiaoxiang@xiaomi.com
@@ -22676,7 +16603,6 @@ tools/copydir.sh alin.jerpelea@sony.com xiaoxiang@xiaomi.com devel@sumpfralle.de
 tools/coredump.py anchao@xiaomi.com xuxingliang@xiaomi.com anjiahao@xiaomi.com alin.jerpelea@sony.com
 tools/csvparser.c alin.jerpelea@sony.com
 tools/csvparser.h simbit18@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-tools/cxd56/.gitignore alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 tools/cxd56/Config.mk alin.jerpelea@sony.com gustavo.nihei@espressif.com bashton@brennanashton.com xiaoxiang@xiaomi.com
 tools/cxd56/Makefile.host alin.jerpelea@sony.com fft@feedforward.com.cn
 tools/cxd56/clefia.c alin.jerpelea@sony.com devel@sumpfralle.de anchao@xiaomi.com
@@ -22759,52 +16685,17 @@ tools/nxstyle.c johannes.schock@nivus.com David.Sidrane@Nscdg.com zhangyuan21@xi
 tools/parsecallstack.py qiaowei@xiaomi.com xiaoxiang@xiaomi.com bashton@brennanashton.com gustavo.nihei@espressif.com alin.jerpelea@sony.com
 tools/parsememdump.py anjiahao@xiaomi.com buxiasen@xiaomi.com xuxingliang@xiaomi.com wangbowen6@xiaomi.com alin.jerpelea@sony.com
 tools/parsetrace.py yinshengkai@xiaomi.com xiajizhong@xiaomi.com alejandro.aguirre@midokura.com anchao@lixiang.com cuiziwei@xiaomi.com
-tools/pic32/.gitignore abdelatif.guettouche@gmail.com xiaoxiang@xiaomi.com
 tools/pic32/Config.mk abdelatif.guettouche@gmail.com liuhaitao@xiaomi.com alin.jerpelea@sony.com 59230071+hartmannathan@users.noreply.github.com xiaoxiang@xiaomi.com
 tools/pic32/Makefile.host abdelatif.guettouche@gmail.com fft@feedforward.com.cn alin.jerpelea@sony.com xiaoxiang@xiaomi.com liuhaitao@xiaomi.com
 tools/pic32/mkpichex.c abdelatif.guettouche@gmail.com 59230071+hartmannathan@users.noreply.github.com alin.jerpelea@sony.com
 tools/pre-commit liuhaitao@xiaomi.com
 tools/process_config.py wangchengdong@lixiang.com
 tools/process_config.sh yinshengkai@xiaomi.com 25596072+ValentiWorkLearning@users.noreply.github.com 6445757+ajuckler@users.noreply.github.com anchao.archer@bytedance.com 101105604+simbit18@users.noreply.github.com
-tools/pynuttx/.gitignore yinshengkai@xiaomi.com
-tools/pynuttx/gdbinit.py yinshengkai@xiaomi.com
-tools/pynuttx/nxgdb/circbuf.py xuxingliang@xiaomi.com
-tools/pynuttx/nxgdb/debug.py yinshengkai@xiaomi.com
-tools/pynuttx/nxgdb/diagnose.py yinshengkai@xiaomi.com
-tools/pynuttx/nxgdb/dmesg.py yinshengkai@xiaomi.com yangao1@xiaomi.com devel@sumpfralle.de
-tools/pynuttx/nxgdb/fs.py yinshengkai@xiaomi.com xuxingliang@xiaomi.com dongjiuzhu1@xiaomi.com devel@sumpfralle.de
-tools/pynuttx/nxgdb/gcore.py yinshengkai@xiaomi.com
-tools/pynuttx/nxgdb/irq.py xuxingliang@xiaomi.com
-tools/pynuttx/nxgdb/lists.py yinshengkai@xiaomi.com
-tools/pynuttx/nxgdb/macros.py yinshengkai@xiaomi.com devel@sumpfralle.de
-tools/pynuttx/nxgdb/memcheck.py yinshengkai@xiaomi.com
-tools/pynuttx/nxgdb/memdump.py yinshengkai@xiaomi.com xuxingliang@xiaomi.com
-tools/pynuttx/nxgdb/memleak.py yinshengkai@xiaomi.com xuxingliang@xiaomi.com
-tools/pynuttx/nxgdb/mm.py yinshengkai@xiaomi.com xuxingliang@xiaomi.com
-tools/pynuttx/nxgdb/net.py yinshengkai@xiaomi.com
-tools/pynuttx/nxgdb/prefix.py yinshengkai@xiaomi.com
-tools/pynuttx/nxgdb/profile.py yinshengkai@xiaomi.com
-tools/pynuttx/nxgdb/protocols/circbuf.py xuxingliang@xiaomi.com
-tools/pynuttx/nxgdb/protocols/fs.py yinshengkai@xiaomi.com dongjiuzhu1@xiaomi.com
-tools/pynuttx/nxgdb/protocols/irq.py xuxingliang@xiaomi.com
-tools/pynuttx/nxgdb/protocols/mm.py yinshengkai@xiaomi.com
-tools/pynuttx/nxgdb/protocols/thread.py yinshengkai@xiaomi.com dongjiuzhu1@xiaomi.com
-tools/pynuttx/nxgdb/protocols/uorb.py xuxingliang@xiaomi.com
-tools/pynuttx/nxgdb/protocols/value.py yinshengkai@xiaomi.com
-tools/pynuttx/nxgdb/protocols/wdog.py yinshengkai@xiaomi.com
-tools/pynuttx/nxgdb/protocols/wqueue.py yinshengkai@xiaomi.com
-tools/pynuttx/nxgdb/rpmsg.py yinshengkai@xiaomi.com
-tools/pynuttx/nxgdb/stack.py yinshengkai@xiaomi.com devel@sumpfralle.de
-tools/pynuttx/nxgdb/thread.py yinshengkai@xiaomi.com devel@sumpfralle.de
-tools/pynuttx/nxgdb/uorb.py xuxingliang@xiaomi.com
-tools/pynuttx/nxgdb/utils.py yinshengkai@xiaomi.com xuxingliang@xiaomi.com devel@sumpfralle.de chenzhijia@xiaomi.com
-tools/pynuttx/nxgdb/wdog.py yinshengkai@xiaomi.com
-tools/pynuttx/nxgdb/wqueue.py yinshengkai@xiaomi.com
-tools/pynuttx/pyproject.toml yinshengkai@xiaomi.com neo.xu1990@gmail.com
-tools/pynuttx/requirements.txt yinshengkai@xiaomi.com
+
+tools/pynuttx/* yinshengkai@xiaomi.com
+
 tools/refresh.sh xiaoxiang@xiaomi.com acassis@gmail.com alin.jerpelea@sony.com wangjianyu3@xiaomi.com
 tools/rmcr.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-tools/rp2040/.gitignore y.512.nakamura@gmail.com
 tools/rp2040/Config.mk wangjianyu3@xiaomi.com y.512.nakamura@gmail.com nicco.maggioni@gmail.com masayuki.ishikawa@gmail.com me@galexite.uk
 tools/rp2040/make_flash_fs.c 58759586+curuvar@users.noreply.github.com gustavo.nihei@espressif.com petro.karashchenko@gmail.com alin.jerpelea@sony.com
 tools/rp23xx/Config.mk nicco.maggioni@gmail.com pbjd97@gmail.com marco.casaroli@gmail.com
@@ -22833,11 +16724,11 @@ tools/unlink.bat alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 tools/unlink.sh alin.jerpelea@sony.com xiaoxiang@xiaomi.com manuelstuehn@freenet.de
 tools/version.sh xiaoxiang@xiaomi.com alin.jerpelea@sony.com abdelatif.guettouche@gmail.com
 tools/xmlrpc_test.py alin.jerpelea@sony.com bashton@brennanashton.com tomek@cedro.info
-tools/zds/.gitignore xiaoxiang@xiaomi.com
 tools/zds/Config.mk alin.jerpelea@sony.com
 tools/zds/Makefile xiaoxiang@xiaomi.com alin.jerpelea@sony.com
 tools/zds/zdsar.c spudaneco@gmail.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 tools/zipme.sh abdelatif.guettouche@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com
+
 video/Kconfig jordi@midokura.com
 video/Makefile alin.jerpelea@sony.com xiaoxiang@xiaomi.com yamamoto@midokura.com masayuki.ishikawa@gmail.com
 video/videomode/Kconfig xiaoxiang@xiaomi.com
@@ -22847,60 +16738,7 @@ video/videomode/vesagtf.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
 video/videomode/videomode_dump.c alin.jerpelea@sony.com
 video/videomode/videomode_lookup.c alin.jerpelea@sony.com hartman.nathan@gmail.com
 video/videomode/videomode_sort.c alin.jerpelea@sony.com
-wireless/Kconfig jordi@midokura.com
-wireless/Makefile alin.jerpelea@sony.com xiaoxiang@xiaomi.com yamamoto@midokura.com masayuki.ishikawa@gmail.com
-wireless/bluetooth/Kconfig lwazeh@gmail.com tiago.medicci@espressif.com you@example.com matias@protobits.dev
-wireless/bluetooth/bt_atomic.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com hujun5@xiaomi.com zhangyuan29@xiaomi.com
-wireless/bluetooth/bt_att.c petro.karashchenko@gmail.com alin.jerpelea@sony.com you@example.com lwazeh@gmail.com
-wireless/bluetooth/bt_att.h alin.jerpelea@sony.com petro.karashchenko@gmail.com anchao@xiaomi.com xiaoxiang@xiaomi.com
-wireless/bluetooth/bt_buf.c liguiding@fishsemi.com hujun5@xiaomi.com masayuki.ishikawa@gmail.com xiaoxiang@xiaomi.com
-wireless/bluetooth/bt_buf.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-wireless/bluetooth/bt_conn.c lwazeh@gmail.com xiaoxiang@xiaomi.com alin.jerpelea@sony.com petro.karashchenko@gmail.com
-wireless/bluetooth/bt_conn.h alin.jerpelea@sony.com lwazeh@gmail.com liguiding1@xiaomi.com xiaoxiang@xiaomi.com
-wireless/bluetooth/bt_gatt.c alin.jerpelea@sony.com anchao@xiaomi.com lwazeh@gmail.com xiaoxiang@xiaomi.com
-wireless/bluetooth/bt_hcicore.c lwazeh@gmail.com dave@marples.net bashton@brennanashton.com matias@protobits.dev
-wireless/bluetooth/bt_hcicore.h alin.jerpelea@sony.com matias@protobits.dev anchao@xiaomi.com bashton@brennanashton.com
-wireless/bluetooth/bt_ioctl.c lwazeh@gmail.com alin.jerpelea@sony.com anjiahao@xiaomi.com xiaoxiang@xiaomi.com
-wireless/bluetooth/bt_ioctl.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-wireless/bluetooth/bt_keys.c alin.jerpelea@sony.com
-wireless/bluetooth/bt_keys.h alin.jerpelea@sony.com you@example.com
-wireless/bluetooth/bt_l2cap.c alin.jerpelea@sony.com petro.karashchenko@gmail.com lwazeh@gmail.com
-wireless/bluetooth/bt_l2cap.h alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-wireless/bluetooth/bt_netdev.c matias@protobits.dev zhanghongyu@xiaomi.com alin.jerpelea@sony.com lwazeh@gmail.com
-wireless/bluetooth/bt_queue.c alin.jerpelea@sony.com liguiding1@xiaomi.com michal.lyszczek@bofc.pl 59230071+hartmannathan@users.noreply.github.com
-wireless/bluetooth/bt_queue.h alin.jerpelea@sony.com liguiding1@xiaomi.com xiaoxiang@xiaomi.com michal.lyszczek@bofc.pl
-wireless/bluetooth/bt_services.c lwazeh@gmail.com alin.jerpelea@sony.com
-wireless/bluetooth/bt_smp.c you@example.com alin.jerpelea@sony.com petro.karashchenko@gmail.com anchao@xiaomi.com
-wireless/bluetooth/bt_smp.h alin.jerpelea@sony.com you@example.com xiaoxiang@xiaomi.com
-wireless/bluetooth/bt_uuid.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-wireless/ieee802154/Kconfig anthony@vergeaero.com sebastien@lorquet.fr anjiahao@xiaomi.com xiaoxiang@xiaomi.com
-wireless/ieee802154/README.txt anthony@vergeaero.com xiaoxiang@xiaomi.com
-wireless/ieee802154/ieee802154_primitive.c anthony@vergeaero.com alin.jerpelea@sony.com liguiding@fishsemi.com acassis@gmail.com
-wireless/ieee802154/mac802154.c anthony@vergeaero.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com alin.jerpelea@sony.com
-wireless/ieee802154/mac802154.h anthony@vergeaero.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com
-wireless/ieee802154/mac802154_assoc.c anthony@vergeaero.com alin.jerpelea@sony.com anjiahao@xiaomi.com xiaoxiang@xiaomi.com
-wireless/ieee802154/mac802154_assoc.h anthony@vergeaero.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-wireless/ieee802154/mac802154_bind.c anthony@vergeaero.com alin.jerpelea@sony.com
-wireless/ieee802154/mac802154_data.c anthony@vergeaero.com alin.jerpelea@sony.com anjiahao@xiaomi.com xiaoxiang@xiaomi.com
-wireless/ieee802154/mac802154_data.h anthony@vergeaero.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-wireless/ieee802154/mac802154_device.c anthony@vergeaero.com alin.jerpelea@sony.com anjiahao@xiaomi.com xiaoxiang@xiaomi.com
-wireless/ieee802154/mac802154_disassoc.c anthony@vergeaero.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-wireless/ieee802154/mac802154_get_mhrlen.c anthony@vergeaero.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-wireless/ieee802154/mac802154_getset.c anthony@vergeaero.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-wireless/ieee802154/mac802154_gts.c anthony@vergeaero.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-wireless/ieee802154/mac802154_internal.h anthony@vergeaero.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com alin.jerpelea@sony.com
-wireless/ieee802154/mac802154_ioctl.c anthony@vergeaero.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-wireless/ieee802154/mac802154_loopback.c anthony@vergeaero.com alin.jerpelea@sony.com zhanghongyu@xiaomi.com xiaoxiang@xiaomi.com
-wireless/ieee802154/mac802154_netdev.c anthony@vergeaero.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com zhanghongyu@xiaomi.com
-wireless/ieee802154/mac802154_orphan.c anthony@vergeaero.com alin.jerpelea@sony.com
-wireless/ieee802154/mac802154_poll.c anthony@vergeaero.com alin.jerpelea@sony.com anjiahao@xiaomi.com juha.niskanen@haltian.com
-wireless/ieee802154/mac802154_poll.h anthony@vergeaero.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-wireless/ieee802154/mac802154_purge.c anthony@vergeaero.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-wireless/ieee802154/mac802154_reset.c anthony@vergeaero.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-wireless/ieee802154/mac802154_rxenable.c anthony@vergeaero.com alin.jerpelea@sony.com anjiahao@xiaomi.com juha.niskanen@haltian.com
-wireless/ieee802154/mac802154_scan.c anthony@vergeaero.com alin.jerpelea@sony.com anjiahao@xiaomi.com anchao@xiaomi.com
-wireless/ieee802154/mac802154_scan.h anthony@vergeaero.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-wireless/ieee802154/mac802154_start.c anthony@vergeaero.com alin.jerpelea@sony.com anjiahao@xiaomi.com
-wireless/ieee802154/mac802154_sync.c anthony@vergeaero.com alin.jerpelea@sony.com xiaoxiang@xiaomi.com
-wireless/pktradio/pktradio_loopback.c alin.jerpelea@sony.com zhanghongyu@xiaomi.com xiaoxiang@xiaomi.com anthony@vergeaero.com
-wireless/pktradio/pktradio_metadata.c alin.jerpelea@sony.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com liguiding@fishsemi.com
+
+wireless/bluetooth/* alin.jerpelea@sony.com xiaoxiang@xiaomi.com lwazeh@gmail.com tiago.medicci@espressif.com matias@protobits.dev petro.karashchenko@gmail.com
+wireless/ieee802154/* anthony@vergeaero.com xiaoxiang@xiaomi.com anjiahao@xiaomi.com alin.jerpelea@sony.com
+wireless/pktradio/* alin.jerpelea@sony.com zhanghongyu@xiaomi.com xiaoxiang@xiaomi.com anthony@vergeaero.com


### PR DESCRIPTION
## Summary

To prevent reaching the 3MB limit on the CODEOWNERS file, this commit replaces some multi-file entries with wildcard entries.

Part of #18436 to fix the immediate file size limit issue, but not all entries
are converted.

## Impact

CODEOWNERS file is small enough to add to/update now.

## Testing

N/A, can't test file.