### PR TITLE
docs/documentation: Mention installation of PlantUML

### DIFF
--- a/Documentation/contributing/documentation.rst
+++ b/Documentation/contributing/documentation.rst
@@ -20,7 +20,7 @@ To render the Documentation locally, you should clone the NuttX main repository 
      project `site <https://github.com/pyenv/pyenv#installation>`_.
 
     .. code-block:: console
-      
+
       $ pip3 install pipenv
       $ cd Documentation/
       $ # install the dependencies into a virtual environment
@@ -28,7 +28,15 @@ To render the Documentation locally, you should clone the NuttX main repository 
       $ # activate the virtual environment
       $ pipenv shell
 
-  2. Build documentation:
+  2. `Install the PlantUML tool <https://www.javiljoen.net/n/installing-plantuml.html>`_
+     (used to render UML diagrams) and ensure it is on your ``PATH``.
+
+     .. code:: console
+
+        $ sudo apt install plantuml
+        $ plantuml -version
+
+  3. Build documentation:
 
     .. code-block:: console
 


### PR DESCRIPTION
## Summary

Include information about installing PlantUML for the build process now that it has been included for UML diagram rendering.

Closes #18470.

## Impact

No hidden requirements.

## Testing

Local documentation build and verification of render in browser.