### PR TITLE
boards/arm/stm32*/: Align ARM STM32 idle stack

### DIFF
--- a/boards/arm/stm32/axoloti/scripts/kernel-space.ld
+++ b/boards/arm/stm32/axoloti/scripts/kernel-space.ld
@@ -79,7 +79,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > ksram
 

--- a/boards/arm/stm32/axoloti/scripts/user-space.ld
+++ b/boards/arm/stm32/axoloti/scripts/user-space.ld
@@ -93,7 +93,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32/clicker2-stm32/scripts/flash.ld
+++ b/boards/arm/stm32/clicker2-stm32/scripts/flash.ld
@@ -110,7 +110,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/clicker2-stm32/scripts/kernel-space.ld
+++ b/boards/arm/stm32/clicker2-stm32/scripts/kernel-space.ld
@@ -85,7 +85,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > ksram
 

--- a/boards/arm/stm32/clicker2-stm32/scripts/user-space.ld
+++ b/boards/arm/stm32/clicker2-stm32/scripts/user-space.ld
@@ -87,7 +87,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32/cloudctrl/scripts/cloudctrl-dfu.ld
+++ b/boards/arm/stm32/cloudctrl/scripts/cloudctrl-dfu.ld
@@ -88,7 +88,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/cloudctrl/scripts/cloudctrl.ld
+++ b/boards/arm/stm32/cloudctrl/scripts/cloudctrl.ld
@@ -98,7 +98,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/fire-stm32v2/scripts/fire-stm32v2-dfu.ld
+++ b/boards/arm/stm32/fire-stm32v2/scripts/fire-stm32v2-dfu.ld
@@ -100,7 +100,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/fire-stm32v2/scripts/fire-stm32v2.ld
+++ b/boards/arm/stm32/fire-stm32v2/scripts/fire-stm32v2.ld
@@ -101,7 +101,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/mikroe-stm32f4/scripts/kernel-space.ld
+++ b/boards/arm/stm32/mikroe-stm32f4/scripts/kernel-space.ld
@@ -79,7 +79,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > ksram
 

--- a/boards/arm/stm32/mikroe-stm32f4/scripts/user-space.ld
+++ b/boards/arm/stm32/mikroe-stm32f4/scripts/user-space.ld
@@ -80,7 +80,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32/nucleo-f401re/scripts/flash.ld
+++ b/boards/arm/stm32/nucleo-f401re/scripts/flash.ld
@@ -89,7 +89,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/nucleo-f410rb/scripts/f410rb.ld
+++ b/boards/arm/stm32/nucleo-f410rb/scripts/f410rb.ld
@@ -101,7 +101,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/nucleo-f411re/scripts/flash.ld
+++ b/boards/arm/stm32/nucleo-f411re/scripts/flash.ld
@@ -101,7 +101,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/nucleo-f412zg/scripts/f412zg.ld
+++ b/boards/arm/stm32/nucleo-f412zg/scripts/f412zg.ld
@@ -99,7 +99,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/nucleo-f429zi/scripts/kernel-space.ld
+++ b/boards/arm/stm32/nucleo-f429zi/scripts/kernel-space.ld
@@ -79,7 +79,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > ksram
 

--- a/boards/arm/stm32/nucleo-f429zi/scripts/user-space.ld
+++ b/boards/arm/stm32/nucleo-f429zi/scripts/user-space.ld
@@ -93,7 +93,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32/nucleo-f446re/scripts/f446re.ld
+++ b/boards/arm/stm32/nucleo-f446re/scripts/f446re.ld
@@ -101,7 +101,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/olimex-stm32-e407/scripts/f407ze.ld
+++ b/boards/arm/stm32/olimex-stm32-e407/scripts/f407ze.ld
@@ -105,7 +105,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/olimex-stm32-e407/scripts/f407zg.ld
+++ b/boards/arm/stm32/olimex-stm32-e407/scripts/f407zg.ld
@@ -105,7 +105,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/olimex-stm32-p407/scripts/flash.ld
+++ b/boards/arm/stm32/olimex-stm32-p407/scripts/flash.ld
@@ -104,7 +104,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/olimex-stm32-p407/scripts/kernel-space.ld
+++ b/boards/arm/stm32/olimex-stm32-p407/scripts/kernel-space.ld
@@ -80,7 +80,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > ksram
 

--- a/boards/arm/stm32/olimex-stm32-p407/scripts/user-space.ld
+++ b/boards/arm/stm32/olimex-stm32-p407/scripts/user-space.ld
@@ -93,7 +93,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32/omnibusf4/scripts/kernel-space.ld
+++ b/boards/arm/stm32/omnibusf4/scripts/kernel-space.ld
@@ -78,7 +78,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > ksram
 

--- a/boards/arm/stm32/omnibusf4/scripts/user-space.ld
+++ b/boards/arm/stm32/omnibusf4/scripts/user-space.ld
@@ -80,7 +80,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32/photon/scripts/photon_dfu.ld
+++ b/boards/arm/stm32/photon/scripts/photon_dfu.ld
@@ -117,7 +117,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/photon/scripts/photon_jtag.ld
+++ b/boards/arm/stm32/photon/scripts/photon_jtag.ld
@@ -101,7 +101,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/stm3240g-eval/scripts/kernel-space.ld
+++ b/boards/arm/stm32/stm3240g-eval/scripts/kernel-space.ld
@@ -79,7 +79,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > ksram
 

--- a/boards/arm/stm32/stm3240g-eval/scripts/user-space.ld
+++ b/boards/arm/stm32/stm3240g-eval/scripts/user-space.ld
@@ -80,7 +80,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32/stm32butterfly2/scripts/dfu.ld
+++ b/boards/arm/stm32/stm32butterfly2/scripts/dfu.ld
@@ -98,7 +98,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/stm32butterfly2/scripts/flash.ld
+++ b/boards/arm/stm32/stm32butterfly2/scripts/flash.ld
@@ -98,7 +98,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/stm32f411-minimum/scripts/stm32f411ce.ld
+++ b/boards/arm/stm32/stm32f411-minimum/scripts/stm32f411ce.ld
@@ -101,7 +101,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/stm32f411e-disco/scripts/f411ve.ld
+++ b/boards/arm/stm32/stm32f411e-disco/scripts/f411ve.ld
@@ -101,7 +101,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/stm32f429i-disco/scripts/kernel-space.ld
+++ b/boards/arm/stm32/stm32f429i-disco/scripts/kernel-space.ld
@@ -79,7 +79,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > ksram
 

--- a/boards/arm/stm32/stm32f429i-disco/scripts/ofloader.ld
+++ b/boards/arm/stm32/stm32f429i-disco/scripts/ofloader.ld
@@ -130,7 +130,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/stm32f429i-disco/scripts/user-space.ld
+++ b/boards/arm/stm32/stm32f429i-disco/scripts/user-space.ld
@@ -93,7 +93,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32/stm32f4discovery/scripts/kernel-space.ld
+++ b/boards/arm/stm32/stm32f4discovery/scripts/kernel-space.ld
@@ -78,7 +78,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > ksram
 

--- a/boards/arm/stm32/stm32f4discovery/scripts/user-space.ld
+++ b/boards/arm/stm32/stm32f4discovery/scripts/user-space.ld
@@ -93,7 +93,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32/stm32ldiscovery/scripts/stm32l152rb.ld
+++ b/boards/arm/stm32/stm32ldiscovery/scripts/stm32l152rb.ld
@@ -106,7 +106,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/stm32ldiscovery/scripts/stm32l152rc.ld
+++ b/boards/arm/stm32/stm32ldiscovery/scripts/stm32l152rc.ld
@@ -106,7 +106,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/stm32vldiscovery/scripts/stm32vldiscovery.ld
+++ b/boards/arm/stm32/stm32vldiscovery/scripts/stm32vldiscovery.ld
@@ -99,7 +99,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/viewtool-stm32f107/scripts/dfu.ld
+++ b/boards/arm/stm32/viewtool-stm32f107/scripts/dfu.ld
@@ -98,7 +98,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32/viewtool-stm32f107/scripts/flash.ld
+++ b/boards/arm/stm32/viewtool-stm32f107/scripts/flash.ld
@@ -98,7 +98,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32f0l0g0/nucleo-c071rb/scripts/flash.ld
+++ b/boards/arm/stm32f0l0g0/nucleo-c071rb/scripts/flash.ld
@@ -90,7 +90,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32f0l0g0/nucleo-c092rc/scripts/flash.ld
+++ b/boards/arm/stm32f0l0g0/nucleo-c092rc/scripts/flash.ld
@@ -90,7 +90,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32f0l0g0/nucleo-f072rb/scripts/flash.ld
+++ b/boards/arm/stm32f0l0g0/nucleo-f072rb/scripts/flash.ld
@@ -90,7 +90,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32f0l0g0/nucleo-f091rc/scripts/flash.ld
+++ b/boards/arm/stm32f0l0g0/nucleo-f091rc/scripts/flash.ld
@@ -90,7 +90,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32f0l0g0/stm32f051-discovery/scripts/flash.ld
+++ b/boards/arm/stm32f0l0g0/stm32f051-discovery/scripts/flash.ld
@@ -89,7 +89,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32f0l0g0/stm32f072-discovery/scripts/flash.ld
+++ b/boards/arm/stm32f0l0g0/stm32f072-discovery/scripts/flash.ld
@@ -89,7 +89,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32f7/nucleo-f722ze/scripts/flash.ld
+++ b/boards/arm/stm32f7/nucleo-f722ze/scripts/flash.ld
@@ -115,7 +115,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram1
 

--- a/boards/arm/stm32f7/nucleo-f722ze/scripts/kernel-space.ld
+++ b/boards/arm/stm32f7/nucleo-f722ze/scripts/kernel-space.ld
@@ -78,7 +78,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > ksram
 

--- a/boards/arm/stm32f7/nucleo-f722ze/scripts/user-space.ld
+++ b/boards/arm/stm32f7/nucleo-f722ze/scripts/user-space.ld
@@ -80,7 +80,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32f7/nucleo-f746zg/scripts/flash.ld
+++ b/boards/arm/stm32f7/nucleo-f746zg/scripts/flash.ld
@@ -115,7 +115,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram1
 

--- a/boards/arm/stm32f7/nucleo-f746zg/scripts/kernel-space.ld
+++ b/boards/arm/stm32f7/nucleo-f746zg/scripts/kernel-space.ld
@@ -78,7 +78,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > ksram
 

--- a/boards/arm/stm32f7/nucleo-f746zg/scripts/user-space.ld
+++ b/boards/arm/stm32f7/nucleo-f746zg/scripts/user-space.ld
@@ -80,7 +80,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32f7/nucleo-f767zi/scripts/flash.ld
+++ b/boards/arm/stm32f7/nucleo-f767zi/scripts/flash.ld
@@ -115,7 +115,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram1
 

--- a/boards/arm/stm32f7/nucleo-f767zi/scripts/kernel-space.ld
+++ b/boards/arm/stm32f7/nucleo-f767zi/scripts/kernel-space.ld
@@ -78,7 +78,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > ksram
 

--- a/boards/arm/stm32f7/nucleo-f767zi/scripts/user-space.ld
+++ b/boards/arm/stm32f7/nucleo-f767zi/scripts/user-space.ld
@@ -80,7 +80,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32f7/steval-eth001v1/scripts/flash.ld
+++ b/boards/arm/stm32f7/steval-eth001v1/scripts/flash.ld
@@ -115,7 +115,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram1
 

--- a/boards/arm/stm32f7/stm32f746-ws/scripts/flash.ld
+++ b/boards/arm/stm32f7/stm32f746-ws/scripts/flash.ld
@@ -115,7 +115,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram1
 

--- a/boards/arm/stm32f7/stm32f746-ws/scripts/kernel-space.ld
+++ b/boards/arm/stm32f7/stm32f746-ws/scripts/kernel-space.ld
@@ -78,7 +78,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > ksram
 

--- a/boards/arm/stm32f7/stm32f746-ws/scripts/user-space.ld
+++ b/boards/arm/stm32f7/stm32f746-ws/scripts/user-space.ld
@@ -80,7 +80,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32f7/stm32f746g-disco/scripts/flash.ld
+++ b/boards/arm/stm32f7/stm32f746g-disco/scripts/flash.ld
@@ -115,7 +115,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram1
 

--- a/boards/arm/stm32f7/stm32f746g-disco/scripts/kernel-space.ld
+++ b/boards/arm/stm32f7/stm32f746g-disco/scripts/kernel-space.ld
@@ -78,7 +78,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > ksram
 

--- a/boards/arm/stm32f7/stm32f746g-disco/scripts/user-space.ld
+++ b/boards/arm/stm32f7/stm32f746g-disco/scripts/user-space.ld
@@ -80,7 +80,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32f7/stm32f769i-disco/scripts/flash.ld
+++ b/boards/arm/stm32f7/stm32f769i-disco/scripts/flash.ld
@@ -115,7 +115,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram1
 

--- a/boards/arm/stm32f7/stm32f769i-disco/scripts/kernel-space.ld
+++ b/boards/arm/stm32f7/stm32f769i-disco/scripts/kernel-space.ld
@@ -78,7 +78,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > ksram
 

--- a/boards/arm/stm32f7/stm32f769i-disco/scripts/user-space.ld
+++ b/boards/arm/stm32f7/stm32f769i-disco/scripts/user-space.ld
@@ -80,7 +80,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32f7/stm32f777zit6-meadow/scripts/user-space.ld
+++ b/boards/arm/stm32f7/stm32f777zit6-meadow/scripts/user-space.ld
@@ -80,7 +80,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32h5/nucleo-h563zi/scripts/flash.ld
+++ b/boards/arm/stm32h5/nucleo-h563zi/scripts/flash.ld
@@ -86,7 +86,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32h5/nucleo-h563zi/scripts/tfm-ns.ld
+++ b/boards/arm/stm32h5/nucleo-h563zi/scripts/tfm-ns.ld
@@ -97,7 +97,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32h7/linum-stm32h753bi/scripts/flash.ld
+++ b/boards/arm/stm32h7/linum-stm32h753bi/scripts/flash.ld
@@ -166,7 +166,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32h7/linum-stm32h753bi/scripts/gnu-elf.ld
+++ b/boards/arm/stm32h7/linum-stm32h753bi/scripts/gnu-elf.ld
@@ -107,7 +107,7 @@ SECTIONS
       *(.sbss.*)
       *(.gnu.linkonce.b*)
       *(COMMON)
-      . = ALIGN(4);
+      . = ALIGN(8);
       _ebss = . ;
     }
 

--- a/boards/arm/stm32h7/linum-stm32h753bi/scripts/user-space.ld
+++ b/boards/arm/stm32h7/linum-stm32h753bi/scripts/user-space.ld
@@ -79,7 +79,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32h7/nucleo-h723zg/scripts/flash-mcuboot-app.ld
+++ b/boards/arm/stm32h7/nucleo-h723zg/scripts/flash-mcuboot-app.ld
@@ -165,7 +165,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32h7/nucleo-h723zg/scripts/flash-mcuboot-loader.ld
+++ b/boards/arm/stm32h7/nucleo-h723zg/scripts/flash-mcuboot-loader.ld
@@ -165,7 +165,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32h7/nucleo-h723zg/scripts/flash.ld
+++ b/boards/arm/stm32h7/nucleo-h723zg/scripts/flash.ld
@@ -165,7 +165,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32h7/nucleo-h723zg/scripts/kernel.space.ld
+++ b/boards/arm/stm32h7/nucleo-h723zg/scripts/kernel.space.ld
@@ -78,7 +78,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > ksram
 

--- a/boards/arm/stm32h7/nucleo-h723zg/scripts/user-space.ld
+++ b/boards/arm/stm32h7/nucleo-h723zg/scripts/user-space.ld
@@ -80,7 +80,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32h7/nucleo-h743zi/scripts/flash-mcuboot-app.ld
+++ b/boards/arm/stm32h7/nucleo-h743zi/scripts/flash-mcuboot-app.ld
@@ -169,7 +169,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32h7/nucleo-h743zi/scripts/flash-mcuboot-loader.ld
+++ b/boards/arm/stm32h7/nucleo-h743zi/scripts/flash-mcuboot-loader.ld
@@ -169,7 +169,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32h7/nucleo-h743zi/scripts/flash-nxboot-app.ld
+++ b/boards/arm/stm32h7/nucleo-h743zi/scripts/flash-nxboot-app.ld
@@ -191,7 +191,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32h7/nucleo-h743zi/scripts/flash-nxboot-loader.ld
+++ b/boards/arm/stm32h7/nucleo-h743zi/scripts/flash-nxboot-loader.ld
@@ -189,7 +189,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32h7/nucleo-h743zi/scripts/flash.ld
+++ b/boards/arm/stm32h7/nucleo-h743zi/scripts/flash.ld
@@ -169,7 +169,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32h7/nucleo-h743zi/scripts/kernel.space.ld
+++ b/boards/arm/stm32h7/nucleo-h743zi/scripts/kernel.space.ld
@@ -78,7 +78,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > ksram
 

--- a/boards/arm/stm32h7/nucleo-h743zi/scripts/user-space.ld
+++ b/boards/arm/stm32h7/nucleo-h743zi/scripts/user-space.ld
@@ -80,7 +80,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32h7/nucleo-h743zi2/scripts/flash.ld
+++ b/boards/arm/stm32h7/nucleo-h743zi2/scripts/flash.ld
@@ -169,7 +169,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32h7/nucleo-h743zi2/scripts/user-space.ld
+++ b/boards/arm/stm32h7/nucleo-h743zi2/scripts/user-space.ld
@@ -80,7 +80,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32h7/nucleo-h745zi/scripts/flash.ld
+++ b/boards/arm/stm32h7/nucleo-h745zi/scripts/flash.ld
@@ -113,7 +113,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32h7/nucleo-h745zi/scripts/flash_m4.ld
+++ b/boards/arm/stm32h7/nucleo-h745zi/scripts/flash_m4.ld
@@ -105,7 +105,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32h7/openh743i/scripts/flash.ld
+++ b/boards/arm/stm32h7/openh743i/scripts/flash.ld
@@ -166,7 +166,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32h7/portenta-h7/scripts/flash.ld
+++ b/boards/arm/stm32h7/portenta-h7/scripts/flash.ld
@@ -119,7 +119,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32h7/portenta-h7/scripts/flash_m4.ld
+++ b/boards/arm/stm32h7/portenta-h7/scripts/flash_m4.ld
@@ -105,7 +105,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32h7/stm32h745i-disco/scripts/flash.ld
+++ b/boards/arm/stm32h7/stm32h745i-disco/scripts/flash.ld
@@ -188,7 +188,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32h7/stm32h745i-disco/scripts/flash_m4.ld
+++ b/boards/arm/stm32h7/stm32h745i-disco/scripts/flash_m4.ld
@@ -104,7 +104,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32h7/stm32h745i-disco/scripts/gnu-elf.ld
+++ b/boards/arm/stm32h7/stm32h745i-disco/scripts/gnu-elf.ld
@@ -107,7 +107,7 @@ SECTIONS
       *(.sbss.*)
       *(.gnu.linkonce.b*)
       *(COMMON)
-      . = ALIGN(4);
+      . = ALIGN(8);
       _ebss = . ;
     }
 

--- a/boards/arm/stm32h7/stm32h745i-disco/scripts/user-space.ld
+++ b/boards/arm/stm32h7/stm32h745i-disco/scripts/user-space.ld
@@ -80,7 +80,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32h7/stm32h747i-disco/scripts/flash.ld
+++ b/boards/arm/stm32h7/stm32h747i-disco/scripts/flash.ld
@@ -167,7 +167,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32h7/stm32h747i-disco/scripts/kernel.space.ld
+++ b/boards/arm/stm32h7/stm32h747i-disco/scripts/kernel.space.ld
@@ -78,7 +78,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > ksram
 

--- a/boards/arm/stm32h7/stm32h747i-disco/scripts/user-space.ld
+++ b/boards/arm/stm32h7/stm32h747i-disco/scripts/user-space.ld
@@ -80,7 +80,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32h7/stm32h750b-dk/scripts/flash.ld
+++ b/boards/arm/stm32h7/stm32h750b-dk/scripts/flash.ld
@@ -187,7 +187,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32h7/stm32h750b-dk/scripts/flash_m4.ld
+++ b/boards/arm/stm32h7/stm32h750b-dk/scripts/flash_m4.ld
@@ -102,7 +102,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32h7/stm32h750b-dk/scripts/gnu-elf.ld
+++ b/boards/arm/stm32h7/stm32h750b-dk/scripts/gnu-elf.ld
@@ -105,7 +105,7 @@ SECTIONS
       *(.sbss.*)
       *(.gnu.linkonce.b*)
       *(COMMON)
-      . = ALIGN(4);
+      . = ALIGN(8);
       _ebss = . ;
     }
 

--- a/boards/arm/stm32h7/stm32h750b-dk/scripts/user-space.ld
+++ b/boards/arm/stm32h7/stm32h750b-dk/scripts/user-space.ld
@@ -78,7 +78,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32h7/weact-stm32h743/scripts/flash.ld
+++ b/boards/arm/stm32h7/weact-stm32h743/scripts/flash.ld
@@ -169,7 +169,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32h7/weact-stm32h743/scripts/user-space.ld
+++ b/boards/arm/stm32h7/weact-stm32h743/scripts/user-space.ld
@@ -80,7 +80,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32h7/weact-stm32h750/scripts/flash.ld
+++ b/boards/arm/stm32h7/weact-stm32h750/scripts/flash.ld
@@ -169,7 +169,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32h7/weact-stm32h750/scripts/user-space.ld
+++ b/boards/arm/stm32h7/weact-stm32h750/scripts/user-space.ld
@@ -80,7 +80,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32l4/b-l475e-iot01a/scripts/flash.ld
+++ b/boards/arm/stm32l4/b-l475e-iot01a/scripts/flash.ld
@@ -91,7 +91,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32l4/nucleo-l432kc/scripts/l432kc.ld
+++ b/boards/arm/stm32l4/nucleo-l432kc/scripts/l432kc.ld
@@ -88,7 +88,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32l4/nucleo-l452re/scripts/l452re-flash.ld
+++ b/boards/arm/stm32l4/nucleo-l452re/scripts/l452re-flash.ld
@@ -88,7 +88,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32l4/nucleo-l476rg/scripts/l476rg.ld
+++ b/boards/arm/stm32l4/nucleo-l476rg/scripts/l476rg.ld
@@ -88,7 +88,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32l4/nucleo-l496zg/scripts/kernel-space.ld
+++ b/boards/arm/stm32l4/nucleo-l496zg/scripts/kernel-space.ld
@@ -78,7 +78,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > ksram
 

--- a/boards/arm/stm32l4/nucleo-l496zg/scripts/l496zg-flash.ld
+++ b/boards/arm/stm32l4/nucleo-l496zg/scripts/l496zg-flash.ld
@@ -88,7 +88,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32l4/nucleo-l496zg/scripts/user-space.ld
+++ b/boards/arm/stm32l4/nucleo-l496zg/scripts/user-space.ld
@@ -80,7 +80,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32l4/stm32l476-mdk/scripts/stm32l476-mdk.ld
+++ b/boards/arm/stm32l4/stm32l476-mdk/scripts/stm32l476-mdk.ld
@@ -93,7 +93,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32l4/stm32l476vg-disco/scripts/kernel-space.ld
+++ b/boards/arm/stm32l4/stm32l476vg-disco/scripts/kernel-space.ld
@@ -78,7 +78,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > ksram
 

--- a/boards/arm/stm32l4/stm32l476vg-disco/scripts/stm32l476vg-disco.ld
+++ b/boards/arm/stm32l4/stm32l476vg-disco/scripts/stm32l476vg-disco.ld
@@ -93,7 +93,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32l4/stm32l476vg-disco/scripts/user-space.ld
+++ b/boards/arm/stm32l4/stm32l476vg-disco/scripts/user-space.ld
@@ -80,7 +80,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32l4/stm32l4r9ai-disco/scripts/kernel-space.ld
+++ b/boards/arm/stm32l4/stm32l4r9ai-disco/scripts/kernel-space.ld
@@ -78,7 +78,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > ksram
 

--- a/boards/arm/stm32l4/stm32l4r9ai-disco/scripts/stm32l4r9ai-disco.ld
+++ b/boards/arm/stm32l4/stm32l4r9ai-disco/scripts/stm32l4r9ai-disco.ld
@@ -96,7 +96,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32l4/stm32l4r9ai-disco/scripts/user-space.ld
+++ b/boards/arm/stm32l4/stm32l4r9ai-disco/scripts/user-space.ld
@@ -80,7 +80,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > usram
 

--- a/boards/arm/stm32l5/nucleo-l552ze/scripts/flash.ld
+++ b/boards/arm/stm32l5/nucleo-l552ze/scripts/flash.ld
@@ -86,7 +86,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32l5/stm32l562e-dk/scripts/tfm-ns.ld
+++ b/boards/arm/stm32l5/stm32l562e-dk/scripts/tfm-ns.ld
@@ -97,7 +97,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32u5/b-u585i-iot02a/scripts/flash.ld
+++ b/boards/arm/stm32u5/b-u585i-iot02a/scripts/flash.ld
@@ -86,7 +86,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32u5/b-u585i-iot02a/scripts/tfm-ns.ld
+++ b/boards/arm/stm32u5/b-u585i-iot02a/scripts/tfm-ns.ld
@@ -97,7 +97,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32u5/nucleo-u5a5zj-q/scripts/flash.ld
+++ b/boards/arm/stm32u5/nucleo-u5a5zj-q/scripts/flash.ld
@@ -86,7 +86,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32u5/nucleo-u5a5zj-q/scripts/tfm-ns.ld
+++ b/boards/arm/stm32u5/nucleo-u5a5zj-q/scripts/tfm-ns.ld
@@ -97,7 +97,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 

--- a/boards/arm/stm32wb/flipperzero/scripts/flipperzero.ld
+++ b/boards/arm/stm32wb/flipperzero/scripts/flipperzero.ld
@@ -97,7 +97,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram1
 

--- a/boards/arm/stm32wb/nucleo-wb55rg/scripts/wb55rg.ld
+++ b/boards/arm/stm32wb/nucleo-wb55rg/scripts/wb55rg.ld
@@ -97,7 +97,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram1
 

--- a/boards/arm/stm32wl5/nucleo-wl55jc/scripts/wl55jc.ld
+++ b/boards/arm/stm32wl5/nucleo-wl55jc/scripts/wl55jc.ld
@@ -88,7 +88,7 @@ SECTIONS
         *(.bss .bss.*)
         *(.gnu.linkonce.b.*)
         *(COMMON)
-        . = ALIGN(4);
+        . = ALIGN(8);
         _ebss = ABSOLUTE(.);
     } > sram
 


### PR DESCRIPTION
This patch fixes [BUG #18558] for STM32 variants by aligning _ebss symbol(used as base of idle stack) in linker files to 8-byte boundary to conform to AAPCS-32. This PR does not address all possible ARM cases where idles tack does not align to AAPCS-32.

## Summary

Currently STM32 builds use _ebss symbol (located at end of .bss linker section) as the base address of the idle stack, but _ebss is not aligned to AAPCS-32 required 8-byte boundary.  Normally this isn't an issue but vararg processing by GCC forcibly aligns accesses of long long on 8-byte boundaries causing remaining varargs to be misaligned. Depending on stack content this bug can cause an exception.

While adding code to remove the "Missing logic" warning in stm32_irq.c:152 I ran into a bus fault exception while calling syslog() from stm32_dumpnvic during startup(which uses the idle stack) on a nucleo-stm32h743zi2 board(based on stm32h7). This was also observed on nucleo-f446re(stm32) and nuclio-f767zi(stm32f7) when configured to have an unaligned idle stack.

The fix is to force _ebss alignment to an 8-byte boundary in the linker files.

## Impact
If _ebss is not aligned on an 8-byte boundary then any varag processing in the idle task (e.g. syslog message with timestamps) can cause an exception.  This issue I believe potentially affects a vast majority of 32-bit ARM ports(arm64 looks to use a separate properly aligned section for the idle stack).

## Testing

Build Host:

    OS: Ubuntu 24.04.4 LTS
    Compiler: arm-none-eabi-gcc 13.2.1

Target:

    Architecture: ARM (STM32H7x3ZIx)
    Board: Nucleo-h743zi2
    Configuration: Default nucleo-h743zi2:jumbo 

    Architecture: ARM (STM32F767ZITx)
    Board: Nucleo-f767zi
    Configuration: Default nucleo-h767zi:nsh

    Architecture: ARM (STM32F446RETx)
    Board: Nucleo-f446re
    Configuration: Default nucleo-f446re:nsh 

in 'make menuconfig' enable ARCH_IRQPRIO, DEBUG_FEATURES, DEBUG_IRQ, DEBUG_IRQ_INFO, then built/booted(log for nucleo-h743zi2 shown) to have syslog messages called from idle task:

```
NuttShell (NSH) NuttX-12.12.0
nsh> uname -a
NuttX  12.12.0 43c15b3ddb-dirty Mar 20 2026 10:47:30 arm nucleo-h743zi2
nsh> dmesg
[    0.000000] [  INFO] Idle_Task: stm32_dumpnvic: NVIC (initial, irq=179):
[    0.000000] [  INFO] Idle_Task: stm32_dumpnvic:   INTCTRL:    00000000 VECTAB:  08000000
[    0.000000] [  INFO] Idle_Task: stm32_dumpnvic:   IRQ ENABLE: 00000000 00000000 00000000
[    0.000000] [  INFO] Idle_Task: stm32_dumpnvic:   SYSH_PRIO:  00808080 70000000 80800080
[    0.000000] [  INFO] Idle_Task: stm32_dumpnvic:   IRQ PRIO:   80808080 80808080 80808080 80808080
[    0.000000] [  INFO] Idle_Task: stm32_dumpnvic:               80808080 80808080 80808080 80nsh>


```
Repeated on nucleo-f767zi and nucleo-f446re.

