### PR TITLE
arch/arm/src/samvX/sam_gpioirq.c: fix pin base address calculation

### DIFF
--- a/arch/arm/src/sam34/sam_gpioirq.c
+++ b/arch/arm/src/sam34/sam_gpioirq.c
@@ -82,7 +82,7 @@
 static inline uint32_t sam_gpiobase(gpio_pinset_t pinset)
 {
   int port = (pinset & GPIO_PORT_MASK) >> GPIO_PORT_SHIFT;
-  return SAM_PION_BASE(port >> GPIO_PORT_SHIFT);
+  return SAM_PION_BASE(port);
 }
 
 /****************************************************************************

--- a/arch/arm/src/samv7/sam_gpioirq.c
+++ b/arch/arm/src/samv7/sam_gpioirq.c
@@ -71,7 +71,7 @@
 static inline uint32_t sam_gpiobase(gpio_pinset_t pinset)
 {
   int port = (pinset & GPIO_PORT_MASK) >> GPIO_PORT_SHIFT;
-  return SAM_PION_BASE(port >> GPIO_PORT_SHIFT);
+  return SAM_PION_BASE(port);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary
GPIO PIN base address calculation had double right shift, thus call to `SAM_PION_BASE` was always with `port = 0` instead of correct port number. As a result, function `sam_gpioirq` didn't correctly configure additional interrupt modes (only rising or falling edge and level interrupts).

The issue occured on SAMv7 and SAM34 platforms (likely copy-pasted from one to another).

## Impact
Allows to use additional interrupts (falling/rising edge, level) on GPIO pins.

## Testing
Tested on custom SAMv7 board. I noticed the issue while debugging a custom button on pin PD24 configured as

```
#define GPIO_PUSHBUTTON     (GPIO_INPUT | GPIO_CFG_DEFAULT | \
                             GPIO_CFG_DEGLITCH | GPIO_INT_FALLING | \
                             GPIO_PORT_PIOD | GPIO_PIN24) /* PD_24 */
```

The application received the interrupt on both press and release events before the fix, now it correctly reacts only to falling edge.