### PR TITLE
boards/esp32s3: Fix MAC address byte order in LAN9250 driver

### DIFF
--- a/boards/xtensa/esp32s3/common/src/esp32s3_lan9250.c
+++ b/boards/xtensa/esp32s3/common/src/esp32s3_lan9250.c
@@ -188,8 +188,8 @@ static int lan9250_getmac(const struct lan9250_lower_s *lower, uint8_t *mac)
 {
   int fd;
   int ret;
-#ifndef CONFIG_ESP32S3_UNIVERSAL_MAC_ADDRESSES_FOUR
   int i;
+#ifndef CONFIG_ESP32S3_UNIVERSAL_MAC_ADDRESSES_FOUR
   uint8_t tmp;
 #endif
 
@@ -226,6 +226,11 @@ static int lan9250_getmac(const struct lan9250_lower_s *lower, uint8_t *mac)
     }
 
   close(fd);
+
+  for (i = 0; i < 6; i++)
+    {
+      mac[i] = mac[5 - i];
+    }
 
 #ifdef CONFIG_ESP32S3_UNIVERSAL_MAC_ADDRESSES_FOUR
   mac[5] += 3;


### PR DESCRIPTION
## Summary
boards/xtensa/esp32s3_lan9250.c:

Fix MAC address byte order by reversing 6 bytes after reading from eFuse
Adjust offset logic to apply after byte reversal, ensuring Ethernet MAC is base_mac +3
Comply with Espressif's MAC address generation specification for ESP32S3

## Impact
- Fixes incorrect MAC address display and usage on ESP32S3 boards with LAN9250
- Affects only ESP32S3 platform with LAN9250 Ethernet chip
- No impact on other platforms or network drivers

## Testing
Tested on ESP32S3 with LAN9250 Ethernet module:

Before fix:
```
wlan0   Link encap:Ethernet HWaddr dc:54:75:f2:a4:78 at UP mtu 1500
eth0     Link encap:Ethernet HWaddr 78:a4:f2:75:54:df at DOWN mtu 1500
```

After fix:
```
wlan0   Link encap:Ethernet HWaddr dc:54:75:f2:a4:78 at UP mtu 1500
eth0     Link encap:Ethernet HWaddr dc:54:75:f2:a4:7b at DOWN mtu 1500
```