### PR TITLE
sched/misc: fix incorrect mutex holder retrieval in assert backtrace

### DIFF
--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -576,7 +576,7 @@ static void dump_lockholder(pid_t tid)
   backtrace_format(buf, sizeof(buf), mutex->backtrace,
                    CONFIG_LIBC_MUTEX_BACKTRACE);
 
-  _alert("Mutex holder(%d) backtrace:%s\n", mutex->holder, buf);
+  _alert("Mutex holder(%d) backtrace:%s\n", nxmutex_get_holder(mutex), buf);
 }
 #else
 #  define dump_lockholder(tid)


### PR DESCRIPTION

## Summary

sched/misc: fix incorrect mutex holder retrieval in assert backtrace

The dump_lockholder() function in assert.c was directly accessing themutex->holder
member variable to print the mutex holder's thread ID inthe backtrace log. This is
incorrect because the holder field is aprivate implementation detail of the mutex structure,
and the properAPI nxmutex_get_holder() should be used to retrieve the holder ID.

Using the public API ensures consistency with mutex state management,avoids potential issues
with future changes to the mutex structure'sinternal layout, and adheres to the kernel's
encapsulation principles.

This fix corrects the log output to show the accurate mutex holder IDwhen assertion failures
related to mutex locks occur, improving thedebuggability of lock-related issues.

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A, debug holder in assert

## Testing

nsh/sim: ostest