### PR TITLE
 boards/arm/stm32: CMake added ViewTool stm32f107 board

### DIFF
--- a/boards/arm/stm32/viewtool-stm32f107/CMakeLists.txt
+++ b/boards/arm/stm32/viewtool-stm32f107/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# boards/arm/stm32/viewtool-stm32f107/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/arm/stm32/viewtool-stm32f107/src/CMakeLists.txt
+++ b/boards/arm/stm32/viewtool-stm32f107/src/CMakeLists.txt
@@ -1,0 +1,83 @@
+# ##############################################################################
+# boards/arm/stm32/viewtool-stm32f107/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS stm32_boot.c stm32_bringup.c stm32_leds.c stm32_spi.c)
+
+if(CONFIG_STM32_CAN_CHARDRIVER)
+  list(APPEND SRCS stm32_can.c)
+endif()
+
+if(CONFIG_MMCSD)
+  list(APPEND SRCS stm32_mmcsd.c)
+endif()
+
+if(CONFIG_STM32_OTGFS)
+  list(APPEND SRCS stm32_usbdev.c)
+else()
+  if(CONFIG_STM32_USB)
+    list(APPEND SRCS stm32_usbdev.c)
+  endif()
+endif()
+
+if(CONFIG_INPUT_ADS7843E)
+  list(APPEND SRCS stm32_ads7843e.c)
+endif()
+
+if(CONFIG_LCD_SSD1289)
+  list(APPEND SRCS stm32_ssd1289.c)
+endif()
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS stm32_appinit.c)
+endif()
+
+if(CONFIG_USBMSC)
+  list(APPEND SRCS stm32_usbmsc.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS stm32_buttons.c)
+endif()
+
+if(CONFIG_VIEWTOOL_HIGHPRI)
+  list(APPEND SRCS stm32_highpri.c)
+endif()
+
+if(CONFIG_VIEWTOOL_FT80X_SPI1)
+  list(APPEND SRCS stm32_ft80x.c)
+elseif(CONFIG_VIEWTOOL_FT80X_SPI2)
+  list(APPEND SRCS stm32_ft80x.c)
+endif()
+
+if(CONFIG_VIEWTOOL_MAX3421E_SPI1)
+  list(APPEND SRCS stm32_max3421e.c)
+elseif(CONFIG_VIEWTOOL_MAX3421E_SPI2)
+  list(APPEND SRCS stm32_max3421e.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+if(CONFIG_STM32_DFU)
+  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/dfu.ld")
+else()
+  set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")
+endif()


### PR DESCRIPTION
## Summary

- CMake added ViewTool stm32f107 board

## Impact

Impact on user: This PR adds ViewTool stm32f107 board with CMake build

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

<details>
<summary>viewtool-stm32f107:nsh</summary>

```
D:\nuttxtmp\nuttx>cmake -B build -DBOARD_CONFIG=viewtool-stm32f107:nsh -GNinja
-- Found Python3: C:/Users/bit/AppData/Local/Programs/Python/Python313/python.exe (found version "3.13.3") found components: Interpreter
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Initializing NuttX
Loaded configuration 'D:/nuttxtmp/nuttx/build/.config.compressed'
Minimal configuration saved to 'D:/nuttxtmp/nuttx/build/defconfig.tmp'
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  viewtool-stm32f107
--   Config: nsh
--   Appdir: D:/nuttxtmp/apps
-- Building for: Ninja
-- The C compiler identification is GNU 14.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/mingw/mingw64/bin/gcc.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- NuttX Host Tools
-- CMake C compiler: GNU
-- CMake system name: Windows
-- CMake host system processor: AMD64
   TOOLS_DIR path is "D:/nuttxtmp/nuttx"
   HOST = WINDOWS NATIVE
-- Configuring done (1.2s)
-- Generating done (0.0s)
-- Build files have been written to: D:/nuttxtmp/nuttx/build/bin_host
-- The C compiler identification is GNU 13.2.1
-- The CXX compiler identification is GNU 13.2.1
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/gcc-arm-none-eabi/bin/arm-none-eabi-gcc.exe
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (14.6s)
-- Generating done (2.6s)
-- Build files have been written to: D:/nuttxtmp/nuttx/build

D:\nuttxtmp\nuttx>cmake --build build
[28/1148] Building C object arch/CMakeFiles/arch.dir/arm/src/stm32/stm32_gpio.c.o
D:/nuttxtmp/nuttx/arch/arm/src/stm32/stm32_gpio.c:44:11: note: '#pragma message: CONFIG_STM32_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py'
   44 | #  pragma message "CONFIG_STM32_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
      |           ^~~~~~~
[1147/1148] Linking C executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:       84280 B       256 KB     32.15%
            sram:        5572 B        64 KB      8.50%
[1148/1148] Generating nuttx.hex

```
</details>