### PR TITLE
sched/misc: fix incomplete data emission in coredump elf_emit function

### DIFF
--- a/sched/misc/coredump.c
+++ b/sched/misc/coredump.c
@@ -149,7 +149,7 @@ static int elf_emit(FAR struct elf_dumpinfo_s *cinfo,
   while (total > 0)
     {
       ret = lib_stream_puts(cinfo->stream, ptr, total);
-      if (ret < 0)
+      if (ret <= 0)
         {
           break;
         }


### PR DESCRIPTION
## Summary

sched/misc: fix incomplete data emission in coredump elf_emit function

The elf_emit() function in coredump.c was only checking for negative returnvalues
from lib_stream_puts() to detect write failures. However, lib_stream_puts()can return 0
to indicate that no bytes were written (e.g., due to stream full,end-of-file, or other
non-error conditions that prevent data writing).

This oversight meant that cases where lib_stream_puts() returned 0 would bypassthe error handling,
leading to incomplete data emission in the core dump withoutany failure indication.
The loop would continue attempting to write the remainingdata, resulting in partial or corrupted core dump files.

This fix modifies the condition from ret < 0 to ret <= 0 to:

1. Catch both error conditions (negative return values) and zero-byte writes.
2. Immediately break the write loop and propagate the failure, ensuring the core
   dump process correctly aborts when data cannot be written.

This change improves the reliability of core dump generation by ensuring allfailed or
incomplete write attempts are properly handled, preventing corruptedcore dump files.

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

sim/nsh, ostest
sabre-6quad/coredump