### PR TITLE
arm: Update UNUSED()

### DIFF
--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -625,7 +625,7 @@
 /* Indicate that a local variable is not used */
 
 #  ifndef UNUSED
-#    define UNUSED(a) ((void)(1 || &(a)))
+#    define UNUSED(a) (void)(a)
 #  endif
 
 #  if defined(__clang__)


### PR DESCRIPTION
Update UNUSED() for arm builds

## Summary

+ Change arm definition of UNUSED() for gcc/clang builds to cast arg to void.
+ Enable -Wunused-parameter warning for ARM non-GHS toolchains.
+ Fix unused parameter warnings where argc is unused.  In cases where corresponding argv[] is used, first return ERROR if argc is less than dimension of argv[].

Note: This PR does not address all now-generated unused parameter warnings on ARM.

## Impact

+ User experience: No adaptation required.
+ Build: No impact(outside of unused parameter warnings on ARM)
+ Hardware: Should not affect ARM-based boards.
+ Documentation: No impact.
+ Security: No impact.
+ Compatibility: No impact.

## Testing

Build Host:

+ OS: Ubuntu 24.04.4 LTS
+ Compiler: arm-none-eabi-gcc 13.2.1

Target:

+ Architecture: ARM (STM32H7x3ZIx)
+ Board: Nucleo-h743zi2
+ Configuration: Default nucleo-h743zi2:jumbo configuration

Testing performed:

+ Connected Ethernet to nucleo-h743zi2
+ Connected FAT-32 USB stick via OTG cable to USB OTG connector
+ Ran commands/log as shown in target documentation

Runtime testing:
```
   ADE
   telnetd [6:100]
   
   NuttShell (NSH) NuttX-12.12.0
   nsh> uname -a
   NuttX  12.12.0 6d092be2b1-dirty Feb 25 2026 14:41:19 arm nucleo-h743zi2
   nsh> ?
   help usage:  help [-v] [<cmd>]
   
       .           cp          expr        mkrd        route       truncate
       [           cmp         false       mount       set         uname
       ?           dirname     fdinfo      mv          kill        umount
       addroute    date        free        nslookup    pkill       unset
       alias       delroute    help        pidof       sleep       uptime
       unalias     df          hexdump     printf      usleep      watch
       arp         dmesg       ifconfig    ps          source      wget
       basename    echo        irqinfo     pwd         test        xd
       break       env         ls          reboot      top         wait
       cat         exec        mkdir       rm          time
       cd          exit        mkfatfs     rmdir       true
   
   Builtin Apps:
       buttons     getprime    netcat      ping        tc
       dd          hidkbd      nsh         renew       telnetd
       fstest      iperf       ostest      sh
   nsh> date; sleep 2; date
   Tue, Dec 06 00:00:30 2011
   Tue, Dec 06 00:00:32 2011
   nsh> ls
   /:
    dev/
    mnt/
    proc/
   nsh> free
         total       used       free    maxused    maxfree  nused  nfree name
        956460     158452     798008     158848     464408     64      5 Umem
   nsh> irqinfo
   IRQ HANDLER  ARGUMENT    COUNT    RATE    TIME
    11 080012f1 00000000       1136   34.708    0
    15 08007f21 00000000       3273  100.000    1
    55 080007a1 24000000       1425   43.538    5
    77 08008371 00000000          8    0.244    2
   117 0803c395 00000000        206    6.324 21558
   nsh> ifconfig
   eth0    Link encap:Ethernet HWaddr ea:63:b9:20:1d:46 at RUNNING mtu 1486
           inet addr:10.0.0.2 DRaddr:10.0.0.1 Mask:255.255.255.0
   
   lo      Link encap:Local Loopback at RUNNING mtu 1518
           inet addr:127.0.0.1 DRaddr:127.0.0.1 Mask:255.0.0.0
   
                IPv4   TCP   UDP  ICMP
   Received     0003  0000  0003  0000
   Dropped      0000  0000  0000  0000
     IPv4        VHL: 0000   Frg: 0000
     Checksum   0000  0000  0000  ----
     TCP         ACK: 0000   SYN: 0000
                 RST: 0000  0000
     Type       0000  ----  ----  0000
   Sent         0000  0000  0000  0000
     Rexmit     ----  0000  ----  ----
   nsh> renew eth0
   nsh> ifconfig eth0
   eth0    Link encap:Ethernet HWaddr ea:63:b9:20:1d:46 at RUNNING mtu 1486
           inet addr:192.168.3.110 DRaddr:192.168.3.1 Mask:255.255.255.0
   
   nsh> ping www.google.com
   PING 142.250.217.132 56 bytes of data
   56 bytes from 142.250.217.132: icmp_seq=0 time=20.0 ms
   56 bytes from 142.250.217.132: icmp_seq=1 time=20.0 ms
   56 bytes from 142.250.217.132: icmp_seq=2 time=10.0 ms
   56 bytes from 142.250.217.132: icmp_seq=3 time=10.0 ms
   56 bytes from 142.250.217.132: icmp_seq=4 time=10.0 ms
   56 bytes from 142.250.217.132: icmp_seq=5 time=20.0 ms
   56 bytes from 142.250.217.132: icmp_seq=6 time=10.0 ms
   56 bytes from 142.250.217.132: icmp_seq=7 time=10.0 ms
   56 bytes from 142.250.217.132: icmp_seq=8 time=10.0 ms
   56 bytes from 142.250.217.132: icmp_seq=9 time=10.0 ms
   10 packets transmitted, 10 received, 0% packet loss, time 10100 ms
   rtt min/avg/max/mdev = 10.000/13.000/20.000/4.582 ms
   nsh> ls /dev
   /dev:
    buttons
    console
    kmsg
    null
    rammtd
    sda
    telnet
    ttyS0
    zero
   nsh> ls /mnt
   /mnt:
    lfs/
   nsh> echo "This will go away on reboot." > /mnt/lfs/afile
   nsh> cat /mnt/lfs/afile
   This will go away on reboot.
   nsh> mount -t vfat /dev/sda /mnt/sda
   nsh> echo "This will stay on the USB drive" > /mnt/sda/afile
   nsh> ls /mnt/sda
   /mnt/sda:
    GARMIN/
    afile
   nsh> ls /mnt/lfs
   /mnt/lfs:
    .
    ..
    afile
   nsh> ls /mnt
   /mnt:
    lfs/
    sda/
   nsh> mount -t vfat /dev/sda /mnt/sda
   nsh: mount: mount failed: 20
   nsh> ls /mnt/sda
   /mnt/sda:
    GARMIN/
    afile
   nsh> cat /mnt/sda/afile
   This will stay on the USB drive
   nsh>

```

```
   peter@legion:~$ telnet 192.168.3.110
   Trying 192.168.3.110...
   Connected to 192.168.3.110.
   Escape character is '^]'.
   
   NuttShell (NSH) NuttX-12.12.0
   nsh> ps
     TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK    USED FILLED    CPU COMMAND
       0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0001000 0000544  54.4%  100.0% Idle_Task
       1     0     0 224 RR       Kthread   - Waiting  Semaphore 0000000000000000 0001976 0000592  29.9%   0.0% hpwork 0x24000120 0x24000168
       2     0     0 100 RR       Kthread   - Waiting  Semaphore 0000000000000000 0001976 0000592  29.9%   0.0% lpwork 0x240000bc 0x24000104
       3     3     0 100 RR       Task      - Waiting  Semaphore 0000000000000000 0004048 0001736  42.8%   0.0% nsh_main
       4     0     0 100 RR       Kthread   - Waiting  Semaphore 0000000000000000 0002008 0000856  42.6%   0.0% usbhost
       5     0     0  50 RR       Kthread   - Waiting  Signal    0000000000000000 0004048 0000536  13.2%   0.0% USB_Monitor
       6     6     0 100 RR       Task      - Waiting  Semaphore 0000000000000000 0002008 0000880  43.8%   0.0% telnetd
      10    10     0 100 RR       Task      - Running            0000000000000000 0002000 0001864  93.2%!  0.0% Telnet_session
   nsh> ^]
   telnet> quit
   Connection closed.
   peter@legion:~$ 
```
