### PR TITLE
arch/arm/src/stm32h5: add support for HW RNG.

### DIFF
--- a/arch/arm/src/stm32h5/CMakeLists.txt
+++ b/arch/arm/src/stm32h5/CMakeLists.txt
@@ -68,6 +68,10 @@ if(CONFIG_STM32H5_FDCAN_CHARDRIVER)
   list(APPEND SRCS stm32_fdcan.c)
 endif()
 
+if(CONFIG_STM32H5_RNG)
+  list(APPEND SRCS stm32_rng.c)
+endif()
+
 if(CONFIG_STM32H5_ICACHE)
   list(APPEND SRCS stm32_icache.c)
 endif()

--- a/arch/arm/src/stm32h5/Kconfig
+++ b/arch/arm/src/stm32h5/Kconfig
@@ -356,6 +356,11 @@ config STM32H5_ADC2
 	default n
 	select STM32H5_ADC
 
+config STM32H5_RNG
+	bool "RNG"
+	default n
+	select ARCH_HAVE_RNG
+
 config STM32H5_DMA1
 	bool "DMA1"
 	default n

--- a/arch/arm/src/stm32h5/Make.defs
+++ b/arch/arm/src/stm32h5/Make.defs
@@ -64,6 +64,10 @@ ifeq ($(CONFIG_STM32H5_FDCAN_CHARDRIVER),y)
 CHIP_CSRCS += stm32_fdcan.c
 endif
 
+ifeq ($(CONFIG_STM32H5_RNG),y)
+CHIP_CSRCS += stm32_rng.c
+endif
+
 ifeq ($(CONFIG_STM32H5_ICACHE),y)
 CHIP_CSRCS += stm32_icache.c
 endif

--- a/arch/arm/src/stm32h5/hardware/stm32_rng.h
+++ b/arch/arm/src/stm32h5/hardware/stm32_rng.h
@@ -1,0 +1,64 @@
+/****************************************************************************
+ * arch/arm/src/stm32h5/hardware/stm32_rng.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_STM32H5_HARDWARE_STM32_RNG_H
+#define __ARCH_ARM_SRC_STM32H5_HARDWARE_STM32_RNG_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include "chip.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Register Offsets *********************************************************/
+
+#define STM32_RNG_CR_OFFSET       0x0000  /* RNG Control Register */
+#define STM32_RNG_SR_OFFSET       0x0004  /* RNG Status Register */
+#define STM32_RNG_DR_OFFSET       0x0008  /* RNG Data Register */
+
+/* Register Addresses *******************************************************/
+
+#define STM32_RNG_CR              (STM32_RNG_BASE+STM32_RNG_CR_OFFSET)
+#define STM32_RNG_SR              (STM32_RNG_BASE+STM32_RNG_SR_OFFSET)
+#define STM32_RNG_DR              (STM32_RNG_BASE+STM32_RNG_DR_OFFSET)
+
+/* Register Bitfield Definitions ********************************************/
+
+/* RNG Control Register */
+
+#define RNG_CR_RNGEN              (1 << 2)  /* Bit 2: RNG enable */
+#define RNG_CR_IE                 (1 << 3)  /* Bit 3: Interrupt enable */
+
+/* RNG Status Register */
+
+#define RNG_SR_DRDY               (1 << 0) /* Bit 0: Data ready */
+#define RNG_SR_CECS               (1 << 1) /* Bit 1: Clock error current status */
+#define RNG_SR_SECS               (1 << 2) /* Bit 2: Seed error current status */
+#define RNG_SR_CEIS               (1 << 5) /* Bit 5: Clock error interrupt status */
+#define RNG_SR_SEIS               (1 << 6) /* Bit 6: Seed error interrupt status */
+
+#endif /* __ARCH_ARM_SRC_STM32H5_HARDWARE_STM32_RNG_H */

--- a/arch/arm/src/stm32h5/stm32_rng.c
+++ b/arch/arm/src/stm32h5/stm32_rng.c
@@ -1,0 +1,330 @@
+/****************************************************************************
+ * arch/arm/src/stm32h5/stm32_rng.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <debug.h>
+#include <errno.h>
+
+#include <nuttx/irq.h>
+#include <nuttx/arch.h>
+#include <nuttx/mutex.h>
+#include <nuttx/fs/fs.h>
+#include <nuttx/drivers/drivers.h>
+
+#include "hardware/stm32_rng.h"
+#include "arm_internal.h"
+
+#if defined(CONFIG_DEV_RANDOM) || defined(CONFIG_DEV_URANDOM_ARCH)
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int stm32_rng_initialize(void);
+static int stm32_rnginterrupt(int irq, void *context, void *arg);
+static void stm32_rngenable(void);
+static void stm32_rngdisable(void);
+static ssize_t stm32_rngread(struct file *filep, char *buffer, size_t);
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct rng_dev_s
+{
+  mutex_t rd_devlock;   /* Threads can only exclusively access the RNG */
+  sem_t rd_readsem;     /* To block until the buffer is filled  */
+  char *rd_buf;
+  size_t rd_buflen;
+  uint32_t rd_lastval;
+  bool rd_first;
+};
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static struct rng_dev_s g_rngdev =
+{
+  .rd_devlock = NXMUTEX_INITIALIZER,
+  .rd_readsem = SEM_INITIALIZER(0),
+};
+
+static const struct file_operations g_rngops =
+{
+  NULL,            /* open */
+  NULL,            /* close */
+  stm32_rngread,   /* read */
+};
+
+/****************************************************************************
+ * Private functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: stm32_rng_initialize
+ ****************************************************************************/
+
+static int stm32_rng_initialize(void)
+{
+  _info("Initializing RNG\n");
+
+  if (irq_attach(STM32_IRQ_RNG, stm32_rnginterrupt, NULL))
+    {
+      /* We could not attach the ISR to the interrupt */
+
+      _info("Could not attach IRQ.\n");
+
+      return -EAGAIN;
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: stm32_rngenable
+ ****************************************************************************/
+
+static void stm32_rngenable(void)
+{
+  uint32_t regval;
+
+  g_rngdev.rd_first = true;
+
+  /* Enable generation and interrupts */
+
+  regval  = getreg32(STM32_RNG_CR);
+  regval |= RNG_CR_RNGEN;
+  regval |= RNG_CR_IE;
+  putreg32(regval, STM32_RNG_CR);
+
+  up_enable_irq(STM32_IRQ_RNG);
+}
+
+/****************************************************************************
+ * Name: stm32_rngdisable
+ ****************************************************************************/
+
+static void stm32_rngdisable(void)
+{
+  uint32_t regval;
+
+  up_disable_irq(STM32_IRQ_RNG);
+
+  regval  =  getreg32(STM32_RNG_CR);
+  regval &= ~RNG_CR_IE;
+  regval &= ~RNG_CR_RNGEN;
+  putreg32(regval, STM32_RNG_CR);
+}
+
+/****************************************************************************
+ * Name: stm32_rnginterrupt
+ ****************************************************************************/
+
+static int stm32_rnginterrupt(int irq, void *context, void *arg)
+{
+  uint32_t rngsr;
+  uint32_t data;
+
+  rngsr = getreg32(STM32_RNG_SR);
+  if (rngsr & RNG_SR_CEIS) /* Check for clock error int stat */
+    {
+      /* Clear it, we will try again. */
+
+      putreg32(rngsr & ~RNG_SR_CEIS, STM32_RNG_SR);
+      return OK;
+    }
+
+  if (rngsr & RNG_SR_SEIS) /* Check for seed error in int stat */
+    {
+      uint32_t crval;
+
+      /* Clear seed error, then disable/enable the rng and try again. */
+
+      putreg32(rngsr & ~RNG_SR_SEIS, STM32_RNG_SR);
+      crval = getreg32(STM32_RNG_CR);
+      crval &= ~RNG_CR_RNGEN;
+      putreg32(crval, STM32_RNG_CR);
+      crval |= RNG_CR_RNGEN;
+      putreg32(crval, STM32_RNG_CR);
+      return OK;
+    }
+
+  if (!(rngsr & RNG_SR_DRDY)) /* Data ready must be set */
+    {
+      /* This random value is not valid, we will try again. */
+
+      return OK;
+    }
+
+  data = getreg32(STM32_RNG_DR);
+
+  /* As required by the FIPS PUB (Federal Information Processing Standard
+   * Publication) 140-2, the first random number generated after setting the
+   * RNGEN bit should not be used, but saved for comparison with the next
+   * generated random number. Each subsequent generated random number has to
+   * be compared with the previously generated number. The test fails if any
+   * two compared numbers are equal (continuous random number generator
+   * test).
+   */
+
+  if (g_rngdev.rd_first)
+    {
+      g_rngdev.rd_first = false;
+      g_rngdev.rd_lastval = data;
+      return OK;
+    }
+
+  if (g_rngdev.rd_lastval == data)
+    {
+      /* Two subsequent same numbers, we will try again. */
+
+      return OK;
+    }
+
+  /* If we get here, the random number is valid. */
+
+  g_rngdev.rd_lastval = data;
+
+  if (g_rngdev.rd_buflen >= 4)
+    {
+      g_rngdev.rd_buflen -= 4;
+      *(uint32_t *)&g_rngdev.rd_buf[g_rngdev.rd_buflen] = data;
+    }
+  else
+    {
+      while (g_rngdev.rd_buflen > 0)
+        {
+          g_rngdev.rd_buf[--g_rngdev.rd_buflen] = (char)data;
+          data >>= 8;
+        }
+    }
+
+  if (g_rngdev.rd_buflen == 0)
+    {
+      /* Buffer filled, stop further interrupts. */
+
+      stm32_rngdisable();
+      nxsem_post(&g_rngdev.rd_readsem);
+    }
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: stm32_rngread
+ ****************************************************************************/
+
+static ssize_t stm32_rngread(struct file *filep, char *buffer, size_t buflen)
+{
+  int ret;
+
+  ret = nxmutex_lock(&g_rngdev.rd_devlock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  /* We've got the device semaphore, proceed with reading */
+
+  /* Reset the operation semaphore with 0 for blocking until the
+   * buffer is filled from interrupts.
+   */
+
+  nxsem_reset(&g_rngdev.rd_readsem, 0);
+
+  g_rngdev.rd_buflen = buflen;
+  g_rngdev.rd_buf = buffer;
+
+  /* Enable RNG with interrupts */
+
+  stm32_rngenable();
+
+  /* Wait until the buffer is filled */
+
+  ret = nxsem_wait(&g_rngdev.rd_readsem);
+
+  /* Free RNG via the device mutex for next use */
+
+  nxmutex_unlock(&g_rngdev.rd_devlock);
+  return ret < 0 ? ret : buflen;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: devrandom_register
+ *
+ * Description:
+ *   Initialize the RNG hardware and register the /dev/random driver.
+ *   Must be called BEFORE devurandom_register.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_DEV_RANDOM
+void devrandom_register(void)
+{
+  stm32_rng_initialize();
+  register_driver("/dev/random", &g_rngops, 0444, NULL);
+}
+#endif
+
+/****************************************************************************
+ * Name: devurandom_register
+ *
+ * Description:
+ *   Register /dev/urandom
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_DEV_URANDOM_ARCH
+void devurandom_register(void)
+{
+#ifndef CONFIG_DEV_RANDOM
+  stm32_rng_initialize();
+#endif
+  register_driver("/dev/urandom", &g_rngops, 0444, NULL);
+}
+#endif
+
+#endif /* CONFIG_DEV_RANDOM || CONFIG_DEV_URANDOM_ARCH */

--- a/arch/arm/src/stm32h5/stm32h5xx_rcc.c
+++ b/arch/arm/src/stm32h5/stm32h5xx_rcc.c
@@ -63,8 +63,15 @@ static_assert(CONFIG_BOARD_LOOPSPERMSEC != -1,
 /* Determine if board wants to use HSI48 as 48 MHz oscillator. */
 
 #if defined(CONFIG_STM32H5_HAVE_HSI48) && defined(STM32H5_USE_CLK48)
-#  if STM32H5_CLKUSB_SEL == RCC_CCIPR4_USBSEL_HSI48KERCK
-#    define STM32H5_USE_HSI48 1
+#  if defined(STM32H5_CLKUSB_SEL)
+#    if (STM32H5_CLKUSB_SEL == RCC_CCIPR4_USBSEL_HSI48KERCK)
+#      define STM32H5_USE_HSI48 1
+#    endif
+#  endif
+#  if defined(STM32H5_CLKRNG_SEL)
+#    if (STM32H5_CLKRNG_SEL == RCC_CCIPR5_RNGSEL_HSI48KERCK)
+#      define STM32H5_USE_HSI48 1
+#    endif
 #  endif
 #endif
 
@@ -1194,11 +1201,22 @@ void stm32_stdclockconfig(void)
       putreg32(regval, STM32_RCC_CCIPR3);
 #endif
 
+      /* Configure USB source clock */
+
 #if defined(STM32H5_CLKUSB_SEL)
       regval = getreg32(STM32_RCC_CCIPR4);
       regval &= ~RCC_CCIPR4_USBSEL_MASK;
       regval |= STM32H5_CLKUSB_SEL;
       putreg32(regval, STM32_RCC_CCIPR4);
+#endif
+
+      /* Configure RNG source clock */
+
+#if defined(STM32H5_CLKRNG_SEL)
+      regval = getreg32(STM32_RCC_CCIPR5);
+      regval &= ~RCC_CCIPR5_RNGSEL_MASK;
+      regval |= STM32H5_CLKRNG_SEL;
+      putreg32(regval, STM32_RCC_CCIPR5);
 #endif
     }
 }

--- a/boards/arm/stm32h5/nucleo-h563zi/include/board.h
+++ b/boards/arm/stm32h5/nucleo-h563zi/include/board.h
@@ -161,6 +161,10 @@
 #  define STM32H5_HSI48_SYNCSRC   SYNCSRC_NONE
 #endif
 
+#if defined(CONFIG_STM32H5_RNG)
+#  define STM32H5_CLKRNG_SEL      RCC_CCIPR5_RNGSEL_HSI48KERCK
+#endif
+
 /* Enable LSE (for the RTC) */
 
 #define STM32_USE_LSE           1


### PR DESCRIPTION
Driver copied from stm32f7, which includes CEIS/SEIS clearing per reference manual.

## Summary

STM32H5 MCUs have a random number generation. According to the datasheets, the whole family has it, so there is no need
to make the change conditional on specific part number as other families (STM32H7, for example, do).

There are two slightly different implementations of the RNG driver. One is used in plain stm32, stm32h7,and stm32f0l0g0: when error flags SEIS/CEIS are set it just reads DR again. The other is used in stm32f7 and stm32l4: it clears those flags and disables/re-enables RNG on failure. This second one is the correct procedure according to the manual, so I have made stm32h5 one used that one (copies from stm32f7).

## Impact

This change will affect all STM32H5 platforms, making /dev/random appear and /dev/urandom support available for selection using Kconfig.

## Testing

Host:
```
$ uname -a
Linux 40f6844c7dd8 6.8.0-101-generic #101~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Wed Feb 11 13:19:54 UTC  x86_64 x86_64 x86_64 GNU/Linux

$ arm-none-eabi-gcc --version
arm-none-eabi-gcc (GNU Arm Embedded Toolchain 10-2020-q4-major) 10.2.1 20201103 (release)
Copyright (C) 2020 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

Board is NUCLEO-H563ZI

Tested using nsh to get random numbers from RNG.
Build:
```
nuttx$ tools/configure.sh -l nucleo-h563zi:nsh
  Copy files
  Select CONFIG_HOST_LINUX=y
  Refreshing...
CP: arch/dummy/Kconfig to /home/carlossanchez/src/nuttx/arch/dummy/dummy_kconfig
CP: boards/dummy/Kconfig to /home/carlossanchez/src/nuttx/boards/dummy/dummy_kconfig
LN: platform/board to /home/carlossanchez/src/nuttx-apps/platform/dummy
LN: include/arch to arch/arm/include
LN: include/arch/board to /home/carlossanchez/src/nuttx/boards/arm/stm32h5/nucleo-h563zi/include
LN: drivers/platform to /home/carlossanchez/src/nuttx/drivers/dummy
LN: include/arch/chip to /home/carlossanchez/src/nuttx/arch/arm/include/stm32h5
LN: arch/arm/src/chip to /home/carlossanchez/src/nuttx/arch/arm/src/stm32h5
LN: arch/arm/src/board to /home/carlossanchez/src/nuttx/boards/arm/stm32h5/nucleo-h563zi/src
#
# configuration written to .config
#
nuttx$ make menuconfig
[System Type -> STM32H5 Peripheral Selection -> Enable RNG]
nuttx$ make
```

NSH prompt:
```
ABCG
stm32_rng_initialize: Initializing RNG

NuttShell (NSH) NuttX-12.12.0
nsh> hexdump /dev/random count=4
/dev/random at 00000000:
0000: f6 12 50 83                                     ..P.
nsh> hexdump /dev/random count=4
/dev/random at 00000000:
0000: 7e ac bb a7                                     ~...
```