### PR TITLE
sched/misc: fix potential out-of-bounds access in coredump stack emission

### DIFF
--- a/sched/misc/coredump.c
+++ b/sched/misc/coredump.c
@@ -429,6 +429,13 @@ static void elf_emit_tcb_stack(FAR struct elf_dumpinfo_s *cinfo,
   len = ALIGN_UP(len + (buf - sp), PROGRAM_ALIGNMENT);
   buf = sp;
 
+  /* Avoid out-of-bounds access */
+
+  if (buf + len > (uintptr_t)tcb->stack_base_ptr + tcb->adj_stack_size)
+    {
+      len = (uintptr_t)tcb->stack_base_ptr + tcb->adj_stack_size - buf;
+    }
+
   elf_emit(cinfo, (FAR void *)buf, len);
 
   /* Align to page */


### PR DESCRIPTION
## Summary

sched/misc: fix potential out-of-bounds access in coredump stack emission

The elf_emit_tcb_stack() function in coredump.c was calculating the stackbuffer length
and emitting the stack data without validating whether thecalculated buffer range
(buf + len) exceeds the actual bounds of the TCB'sstack memory region (stack_base_ptr + adj_stack_size).

This could lead to out-of-bounds memory access when the calculated stacklength is larger
than the available stack space, potentially causing memorycorruption, crashes, or incorrect
core dump generation.

This fix adds a bounds check:
1. Compares the end of the intended stack buffer (buf + len) against the
   upper limit of the TCB's stack (stack_base_ptr + adj_stack_size).
2. If the buffer would exceed the stack bounds, truncates the length to fit
   within the valid stack memory range.

The change ensures safe memory access during core dump generation,preventing out-of-bounds
reads and improving the robustness of the coredumpfeature.

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

sim/nsh, ostest
sabre-6quad/coredump