### PR TITLE
video/imgdata: fix IMGDATA_SET_BUF macro int-conversion warning

### DIFF
--- a/include/nuttx/video/imgdata.h
+++ b/include/nuttx/video/imgdata.h
@@ -56,7 +56,7 @@
 #define IMGDATA_UNINIT(d) \
   ((d)->ops->uninit ? (d)->ops->uninit(d) : -ENOTTY)
 #define IMGDATA_SET_BUF(d, n, f, a, s) \
-  ((d)->ops->set_buf ? (d)->ops->set_buf(d, n, f, a, s) : NULL)
+  ((d)->ops->set_buf ? (d)->ops->set_buf(d, n, f, a, s) : -ENOTTY)
 #define IMGDATA_VALIDATE_FRAME_SETTING(d, n, f, i) \
   ((d)->ops->validate_frame_setting ? \
    (d)->ops->validate_frame_setting(d, n, f, i) : -ENOTTY)


### PR DESCRIPTION
## Summary

video/imgdata: fix IMGDATA_SET_BUF macro int-conversion warning

set_buf return type is not a pointer but an integer, this will cause -Wint-conversion error.

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

sim/nsh: ostest