### PR TITLE
ci: add nxboot OTA resilience canary workflow

### DIFF
--- a/.github/workflows/ota-resilience-canary.yml
+++ b/.github/workflows/ota-resilience-canary.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: neilberkman/tardigrade
-          ref: b90b61f7aefa813aac8e565217172d936d70c4ba
+          ref: 7aaa1dbe663297345365c5c562250d9796574150
           path: tardigrade
           persist-credentials: false
 


### PR DESCRIPTION
## Summary

nxboot currently has no automated testing for power-loss resilience during OTA updates. A power cut at the wrong moment during a firmware update can leave a device permanently bricked — this is a known failure class in other bootloaders (MCUboot PRs #2100, #2109, #2199 all shipped bricking regressions that were only found after release).

This PR adds a weekly canary workflow that builds the nucleo-h743zi nxboot-loader and nxboot-app configs, then uses [tardigrade](https://github.com/neilberkman/tardigrade) (a Renode-based fault-injection harness) to inject power-loss faults at write points during the OTA update path and verify the device always recovers to a bootable state.

**What it does:** builds nxboot from this repo's configs, emulates an OTA update in Renode, interrupts it at ~64 points across the full write range, and checks that the bootloader recovers every time.

**What it does not do:** it runs on a weekly schedule and `workflow_dispatch` only. It does not trigger on push or pull_request, so it never blocks normal development or CI. If it ever becomes a nuisance, deleting the one YAML file has zero impact on the project.

**Dependencies:** requires the nucleo-h743zi nxboot board configs from #18509 to be merged first. Tardigrade is pinned by full commit SHA.

## Impact

- Adds one new workflow file (`.github/workflows/ota-resilience-canary.yml`)
- No impact on existing CI, builds, or code
- Weekly schedule only — no push/PR triggers
- Self-contained: no changes to any existing files

## Testing

Workflow run on fork ([run #22888336237](https://github.com/neilberkman/nuttx/actions/runs/22888336237)):

```
Profile: nuttx_nxboot_canary
Verdict: PASS
Calibrated writes: 100000
Fault points: 34
Issues: 0
Bricks: 0
Control outcome: success
Control multi-boot: converged exec
```

Total runtime: 7m17s on a single `ubuntu-22.04` runner.

Signed-off-by: Neil Berkman <neil@xuku.com>