### PR TITLE
CI: fix labeler for common boards files

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -183,6 +183,12 @@
       - any-glob-to-any-file: 'cmake/**'
       - any-glob-to-any-file: 'tools/*.mk'
       - any-glob-to-any-file: 'tools/*.sh'
+      - any-glob-to-any-file: 'boards/Kconfig'
+      - any-glob-to-any-file: 'boards/CMakeLists.txt'
+      - any-glob-to-any-file: 'boards/Makefile'
+      - any-glob-to-any-file: 'boards/Board.mk'
+      - any-glob-to-any-file: 'boards/boardctl.c'
+      - any-glob-to-any-file: 'boards/dummy.c'
 
 "Area: CI":
   - changed-files:


### PR DESCRIPTION
## Summary
CI: fix labeler for common boards files

fix issue from https://github.com/apache/nuttx/pull/18500#issuecomment-4015816134

## Impact
Fix labeler for common boards files.
Touching these files should trigger the building of all boards

## Testing
CI