### PR TITLE
wireless/cc1101: Add standard RF IOCTL support

### DIFF
--- a/drivers/wireless/cc1101.c
+++ b/drivers/wireless/cc1101.c
@@ -102,6 +102,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/signal.h>
 #include <nuttx/fs/fs.h>
+#include <nuttx/wireless/ioctl.h>
 #include <nuttx/wireless/cc1101.h>
 
 /****************************************************************************
@@ -294,6 +295,8 @@ static ssize_t cc1101_file_write(FAR struct file *filep,
                                  size_t buflen);
 static int cc1101_file_poll(FAR struct file *filep, FAR struct pollfd *fds,
                             bool setup);
+static int cc1101_file_ioctl(FAR struct file *filep, int cmd,
+                             unsigned long arg);
 
 /****************************************************************************
  * Private Data
@@ -306,7 +309,7 @@ static const struct file_operations g_cc1101ops =
   cc1101_file_read,  /* read */
   cc1101_file_write, /* write */
   NULL,              /* seek */
-  NULL,              /* ioctl */
+  cc1101_file_ioctl, /* ioctl */
   NULL,              /* mmap */
   NULL,              /* truncate */
   cc1101_file_poll   /* poll */
@@ -1573,4 +1576,349 @@ int cc1101_isr(int irq, FAR void *context, FAR void *arg)
 
   work_queue(HPWORK, &dev->irq_work, cc1101_isr_process, arg, 0);
   return 0;
+}
+
+/****************************************************************************
+ * Name: cc1101_file_ioctl
+ *
+ * Description:
+ * Standard driver ioctl method. Maps common RF IOCTLs to CC1101 registers.
+ *
+ ****************************************************************************/
+
+static int cc1101_file_ioctl(FAR struct file *filep, int cmd,
+                             unsigned long arg)
+{
+  FAR struct inode *inode;
+  FAR struct cc1101_dev_s *dev;
+  int ret = OK;
+  const uint32_t f_xosc = 26000000; /* CC1101 typical XOSC is 26 MHz */
+
+  /* Pointer castings moved to the top of the function per coding style */
+
+  FAR uint32_t *ptr32 = (FAR uint32_t *)((uintptr_t)arg);
+  FAR int32_t *ptr32_s = (FAR int32_t *)((uintptr_t)arg);
+  FAR uint8_t *ptr8 = (FAR uint8_t *)((uintptr_t)arg);
+  FAR enum wlioc_modulation_e *mod =
+    (FAR enum wlioc_modulation_e *)((uintptr_t)arg);
+
+  wlinfo("cmd: %d arg: %ld\n", cmd, arg);
+  inode = filep->f_inode;
+
+  DEBUGASSERT(inode->i_private);
+  dev  = inode->i_private;
+
+  /* Get exclusive access to the driver data structure */
+
+  ret = nxmutex_lock(&dev->devlock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  /* Process the IOCTL by command */
+
+  switch (cmd)
+    {
+      /* 1. Radio Frequency */
+
+      case WLIOC_SETRADIOFREQ:
+        {
+          uint64_t freq_word;
+          uint8_t regs[3];
+          uint8_t channr;
+
+          DEBUGASSERT(ptr32 != NULL);
+
+          freq_word = ((uint64_t)(*ptr32) << 16) / f_xosc;
+          regs[0] = (uint8_t)((freq_word >> 16) & 0xff);
+          regs[1] = (uint8_t)((freq_word >> 8) & 0xff);
+          regs[2] = (uint8_t)(freq_word & 0xff);
+
+          ret = cc1101_access(dev, CC1101_FREQ2, regs, -3);
+          if (ret >= 0)
+            {
+              channr = 0;
+              ret = cc1101_access(dev, CC1101_CHANNR, &channr, -1);
+              if (ret >= 0)
+                {
+                  ret = OK;
+                }
+            }
+        }
+        break;
+
+      case WLIOC_GETRADIOFREQ:
+        {
+          uint8_t regs[3];
+          uint32_t freq_word;
+
+          DEBUGASSERT(ptr32 != NULL);
+
+          ret = cc1101_access(dev, CC1101_FREQ2, regs, 3);
+          if (ret >= 0)
+            {
+              freq_word = (regs[0] << 16) | (regs[1] << 8) | regs[2];
+              *ptr32 = (uint32_t)(((uint64_t)freq_word * f_xosc) >> 16);
+              ret = OK;
+            }
+        }
+        break;
+
+      /* 2. Node Address */
+
+      case WLIOC_SETADDR:
+        {
+          DEBUGASSERT(ptr8 != NULL);
+
+          ret = cc1101_access(dev, CC1101_ADDR, ptr8, -1);
+          if (ret >= 0)
+            {
+              ret = OK;
+            }
+        }
+        break;
+
+      case WLIOC_GETADDR:
+        {
+          DEBUGASSERT(ptr8 != NULL);
+
+          ret = cc1101_access(dev, CC1101_ADDR, ptr8, 1);
+          if (ret >= 0)
+            {
+              ret = OK;
+            }
+        }
+        break;
+
+      /* 3. Output Power */
+
+      case WLIOC_SETTXPOWER:
+        {
+          DEBUGASSERT(ptr32_s != NULL);
+
+          cc1101_setpower(dev, (uint8_t)*ptr32_s);
+          ret = OK;
+        }
+        break;
+
+      case WLIOC_GETTXPOWER:
+        {
+          DEBUGASSERT(ptr32_s != NULL);
+
+          *ptr32_s = (int32_t)dev->power;
+          ret = OK;
+        }
+        break;
+
+      /* 4. Modulation Technology */
+
+      case WLIOC_SETMODU:
+        {
+          uint8_t mdmcfg2;
+
+          DEBUGASSERT(mod != NULL);
+
+          ret = cc1101_access(dev, CC1101_MDMCFG2, &mdmcfg2, 1);
+          if (ret >= 0)
+            {
+              mdmcfg2 &= ~0x70;
+              switch (*mod)
+                {
+                  case WLIOC_FSK:
+                    mdmcfg2 |= 0x00;
+                    break;
+                  case WLIOC_GFSK:
+                    mdmcfg2 |= 0x10;
+                    break;
+                  case WLIOC_OOK:
+                    mdmcfg2 |= 0x30;
+                    break;
+                  default:
+                    ret = -ENOTSUP;
+                    break;
+                }
+
+              if (ret >= 0)
+                {
+                  ret = cc1101_access(dev, CC1101_MDMCFG2, &mdmcfg2, -1);
+                  if (ret >= 0)
+                    {
+                      ret = OK;
+                    }
+                }
+            }
+        }
+        break;
+
+      case WLIOC_GETMODU:
+        {
+          uint8_t mdmcfg2;
+          uint8_t mod_format;
+
+          DEBUGASSERT(mod != NULL);
+
+          ret = cc1101_access(dev, CC1101_MDMCFG2, &mdmcfg2, 1);
+          if (ret >= 0)
+            {
+              mod_format = (mdmcfg2 & 0x70) >> 4;
+              switch (mod_format)
+                {
+                  case 0x00:
+                  case 0x04:
+                    *mod = WLIOC_FSK;
+                    break;
+                  case 0x01:
+                    *mod = WLIOC_GFSK;
+                    break;
+                  case 0x03:
+                    *mod = WLIOC_OOK;
+                    break;
+                  default:
+                    ret = -ENOTSUP;
+                    break;
+                }
+
+              if (ret >= 0)
+                {
+                  ret = OK;
+                }
+            }
+        }
+        break;
+
+      /* 5. Bitrate / Data Rate */
+
+      case WLIOC_FSK_SETBITRATE:
+      case WLIOC_OOK_SETBITRATE:
+        {
+          uint64_t w;
+          uint8_t e = 0;
+          uint8_t m;
+          uint8_t mdmcfg4;
+
+          DEBUGASSERT(ptr32 != NULL);
+
+          w = ((uint64_t)(*ptr32) << 28) / f_xosc;
+          while (w > 511 && e < 15)
+            {
+              w >>= 1;
+              e++;
+            }
+
+          if (w < 256)
+            {
+              w = 256;
+            }
+
+          m = (uint8_t)(w - 256);
+
+          ret = cc1101_access(dev, CC1101_MDMCFG4, &mdmcfg4, 1);
+          if (ret >= 0)
+            {
+              mdmcfg4 = (mdmcfg4 & 0xf0) | (e & 0x0f);
+              ret = cc1101_access(dev, CC1101_MDMCFG4, &mdmcfg4, -1);
+              if (ret >= 0)
+                {
+                  ret = cc1101_access(dev, CC1101_MDMCFG3, &m, -1);
+                  if (ret >= 0)
+                    {
+                      ret = OK;
+                    }
+                }
+            }
+        }
+        break;
+
+      case WLIOC_FSK_GETBITRATE:
+      case WLIOC_OOK_GETBITRATE:
+        {
+          uint8_t mdmcfg4;
+          uint8_t mdmcfg3;
+          uint8_t e;
+          uint8_t m;
+
+          DEBUGASSERT(ptr32 != NULL);
+
+          if (cc1101_access(dev, CC1101_MDMCFG4, &mdmcfg4, 1) >= 0 &&
+              cc1101_access(dev, CC1101_MDMCFG3, &mdmcfg3, 1) >= 0)
+            {
+              e = mdmcfg4 & 0x0f;
+              m = mdmcfg3;
+              *ptr32 = (uint32_t)((((uint64_t)(256 + m) << e) *
+                f_xosc) >> 28);
+              ret = OK;
+            }
+          else
+            {
+              ret = -EIO;
+            }
+        }
+        break;
+
+      /* 6. FSK Frequency Deviation */
+
+      case WLIOC_FSK_SETFDEV:
+        {
+          uint64_t w;
+          uint8_t e = 0;
+          uint8_t m;
+          uint8_t deviatn;
+
+          DEBUGASSERT(ptr32 != NULL);
+
+          w = ((uint64_t)(*ptr32) << 17) / f_xosc;
+          while (w > 15 && e < 7)
+            {
+              w >>= 1;
+              e++;
+            }
+
+          if (w < 8)
+            {
+              w = 8;
+            }
+
+          m = (uint8_t)(w - 8);
+
+          deviatn = (e << 4) | (m & 0x07);
+          ret = cc1101_access(dev, CC1101_DEVIATN, &deviatn, -1);
+          if (ret >= 0)
+            {
+              ret = OK;
+            }
+        }
+        break;
+
+      case WLIOC_FSK_GETFDEV:
+        {
+          uint8_t deviatn;
+          uint8_t e;
+          uint8_t m;
+
+          DEBUGASSERT(ptr32 != NULL);
+
+          ret = cc1101_access(dev, CC1101_DEVIATN, &deviatn, 1);
+          if (ret >= 0)
+            {
+              e = (deviatn >> 4) & 0x07;
+              m = deviatn & 0x07;
+              *ptr32 = (uint32_t)((((uint64_t)(8 + m) << e) * f_xosc) >> 17);
+              ret = OK;
+            }
+        }
+        break;
+
+      case WLIOC_SETFINEPOWER:
+      case WLIOC_GETFINEPOWER:
+        ret = -ENOSYS;
+        break;
+
+      default:
+        ret = -ENOTTY;
+        break;
+    }
+
+  nxmutex_unlock(&dev->devlock);
+  return ret;
 }


### PR DESCRIPTION
## Summary

The CC1101 driver previously lacked support for standard NuttX wireless IOCTL commands, preventing runtime configuration of radio parameters by user-space applications.

This change implements the `cc1101_file_ioctl` function to map abstract `WLIOC_*` commands to specific CC1101 hardware registers.

* **Radio Frequency (`WLIOC_SETRADIOFREQ`):** Calculates the 24-bit frequency word and applies it to `FREQ[2:0]`, while zeroing `CHANNR` to prevent offset calculation errors.
* **Address (`WLIOC_SETADDR`):** Maps to the single-byte hardware `ADDR` register.
* **Output Power (`WLIOC_SETTXPOWER`):** Maps absolute dBm index values to the internal `PATABLE` via existing `cc1101_setpower` API.
* **Modulation (`WLIOC_SETMODU`):** Applies bitmasks to `MDMCFG2` to support FSK, GFSK, and OOK, while actively rejecting unsupported formats like LoRa with `-ENOTSUP`.
* **Data Rate (`WLIOC_FSK_SETBITRATE`):** Calculates the required exponent and mantissa, updating `MDMCFG4` and `MDMCFG3` without overwriting receiver bandwidth configurations.
* **FSK Deviation (`WLIOC_FSK_SETFDEV`):** Computes and applies the frequency deviation exponent and mantissa to the `DEVIATN` register.

Additionally, this implementation normalizes positive SPI status bytes returned by `cc1101_access` to `OK` (`0`), ensuring POSIX compliance and preventing silent bypasses of subsequent register writes.

## Impact

* **Users/API:** Exposes dynamic configuration capabilities to user-space applications via standard POSIX `ioctl()` calls using the `<nuttx/wireless/ioctl.h>` interface.
* **Hardware:** Specific to the CC1101 transceiver.
* **Compatibility:** Fully compatible with existing RF IOCTL definitions. Commands not applicable to CC1101 hardware (e.g., LoRa parameters, fine power steps) correctly return `-ENOSYS` or `-ENOTSUP`.
* **Build/Security:** No impact on the core build process or system security.

## Testing

To verify the quantitative accuracy of the mathematical conversions (e.g., Hz to register words, bps to mantissa/exponent) and ensure no regressions, a custom user-space application (`ecrf_test`) was executed.

Testing was performed on an ESP32 hardware platform interfacing with dual CC1101 modules (`/dev/radio0`, `/dev/radio1`) and an nRF24L01 module (`/dev/nrf24l01`), validating a multi-transceiver architecture similar to the EvilCrowRF-V2 project. The test performs sequential `WLIOC_SET*` and `WLIOC_GET*` operations, comparing the targeted integer values against the actual values calculated and read back from the hardware registers.

**Runtime Logs:**

```text
nsh> ecrf_test
--- EvilCrowRF-V2 Hardware Validation ---

Testing device: /dev/radio0
  [PASS] FD: 3
Starting CC1101 IOCTL hardware test on /dev/radio0...
  [PASS] Frequency: Target 433000000 Hz, Actual 432999816 Hz
  [PASS] Address: Target 0x5A, Actual 0x5A
  [PASS] TX Power Index: Target 2, Actual 2
  [PASS] Modulation: Target 2, Actual 2
  [PASS] Bitrate: Target 250000 bps, Actual 249938 bps
  [PASS] FSK Deviation: Target 47000 Hz, Actual 44433 Hz
CC1101 IOCTL hardware test completed successfully.

Testing device: /dev/radio1
  [PASS] FD: 3
Starting CC1101 IOCTL hardware test on /dev/radio1...
  [PASS] Frequency: Target 433000000 Hz, Actual 432999816 Hz
  [PASS] Address: Target 0x5A, Actual 0x5A
  [PASS] TX Power Index: Target 2, Actual 2
  [PASS] Modulation: Target 2, Actual 2
  [PASS] Bitrate: Target 250000 bps, Actual 249938 bps
  [PASS] FSK Deviation: Target 47000 Hz, Actual 44433 Hz
CC1101 IOCTL hardware test completed successfully.

Testing device: /dev/nrf24l01
  [PASS] FD: 3
Starting nRF24L01 IOCTL tests...
  [PASS] Freq: 2450000000 Hz
  [PASS] TX Power: -6 dBm
  [PASS] Fine TX Power: 0 (0.01 dBm)
  [PASS] Modulation correctly rejected non-GFSK.
  [PASS] Address: AA:BB:CC:DD:EE
  [PASS] Retransmit Config (Delay: 5, Count: 10)
  [PASS] Data Rate: 2Mbps
  [PASS] State Transition to STANDBY
  [PASS] TX Payload NoACK: Enabled
Testing completed. Failures: 0

```