### PR TITLE
CI: Retry build upon failure

### DIFF
--- a/Documentation/components/tools/testbuild.rst
+++ b/Documentation/components/tools/testbuild.rst
@@ -23,7 +23,7 @@ option shows the usage:
      -a <appsdir> provides the relative path to the apps/ directory.  Default ../apps
      -t <topdir> provides the absolute path to top nuttx/ directory.  Default ../nuttx
      -p only print the list of configs without running any builds
-     -A store the build executable artifact in ARTIFACTDIR (defaults to ../buildartifacts
+     -A store the build executable artifact in ARTIFACTDIR (defaults to ../buildartifacts)
      -C Skip tree cleanness check.
      -G Use "git clean -xfdq" instead of "make distclean" to clean the tree.
         This option may speed up the builds. However, note that:
@@ -73,3 +73,12 @@ The prefix ``-`` can be used to skip a configuration::
 or skip a configuration on a specific host(e.g. Darwin)::
 
   -Darwin,sim:rpserver
+
+This script will rebuild each configuration, upon failure, up to 3 times.
+Each rebuild will be attempted after a randomised delay with exponential
+backoff, initially set to 60 seconds. The rebuilds will mitigate the
+effects of intermittent download failures that occur in GitHub Actions.
+
+If the build fails after 3 retries, subsequent configurations will not
+be allowed to rebuild upon failure.  This is to prevent cascading build
+failures from overloading GitHub Actions.

--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -24,6 +24,7 @@ nuttx=$WD/../nuttx
 
 progname=$0
 fail=0
+maxbuilds=4  # Retry 3 times on failure
 APPSDIR=$WD/../apps
 if [ -z $ARTIFACTDIR ]; then
   ARTIFACTDIR=$WD/../buildartifacts
@@ -580,6 +581,49 @@ function dotest {
   fi
 }
 
+# Build one entry from the test list file. Retry on failure.
+function retrytest {
+  # Remember the Fail Status and clear it for each build
+  local line=$1
+  local prevfail=$fail
+  local backoff=60  # Initial Exponential Backoff, in seconds
+
+  # Build and retry on failure, with Random Exponential Backoff
+  for ((i = 1; i <= $maxbuilds; i++)); do
+    echo "Build Attempt $i of $maxbuilds"
+    fail=0
+    dotest $line
+
+    # Don't retry if the build succeeded
+    if [ ${fail} -eq 0 ]; then
+      break
+    else
+      # Build Failed: Clean up any corrupted downloads, don't reuse
+      git -C $nuttx clean -fd
+      git -C $APPSDIR clean -fd
+      pushd $nuttx ; git status ; popd
+      pushd $APPSDIR ; git status ; popd
+    fi
+
+    # If this is Final Retry: Don't retry subsequent builds
+    if [ $i -eq $maxbuilds ]; then
+			maxbuilds=1
+      break
+    fi
+
+    # Wait for Random Exponential Backoff, then retry
+    delay=$(( (RANDOM % $backoff) + 1 ))
+    echo "Wait $delay seconds ($backoff backoff)"
+    backoff=$(($backoff * 2))
+    sleep $delay
+  done
+
+  # Return the Previous Fail Status, unless this build failed
+  if [ ${fail} -eq 0 ]; then
+    fail=$prevfail
+  fi
+}
+
 # Perform the build test for each entry in the test list file
 
 for line in $testlist; do
@@ -588,10 +632,10 @@ for line in $testlist; do
     dir=`echo $line | cut -d',' -f1`
     list=`find boards$dir -name defconfig | cut -d'/' -f4,6`
     for i in ${list}; do
-      dotest $i${line/"$dir"/}
+      retrytest $i${line/"$dir"/}
     done
   else
-    dotest $line
+    retrytest $line
   fi
 done
 


### PR DESCRIPTION
## Summary

In Jan-Feb 2026: NuttX CI hit a [record high usage of GitHub Runners](https://github.com/apache/nuttx/issues/17914), exceeding the limit enforced by ASF Infrastructure Team. We analysed the PRs and discovered that most GitHub Runners were wasted on __(1) Failure to Download the Build Dependencies__ for DTC Device Tree, OpenAMP Messaging, MicroADB Debugger, MCUBoot Bootloader, NimBLE Bluetooth, etc __(2) Resubmitting PR Commits__:

- [Video: Analysing the Most Expensive PR](https://youtu.be/swFaxaTCEQg)
- [Video: Second Most Expensive PR](https://youtu.be/uSpQkzBogEw)
- [Video: Third Most Expensive PR](https://youtu.be/J7w1gyjwZ1w)
- [Video: Most Expensive Apps PR](https://youtu.be/182h8cRpfvI)
- [Spreadsheet: Most Expensive PRs](https://docs.google.com/spreadsheets/d/1HY7fIZzd_fs3QPyA0TX7vsYOjL86m1fNOf1Wls93luI/edit?gid=70515654#gid=70515654)

Why would __Download Failures__ waste GitHub Runners? That's because Download Failures will terminate the Entire CI Build (across All CI Jobs), requiring a restart of the CI Build. And the CI Build isn't terminated immediately upon failure: NuttX CI waits for the CI Job to complete (e.g. `arm-01`), before terminating the CI Build. Which means that CI Builds can get terminated 2.5 hours into the CI Build, wasting 2.5 elapsed hours x [7.4 parallel processes](https://lupyuen.org/articles/ci3#live-metric-for-full-time-runners) of GitHub Runners.

This PR proposes to __Retry the Build for Each CI Target__. NuttX CI shall rebuild each CI Target (e.g. `sim:nsh`), upon failure, up to 3 times (total 4 builds). Each rebuild will be attempted after a Randomised Delay with Exponential
Backoff, initially set to 60 seconds, then 120 seconds, 240 seconds. The rebuilds will mitigate the effects of Intermittent Download Failures that occur in GitHub Actions. (And eliminate developer frustration)

If the build fails after 3 retries: Subsequent CI Targets will __not be allowed to rebuild__ upon failure. This is to prevent cascading build failures from overloading GitHub Actions, and consuming too many GitHub Runners.

Note that NuttX CI shall retry the build for __Any Kind of Build Failure__, including Download Failures, Compile Errors and Config Errors. We designed it simplistically due to our current constraints: (1) Lack of CI Expertise (2) NuttX CI is Mission Critical (3) Legacy CI Scripts are Highly Complex (explained below). To prevent Compile Errors and Config Errors: We expect NuttX Devs to [Build and Test PRs in Our Own Repos](https://github.com/apache/nuttx/issues/18568), before submitting to NuttX.

What about __Resubmitting PR Commits__ and its wastage of GitHub Runners? We also require NuttX Devs to [Build and Test PRs in Our Own Repos](https://github.com/apache/nuttx/issues/18568), before resubmitting to NuttX. GitHub Runners will then be charged to the developer's quota, without affecting the GitHub Runners quota for Apache NuttX Project. We plan to [Kill All CI Jobs](https://youtu.be/182h8cRpfvI?si=MmAuwLISZPPMoqDq&t=1479) for PRs that have been switched to Draft Mode. We'll monitor this through the [NuttX Build Monitor](https://github.com/apache/nuttx/issues/18659).

### Modified Files

`tools/testbuild.sh`: We introduce a New Wrapper Function `retrytest` that will call the Existing Function `dotest`, to build the CI Target and retry on error.

`Documentation/components/tools/testbuild.rst`: Updated the `testbuild.sh` doc with the Retry Logic.

![retry-build](https://github.com/user-attachments/assets/f62fecc0-1ad2-4316-82e8-e7892d55e85c)

## Impact

NuttX CI shall retry the build for __Any Kind of Build Failure__, including Download Failures, Compile Errors and Config Errors. We designed it simplistically due to our current constraints:

1. __Lack of CI Expertise:__ We have a tiny team of 2 part-time volunteers, managing everything in NuttX CI. We cannot afford to roll out and maintain Complex CI Solutions. That's why we are not able to detect the kind of Build Failure and handle it intelligently: Download Failure vs Compile Error vs Config Error

2. __NuttX CI is Mission Critical:__ NuttX CI must run continuously 24 x 7, especially during Peak Periods (Jan-Feb) and NuttX Release Windows. NuttX CI must never fail e.g. due to the Retry Logic.

3. __Legacy CI Scripts are Highly Complex:__ We have inherited many Legacy CI Scripts that we don't completely understand. Therefore we won't patch Individual CI Scripts, but instead, we introduce a New Wrapper Function `retrytest` that will call the Existing Function `dotest`, to build the Legacy CI Target and retry on error.

4. To prevent __Compile Errors and Config Errors:__ We expect NuttX Devs to [Build and Test PRs in Our Own Repos](https://github.com/apache/nuttx/issues/18568), before submitting to NuttX.

5. To minimise the Retry Delay for __Compile Errors and Config Errors:__ Subsequent CI Targets will __not be allowed to rebuild__ upon failure. This is to prevent cascading build failures from consuming too many GitHub Runners. (Also avoid wasting our developer's time)

With this simplistic solution, we hope to minimise any Retry Delays while eliminating Developer Frustration for failed downloads:

  * _Is new feature added?_ YES: CI Builds will now retry upon failure

  * _Impact on build / user?_ YES. CI Builds should no longer be terminated due to Download Failures. But CI Builds will be slightly slower (approx 5.6 minutes, see below) if there are Compile Errors and Config Errors, due to the Retry Logic. We expect NuttX Devs to [Build and Test PRs in Our Own Repos](https://github.com/apache/nuttx/issues/18568), before submitting to NuttX.

  * _Impact on hardware / compatibility / security?_ NO. We are reusing all Legacy CI Scripts, without changes.

  * _Impact on documentation?_ YES. We have updated the `testbuild.sh` doc with the Retry Logic.

## Testing

Why do we __Retry 3 Times__? We tested the Retry Logic over the Past 4 Weeks, across [50 Builds](https://github.com/apache/nuttx/actions/workflows/build.yml?query=branch%3Aretry-build+) in NuttX Production CI. Our Retry Logic successfully mitigated the following Download Failures, with a maximum of 3 retries (total 4 attempts). That's why we decided to Retry 3 Times:

```
Build Attempt 1 of N
Configuration/Tool: qemu-armv8a/netnsh_smp
Error: cannot find zipfile directory in one of libmetal.zip
...
Wait 58 seconds (60 backoff)
Build Attempt 2 of N
Configuration/Tool: qemu-armv8a/netnsh_smp
(Same download error)
...
Wait 2 seconds (120 backoff)
Build Attempt 3 of N
Configuration/Tool: qemu-armv8a/netnsh_smp
(Same download error)
...
Wait 103 seconds (240 backoff)
Build Attempt 4 of N
Configuration/Tool: qemu-armv8a/netnsh_smp
(Successful at 4th attempt yay!)
```

1. `qemu-armv8a:netnsh_smp` OK after 4 attempts: [OpenAMP libmetal download retry](https://github.com/apache/nuttx/actions/runs/23934730717/job/69808952043#step:10:586)
 
1. `esp32s3-devkit:eth_lan9250` OK after 3 attempts: [Xtensa codeload.github download retry](https://github.com/apache/nuttx/actions/runs/23882896642/job/69641956931#step:10:911)

1. `icicle:rpmsg-ch2` OK after 2 attempts: [OpenAMP libmetal download retry](https://github.com/apache/nuttx/actions/runs/23979623780/job/69941955975#step:10:541)

1. `sim:matter` OK after 2 attempts: [LLVM libcxx download retry](https://github.com/apache/nuttx/actions/runs/23934730717/job/69808952040#step:10:964)

1. `sim:matter` OK after 2 attempts: [NestLabs nlunit-test download retry](https://github.com/apache/nuttx/actions/runs/23934730717/job/69808952040#step:10:964)

1. `nrf52832-dk:sdc` OK after 2 attempts: [nRFConnect sdk-nrfxlib download retry](https://github.com/apache/nuttx/actions/runs/23979623780/job/69941955961#step:10:1145)

   [(We exclude sim:nxcamera, which has been fixed)](https://github.com/apache/nuttx-apps/pull/3449)

<hr>

__For Compile Errors:__ Subsequent CI Targets will not be allowed to rebuild upon failure. To test this, we simulate a Compile Error: https://github.com/lupyuen13/nuttx/actions/runs/24430763763/job/71374671998#step:10:273

```
Build Attempt 1 of 4 @ 2026-04-15 01:09:04
Error: SIMULATED_COMPILE_ERROR' undeclared
...
Wait 38 seconds (60 backoff)
Build Attempt 2 of 4 @ 2026-04-15 01:10:35
(Same compile error)
...
Wait 75 seconds (120 backoff)
Build Attempt 3 of 4 @ 2026-04-15 01:12:18
(Same compile error)
...
Wait 183 seconds (240 backoff)
Build Attempt 4 of 4 @ 2026-04-15 01:15:49
(Same compile error)
...
(Next CI Target)
Build Attempt 1 of 1 @ 2026-04-15 01:16:16
```

Note that Max Attempts has been reduced to 1 (instead of 4). We see that Subsequent CI Targets will not be allowed to rebuild upon failure: https://github.com/lupyuen13/nuttx/actions/runs/24430763763/job/71374671998#step:10:516

```
Build Attempt 1 of 1: pinephone/lvgl
Error: SIMULATED_COMPILE_ERROR' undeclared
...
Build Attempt 1 of 1: pinephone/sensor
(Same compile error)
```

From above: We see that the Retry Delay is 5.6 minutes. Which means that our developers shall wait roughly 5.6 minutes for the First Compile Error to complete all retries. Subsequent Compile Errors will not incur any Retry Delay:

```
(First CI Target)
Build Attempt 1 of 4 @ 2026-04-15 01:09:04
Build Attempt 2 of 4 @ 2026-04-15 01:10:35
...
(Next CI Target)
Build Attempt 1 of 1 @ 2026-04-15 01:16:16
```

<hr>

__For Config Errors:__ Subsequent CI Targets will not be allowed to rebuild upon failure. To test this, we simulate a Config Error: https://github.com/lupyuen13/nuttx/actions/runs/24430804675/job/71374813812#step:10:272

```
Build Attempt 1 of 4: pinephone/nsh
  [1/1] Normalize pinephone/nsh
8d7
< CONFIG_SECOND_SIMULATED_CONFIG_ERROR=0
...
Wait 24 seconds (60 backoff)
Build Attempt 2 of 4
(Same config error)
...
Wait 65 seconds (120 backoff)
Build Attempt 3 of 4
(Same config error)
...
Wait 105 seconds (240 backoff)
Build Attempt 4 of 4
(Same config error)
```

Note that Max Attempts will be reduced to 1 (instead of 4). We see that Subsequent CI Targets will not be allowed to rebuild upon failure: https://github.com/lupyuen13/nuttx/actions/runs/24430804675/job/71374813812#step:10:469

```
Build Attempt 1 of 1: pinephone/lcd
...
Build Attempt 1 of 1: pinephone/lvgl
```

<hr>

_Could this Download Failure be a problem with GitHub Actions? Shouldn't we escalate to GitHub?_

Outside GitHub Actions: We see the same Download Failures happening in our [NuttX Build Farm](https://lupyuen.org/articles/dashboard) (see below), which runs on a Home PC. Thus it's not a problem specific to GitHub Actions. We should not assume that Dependency Downloads are perfect, we should always retry.

- NuttX Build Farm `qemu-armv8a:netnsh_smp`: [argtable3 download failed](https://gitlab.com/lupyuen/nuttx-build-log/-/snippets/5974610#L1915)

- NuttX Build Farm `sim:lua`: [lua download failed](https://gitlab.com/lupyuen/nuttx-build-log/-/snippets/5973861#L1219)

_NuttX CI uses a Docker Container, in GitHub Actions and in NuttX Build Farm. Maybe our Docker Image isn't configured correctly for networking?_

That's possible. However our team has no expertise to troubleshoot Docker Networking.

_Isn't it easier to fix the curl command in our Build Scripts to do retry?_

There are at least [73 curl commands](https://github.com/search?q=repo%3Aapache%2Fnuttx-apps+curl+language%3AMakefile&type=code&p=2&l=Makefile) in our Build Scripts. We will require significant effort to change and test all 73 curl commands. FYI curl also supports [Exponential Backoff](https://everything.curl.dev/usingcurl/downloads/retry.html#tweak-your-retries) (not randomised though).

More videos on CI Build Retry:
- [Apache NuttX RTOS: Retrying a CI Build](https://www.youtube.com/watch?v=LBhEJ6Qf4iM)
- [Apache NuttX RTOS: Testing of Retry for CI Builds](https://youtu.be/RbO4b8sN_do)
- [Apache NuttX RTOS: More Testing of Retry for CI Builds](https://youtu.be/fPYsLWljAHY)
