### PR TITLE
arch/arm: Add necessary conversion between tick and usec in systick_interrupt

### DIFF
--- a/arch/arm/src/armv7-m/arm_systick.c
+++ b/arch/arm/src/armv7-m/arm_systick.c
@@ -255,8 +255,11 @@ static int systick_interrupt(int irq, void *context, void *arg)
   if (lower->callback && systick_is_running())
     {
       uint32_t reload = getreg32(NVIC_SYSTICK_RELOAD);
-      uint32_t interval = usec_from_count(
-        RELOAD2TIMEOUT(reload), lower->freq);
+
+      /* Convert count to us then to tick for callback parameter */
+
+      uint32_t interval = USEC2TICK(usec_from_count(
+        RELOAD2TIMEOUT(reload), lower->freq));
       uint32_t next_interval = interval;
 
       lower->next_interval = &next_interval;
@@ -264,8 +267,10 @@ static int systick_interrupt(int irq, void *context, void *arg)
         {
           if (next_interval && next_interval != interval)
             {
+              /* Recover tick to us then to count for register writing */
+
               reload = TIMEOUT2RELOAD(
-                usec_to_count(next_interval, lower->freq));
+                usec_to_count(TICK2USEC(next_interval), lower->freq));
               putreg32(CLAMP_RELOAD(reload), NVIC_SYSTICK_RELOAD);
               putreg32(0, NVIC_SYSTICK_CURRENT);
             }

--- a/arch/arm/src/armv8-m/arm_systick.c
+++ b/arch/arm/src/armv8-m/arm_systick.c
@@ -255,8 +255,11 @@ static int systick_interrupt(int irq, void *context, void *arg)
   if (lower->callback && systick_is_running())
     {
       uint32_t reload = getreg32(NVIC_SYSTICK_RELOAD);
-      uint32_t interval = usec_from_count(
-        RELOAD2TIMEOUT(reload), lower->freq);
+
+      /* Convert count to us then to tick for callback parameter */
+
+      uint32_t interval = USEC2TICK(usec_from_count(
+        RELOAD2TIMEOUT(reload), lower->freq));
       uint32_t next_interval = interval;
 
       lower->next_interval = &next_interval;
@@ -264,8 +267,10 @@ static int systick_interrupt(int irq, void *context, void *arg)
         {
           if (next_interval && next_interval != interval)
             {
+              /* Recover tick to us then to count for register writing */
+
               reload = TIMEOUT2RELOAD(
-                usec_to_count(next_interval, lower->freq));
+                usec_to_count(TICK2USEC(next_interval), lower->freq));
               putreg32(CLAMP_RELOAD(reload), NVIC_SYSTICK_RELOAD);
               putreg32(0, NVIC_SYSTICK_CURRENT);
             }


### PR DESCRIPTION
# fix tickless issue

# Summary
* default tickless scheme with arm_systick.c don't works
* we add necessary conversion between tick and usec in systick_interrupt
* the local variable next_interval as the first parameter of low->callback , which unit is tick not usec,
  it seem that we must do conversion before and after calling

# Impact
just fix tickless issue

# Testing
We test this commit on our own platform:

## hardware
* cpu ： cm55@armv8-m
* systick clk: 1M
## config
```
CONFIG_ARMV8_SYSTICK=y
CONFIG_PER_TICK=1000
CONFIG_RR_INTERVAL=5
CONFIG_SCHED_TICKLESS=y
CONFIG_SYSTEM_TIMER64=y
CONFIG_TIMER_ARCH=y
```
## test code
we add some testing code about delay in our chip's xxx_bring_up stage
```
syslog(LOG_INFO, "per_tick: %d\n", USER_PER_TICK);
syslog(LOG_INFO, "delay begin: %lu\n", clock_get_sched_ticks());
usleep(1000000);
syslog(LOG_INFO, "delay 1s: %lu\n", clock_get_sched_ticks());
usleep(5000000);
syslog(LOG_INFO, "delay 5s: %lu\n", clock_get_sched_ticks());
usleep(10000000);
syslog(LOG_INFO, "delay 10s: %lu\n", clock_get_sched_ticks());
```
## test result
### master branch
```
....
# can' t run these test code , no logs
```
### add commit
```
[19:22:20.959]收←◆per tick: 1000
delay begin: 322

[19:22:21.956]收←◆delay 1s: 1323

[19:22:26.944]收←◆delay 5s: 6324

[19:22:36.919]收←◆delay 10s: 16325
```