### PR TITLE
nxgdb: change the symbol g_statenames to nxsched_get_stateinfo::g_statenames

### DIFF
--- a/tools/pynuttx/nxgdb/thread.py
+++ b/tools/pynuttx/nxgdb/thread.py
@@ -216,7 +216,7 @@ class Nxinfothreads(gdb.Command):
     def invoke(self, args, from_tty):
         npidhash = gdb.parse_and_eval("g_npidhash")
         pidhash = gdb.parse_and_eval("g_pidhash")
-        statenames = gdb.parse_and_eval("g_statenames")
+        statenames = gdb.parse_and_eval("nxsched_get_stateinfo::g_statenames")
 
         if utils.is_target_smp():
             gdb.write(


### PR DESCRIPTION
…tenames


*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

I0680e48d8ff8847c8712e1a54efe32d320e7c84d changes the scope of the symbol definition. So nxgdb needs to synchronize this modification.

Fix #18474

## Impact

Now GDB plugin `info thread` works.

## Testing

build with sim:nsh
Before:
```
(gdb) source tools/pynuttx/gdbinit.py
Registering NuttX GDB commands from /home/neo/projects/nuttx/nuttx/tools/pynuttx/nxgdb
set pagination off
set python print-stack full
"handle SIGUSR1 "nostop" "pass" "noprint"
Load macro: /tmp/3df76db52d986a940e63adff59ebed4d.json
info
 if use thread command, please don't use 'continue', use 'c' instead !!!
 if use thread command, please don't use 'step', use 's' instead !!!
Build version:  "8b2ef0801de Mar  2 2026 10:50:40"

(gdb) info threads
Traceback (most recent call last):
  File "/home/neo/projects/nuttx/nuttx/tools/pynuttx/nxgdb/thread.py", line 219, in invoke
    statenames = gdb.parse_and_eval("g_statenames")
gdb.error: No symbol "g_statenames" in current context.
Error occurred in Python: No symbol "g_statenames" in current context.
(gdb)

```

After:
```
(gdb) info nxt
Index Tid  Pid  Thread                Info                                                                             Frame
*0    0    0    Thread 0x40172d60     (Name: Idle_Task, State: Running, Priority: 0, Stack: 69584) 0x7ffff7ce578a	clock_nanosleep() at ../sysdeps/unix/sysv/linux/clock_nanosleep.c:78
 1    1    0    Thread 0x7ffff3c004a8 (Name: sim_loop_wq, State: Waiting,Semaphore, Priority: 224, Stack: 67456) No symbol with pc
 2    2    0    Thread 0x7ffff3d112a0 (Name: hpwork, State: Waiting,Semaphore, Priority: 224, Stack: 67464) No symbol with pc
 3    3    3    Thread 0x7ffff3d21f60 (Name: nsh_main, State: Waiting,Semaphore, Priority: 100, Stack: 67496) No symbol with pc
(gdb)
```