### PR TITLE
boards/xtensa/esp32s3: fix WiFi init by using CONFIG_ESPRESSIF_WIFI

### DIFF
--- a/boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_bringup.c
@@ -42,7 +42,7 @@
 #  include "esp32s3_board_tim.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WLAN
+#ifdef CONFIG_ESPRESSIF_WIFI
 #  include "esp32s3_board_wlan.h"
 #endif
 
@@ -211,7 +211,7 @@ int esp32s3_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WLAN
+#ifdef CONFIG_ESPRESSIF_WIFI
   ret = board_wlan_init();
   if (ret < 0)
     {

--- a/boards/xtensa/esp32s3/esp32s3-eye/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/esp32s3-eye/src/esp32s3_bringup.c
@@ -42,7 +42,7 @@
 #  include "esp32s3_board_tim.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WLAN
+#ifdef CONFIG_ESPRESSIF_WIFI
 #  include "esp32s3_board_wlan.h"
 #endif
 
@@ -202,7 +202,7 @@ int esp32s3_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WLAN
+#ifdef CONFIG_ESPRESSIF_WIFI
   ret = board_wlan_init();
   if (ret < 0)
     {

--- a/boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3_bringup.c
@@ -45,7 +45,7 @@
 #  include "esp32s3_board_tim.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WLAN
+#ifdef CONFIG_ESPRESSIF_WIFI
 #  include "esp32s3_board_wlan.h"
 #endif
 
@@ -412,7 +412,7 @@ int esp32s3_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WLAN
+#ifdef CONFIG_ESPRESSIF_WIFI
   ret = board_wlan_init();
   if (ret < 0)
     {

--- a/boards/xtensa/esp32s3/esp32s3-lcd-ev/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/esp32s3-lcd-ev/src/esp32s3_bringup.c
@@ -45,7 +45,7 @@
 #  include "esp32s3_board_tim.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WLAN
+#ifdef CONFIG_ESPRESSIF_WIFI
 #  include "esp32s3_board_wlan.h"
 #endif
 
@@ -304,7 +304,7 @@ int esp32s3_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WLAN
+#ifdef CONFIG_ESPRESSIF_WIFI
   ret = board_wlan_init();
   if (ret < 0)
     {

--- a/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_bringup.c
@@ -45,7 +45,7 @@
 #  include "esp32s3_board_tim.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WLAN
+#ifdef CONFIG_ESPRESSIF_WIFI
 #  include "esp32s3_board_wlan.h"
 #endif
 
@@ -406,7 +406,7 @@ int esp32s3_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WLAN
+#ifdef CONFIG_ESPRESSIF_WIFI
   ret = board_wlan_init();
   if (ret < 0)
     {


### PR DESCRIPTION
## Summary

The WiFi driver refactor renamed the Kconfig symbol from `CONFIG_ESPRESSIF_WLAN` to `CONFIG_ESPRESSIF_WIFI`, but several ESP32-S3 board bringup files were not updated accordingly. This caused `board_wlan_init()` to be compiled out by the preprocessor, so the `wlan0` network interface never appeared at runtime.

This patch updates the `#ifdef` guards in all affected ESP32-S3 board bringup files from `CONFIG_ESPRESSIF_WLAN` to `CONFIG_ESPRESSIF_WIFI`:

- `boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_bringup.c`
- `boards/xtensa/esp32s3/esp32s3-eye/src/esp32s3_bringup.c`
- `boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3_bringup.c`
- `boards/xtensa/esp32s3/esp32s3-lcd-ev/src/esp32s3_bringup.c`
- `boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_bringup.c`

Each file has two occurrences replaced: one guarding the `#include "esp32s3_board_wlan.h"` and one guarding the `board_wlan_init()` call in `esp32s3_bringup()`.

## Impact

- Users who enable WiFi on the affected ESP32-S3 boards will now correctly get the `wlan0` interface registered during bringup.
- No impact on boards that do not enable `CONFIG_ESPRESSIF_WIFI`.
- No API, build system, or documentation changes. Pure bug fix for a Kconfig symbol rename that was missed in these files.

## Testing

Host: Linux x86_64

Board: lckfb-szpi-esp32s3 (ESP32-S3)

Steps:
1. Configure with a WiFi-enabled defconfig (`CONFIG_ESPRESSIF_WIFI=y`).
2. Build: `make -j$(nproc)`
3. Flash: `esptool.py -p /dev/ttyUSB0 -b 921600 write_flash 0x0 nuttx.bin`
4. Boot and verify `wlan0` interface is present via `ifconfig`.

Before this patch, `board_wlan_init()` was never called and `ifconfig` showed no `wlan0`. After this patch, `wlan0` appears correctly.