### PR TITLE
arch/xtensa/esp32: Fix buffer overflow in SPI poll exchange

### DIFF
--- a/arch/xtensa/src/esp32/esp32_spi.c
+++ b/arch/xtensa/src/esp32/esp32_spi.c
@@ -1104,12 +1104,19 @@ static void esp32_spi_poll_exchange(struct esp32_spi_priv_s *priv,
       for (int i = 0 ; i < transfer_size; i += sizeof(uint32_t))
         {
           uint32_t w_wd = UINT32_MAX;
+          uint32_t chunk = transfer_size - i;
+
+          if (chunk > sizeof(uint32_t))
+            {
+              chunk = sizeof(uint32_t);
+            }
 
           if (tp != NULL)
             {
-              memcpy(&w_wd, tp, sizeof(uint32_t));
+              w_wd = 0; /* Clear padding */
+              memcpy(&w_wd, tp, chunk);
 
-              tp += sizeof(uintptr_t);
+              tp += chunk;
             }
 
           putreg32(w_wd, data_buf_reg);
@@ -1160,13 +1167,22 @@ static void esp32_spi_poll_exchange(struct esp32_spi_priv_s *priv,
           for (int i = 0 ; i < transfer_size; i += sizeof(uint32_t))
             {
               uint32_t r_wd = getreg32(data_buf_reg);
+              uint32_t chunk = transfer_size - i;
+
+              if (chunk > sizeof(uint32_t))
+                {
+                  chunk = sizeof(uint32_t);
+                }
 
               spiinfo("recv=0x%" PRIx32 " data_reg=0x%" PRIxPTR "\n",
                       r_wd, data_buf_reg);
 
-              memcpy(rp, &r_wd, sizeof(uint32_t));
+              if (rp != NULL)
+                {
+                  memcpy(rp, &r_wd, chunk);
 
-              rp += sizeof(uintptr_t);
+                  rp += chunk;
+                }
 
               /* Update data_buf_reg to point to the next data buffer
                * register.


### PR DESCRIPTION
In esp32_spi_poll_exchange, strictly bound the memcpy sizes and pointer increments to the remaining chunk size.

## Summary

This PR fixes a critical memory corruption (buffer overflow) vulnerability in the ESP32 SPI driver's polling transaction logic (`esp32_spi_poll_exchange`).

**Problem:**
The inner loops of `esp32_spi_poll_exchange` execute `memcpy` operations utilizing a fixed length of `sizeof(uint32_t)` (4 bytes), disregarding the actual remaining `transfer_size`. When an SPI transaction involves a data length that is not a multiple of 4 (for example, a 1-byte register read or write common in sub-GHz radio drivers), the `memcpy` function forces a 4-byte transfer. This results in writing 3 bytes past the allocated buffer boundary, causing stack smashing and resulting in fatal CPU exceptions (e.g., `EXCCAUSE=0000` or `0014`).

**Solution:**
Calculated a precise `chunk` size for every iteration: `uint32_t chunk = transfer_size - i; if (chunk > sizeof(uint32_t)) chunk = sizeof(uint32_t);`. The `memcpy` length and the subsequent pointer increments (`tp += chunk`, `rp += chunk`) are now strictly bounded to this `chunk` value. For TX, the temporary 32-bit register variable is initialized to `0` prior to `memcpy` to ensure proper padding of the hardware FIFO without out-of-bounds memory reads.

## Impact

* **Stability/Security:** Prevents stack corruption and memory out-of-bounds read/write access during SPI polling transactions.
* **Compatibility:** Fixes crashes for all SPI peripherals executing non-word-aligned transfers (e.g., 1-byte or 3-byte payloads).
* **Hardware:** Specific to the ESP32 architecture (`arch/xtensa/src/esp32/esp32_spi.c`).

## Testing

**Host Machine:** Fedora 43 (x86_64)
**Target Hardware:** ESP32-PICO-D4 (Rev 1.1) on Evil Crow RF V2 board.

**Verification Procedure:**

1. Configured the system to use `CONFIG_WL_CC1101`.
2. The CC1101 initialization sequence performs a 1-byte SPI read to fetch the `PARTNUM` and `VERSION` registers using `cc1101_access()`.
3. Executed the system initialization.

**Results Before Patch:**
The 1-byte SPI RX request allocated a 1-byte local buffer. `esp32_spi_poll_exchange` wrote 4 bytes into this buffer, corrupting the return address on the stack. The MCU panicked with `xtensa_user_panic: User Exception: EXCCAUSE=0000` upon function return.

**Results After Patch:**
The 1-byte SPI RX request executes safely. The `memcpy` limits the transfer to exactly 1 byte. No memory corruption occurs.

**Logs (After Patch):**

```text
esp32_spi_poll_exchange: send=0xffffffff data_reg=0x3ff64080
esp32_spi_poll_exchange: recv=0xffffff00 data_reg=0x3ff64080

```

*(The W0 hardware register correctly captures the 1-byte payload into the LSB without overwriting adjacent stack variables).*