### PR TITLE
tools/testbuild.sh: Added a break to the dotest Blacklist and CMake loop

### DIFF
--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -516,6 +516,7 @@ function dotest {
     if [[ "${check}" =~ ${re:1}$ ]]; then
       echo "Skipping: $1"
       skip=1
+      break
     fi
   done
 
@@ -525,6 +526,7 @@ function dotest {
       if [[ "${config/\//:}" == "${l}" ]]; then
         echo "Cmake in present: $1"
         cmake=1
+        break
       fi
     done
   fi


### PR DESCRIPTION
## Summary

CI Improvement
Added break to the dotest Blacklist and CMake loop: it stops at the first match instead of continuing unnecessarily.

## Impact

Impact on user: NO

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

GitHub
https://github.com/simbit18/nuttx_test_pr/actions/runs/23139496528
