### PR TITLE
netdev/netdev_ioctl: log in hex mode for ioctl cmd

### DIFF
--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -579,7 +579,7 @@ static int netdev_cell_ioctl(FAR struct socket *psock, int cmd,
   FAR struct net_driver_s *dev = NULL;
   int ret = -ENOTTY;
 
-  ninfo("cmd: %d\n", cmd);
+  ninfo("cmd: 0x%04x\n", cmd);
 
   if (_CELLIOCVALID(cmd))
     {
@@ -827,7 +827,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
   unsigned int idx = 0;
   int ret = OK;
 
-  ninfo("cmd: %d\n", cmd);
+  ninfo("cmd: 0x%04x\n", cmd);
 
   /* Execute commands that do not need ifr_name or lifr_name */
 
@@ -1378,7 +1378,7 @@ static int netdev_imsf_ioctl(FAR struct socket *psock, int cmd,
   FAR struct net_driver_s *dev;
   int ret = -EINVAL;
 
-  ninfo("cmd: %d\n", cmd);
+  ninfo("cmd: 0x%04x\n", cmd);
 
   /* Execute the command */
 


### PR DESCRIPTION
It's a more friendly when output cmd in hex mode, since it's defined like: 0x7xx

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

when enable ninfo, the previous info is like:
       netdev_ifr_ioctl cmd: 1803
       netdev_ifr_ioctl cmd: 1805

it need a calculator to change it to hex mode when debug, just make it easier to read when debug.
 
## Impact

Just a log.

## Testing
old log: 
      netdev_ifr_ioctl cmd: 1803
      netdev_ifr_ioctl cmd: 1805
 
new log: 
      netdev_ifr_ioctl cmd: 0x070b
      netdev_ifr_ioctl cmd: 0x070d
