### PR TITLE
sched/group: prevent mm_free() of static g_kthread_group

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -117,7 +117,8 @@
 #define GROUP_FLAG_PRIVILEGED      (1 << 1)                      /* Bit 1: Group is privileged */
 #define GROUP_FLAG_DELETED         (1 << 2)                      /* Bit 2: Group has been deleted but not yet freed */
 #define GROUP_FLAG_EXITING         (1 << 3)                      /* Bit 3: Group exit is in progress */
-                                                                 /* Bits 3-7: Available */
+#define GROUP_FLAG_STATIC          (1 << 4)                      /* Bit 4: Group is statically allocated */
+                                                                 /* Bits 5-7: Available */
 
 /* Values for struct child_status_s ch_flags */
 

--- a/sched/group/group_create.c
+++ b/sched/group/group_create.c
@@ -131,6 +131,7 @@ int group_allocate(FAR struct tcb_s *tcb, uint8_t ttype)
     {
       group = &g_kthread_group;
       tcb->group = group;
+      group->tg_flags |= GROUP_FLAG_STATIC;
       if (group->tg_info)
         {
           return OK;

--- a/sched/group/group_leave.c
+++ b/sched/group/group_leave.c
@@ -238,7 +238,8 @@ void group_drop(FAR struct task_group_s *group)
 
   /* Finally, if no one needs the group and it has been deleted, remove it */
 
-  if (group->tg_flags & GROUP_FLAG_DELETED)
+  if ((group->tg_flags & GROUP_FLAG_DELETED) &&
+      !(group->tg_flags & GROUP_FLAG_STATIC))
     {
       /* Release the group container itself */
 


### PR DESCRIPTION
## Summary

When building for small systems with CONFIG_DEFAULT_SMALL=y, this implies CONFIG_DISABLE_PTHREAD and thus HAVE_GROUP_MEMBERS is undefined. When the AppBringUp task finishes, it will in this case try to free g_kthread_group which is obviously not possible.

Add a guard with a new flag "GROUP_FLAG_STATIC" which indicates the memory allocation type. Before freeing, check for this flag.

## Impact

Builds with CONFIG_DEFAULT_SMALL and CONFIG_DISABLE_PTHREAD are working again.

## Testing

### Debug summary

Building for olimexino-stm32:nsh (STM32F103RB).
With CONFIG_DEFAULT_SMALL in the defconfig, the target is booting with following stackdump:

```
Current Version: NuttX  12.12.0 acd69cfafb Mar  9 2026 13:40:14 arm
Assertion failed panic: at file: :0 task: AppBringUp process: Kernel 0x8001065
R0: 200007e4 R1: 00000000 R2: 00000000  R3: 200007e4
R4: 20000ce0 R5: 200007e8 R6: 200007e4  FP: 00000000
R8: 00000000 SB: 00000000 SL: 00000000 R11: 00000000
IP: 00000000 SP: 200016f8 LR: 08004175  PC: 080041b6
xPSR: 01000000 BASEPRI: 00000080 CONTROL: 00000000
EXC_RETURN: fffffff9
User Stack:
  base: 0x20000f68
  size: 00002000
    sp: 0x200016f8
0x200016d8: 200007e4 00000000 00000000 200007e4 00000000 08004175 080041b6 01000000
0x200016f8: 200008d4 200007e8 20000eb0 00000000 00000000 08001f6d 00000000 00000000
0x20001718: 20000eb0 08001c0b 00000000 08001bc9 00000000 00000000 00000000 00000000
0x20001738: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
   PID GROUP PRI POLICY   TYPE    NPX STATE   EVENT      SIGMASK          STACKBASE  STACKSIZE   COMMAND
      0     0   0 FIFO     Kthread -   Ready              0000000000000000 0x200008f8      1000   Idle_Task
      1     0 240 FIFO     Kthread P   Running            0000000000000000 0x20000f68      2000   AppBringUp
      2     2 100 FIFO     Task    -   Ready              0000000000000000 0x200018c0      2000   nsh_main
```
Lookup up PC 0x080041b6 in the system map reveals:
```
..
 .text.mm_delayfree
                0x08004140      0x11a /home/maarten/work/nuttx/nuttx/staging/libmm.a(mm_free.o)
                0x08004140                mm_delayfree
 .text.mm_free  0x0800425a        0xa /home/maarten/work/nuttx/nuttx/staging/libmm.a(mm_free.o)
                0x0800425a 
..
```
Setting a breakpoint with GDB on mm_delayfree() reveals more context. This is the only time the breakpoint is hit; it fails after this.
```
Breakpoint 1.1, mm_delayfree (heap=0x20000ce0, mem=0x200007e8 <g_kthread_group>, delay=false)
    at mm_heap/mm_free.c:92
92	  if (mm_lock(heap) < 0)
(gdb) bt
#0  mm_delayfree (heap=0x20000ce0, mem=0x200007e8 <g_kthread_group>, delay=false) at mm_heap/mm_free.c:92
#1  0x08001f6c in group_release (group=0x200007e8 <g_kthread_group>) at group/group_leave.c:134
#2  group_leave (tcb=0x20000eb0) at group/group_leave.c:190
#3  0x080021fe in nxtask_exithook (tcb=<optimized out>, status=status@entry=0) at task/task_exithook.c:454
#4  0x08001c0a in _exit (status=0) at task/exit.c:97
#5  0x08001bc8 in nxtask_start () at task/task_start.c:112
#6  0x00000000 in ?? ()
(gdb)
```

Note the g_kthread_group in the arguments. It is obvious that a static struct should not be freed.

### Fix validation

After patching, the board boots normally:
```
NuttShell (NSH) NuttX-12.12.0
nsh> help
help usage:  help [-v] [<cmd>]

    ?       help    

Builtin Apps:
    nsh    sh     
nsh> 
```
