### PR TITLE
net/nat: g_nat_lock can be used recursively and nat_lock/unlock should be paired.

### DIFF
--- a/net/nat/nat.c
+++ b/net/nat/nat.c
@@ -118,6 +118,7 @@ int nat_enable(FAR struct net_driver_s *dev)
   if (IFF_IS_NAT(dev->d_flags))
     {
       nwarn("WARNING: NAT was already enabled for %s!\n", dev->d_ifname);
+      nat_unlock();
       return -EEXIST;
     }
 


### PR DESCRIPTION


*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

case: when rndis receive a packet and this packet is going to be forwarded.
1. first lock happen when ipv4_dev_forward call ipv4_nat_outbound;
2. next lock is: ipv4_nat_outbound_entry_find --> nat_port_select --> tcp_selectport --> nat_port_inuse

## Impact

fix assert when NET_NAT is enabled, and packet forwards from one net device to another.

## Testing

without this code, it has below assert:
<img width="591" height="524" alt="image" src="https://github.com/user-attachments/assets/7a1fcfe5-381a-4971-b1e8-82929f77241c" />
