### PR TITLE
arch/sim: fix incomplete HCI socket data reading in simulator interrupt handler

### DIFF
--- a/arch/sim/src/sim/sim_hcisocket.c
+++ b/arch/sim/src/sim/sim_hcisocket.c
@@ -268,7 +268,7 @@ static void sim_bthcisock_interrupt(wdparm_t arg)
 {
   struct bthcisock_s *dev = (struct bthcisock_s *)arg;
 
-  if (host_bthcisock_avail(dev->fd))
+  while (host_bthcisock_avail(dev->fd))
     {
       bthcisock_receive(&dev->drv);
     }


### PR DESCRIPTION
## Summary

arch/sim: fix incomplete HCI socket data reading in simulator interrupt handler

The sim_bthcisock_interrupt() handler for Bluetooth HCI sockets in the simulatorwas using
an if statement to check for available data on the HCI socket. Thismeant that only a single
packet would be read and processed per interrupt trigger,even if multiple packets were waiting
in the socket buffer.

This led to incomplete data processing: unread packets would remain in the bufferuntil the next
interrupt tick, causing delayed handling of Bluetooth HCI events/commands,packet backlogs,
or missed data in high-throughput scenarios.

This fix replaces the if with a while loop to:

1. Continuously check for and read available data from the HCI socket until no more
   packets are present in the buffer.
2. Ensure all pending HCI packets are processed in a single interrupt handler invocation.
3. Eliminate packet backlogs and reduce latency in Bluetooth HCI communication.

The change maintains the same core data reception logic (bthcisock_receive()) butensures it runs
for all available packets, improving the reliability and responsivenessof the simulator's Bluetooth HCI socket implementation.

Signed-off-by: chao an <anchao.archer@bytedance.com>


## Impact

N/A

## Testing

sim/bluetooth
