### PR TITLE
tools/ci/testlist: skip the build of bl602evb:elf

### DIFF
--- a/tools/ci/testlist/risc-v-01.dat
+++ b/tools/ci/testlist/risc-v-01.dat
@@ -1,2 +1,3 @@
 /risc-v/[a-d]*
 /risc-v/e[0-r]*
+-bl602evb:elf


### PR DESCRIPTION
## Summary

This bl602evb:elf configuration has caused job risc-v-01 to fail on several occasions.

`riscv-none-elf-ld: cannot find /github/workspace/sources/nuttx/arch/risc-v/src/crt0.o: No such file or directory`

https://github.com/apache/nuttx/pull/17792

Added -bl602evb:elf to the risc-v-01.dat file to skip the build.

## Impact

Impact on user: NO

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO


## Testing

GitHub

```
====================================================================================
Skipping: bl602evb/elf
Configuration/Tool: bl602evb/elf
2026-03-18 13:42:10
------------------------------------------------------------------------------------
  Cleaning...
  Skipping: bl602evb/elf
====================================================================================
```

https://github.com/simbit18/nuttx_test_pr/actions/runs/23247428900/job/67579843038#logs