### PR TITLE
docs: Fix typos, formatting, and numbering in README.md and CONTRIBUTING.md.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thank you for your interest in contributing to Apache NuttX RTOS :-)
 
 If you haven't yet read
-[The Inviolable Principles of NuttX]( https://github.com/apache/nuttx/blob/master/INVIOLABLES.md)
+[The Inviolable Principles of NuttX](https://github.com/apache/nuttx/blob/master/INVIOLABLES.md)
 please do so first.
 
 Apache NuttX RTOS supports over 15 different architectures, 360+ boards,
@@ -355,8 +355,8 @@ See: https://github.com/apache/nuttx/blob/master/INVIOLABLES.md
 2. Single company / organization commit, review, and merge is not allowed.
 3. Merge of PRs with unresolved discussions and "change request" marks
    is not allowed.
-3. Self committed code merge with or without review is not allowed.
-4. Direct push to master is not allowed.
+4. Self committed code merge with or without review is not allowed.
+5. Direct push to master is not allowed.
 
 Breaking these rules will be punished.
 
@@ -395,7 +395,7 @@ Add g_ prefix to can_dlc_to_len and len_to_can_dlc to
 follow NuttX coding style conventions for global symbols,
 improving code readability and maintainability.
 * you can also use bullet points.
-* to note different thing briefly.
+* to note different things briefly.
 
 Signed-off-by: AuthorName <Valid@EmailAddress>
 ```

--- a/README.md
+++ b/README.md
@@ -3,11 +3,9 @@
 </p>
 
 ![POSIX Badge](https://img.shields.io/badge/POSIX-Compliant-brightgreen?style=flat&label=POSIX)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue
-)](https://nuttx.apache.org/docs/latest/introduction/licensing.html)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue)](https://nuttx.apache.org/docs/latest/introduction/licensing.html)
 ![Issues Tracking Badge](https://img.shields.io/badge/issue_track-github-blue?style=flat&label=Issue%20Tracking)
-[![Contributors](https://img.shields.io/github/contributors/apache/nuttx
-)](https://github.com/apache/nuttx/graphs/contributors)
+[![Contributors](https://img.shields.io/github/contributors/apache/nuttx)](https://github.com/apache/nuttx/graphs/contributors)
 [![GitHub Build Badge](https://github.com/apache/nuttx/workflows/Build/badge.svg)](https://github.com/apache/nuttx/actions/workflows/build.yml)
 [![Documentation Badge](https://github.com/apache/nuttx/workflows/Build%20Documentation/badge.svg)](https://nuttx.apache.org/docs/latest/index.html)
 


### PR DESCRIPTION
## Summary

  * Fix multiple documentation formatting issues in README.md and CONTRIBUTING.md.
  * These are documentation-only changes with no code impact.
  * Changes include:
    - **README.md**: Merge multi-line badge markdown (License and Contributors) into single lines to follow standard markdown format.
    - **CONTRIBUTING.md**: Remove extra leading space in the Inviolable Principles link URL (`( https://...` → `(https://...`).
    - **CONTRIBUTING.md**: Fix duplicate numbering in section 1.17 Merge rules (two items were both numbered `3.`, renumbered correctly to 3, 4, 5).
    - **CONTRIBUTING.md**: Fix typo in section 2.2 commit template example, `different thing` → `different things` (missing plural 's').

## Impact

  * Is new feature added? Is existing feature changed? NO.
  * Impact on user (will user need to adapt to change)? NO.
  * Impact on build (will build process change)? NO.
  * Impact on hardware (will arch(s) / board(s) / driver(s) change)? NO.
  * Impact on documentation (is update required / provided)? YES - this PR is a documentation-only fix.
  * Impact on security (any sort of implications)? NO.
  * Impact on compatibility (backward/forward/interoperability)? NO.

## Testing

  Documentation-only change. No build or runtime testing required.
  Verified markdown rendering locally.

## PR verification Self-Check

  * [x] This PR introduces only one functional change.
  * [x] I have updated all required description fields above.
  * [x] My PR adheres to Contributing [Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) and [Documentation](https://nuttx.apache.org/docs/latest/contributing/index.html) (git commit title and message, coding standard, etc).
  * [ ] My PR is still work in progress (not ready for review).
  * [x] My PR is ready for review and can be safely merged into a codebase.