### PR TITLE
wireless/cc1101: Add Kconfig option to bypass strict version check

### DIFF
--- a/drivers/wireless/Kconfig
+++ b/drivers/wireless/Kconfig
@@ -28,6 +28,19 @@ config CC1101_SPIDEV
 
 endif
 
+config WL_CC1101_IGNORE_VERSION
+	bool "Ignore CC1101 Version Check (Allow Clone Chips)"
+	default n
+	depends on WL_CC1101
+	---help---
+		Some third-party CC1101 clone silicon hardcodes the VERSION
+		register to 0x00. Enabling this option bypasses the strict
+		version verification, allowing these compatible chips to
+		initialize.
+
+		Warning: Enabling this may cause false-positives if the SPI
+		MISO line is shorted to GND.
+
 config WL_GS2200M
 	bool "Telit GS2200M Wi-Fi support"
 	default n

--- a/drivers/wireless/cc1101.c
+++ b/drivers/wireless/cc1101.c
@@ -817,10 +817,27 @@ int cc1101_checkpart(struct cc1101_dev_s *dev)
 
   wlinfo("CC1101 cc1101_checkpart 0x%X 0x%X\n", partnum, version);
 
+#ifndef CONFIG_WL_CC1101_IGNORE_VERSION
+  /* Strict official silicon validation */
+
   if (partnum == CC1101_PARTNUM_VALUE && version == CC1101_VERSION_VALUE)
     {
       return OK;
     }
+#else
+  /* Bypass for third-party clone silicon (e.g., VERSION == 0x00) */
+
+  if (partnum == CC1101_PARTNUM_VALUE)
+    {
+      if (version != CC1101_VERSION_VALUE)
+        {
+          wlwarn("WARNING: Unofficial CC1101 version 0x%02x detected.\\n",
+            version);
+        }
+
+      return OK;
+    }
+#endif
 
   return -ENOTSUP;
 }


### PR DESCRIPTION
## Summary

This PR introduces a Kconfig option (`CONFIG_WL_CC1101_IGNORE_VERSION`) to bypass strict version validation in the CC1101 driver, allowing the initialization of third-party clone silicon.

**Problem:**
The `cc1101_checkpart()` function in `drivers/wireless/cc1101.c` strictly enforces the silicon version to match the official Texas Instruments value (`CC1101_VERSION_VALUE == 0x14`). Many low-cost CC1101 modules in the wild (such as those populated on the Evil Crow RF V2 hardware) utilize compatible clone silicon that hardcodes the `VERSION` register to `0x00`. When the driver encounters these chips, it aborts initialization and returns `-ENOTSUP` (which propagates as `-ENODEV`).

**Solution:**
Added `CONFIG_WL_CC1101_IGNORE_VERSION` to `drivers/wireless/Kconfig`.
When enabled, the driver explicitly permits `VERSION == 0x00` and issues a `wlwarn` indicating a clone chip was detected. The option defaults to `n` (disabled) to preserve the driver's ability to diagnose actual hardware faults, such as a MISO line shorted to GND (which also results in a `0x00` read).

## Impact

* **Compatibility:** Broadens hardware support for users utilizing third-party sub-GHz RF modules.
* **Stability:** Zero impact on existing applications. The feature is strictly opt-in (`default n`).
* **Security:** None.

## Testing

**Host Machine:** Fedora 43 (x86_64)
**Target Hardware:** ESP32-PICO-D4 (Rev 1.1) on Evil Crow RF V2 board (containing two CC1101 clone modules).

**Verification Procedure:**

1. Compiled NuttX with `CONFIG_WL_CC1101=y` and `CONFIG_WL_CC1101_IGNORE_VERSION=y`.
2. Flashed the firmware to the ESP32.
3. Verified the SPI probe and initialization sequence via syslog.
4. Confirmed the successful registration of the character device nodes (`/dev/radio0` and `/dev/radio1`) in NSH.

**Logs:**

```text
cc1101_checkpart: CC1101 cc1101_checkpart 0x0 0x0
cc1101_checkpart: WARNING: CC1101 VERSION=0x00 detected. Proceeding with clone chip bypass.
esp32_spi_select: devid: 00060000 CS: select
esp32_spi_setmode: mode=0
esp32_spi_setbits: nbits=8
esp32_spi_poll_send: send=0x2 and recv=0xe
esp32_spi_poll_exchange: send=0x2e data_reg=0x3ff64080
...
NuttShell (NSH) NuttX-12.12.0
nsh> ls /dev
/dev:
 console
 mmcsd0
 nrf24l01
 null
 radio0
 radio1
 ttyS0
 zero

```