### PR TITLE
arch/tricore: Fix `--help--` in Kconfig

### DIFF
--- a/arch/tricore/Kconfig
+++ b/arch/tricore/Kconfig
@@ -120,7 +120,7 @@ config ARCH_MPU_CODE_NREGIONS
 
 config HAVE_SECURITY_CORE
 	bool
-	--help--
+	---help---
 		In addition to the 6 cores, tc4xx also has one more security core.
 
 config CPU_COREID


### PR DESCRIPTION
## Summary

This PR fixes a typo at `--help--` that causes NuttX Builds to fail, it should have been `---help---`. This is a recurring problem, NuttX CI uses a different way of handling NuttX Configs (it doesn't use `tools/configure.sh`). The typo appears at https://github.com/apache/nuttx/pull/18391

https://github.com/lupyuen/nuttx-riscv64/actions/runs/22929878852/job/66548808341#step:5:161
```
$ tools/configure.sh rv-virt:nsh
arch/tricore/Kconfig:124: syntax error
arch/tricore/Kconfig:123: unknown option "--help--"
arch/tricore/Kconfig:124:warning: ignoring unsupported character ','
arch/tricore/Kconfig:124: unknown option "In"
```

## Impact

This PR fixes the NuttX Build across all targets.

## Testing

NuttX now builds successfully:

```bash
$ tools/configure.sh rv-virt:nsh
# configuration written to .config

$ make
Create version.h
LN: platform/board to /Users/luppy/260311/apps/platform/dummy
Register: hello
Register: dd
Register: nsh
Register: sh
Register: ostest
Register: getprime
CPP:  /Users/luppy/260311/nuttx/boards/risc-v/qemu-rv/rv-virt/scripts/ld.script-LD: nuttx
riscv-none-elf-ld: warning: /Users/luppy/260311/nuttx/nuttx has a LOAD segment with RWX permissions
Memory region         Used Size  Region Size  %age Used
```
