### PR TITLE
libs/libc: add configurable skip count for mutex backtrace addresses

### DIFF
--- a/libs/libc/misc/Kconfig
+++ b/libs/libc/misc/Kconfig
@@ -164,3 +164,11 @@ config LIBC_MUTEX_BACKTRACE
 	---help---
 		Config the depth of backtrace, dumping the backtrace of thread which
 		last acquired the mutex. Disable mutex backtrace by 0.
+
+config LIBC_MUTEX_BACKTRACE_SKIP
+	int "Number of initial addresses to skip in mutex backtrace"
+	depends on LIBC_MUTEX_BACKTRACE > 0
+	default 2
+	---help---
+		Configure how many initial addresses to skip when dumping mutex backtraces.
+		When generating a backtrace, the first skip addresses will be skipped.

--- a/libs/libc/misc/lib_mutex.c
+++ b/libs/libc/misc/lib_mutex.c
@@ -53,8 +53,9 @@ void nxmutex_add_backtrace(FAR mutex_t *mutex)
 {
   int n;
 
-  n = sched_backtrace(nxmutex_get_holder(&mutex), mutex->backtrace,
-                      CONFIG_LIBC_MUTEX_BACKTRACE, 0);
+  n = sched_backtrace(nxmutex_get_holder(mutex), mutex->backtrace,
+                      CONFIG_LIBC_MUTEX_BACKTRACE,
+                      CONFIG_LIBC_MUTEX_BACKTRACE_SKIP);
   if (n < CONFIG_LIBC_MUTEX_BACKTRACE)
     {
       mutex->backtrace[n] = NULL;


### PR DESCRIPTION

## Summary

libs/libc: add configurable skip count for mutex backtrace addresses

This commit introduces a new Kconfig option LIBC_MUTEX_BACKTRACE_SKIP tocontrol the
number of initial addresses skipped when generating mutex backtraces.

Key changes:
1. Add LIBC_MUTEX_BACKTRACE_SKIP Kconfig entry (depends on
LIBC_MUTEX_BACKTRACE > 0), defaulting to 2. This option lets users configure
how many leading addresses are omitted from the mutex backtrace output.

2. Modify the nxmutex_add_backtrace() function to pass the new config value
as the skip parameter to sched_backtrace(), replacing the hardcoded 0.

This enhancement improves the usability of mutex backtraces by allowing removalof uninformative
initial stack frames (e.g., backtrace helper functions ormutex acquisition wrappers), making the
relevant call stack entries more visiblefor debugging lock-related issues.

The default value (2) maintains sensibleout-of-the-box behavior while enabling customization for specific use cases.

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

sim/nsh, ostest
enable CONFIG_LIBC_MUTEX_BACKTRACE