### PR TITLE
wireless/cc1101: Make SPI burst and single frequencies configurable

### DIFF
--- a/drivers/wireless/Kconfig
+++ b/drivers/wireless/Kconfig
@@ -26,6 +26,18 @@ config CC1101_SPIDEV
 		Selects the SPI bus number identifying that SPI interface that
 		connects the CC1101 to the MCU.
 
+config CC1101_SPIFREQ_BURST
+	int "SPI burst frequency"
+	default 6500000
+	---help---
+		SPI burst frequency (Hz, no delay) for CC1101.
+
+config CC1101_SPIFREQ_SINGLE
+	int "SPI single access frequency"
+	default 9000000
+	---help---
+		SPI single access frequency (Hz, single access only - no delay) for CC1101.
+
 endif
 
 config WL_CC1101_IGNORE_VERSION

--- a/drivers/wireless/cc1101.c
+++ b/drivers/wireless/cc1101.c
@@ -109,8 +109,16 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define CC1101_SPIFREQ_BURST    6500000 /* Hz, no delay */
-#define CC1101_SPIFREQ_SINGLE   9000000 /* Hz, single access only - no delay */
+#ifndef CONFIG_CC1101_SPIFREQ_BURST
+#  define CONFIG_CC1101_SPIFREQ_BURST    6500000 /* Hz, no delay */
+#endif
+
+#ifndef CONFIG_CC1101_SPIFREQ_SINGLE
+#  define CONFIG_CC1101_SPIFREQ_SINGLE   9000000 /* Hz, single access only - no delay */
+#endif
+
+#define CC1101_SPIFREQ_BURST    CONFIG_CC1101_SPIFREQ_BURST
+#define CC1101_SPIFREQ_SINGLE   CONFIG_CC1101_SPIFREQ_SINGLE
 
 #define CC1101_MCSM0_VALUE      0x1c
 


### PR DESCRIPTION
## Summary

This PR makes the SPI communication frequencies for the CC1101 wireless driver configurable via Kconfig.

Previously, `CC1101_SPIFREQ_BURST` and `CC1101_SPIFREQ_SINGLE` were hardcoded to 6.5 MHz and 9.0 MHz in `drivers/wireless/cc1101.c`. While these defaults work well for many typical setups, they can cause stability issues on sub-optimal hardware. Platforms with higher routing capacitance, long trace lines, or those that utilize internal GPIO switching matrices (such as the ESP32) can severely degrade SPI signal integrity, causing the CC1101 driver initialization to fail.

This change introduces `CONFIG_CC1101_SPIFREQ_BURST` and `CONFIG_CC1101_SPIFREQ_SINGLE` into `drivers/wireless/Kconfig` and updates the C source file to use these definitions. The original hardcoded values are preserved as the fallback defaults to ensure backward compatibility for existing users.

## Impact

* **Build:** Adds `CONFIG_CC1101_SPIFREQ_BURST` and `CONFIG_CC1101_SPIFREQ_SINGLE` to the configuration menu under the CC1101 driver settings.
* **Runtime:** No change to the default runtime behavior. If users modify the values in `make menuconfig`, the SPI clock speed during CC1101 access will adjust accordingly.
* **Hardware/Architecture:** Architecture-independent. Applies to any hardware utilizing the CC1101 driver, especially beneficial for platforms with restrictive IO constraints.
* **API:** None.

## Testing

* **Build Testing:** Verified that NuttX builds successfully with the default configuration (falling back to the standard 6.5 MHz / 9.0 MHz) and when custom frequencies are specified.
* **Hardware Testing:** Tested on a platform utilizing an internal GPIO matrix (ESP32) where routing capacitance and signal degradation prevented the CC1101 from loading at the default 6.5 MHz / 9.0 MHz speeds. Configured both SPI frequencies to 4.0 MHz via menuconfig, which successfully resolved the signal integrity issues and allowed the CC1101 to initialize and function correctly.