### PR TITLE
libm: fix truncl when long double has same size as double

### DIFF
--- a/libs/libm/libm/lib_truncl.c
+++ b/libs/libm/libm/lib_truncl.c
@@ -44,9 +44,20 @@
  ****************************************************************************/
 
 #ifdef CONFIG_HAVE_LONG_DOUBLE
+#if LDBL_MANT_DIG == DBL_MANT_DIG
+
+/* Cover case when double is the same as long double (64 bit ieee754). */
+
+long double truncl(long double x)
+{
+  return trunc(x);
+}
+
+#else
+
 static const long double toint = 1 / LDBL_EPSILON;
 
-/* FIXME This will only work if long double is 64 bit and little endian */
+/* FIXME This will only work if long double is 80 bit and little endian */
 
 union ldshape
 {
@@ -100,4 +111,5 @@ long double truncl(long double x)
   x += y;
   return s ? -x : x;
 }
+#endif
 #endif


### PR DESCRIPTION
## Summary

The truncl implementation expects 80 bit little endian representation of the floating point number. That is valid for x86 but not for example arm. On arm long double is the same as double.

This was discovered with newer version of GCC (15.2.0) that started emitting warning:

```
  libm/lib_truncl.c: In function 'truncl':
  libm/lib_truncl.c:68:14: error: 'u.i.se' is used uninitialized [-Werror=uninitialized]
     68 |   int e = u.i.se & 0x7fff;
        |           ~~~^~~
  libm/lib_truncl.c:63:17: note: 'u' declared here
     63 |   union ldshape u =
        |                 ^
  libm/lib_truncl.c:69:14: error: 'u.i.se' is used uninitialized [-Werror=uninitialized]
     69 |   int s = u.i.se >> 15;
        |           ~~~^~~
  libm/lib_truncl.c:63:17: note: 'u' declared here
     63 |   union ldshape u =
        |                 ^
  libm/lib_truncl.c:63:17: error: 'u.i.se' is used uninitialized [-Werror=uninitialized]
```

## Impact

This is technically a fix for `truncl` on platforms that have `long double` of the same size as `double`, as the logic was correct only for 80 bit float.

## Testing

The testing was performed only by compilation, as the implementation just redirects to the `trunc` instead. The warning disappeared with the changes made in this PR.