### PR TITLE
cmake: bump minimum required CMake version to 3.20

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,7 @@
 
 # Request a version available on latest Ubuntu LTS (20.04)
 
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.20)
 
 # Handle newer CMake versions correctly by setting policies
 


### PR DESCRIPTION
## Summary

Raise the minimum required CMake version to 3.20,
as the build system is using the `cmake_path()` command, which is available starting from CMake 3.20.

## Impact

cmake build scripts improvement, fix cmake verison issue

## Testing

This is to fix cmake build scripts issue, so CI build will verify this.
