### PR TITLE
arch/risc-v/hpm6000: Use WDOGx naming for watchdog peripherals

### DIFF
--- a/arch/risc-v/src/hpm6000/Kconfig
+++ b/arch/risc-v/src/hpm6000/Kconfig
@@ -34,15 +34,15 @@ config HPM_ENET
 menu "Watchdog"
 
 config HPM_WDOG0
-	bool "watchdog"
+	bool "WDOG0"
 	default n
 
 config HPM_WDOG1
-	bool "watchdog"
+	bool "WDOG1"
 	default n
 
 config HPM_WDOG2
-	bool "watchdog"
+	bool "WDOG2"
 	default n
 
 endmenu # Watchdog


### PR DESCRIPTION
## Summary

Fix duplicate watchdog peripheral prompts in HPM6000 Kconfig by using unique WDOG0, WDOG1, WDOG2 names instead of the generic "watchdog" label. This makes it clear which watchdog is being configured in menuconfig and matches the UART peripheral naming convention (UART0, UART1, etc.) in the same file.

## Impact

- Impact on user: YES - Improves menuconfig readability by showing distinct names for each watchdog peripheral
- Impact on build: NO
- Impact on hardware: NO
- Impact on documentation: NO
- Impact on security: NO
- Impact on compatibility: NO

## Testing

Build Host: Linux, x86_64, GCC
Target: RISC-V hpm6750evk:nsh

Before the fix, menuconfig showed three entries all labeled "watchdog":
```
[ ] watchdog
[ ] watchdog
[ ] watchdog
```

After the fix, menuconfig now shows distinct names:
```
[ ] WDOG0
[ ] WDOG1
[ ] WDOG2
```

The fix follows the same naming pattern used for UART peripherals in the same file (UART0, UART1, etc.).

