### PR TITLE
style: Fix "is is" typo across the codebase.

### DIFF
--- a/arch/arm/src/lpc214x/lpc214x_usbdev.c
+++ b/arch/arm/src/lpc214x/lpc214x_usbdev.c
@@ -198,7 +198,7 @@
 
 /* USB RAM  *****************************************************************
  *
- * UBS_UDCA is is list of 32 pointers to DMA descriptors located at the
+ * UBS_UDCA is a list of 32 pointers to DMA descriptors located at the
  * beginning of USB RAM.  Each pointer points to a DMA descriptor with
  * associated DMA buffer.
  */

--- a/arch/arm/src/sam34/sam_allocateheap.c
+++ b/arch/arm/src/sam34/sam_allocateheap.c
@@ -59,7 +59,7 @@
 #undef HAVE_EXTSRAM2_REGION  /* Assume no external SRAM at CS2 */
 #undef HAVE_EXTSRAM3_REGION  /* Assume no external SRAM at CS3 */
 
-/* Check if external SRAM is supported and, if so, it is is intended
+/* Check if external SRAM is supported and, if so, it is intended
  * to be used as heap.
  */
 

--- a/arch/arm/src/sama5/sam_pmc.c
+++ b/arch/arm/src/sama5/sam_pmc.c
@@ -72,7 +72,7 @@
  *   the frequency of the PPA output clock, PLLACK
  *
  * Assumptions:
- *   PLLA is enabled.  If the PLL is is disabled, either at the input divider
+ *   PLLA is enabled.  If the PLL is disabled, either at the input divider
  *   or the output multiplier, the value zero is returned.
  *
  ****************************************************************************/

--- a/arch/arm/src/sama5/sam_pmc.h
+++ b/arch/arm/src/sama5/sam_pmc.h
@@ -56,7 +56,7 @@ extern "C"
  *   the frequency of the PPA output clock, PLLACK
  *
  * Assumptions:
- *   PLLA is enabled.  If the PLL is is disabled, either at the input divider
+ *   PLLA is enabled.  If the PLL is disabled, either at the input divider
  *   or the output multiplier, the value zero is returned.
  *
  ****************************************************************************/

--- a/arch/arm/src/samv7/sam_allocateheap.c
+++ b/arch/arm/src/samv7/sam_allocateheap.c
@@ -54,7 +54,7 @@
 #define HAVE_EXTSRAM2_REGION  0 /* Assume no external SRAM at CS2 */
 #define HAVE_EXTSRAM3_REGION  0 /* Assume no external SRAM at CS3 */
 
-/* Check if external SDRAM is supported and, if so, it is is intended
+/* Check if external SDRAM is supported and, if so, it is intended
  * to be used as heap.
  */
 

--- a/arch/arm/src/samv7/sam_usbdevhs.c
+++ b/arch/arm/src/samv7/sam_usbdevhs.c
@@ -4518,7 +4518,7 @@ static int sam_pullup(struct usbdev_s *dev, bool enable)
            *     of the reset (USBHS_DEVISR.EORST = 1).
            *
            * The class implementation should not call this method with
-           * enable == true until is is fully initialized and ready to
+           * enable == true until it is fully initialized and ready to
            * accept connections.
            */
 

--- a/arch/z80/include/irq.h
+++ b/arch/z80/include/irq.h
@@ -38,7 +38,7 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* The Z80 stack does not need to be aligned.  Here is is aligned at word
+/* The Z80 stack does not need to be aligned.  Here it is aligned at word
  * (4 byte) boundary.
  */
 

--- a/arch/z80/src/common/z80_createstack.c
+++ b/arch/z80/src/common/z80_createstack.c
@@ -191,7 +191,7 @@ int up_create_stack(FAR struct tcb_s *tcb, size_t stack_size, uint8_t ttype)
 
       top_of_stack = (uintptr_t)tcb->stack_alloc_ptr + stack_size;
 
-      /* The Z80 stack does not need to be aligned.  Here is is aligned at
+      /* The Z80 stack does not need to be aligned.  Here it is aligned at
        * word (4 byte) boundary.
        */
 

--- a/audio/audio_comp.c
+++ b/audio/audio_comp.c
@@ -42,7 +42,7 @@
 
 struct audio_comp_priv_s
 {
-  /* This is is our appearance to the outside world. This *MUST* be the
+  /* This is our appearance to the outside world. This *MUST* be the
    * first element of the structure so that we can freely cast between
    * types struct audio_lowerhalf and struct audio_comp_dev_s.
    */

--- a/audio/pcm_decode.c
+++ b/audio/pcm_decode.c
@@ -51,7 +51,7 @@
 
 struct pcm_decode_s
 {
-  /* This is is our our appearance to the outside world.  This *MUST* be the
+  /* This is our appearance to the outside world.  This *MUST* be the
    * first element of the structure so that we can freely cast between types
    * struct audio_lowerhalf and struct pcm_decode_s.
    */

--- a/boards/arm/a1x/pcduino-a10/include/board.h
+++ b/boards/arm/a1x/pcduino-a10/include/board.h
@@ -86,7 +86,7 @@
 #define LED_ASSERTION       3   /* An assertion failed      N/C  N/C  Soft glow */
 #define LED_PANIC           3   /* The system has crashed   N/C  N/C  2Hz Flashing */
 
-/*      LED_IDLE           ---     MCU is is sleep mode         Not used
+/*      LED_IDLE           ---     MCU is in sleep mode         Not used
  *
  * After booting, LED1 and 3 are not longer used by the system and can be
  * used for other purposes by the application (Of course, all LEDs are

--- a/boards/arm/a1x/pcduino-a10/src/a1x_leds.c
+++ b/boards/arm/a1x/pcduino-a10/src/a1x_leds.c
@@ -65,7 +65,7 @@
  *   LED_SIGNAL        In a signal handler      N/C  N/C  Soft glow
  *   LED_ASSERTION     An assertion failed      N/C  N/C  Soft glow
  *   LED_PANIC         The system has crashed   N/C  N/C  2Hz Flashing
- *   LED_IDLE          MCU is is sleep mode         Not used
+ *   LED_IDLE          MCU is in sleep mode         Not used
  *
  * After booting, LED1 and 3 are not longer used by the system and can be
  * used for other purposes by the application (Of course, all LEDs are
@@ -108,7 +108,7 @@ void a1x_led_initialize(void)
  *   LED_SIGNAL          3   In a signal handler      N/C  N/C  Soft glow
  *   LED_ASSERTION       3   An assertion failed      N/C  N/C  Soft glow
  *   LED_PANIC           3   The system has crashed   N/C  N/C  2Hz Flashing
- *   LED_IDLE           ---  MCU is is sleep mode         Not used
+ *   LED_IDLE           ---  MCU is in sleep mode         Not used
  *
  *   LED1 is illuminated by driving the output pins to a high value
  *   LED3 and LED 4 are illuminated by taking the output to ground.
@@ -162,7 +162,7 @@ void board_autoled_on(int led)
  *   LED_SIGNAL          3   In a signal handler      N/C  N/C  Soft glow
  *   LED_ASSERTION       3   An assertion failed      N/C  N/C  Soft glow
  *   LED_PANIC           3   The system has crashed   N/C  N/C  2Hz Flashing
- *   LED_IDLE           ---  MCU is is sleep mode         Not used
+ *   LED_IDLE           ---  MCU is in sleep mode         Not used
  *
  *   LED1 is illuminated by driving the output pins to a high value
  *   LED3 and LED 4 are illuminated by taking the output to ground.

--- a/boards/arm/a1x/pcduino-a10/src/pcduino_a10.h
+++ b/boards/arm/a1x/pcduino-a10/src/pcduino_a10.h
@@ -87,7 +87,7 @@
  *   LED_SIGNAL        In a signal handler      N/C  N/C  Soft glow
  *   LED_ASSERTION     An assertion failed      N/C  N/C  Soft glow
  *   LED_PANIC         The system has crashed   N/C  N/C  2Hz Flashing
- *   LED_IDLE          MCU is is sleep mode         Not used
+ *   LED_IDLE          MCU is in sleep mode         Not used
  *
  * After booting, LED1 and 3 are not longer used by the system and can be
  * used for other purposes by the application (Of course, all LEDs are

--- a/boards/arm/am335x/beaglebone-black/include/board.h
+++ b/boards/arm/am335x/beaglebone-black/include/board.h
@@ -90,7 +90,7 @@
 #define LED_ASSERTION       3   /* An assertion failed      N/C  N/C  Soft glow */
 #define LED_PANIC           3   /* The system has crashed   N/C  N/C  2Hz Flashing */
 
-/*      LED_IDLE           ---     MCU is is sleep mode         Not used
+/*      LED_IDLE           ---     MCU is in sleep mode         Not used
  *
  * After booting, LED0 and 1 are not longer used by the system and can be
  * used for other purposes by the application (Of course, all LEDs are

--- a/boards/arm/am335x/beaglebone-black/src/am335x_leds.c
+++ b/boards/arm/am335x/beaglebone-black/src/am335x_leds.c
@@ -66,7 +66,7 @@
  *   LED_SIGNAL        In a signal handler      N/C  N/C  Soft glow
  *   LED_ASSERTION     An assertion failed      N/C  N/C  Soft glow
  *   LED_PANIC         The system has crashed   N/C  N/C  2Hz Flashing
- *   LED_IDLE          MCU is is sleep mode         Not used
+ *   LED_IDLE          MCU is in sleep mode         Not used
  *
  * After booting, LED0 and 1 are not longer used by the system and can be
  * used for other purposes by the application (Of course, all LEDs are
@@ -110,7 +110,7 @@ void am335x_led_initialize(void)
  *   LED_SIGNAL          3   In a signal handler      N/C  N/C  Soft glow
  *   LED_ASSERTION       3   An assertion failed      N/C  N/C  Soft glow
  *   LED_PANIC           3   The system has crashed   N/C  N/C  2Hz Flashing
- *   LED_IDLE           ---  MCU is is sleep mode         Not used
+ *   LED_IDLE           ---  MCU is in sleep mode         Not used
  *
  *   LED1 is illuminated by driving the output pins to a high value
  *   LED3 and LED 4 are illuminated by taking the output to ground.
@@ -164,7 +164,7 @@ void board_autoled_on(int led)
  *   LED_SIGNAL          3   In a signal handler      N/C  N/C  Soft glow
  *   LED_ASSERTION       3   An assertion failed      N/C  N/C  Soft glow
  *   LED_PANIC           3   The system has crashed   N/C  N/C  2Hz Flashing
- *   LED_IDLE           ---  MCU is is sleep mode         Not used
+ *   LED_IDLE           ---  MCU is in sleep mode         Not used
  *
  *   LED1 is illuminated by driving the output pins to a high value
  *   LED3 and LED 4 are illuminated by taking the output to ground.

--- a/boards/arm/am335x/beaglebone-black/src/beaglebone-black.h
+++ b/boards/arm/am335x/beaglebone-black/src/beaglebone-black.h
@@ -101,7 +101,7 @@
  *   LED_SIGNAL        In a signal handler      N/C  N/C  Soft glow
  *   LED_ASSERTION     An assertion failed      N/C  N/C  Soft glow
  *   LED_PANIC         The system has crashed   N/C  N/C  2Hz Flashing
- *   LED_IDLE          MCU is is sleep mode         Not used
+ *   LED_IDLE          MCU is in sleep mode         Not used
  *
  * After booting, LED1 and 3 are not longer used by the system and can be
  * used for other purposes by the application (Of course, all LEDs are

--- a/boards/arm/at32/at32f437-mini/include/board.h
+++ b/boards/arm/at32/at32f437-mini/include/board.h
@@ -211,7 +211,7 @@
  *   LED_SIGNAL           In a signal handler          No change
  *   LED_ASSERTION        An assertion failed          No change
  *   LED_PANIC            The system has crashed     OFF      Blinking
- *   LED_IDLE             AT32 is is sleep mode        Not used
+ *   LED_IDLE             AT32 is in sleep mode        Not used
  */
 
 #define LED_STARTED              0

--- a/boards/arm/at32/at32f437-mini/src/at32_autoleds.c
+++ b/boards/arm/at32/at32f437-mini/src/at32_autoleds.c
@@ -58,7 +58,7 @@
  *   LED_SIGNAL           In a signal handler          No change
  *   LED_ASSERTION        An assertion failed          No change
  *   LED_PANIC            The system has crashed     OFF      Blinking
- *   LED_IDLE             AT32 is is sleep mode        Not used
+ *   LED_IDLE             AT32 is in sleep mode        Not used
  */
 
 /****************************************************************************

--- a/boards/arm/efm32/efm32gg-stk3700/include/board.h
+++ b/boards/arm/efm32/efm32gg-stk3700/include/board.h
@@ -200,7 +200,7 @@
 #define LED_SIGNAL        2  /* In a signal handler          No change       */
 #define LED_ASSERTION     2  /* An assertion failed          No change       */
 #define LED_PANIC         3  /* The system has crashed     OFF      Blinking */
-#undef  LED_IDLE             /* MCU is is sleep mode         Not used        */
+#undef  LED_IDLE             /* MCU is in sleep mode         Not used        */
 
 /* Buttons ******************************************************************/
 

--- a/boards/arm/efm32/efm32gg-stk3700/src/efm32_autoleds.c
+++ b/boards/arm/efm32/efm32gg-stk3700/src/efm32_autoleds.c
@@ -52,7 +52,7 @@
  *   LED_SIGNAL           In a signal handler          No change
  *   LED_ASSERTION        An assertion failed          No change
  *   LED_PANIC            The system has crashed     OFF      Blinking
- *   LED_IDLE             STM32 is is sleep mode       Not used
+ *   LED_IDLE             STM32 is in sleep mode       Not used
  *
  * Thus if LED0 statically on, NuttX has successfully booted and is,
  * apparently, running normally.  If LED1 is flashing at approximately

--- a/boards/arm/gd32f4/gd32f450zk-aiotbox/include/board.h
+++ b/boards/arm/gd32f4/gd32f450zk-aiotbox/include/board.h
@@ -216,7 +216,7 @@ typedef enum
 #define LED_SIGNAL         5 /* In a signal handler      ON     OFF   ON   */
 #define LED_ASSERTION      6 /* An assertion failed      OFF    ON    ON   */
 #define LED_PANIC          7 /* The system has crashed   FLASH  ON    ON   */
-#define LED_IDLE           8 /* MCU is is sleep mode     OFF    FLASH OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     OFF    FLASH OFF  */
 
 /* Button definitions *******************************************************/
 

--- a/boards/arm/gd32f4/gd32f450zk-eval/include/board.h
+++ b/boards/arm/gd32f4/gd32f450zk-eval/include/board.h
@@ -216,7 +216,7 @@ typedef enum
 #define LED_SIGNAL         5 /* In a signal handler      ON     OFF   ON   */
 #define LED_ASSERTION      6 /* An assertion failed      OFF    ON    ON   */
 #define LED_PANIC          7 /* The system has crashed   FLASH  ON    ON   */
-#define LED_IDLE           8 /* MCU is is sleep mode     OFF    FLASH OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     OFF    FLASH OFF  */
 
 /* Button definitions *******************************************************/
 

--- a/boards/arm/gd32f4/gd32f470ik-eval/include/board.h
+++ b/boards/arm/gd32f4/gd32f470ik-eval/include/board.h
@@ -238,7 +238,7 @@ typedef enum
 #define LED_SIGNAL         5 /* In a signal handler      ON     OFF   ON   */
 #define LED_ASSERTION      6 /* An assertion failed      OFF    ON    ON   */
 #define LED_PANIC          7 /* The system has crashed   FLASH  ON    ON   */
-#define LED_IDLE           8 /* MCU is is sleep mode     OFF    FLASH OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     OFF    FLASH OFF  */
 
 /* Button definitions *******************************************************/
 

--- a/boards/arm/gd32f4/gd32f470zk-aiotbox/include/board.h
+++ b/boards/arm/gd32f4/gd32f470zk-aiotbox/include/board.h
@@ -238,7 +238,7 @@ typedef enum
 #define LED_SIGNAL         5 /* In a signal handler      ON     OFF   ON   */
 #define LED_ASSERTION      6 /* An assertion failed      OFF    ON    ON   */
 #define LED_PANIC          7 /* The system has crashed   FLASH  ON    ON   */
-#define LED_IDLE           8 /* MCU is is sleep mode     OFF    FLASH OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     OFF    FLASH OFF  */
 
 /* Button definitions *******************************************************/
 

--- a/boards/arm/gd32f4/gd32f470zk-eval/include/board.h
+++ b/boards/arm/gd32f4/gd32f470zk-eval/include/board.h
@@ -238,7 +238,7 @@ typedef enum
 #define LED_SIGNAL         5 /* In a signal handler      ON     OFF   ON   */
 #define LED_ASSERTION      6 /* An assertion failed      OFF    ON    ON   */
 #define LED_PANIC          7 /* The system has crashed   FLASH  ON    ON   */
-#define LED_IDLE           8 /* MCU is is sleep mode     OFF    FLASH OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     OFF    FLASH OFF  */
 
 /* Button definitions *******************************************************/
 

--- a/boards/arm/imx6/sabre-6quad/include/board.h
+++ b/boards/arm/imx6/sabre-6quad/include/board.h
@@ -110,7 +110,7 @@
 #define LED_SIGNAL          2 /* In a signal handler     N/C      */
 #define LED_ASSERTION       2 /* An assertion failed     N/C      */
 #define LED_PANIC           3 /* The system has crashed  FLASH    */
-#undef  LED_IDLE              /* MCU is is sleep mode    Not used */
+#undef  LED_IDLE              /* MCU is in sleep mode    Not used */
 
 /* Thus is LED is statically on, NuttX has successfully  booted and is,
  * apparently, running normally.  If LED is flashing at approximately

--- a/boards/arm/lpc31xx/ea3131/src/lpc31_fillpage.c
+++ b/boards/arm/lpc31xx/ea3131/src/lpc31_fillpage.c
@@ -363,7 +363,7 @@ static inline void lpc31_initsrc(void)
  *  but non-cacheable.  No special actions will be required of
  *  up_fillpage() in order to write into this allocated page.  If the
  *  virtual address maps to a text region, however, this function should
- *  remap the region so that is is read/execute only.  It should be made
+ *  remap the region so that it is read/execute only.  It should be made
  *  cache-able in any case.
 
  * Input Parameters:

--- a/boards/arm/lpc31xx/ea3152/src/lpc31_fillpage.c
+++ b/boards/arm/lpc31xx/ea3152/src/lpc31_fillpage.c
@@ -364,7 +364,7 @@ static inline void lpc31_initsrc(void)
  *  but non-cacheable.  No special actions will be required of
  *  up_fillpage() in order to write into this allocated page.  If the
  *  virtual address maps to a text region, however, this function should
- *  remap the region so that is is read/execute only.  It should be made
+ *  remap the region so that it is read/execute only.  It should be made
  *  cache-able in any case.
 
  * Input Parameters:

--- a/boards/arm/lpc31xx/olimex-lpc-h3131/include/board.h
+++ b/boards/arm/lpc31xx/olimex-lpc-h3131/include/board.h
@@ -119,7 +119,7 @@
 #define LED_SIGNAL           2 /* In a signal handler      N/C    N/C    */
 #define LED_ASSERTION        2 /* An assertion failed      N/C    N/C    */
 #define LED_PANIC            3 /* The system has crashed   N/C  Blinking */
-#undef  LED_IDLE               /* MCU is is sleep mode       Not used    */
+#undef  LED_IDLE               /* MCU is in sleep mode       Not used    */
 
 /* Thus if LED2 is statically on, NuttX has successfully booted and is,
  * apparently, running normmally.  If LED1 is flashing at approximately

--- a/boards/arm/lpc31xx/olimex-lpc-h3131/src/lpc31_leds.c
+++ b/boards/arm/lpc31xx/olimex-lpc-h3131/src/lpc31_leds.c
@@ -76,7 +76,7 @@ void board_autoled_initialize(void)
  *   LED_SIGNAL         2  In a signal handler        N/C      N/C
  *   LED_ASSERTION      2  An assertion failed        N/C      N/C
  *   LED_PANIC          3  The system has crashed     N/C      Blinking
- *   LED_IDLE           -  MCU is is sleep mode         Not used
+ *   LED_IDLE           -  MCU is in sleep mode         Not used
  *
  ****************************************************************************/
 
@@ -122,7 +122,7 @@ void board_autoled_on(int led)
  *   LED_SIGNAL         2  In a signal handler        N/C      N/C
  *   LED_ASSERTION      2  An assertion failed        N/C      N/C
  *   LED_PANIC          3  The system has crashed     N/C      Blinking
- *   LED_IDLE           -  MCU is is sleep mode         Not used
+ *   LED_IDLE           -  MCU is in sleep mode         Not used
  *
  ****************************************************************************/
 

--- a/boards/arm/max326xx/max32660-evsys/include/board.h
+++ b/boards/arm/max326xx/max32660-evsys/include/board.h
@@ -73,7 +73,7 @@
 #define LED_SIGNAL       2 /* In a signal handler     N/C      */
 #define LED_ASSERTION    2 /* An assertion failed     N/C      */
 #define LED_PANIC        3 /* The system has crashed  FLASH    */
-#undef  LED_IDLE           /* MCU is is sleep mode    Not used */
+#undef  LED_IDLE           /* MCU is in sleep mode    Not used */
 
 /* Thus if LED is statically on, NuttX has successfully  booted and is,
  * apparently, running normally.  If LED is flashing at approximately

--- a/boards/arm/max326xx/max32660-evsys/src/max326_autoleds.c
+++ b/boards/arm/max326xx/max32660-evsys/src/max326_autoleds.c
@@ -40,7 +40,7 @@
  *   LED_SIGNAL       2  In a signal handler     N/C
  *   LED_ASSERTION    2  An assertion failed     N/C
  *   LED_PANIC        3  The system has crashed  FLASH
- *   LED_IDLE            MCU is is sleep mode    Not used
+ *   LED_IDLE            MCU is in sleep mode    Not used
  *
  * Thus is LED is statically on, NuttX has successfully  booted and is,
  * apparently, running normally.  If LED is flashing at approximately

--- a/boards/arm/moxart/moxa/include/board.h
+++ b/boards/arm/moxart/moxa/include/board.h
@@ -175,7 +175,7 @@
 #define LED_SIGNAL        2 /* In a signal handler     N/C  GLOW  OFF      */
 #define LED_ASSERTION     2 /* An assertion failed     N/C  GLOW  OFF      */
 #define LED_PANIC         3 /* The system has crashed  N/C  N/C   Blinking */
-#define LED_PANIC         3 /* MCU is is sleep mode    ---- Not used ----  */
+#define LED_PANIC         3 /* MCU is in sleep mode    ---- Not used ----  */
 
 #undef CONFIG_SUPPRESS_SERIAL_INTS
 

--- a/boards/arm/nuc1xx/nutiny-nuc120/include/board.h
+++ b/boards/arm/nuc1xx/nutiny-nuc120/include/board.h
@@ -106,7 +106,7 @@
  *   LED_ASSERTION        An assertion failed      LED ON while handling the
  *                                                        assertion
  *   LED_PANIC            The system has crashed   LED Blinking at 2Hz
- *   LED_IDLE             NUC1XX is is sleep mode   (Optional, not used)
+ *   LED_IDLE             NUC1XX is in sleep mode   (Optional, not used)
  */
 
 #define LED_STARTED       0

--- a/boards/arm/nuc1xx/nutiny-nuc120/src/nuc_led.c
+++ b/boards/arm/nuc1xx/nutiny-nuc120/src/nuc_led.c
@@ -40,7 +40,7 @@
  *   LED_ASSERTION        An assertion failed      LED ON while handling the
  *                                                        assertion
  *   LED_PANIC            The system has crashed   LED Blinking at 2Hz
- *   LED_IDLE             NUC1XX is is sleep mode   (Optional, not used)
+ *   LED_IDLE             NUC1XX is in sleep mode   (Optional, not used)
  */
 
 /****************************************************************************

--- a/boards/arm/ra4/arduino-r4-minima/include/board.h
+++ b/boards/arm/ra4/arduino-r4-minima/include/board.h
@@ -133,7 +133,7 @@
  #define LED_SIGNAL        2  /* In a signal handler      N/C GLOW OFF      */
  #define LED_ASSERTION     2  /* An assertion failed      N/C GLOW OFF      */
  #define LED_PANIC         3  /* The system has crashed   N/C N/C  Blinking */
- #define LED_PANIC         3  /* MCU is is sleep mode    ---- Not used ---- */
+ #define LED_PANIC         3  /* MCU is in sleep mode    ---- Not used ---- */
 
 /* ID_CODE */
 

--- a/boards/arm/ra4/arduino-r4-minima/src/ra4m1_autoleds.c
+++ b/boards/arm/ra4/arduino-r4-minima/src/ra4m1_autoleds.c
@@ -76,7 +76,7 @@
  *   LED_SIGNAL           In a signal handler        N/C      GLOW     OFF
  *   LED_ASSERTION        An assertion failed        N/C      GLOW     OFF
  *   LED_PANIC            The system has crashed     N/C      N/C    Blinking
- *   LED_IDLE             MCU is is sleep mode       ------ Not used --------
+ *   LED_IDLE             MCU is in sleep mode       ------ Not used --------
  *
  * Thus if LED L is statically on, NuttX has successfully booted and is,
  * apparently, running normmally.  If LED RX is glowing, then NuttX is

--- a/boards/arm/ra4/xiao-ra4m1/include/board.h
+++ b/boards/arm/ra4/xiao-ra4m1/include/board.h
@@ -110,7 +110,7 @@
  #define LED_SIGNAL        2  /* In a signal handler      N/C GLOW OFF      */
  #define LED_ASSERTION     2  /* An assertion failed      N/C GLOW OFF      */
  #define LED_PANIC         3  /* The system has crashed   N/C N/C  Blinking */
- #define LED_PANIC         3  /* MCU is is sleep mode    ---- Not used ---- */
+ #define LED_PANIC         3  /* MCU is in sleep mode    ---- Not used ---- */
 
 /* GPIO definitions *********************************************************/
 

--- a/boards/arm/ra4/xiao-ra4m1/src/ra4m1_autoleds.c
+++ b/boards/arm/ra4/xiao-ra4m1/src/ra4m1_autoleds.c
@@ -69,7 +69,7 @@
  *   LED_SIGNAL           In a signal handler        N/C
  *   LED_ASSERTION        An assertion failed        N/C
  *   LED_PANIC            The system has crashed     N/C
- *   LED_IDLE             MCU is is sleep mode      ------
+ *   LED_IDLE             MCU is in sleep mode      ------
  */
 
 /****************************************************************************

--- a/boards/arm/sam34/arduino-due/include/board.h
+++ b/boards/arm/sam34/arduino-due/include/board.h
@@ -187,7 +187,7 @@
 #define LED_SIGNAL        2  /* In a signal handler      N/C GLOW OFF      */
 #define LED_ASSERTION     2  /* An assertion failed      N/C GLOW OFF      */
 #define LED_PANIC         3  /* The system has crashed   N/C N/C  Blinking */
-#define LED_PANIC         3  /* MCU is is sleep mode    ---- Not used ---- */
+#define LED_PANIC         3  /* MCU is in sleep mode    ---- Not used ---- */
 
 /* Thus if LED L is statically on, NuttX has successfully booted and is,
  * apparently, running normmally.  If LED RX is glowing, then NuttX is

--- a/boards/arm/sam34/arduino-due/src/arduino-due.h
+++ b/boards/arm/sam34/arduino-due/src/arduino-due.h
@@ -70,7 +70,7 @@
  *   LED_SIGNAL           In a signal handler        N/C      GLOW     OFF
  *   LED_ASSERTION        An assertion failed        N/C      GLOW     OFF
  *   LED_PANIC            The system has crashed     N/C      N/C    Blinking
- *   LED_IDLE             MCU is is sleep mode       ------ Not used --------
+ *   LED_IDLE             MCU is in sleep mode       ------ Not used --------
  *
  * Thus if LED L is statically on, NuttX has successfully booted and is,
  * apparently, running normmally.  If LED RX is glowing, then NuttX is

--- a/boards/arm/sam34/arduino-due/src/sam_autoleds.c
+++ b/boards/arm/sam34/arduino-due/src/sam_autoleds.c
@@ -76,7 +76,7 @@
  *   LED_SIGNAL           In a signal handler        N/C      GLOW     OFF
  *   LED_ASSERTION        An assertion failed        N/C      GLOW     OFF
  *   LED_PANIC            The system has crashed     N/C      N/C    Blinking
- *   LED_IDLE             MCU is is sleep mode       ------ Not used --------
+ *   LED_IDLE             MCU is in sleep mode       ------ Not used --------
  *
  * Thus if LED L is statically on, NuttX has successfully booted and is,
  * apparently, running normmally.  If LED RX is glowing, then NuttX is

--- a/boards/arm/sam34/flipnclick-sam3x/include/board.h
+++ b/boards/arm/sam34/flipnclick-sam3x/include/board.h
@@ -201,7 +201,7 @@
 #define LED_SIGNAL       4 /* In a signal handler     GLO N/C N/C N/C N/C */
 #define LED_ASSERTION    4 /* An assertion failed     GLO N/C N/C N/C N/C */
 #define LED_PANIC        4 /* The system has crashed  2Hz N/C N/C N/C N/C */
-#undef  LED_IDLE           /* MCU is is sleep mode    ---- Not used ----- */
+#undef  LED_IDLE           /* MCU is in sleep mode    ---- Not used ----- */
 
 /* Thus if LED L is faintly glowing and all other LEDs are off
  * (except LED D which was left on but is no longer controlled by NuttX and

--- a/boards/arm/sam34/flipnclick-sam3x/src/sam_autoleds.c
+++ b/boards/arm/sam34/flipnclick-sam3x/src/sam_autoleds.c
@@ -50,7 +50,7 @@
  *   LED_SIGNAL       In a signal handler     GLO N/C N/C N/C N/C
  *   LED_ASSERTION    An assertion failed     GLO N/C N/C N/C N/C
  *   LED_PANIC        The system has crashed  2Hz N/C N/C N/C N/C
- *   LED_IDLE         MCU is is sleep mode    ---- Not used -----
+ *   LED_IDLE         MCU is in sleep mode    ---- Not used -----
  *
  * Thus if LED L is faintly glowing and all other LEDs are off (except LED
  * D which was left on but is no longer controlled by NuttX and so may be in

--- a/boards/arm/sam34/sam4s-xplained-pro/include/board.h
+++ b/boards/arm/sam34/sam4s-xplained-pro/include/board.h
@@ -221,7 +221,7 @@
 #define LED_SIGNAL           2 /* In a signal handler       OFF             */
 #define LED_ASSERTION        4 /* An assertion failed       No change       */
 #define LED_PANIC            3 /* The system has crashed    Flash @ 250ms   */
-#define LED_IDLE             4 /* MCU is is sleep mode      Not used        */
+#define LED_IDLE             4 /* MCU is in sleep mode      Not used        */
 
 #define LED_D301_OFF true /* GPIO high for OFF */
 #define LED_D301_ON false /* GPIO low for ON */

--- a/boards/arm/sam34/sam4s-xplained-pro/src/sam4s-xplained-pro.h
+++ b/boards/arm/sam34/sam4s-xplained-pro/src/sam4s-xplained-pro.h
@@ -144,7 +144,7 @@
  *   LED_SIGNAL           In a signal handler        No change
  *   LED_ASSERTION        An assertion failed        No change
  *   LED_PANIC            The system has crashed     OFF
- *   LED_IDLE             MCU is is sleep mode       Not used
+ *   LED_IDLE             MCU is in sleep mode       Not used
  */
 
 #define GPIO_D301    (GPIO_OUTPUT | GPIO_CFG_PULLUP | GPIO_OUTPUT_SET | \

--- a/boards/arm/sam34/sam4s-xplained-pro/src/sam_autoleds.c
+++ b/boards/arm/sam34/sam4s-xplained-pro/src/sam_autoleds.c
@@ -55,7 +55,7 @@
  *   LED_SIGNAL           In a signal handler        No change
  *   LED_ASSERTION        An assertion failed        No change
  *   LED_PANIC            The system has crashed     OFF
- *   LED_IDLE             MCU is is sleep mode       Not used
+ *   LED_IDLE             MCU is in sleep mode       Not used
  */
 
 /****************************************************************************

--- a/boards/arm/sam34/sam4s-xplained/include/board.h
+++ b/boards/arm/sam34/sam4s-xplained/include/board.h
@@ -180,7 +180,7 @@
 #define LED_SIGNAL           0 /* In a signal handler         No change       */
 #define LED_ASSERTION        0 /* An assertion failed         No change       */
 #define LED_PANIC            0 /* The system has crashed    OFF      Blinking */
-#define LED_IDLE             0 /* MCU is is sleep mode        Not used        */
+#define LED_IDLE             0 /* MCU is in sleep mode        Not used        */
 
 /* Thus if D9 is statically on, NuttX has successfully booted and is,
  * apparently, running normmally.  If D10 is flashing at approximately

--- a/boards/arm/sam34/sam4s-xplained/src/sam4s-xplained.h
+++ b/boards/arm/sam34/sam4s-xplained/src/sam4s-xplained.h
@@ -67,7 +67,7 @@
  *   LED_SIGNAL           In a signal handler          No change
  *   LED_ASSERTION        An assertion failed          No change
  *   LED_PANIC            The system has crashed     OFF      Blinking
- *   LED_IDLE             MCU is is sleep mode         Not used
+ *   LED_IDLE             MCU is in sleep mode         Not used
  *
  * Thus if D9 is statically on, NuttX has successfully booted and is,
  * apparently, running normmally.  If D10 is flashing at approximately

--- a/boards/arm/sam34/sam4s-xplained/src/sam_autoleds.c
+++ b/boards/arm/sam34/sam4s-xplained/src/sam_autoleds.c
@@ -55,7 +55,7 @@
  *   LED_SIGNAL           In a signal handler          No change
  *   LED_ASSERTION        An assertion failed          No change
  *   LED_PANIC            The system has crashed     OFF      Blinking
- *   LED_IDLE             MCU is is sleep mode         Not used
+ *   LED_IDLE             MCU is in sleep mode         Not used
  */
 
 /****************************************************************************

--- a/boards/arm/sama5/giant-board/include/board.h
+++ b/boards/arm/sama5/giant-board/include/board.h
@@ -112,7 +112,7 @@
 #define LED_SIGNAL        2  /* In a signal handler        N/C       */
 #define LED_ASSERTION     2  /* An assertion failed        N/C       */
 #define LED_PANIC         3  /* The system has crashed     Flash     */
-#undef  LED_IDLE             /* MCU is is sleep mode       Not used  */
+#undef  LED_IDLE             /* MCU is in sleep mode       Not used  */
 
 /* Thus if the Orange LED is statically on, NuttX has successfully  booted
  * and is, apparently, running normally.

--- a/boards/arm/sama5/jupiter-nano/include/board.h
+++ b/boards/arm/sama5/jupiter-nano/include/board.h
@@ -162,7 +162,7 @@
 #define LED_SIGNAL        2  /* In a signal handler        N/C       */
 #define LED_ASSERTION     2  /* An assertion failed        N/C       */
 #define LED_PANIC         3  /* The system has crashed     Flash     */
-#undef  LED_IDLE             /* MCU is is sleep mode       Not used  */
+#undef  LED_IDLE             /* MCU is in sleep mode       Not used  */
 
 /* Thus if the blue LED is statically on, NuttX has successfully  booted
  * and is, apparently, running normally.

--- a/boards/arm/sama5/sama5d2-xult/include/board.h
+++ b/boards/arm/sama5/sama5d2-xult/include/board.h
@@ -338,7 +338,7 @@
 #define LED_SIGNAL        2  /* In a signal handler        N/C       */
 #define LED_ASSERTION     2  /* An assertion failed        N/C       */
 #define LED_PANIC         3  /* The system has crashed     Flash     */
-#undef  LED_IDLE             /* MCU is is sleep mode       Not used  */
+#undef  LED_IDLE             /* MCU is in sleep mode       Not used  */
 
 /* Thus if the Green LED is statically on, NuttX has successfully  booted
  * and is, apparently, running normally.

--- a/boards/arm/sama5/sama5d3-xplained/include/board.h
+++ b/boards/arm/sama5/sama5d3-xplained/include/board.h
@@ -141,7 +141,7 @@
 #define LED_SIGNAL        2  /* In a signal handler          No change       */
 #define LED_ASSERTION     2  /* An assertion failed          No change       */
 #define LED_PANIC         3  /* The system has crashed     OFF      Blinking */
-#undef  LED_IDLE             /* MCU is is sleep mode         Not used        */
+#undef  LED_IDLE             /* MCU is in sleep mode         Not used        */
 
 /* Thus if the blue LED is statically on, NuttX has successfully booted and
  * is, apparently, running normmally.  If the red is flashing at

--- a/boards/arm/sama5/sama5d3-xplained/src/sam_autoleds.c
+++ b/boards/arm/sama5/sama5d3-xplained/src/sam_autoleds.c
@@ -49,7 +49,7 @@
  *   LED_SIGNAL         2  In a signal handler          No change
  *   LED_ASSERTION      2  An assertion failed          No change
  *   LED_PANIC          3  The system has crashed     OFF      Blinking
- *   LED_IDLE          N/A MCU is is sleep mode         Not used
+ *   LED_IDLE          N/A MCU is in sleep mode         Not used
  *
  * Thus if the blue LED is statically on, NuttX has successfully booted and
  * is, apparently, running normally.  If the red is flashing at

--- a/boards/arm/sama5/sama5d3x-ek/include/board.h
+++ b/boards/arm/sama5/sama5d3x-ek/include/board.h
@@ -163,7 +163,7 @@
 #define LED_SIGNAL        2  /* In a signal handler          No change       */
 #define LED_ASSERTION     2  /* An assertion failed          No change       */
 #define LED_PANIC         3  /* The system has crashed     OFF      Blinking */
-#undef  LED_IDLE             /* MCU is is sleep mode         Not used        */
+#undef  LED_IDLE             /* MCU is in sleep mode         Not used        */
 
 /* If CONFIG_SAMA5D3XEK_NOREDLED=y, then the red LED is not used by the
  * system.  The only difference from the above is that it is the blue, not

--- a/boards/arm/sama5/sama5d3x-ek/src/sam_autoleds.c
+++ b/boards/arm/sama5/sama5d3x-ek/src/sam_autoleds.c
@@ -49,7 +49,7 @@
  *   LED_SIGNAL         2  In a signal handler          No change
  *   LED_ASSERTION      2  An assertion failed          No change
  *   LED_PANIC          3  The system has crashed     OFF      Blinking
- *   LED_IDLE          N/A MCU is is sleep mode         Not used
+ *   LED_IDLE          N/A MCU is in sleep mode         Not used
  *
  * Thus if the blue LED is statically on, NuttX has successfully booted and
  * is, apparently, running normally.  If the red is flashing at

--- a/boards/arm/sama5/sama5d4-ek/include/board.h
+++ b/boards/arm/sama5/sama5d4-ek/include/board.h
@@ -142,7 +142,7 @@
 #define LED_SIGNAL        2  /* In a signal handler          No change       */
 #define LED_ASSERTION     2  /* An assertion failed          No change       */
 #define LED_PANIC         3  /* The system has crashed     OFF      Blinking */
-#undef  LED_IDLE             /* MCU is is sleep mode         Not used        */
+#undef  LED_IDLE             /* MCU is in sleep mode         Not used        */
 
 /* Thus if the D0 and D9 are statically on, NuttX has successfully booted and
  * is, apparently, running normally.  If the red D9 LED is flashing at

--- a/boards/arm/sama5/sama5d4-ek/src/sam_autoleds.c
+++ b/boards/arm/sama5/sama5d4-ek/src/sam_autoleds.c
@@ -55,7 +55,7 @@
  *   LED_SIGNAL           In a signal handler          No change
  *   LED_ASSERTION        An assertion failed          No change
  *   LED_PANIC            The system has crashed     OFF      Blinking
- *   LED_IDLE             MCU is is sleep mode         Not used
+ *   LED_IDLE             MCU is in sleep mode         Not used
  *
  * Thus if the D0 and D9 are statically on, NuttX has successfully booted and
  * is, apparently, running normally.  If the red D9 LED is flashing at

--- a/boards/arm/samd5e5/metro-m4/include/board.h
+++ b/boards/arm/samd5e5/metro-m4/include/board.h
@@ -388,7 +388,7 @@
 #define LED_SIGNAL       2 /* In a signal handler     N/C      */
 #define LED_ASSERTION    2 /* An assertion failed     N/C      */
 #define LED_PANIC        3 /* The system has crashed  FLASH    */
-#undef  LED_IDLE           /* MCU is is sleep mode    Not used */
+#undef  LED_IDLE           /* MCU is in sleep mode    Not used */
 
 /* Thus is LED is statically on, NuttX has successfully  booted and is,
  * apparently, running normally.  If LED is flashing at approximately

--- a/boards/arm/samd5e5/metro-m4/src/sam_autoleds.c
+++ b/boards/arm/samd5e5/metro-m4/src/sam_autoleds.c
@@ -50,7 +50,7 @@
  *   LED_SIGNAL          In a signal handler          N/C
  *   LED_ASSERTION       An assertion failed          N/C
  *   LED_PANIC           The system has crashed       FLASH
- *   LED_IDLE            MCU is is sleep mode         Not used
+ *   LED_IDLE            MCU is in sleep mode         Not used
  */
 
 /****************************************************************************

--- a/boards/arm/samd5e5/same54-xplained-pro/include/board.h
+++ b/boards/arm/samd5e5/same54-xplained-pro/include/board.h
@@ -387,7 +387,7 @@
 #define LED_SIGNAL       2 /* In a signal handler     N/C      */
 #define LED_ASSERTION    2 /* An assertion failed     N/C      */
 #define LED_PANIC        3 /* The system has crashed  FLASH    */
-#undef  LED_IDLE           /* MCU is is sleep mode    Not used */
+#undef  LED_IDLE           /* MCU is in sleep mode    Not used */
 
 /* Thus is LED is statically on, NuttX has successfully  booted and is,
  * apparently, running normally.  If LED is flashing at approximately

--- a/boards/arm/samd5e5/same54-xplained-pro/src/sam_autoleds.c
+++ b/boards/arm/samd5e5/same54-xplained-pro/src/sam_autoleds.c
@@ -47,7 +47,7 @@
  *   LED_SIGNAL          In a signal handler          N/C
  *   LED_ASSERTION       An assertion failed          N/C
  *   LED_PANIC           The system has crashed       FLASH
- *   LED_IDLE            MCU is is sleep mode         Not used
+ *   LED_IDLE            MCU is in sleep mode         Not used
  */
 
 /****************************************************************************

--- a/boards/arm/samv7/pic32czca70-curiosity/include/board.h
+++ b/boards/arm/samv7/pic32czca70-curiosity/include/board.h
@@ -231,7 +231,7 @@
 #define LED_SIGNAL           2 /* In a signal handler       No change    */
 #define LED_ASSERTION        2 /* An assertion failed       No change    */
 #define LED_PANIC            3 /* The system has crashed   N/C  Blinking */
-#undef  LED_IDLE               /* MCU is is sleep mode      Not used     */
+#undef  LED_IDLE               /* MCU is in sleep mode      Not used     */
 
 /* Thus if LED0 is statically on, NuttX has successfully booted and is,
  * apparently, running normally.  If LED1 is flashing at approximately

--- a/boards/arm/samv7/pic32czca70-curiosity/src/sam_autoleds.c
+++ b/boards/arm/samv7/pic32czca70-curiosity/src/sam_autoleds.c
@@ -50,7 +50,7 @@
  *   LED_SIGNAL           In a signal handler          No change
  *   LED_ASSERTION        An assertion failed          No change
  *   LED_PANIC            The system has crashed     N/C      Blinking
- *   LED_IDLE             MCU is is sleep mode         Not used
+ *   LED_IDLE             MCU is in sleep mode         Not used
  *   -------------------  -----------------------  -------- --------
  *
  * Thus if LED0 is statically on, NuttX has successfully booted and is,

--- a/boards/arm/samv7/same70-qmtech/include/board.h
+++ b/boards/arm/samv7/same70-qmtech/include/board.h
@@ -214,7 +214,7 @@
 #define LED_SIGNAL       2 /* In a signal handler     N/C      */
 #define LED_ASSERTION    2 /* An assertion failed     N/C      */
 #define LED_PANIC        3 /* The system has crashed  FLASH    */
-#undef  LED_IDLE           /* MCU is is sleep mode    Not used */
+#undef  LED_IDLE           /* MCU is in sleep mode    Not used */
 
 /* Thus is LED is statically on, NuttX has successfully  booted and is,
  * apparently, running normally.  If LED is flashing at approximately

--- a/boards/arm/samv7/same70-xplained/include/board.h
+++ b/boards/arm/samv7/same70-xplained/include/board.h
@@ -216,7 +216,7 @@
 #define LED_SIGNAL       2 /* In a signal handler     N/C      */
 #define LED_ASSERTION    2 /* An assertion failed     N/C      */
 #define LED_PANIC        3 /* The system has crashed  FLASH    */
-#undef  LED_IDLE           /* MCU is is sleep mode    Not used */
+#undef  LED_IDLE           /* MCU is in sleep mode    Not used */
 
 /* Thus is LED is statically on, NuttX has successfully  booted and is,
  * apparently, running normally.  If LED is flashing at approximately

--- a/boards/arm/samv7/samv71-xult/include/board.h
+++ b/boards/arm/samv7/samv71-xult/include/board.h
@@ -232,7 +232,7 @@
 #define LED_SIGNAL           2 /* In a signal handler       No change    */
 #define LED_ASSERTION        2 /* An assertion failed       No change    */
 #define LED_PANIC            3 /* The system has crashed   N/C  Blinking */
-#undef  LED_IDLE               /* MCU is is sleep mode      Not used     */
+#undef  LED_IDLE               /* MCU is in sleep mode      Not used     */
 
 /* Thus if LED0 is statically on, NuttX has successfully booted and is,
  * apparently, running normally.  If LED1 is flashing at approximately

--- a/boards/arm/samv7/samv71-xult/src/sam_autoleds.c
+++ b/boards/arm/samv7/samv71-xult/src/sam_autoleds.c
@@ -51,7 +51,7 @@
  *   LED_SIGNAL           In a signal handler          No change
  *   LED_ASSERTION        An assertion failed          No change
  *   LED_PANIC            The system has crashed     N/C      Blinking
- *   LED_IDLE             MCU is is sleep mode         Not used
+ *   LED_IDLE             MCU is in sleep mode         Not used
  *   -------------------  -----------------------  -------- --------
  *
  * Thus if LED0 is statically on, NuttX has successfully booted and is,

--- a/boards/arm/stm32/b-g431b-esc1/include/board.h
+++ b/boards/arm/stm32/b-g431b-esc1/include/board.h
@@ -289,7 +289,7 @@
  *   LED_SIGNAL          In a signal handler      No change
  *   LED_ASSERTION       An assertion failed      No change
  *   LED_PANIC           The system has crashed   Blinking
- *   LED_IDLE            STM32 is is sleep mode   Not used
+ *   LED_IDLE            STM32 is in sleep mode   Not used
  */
 
 #define LED_STARTED      0

--- a/boards/arm/stm32/b-g474e-dpow1/include/board.h
+++ b/boards/arm/stm32/b-g474e-dpow1/include/board.h
@@ -160,7 +160,7 @@
  * | LED_SIGNAL         | In a signal handler     | No change  |
  * | LED_ASSERTION      | An assertion failed     | No change  |
  * | LED_PANIC          | The system has crashed  | 0 B 0 0    |
- * | LED_IDLE           | STM32 is is sleep mode  | Not used   |
+ * | LED_IDLE           | STM32 is in sleep mode  | Not used   |
  * |--------------------|-------------------------|------------|
  *
  * LED states legend:

--- a/boards/arm/stm32/clicker2-stm32/include/board.h
+++ b/boards/arm/stm32/clicker2-stm32/include/board.h
@@ -215,7 +215,7 @@
  *   LED_SIGNAL           In a signal handler          No change
  *   LED_ASSERTION        An assertion failed          No change
  *   LED_PANIC            The system has crashed     OFF      Blinking
- *   LED_IDLE             STM32 is is sleep mode       Not used
+ *   LED_IDLE             STM32 is in sleep mode       Not used
  */
 
 #define LED_STARTED              0

--- a/boards/arm/stm32/clicker2-stm32/src/stm32_autoleds.c
+++ b/boards/arm/stm32/clicker2-stm32/src/stm32_autoleds.c
@@ -35,7 +35,7 @@
  *   LED_SIGNAL           In a signal handler          No change
  *   LED_ASSERTION        An assertion failed          No change
  *   LED_PANIC            The system has crashed     OFF      Blinking
- *   LED_IDLE             STM32 is is sleep mode       Not used
+ *   LED_IDLE             STM32 is in sleep mode       Not used
  *
  *   VALUE
  *   --------------------------------------------  -------- --------

--- a/boards/arm/stm32/emw3162/include/board.h
+++ b/boards/arm/stm32/emw3162/include/board.h
@@ -141,7 +141,7 @@
 #define LED_SIGNAL       2 /* In a signal handler     N/C      */
 #define LED_ASSERTION    2 /* An assertion failed     N/C      */
 #define LED_PANIC        3 /* The system has crashed  FLASH    */
-#undef  LED_IDLE           /* MCU is is sleep mode    Not used */
+#undef  LED_IDLE           /* MCU is in sleep mode    Not used */
 
 /* Thus if LED is statically on, NuttX has successfully  booted and is,
  * apparently, running normally.  If LED is flashing at approximately

--- a/boards/arm/stm32/nucleo-f103rb/include/board.h
+++ b/boards/arm/stm32/nucleo-f103rb/include/board.h
@@ -136,7 +136,7 @@
  *   LED_SIGNAL          In a signal handler      No change
  *   LED_ASSERTION       An assertion failed      No change
  *   LED_PANIC           The system has crashed   Blinking
- *   LED_IDLE            STM32 is is sleep mode   Not used
+ *   LED_IDLE            STM32 is in sleep mode   Not used
  */
 
 #define LED_STARTED      0

--- a/boards/arm/stm32/nucleo-f207zg/include/board.h
+++ b/boards/arm/stm32/nucleo-f207zg/include/board.h
@@ -168,7 +168,7 @@
 #define LED_SIGNAL         5 /* In a signal handler      N/C    GLOW  N/C  */
 #define LED_ASSERTION      6 /* An assertion failed      GLOW   N/C   GLOW */
 #define LED_PANIC          7 /* The system has crashed   Blink  OFF   N/C  */
-#define LED_IDLE           8 /* MCU is is sleep mode     ON     OFF   OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     ON     OFF   OFF  */
 
 /* Button definitions *******************************************************/
 

--- a/boards/arm/stm32/nucleo-f302r8/include/board.h
+++ b/boards/arm/stm32/nucleo-f302r8/include/board.h
@@ -162,7 +162,7 @@
  *   LED_SIGNAL          In a signal handler      No change
  *   LED_ASSERTION       An assertion failed      No change
  *   LED_PANIC           The system has crashed   Blinking
- *   LED_IDLE            STM32 is is sleep mode   Not used
+ *   LED_IDLE            STM32 is in sleep mode   Not used
  */
 
 #define LED_STARTED      0

--- a/boards/arm/stm32/nucleo-f303re/include/board.h
+++ b/boards/arm/stm32/nucleo-f303re/include/board.h
@@ -164,7 +164,7 @@
  *   LED_SIGNAL          In a signal handler      No change
  *   LED_ASSERTION       An assertion failed      No change
  *   LED_PANIC           The system has crashed   Blinking
- *   LED_IDLE            STM32 is is sleep mode   Not used
+ *   LED_IDLE            STM32 is in sleep mode   Not used
  */
 
 #define LED_STARTED      0

--- a/boards/arm/stm32/nucleo-f303ze/include/board.h
+++ b/boards/arm/stm32/nucleo-f303ze/include/board.h
@@ -167,7 +167,7 @@
 #define LED_SIGNAL         5 /* In a signal handler      N/C    GLOW  N/C  */
 #define LED_ASSERTION      6 /* An assertion failed      GLOW   N/C   GLOW */
 #define LED_PANIC          7 /* The system has crashed   Blink  OFF   N/C  */
-#define LED_IDLE           8 /* MCU is is sleep mode     ON     OFF   OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     ON     OFF   OFF  */
 
 /* Button definitions *******************************************************/
 

--- a/boards/arm/stm32/nucleo-f334r8/include/board.h
+++ b/boards/arm/stm32/nucleo-f334r8/include/board.h
@@ -160,7 +160,7 @@
  *   LED_SIGNAL          In a signal handler      No change
  *   LED_ASSERTION       An assertion failed      No change
  *   LED_PANIC           The system has crashed   Blinking
- *   LED_IDLE            STM32 is is sleep mode   Not used
+ *   LED_IDLE            STM32 is in sleep mode   Not used
  */
 
 #define LED_STARTED      0

--- a/boards/arm/stm32/nucleo-f401re/include/board.h
+++ b/boards/arm/stm32/nucleo-f401re/include/board.h
@@ -339,7 +339,7 @@
  *   LED_SIGNAL           In a signal handler        No change
  *   LED_ASSERTION        An assertion failed        No change
  *   LED_PANIC            The system has crashed     Blinking
- *   LED_IDLE             MCU is is sleep mode       Not used
+ *   LED_IDLE             MCU is in sleep mode       Not used
  *
  * Thus if LD2, NuttX has successfully booted and is, apparently, running
  * normally.  If LD2 is flashing at approximately 2Hz, then a fatal error

--- a/boards/arm/stm32/nucleo-f410rb/include/board.h
+++ b/boards/arm/stm32/nucleo-f410rb/include/board.h
@@ -272,7 +272,7 @@
  *   LED_SIGNAL           In a signal handler        No change
  *   LED_ASSERTION        An assertion failed        No change
  *   LED_PANIC            The system has crashed     Blinking
- *   LED_IDLE             MCU is is sleep mode       Not used
+ *   LED_IDLE             MCU is in sleep mode       Not used
  *
  * Thus if LD2, NuttX has successfully booted and is, apparently, running
  * normally.  If LD2 is flashing at approximately 2Hz, then a fatal error

--- a/boards/arm/stm32/nucleo-f411re/include/board.h
+++ b/boards/arm/stm32/nucleo-f411re/include/board.h
@@ -336,7 +336,7 @@
  *   LED_SIGNAL           In a signal handler        No change
  *   LED_ASSERTION        An assertion failed        No change
  *   LED_PANIC            The system has crashed     Blinking
- *   LED_IDLE             MCU is is sleep mode       Not used
+ *   LED_IDLE             MCU is in sleep mode       Not used
  *
  * Thus if LD2, NuttX has successfully booted and is, apparently, running
  * normally.  If LD2 is flashing at approximately 2Hz, then a fatal error

--- a/boards/arm/stm32/nucleo-f412zg/include/board.h
+++ b/boards/arm/stm32/nucleo-f412zg/include/board.h
@@ -201,7 +201,7 @@ GPIO_SPEED_50MHz)
  *   LED_SIGNAL           In a signal handler
  *   LED_ASSERTION        An assertion failed
  *   LED_PANIC            The system has crashed
- *   LED_IDLE             MCU is is sleep mode
+ *   LED_IDLE             MCU is in sleep mode
  *
  * Thus if LD2, NuttX has successfully booted and is, apparently, running
  * normally.  If LD2 is flashing at approximately 2Hz, then a fatal error

--- a/boards/arm/stm32/nucleo-f429zi/include/board.h
+++ b/boards/arm/stm32/nucleo-f429zi/include/board.h
@@ -224,7 +224,7 @@
 #define LED_SIGNAL         5 /* In a signal handler      N/C    GLOW  N/C  */
 #define LED_ASSERTION      6 /* An assertion failed      GLOW   N/C   GLOW */
 #define LED_PANIC          7 /* The system has crashed   Blink  OFF   N/C  */
-#define LED_IDLE           8 /* MCU is is sleep mode     ON     OFF   OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     ON     OFF   OFF  */
 
 /* Thus if the Green LED is statically on, NuttX has successfully booted and
  * is, apparently, running normally.  If the Red LED is flashing at

--- a/boards/arm/stm32/nucleo-f446re/include/board.h
+++ b/boards/arm/stm32/nucleo-f446re/include/board.h
@@ -350,7 +350,7 @@
  *   LED_SIGNAL           In a signal handler        No change
  *   LED_ASSERTION        An assertion failed        No change
  *   LED_PANIC            The system has crashed     Blinking
- *   LED_IDLE             MCU is is sleep mode       Not used
+ *   LED_IDLE             MCU is in sleep mode       Not used
  *
  * Thus if LD2, NuttX has successfully booted and is, apparently, running
  * normally.  If LD2 is flashing at approximately 2Hz, then a fatal error

--- a/boards/arm/stm32/nucleo-g431kb/include/board.h
+++ b/boards/arm/stm32/nucleo-g431kb/include/board.h
@@ -209,7 +209,7 @@
  *   LED_SIGNAL          In a signal handler      No change
  *   LED_ASSERTION       An assertion failed      No change
  *   LED_PANIC           The system has crashed   Blinking
- *   LED_IDLE            STM32 is is sleep mode   Not used
+ *   LED_IDLE            STM32 is in sleep mode   Not used
  */
 
 #define LED_STARTED      0

--- a/boards/arm/stm32/nucleo-g431rb/include/board.h
+++ b/boards/arm/stm32/nucleo-g431rb/include/board.h
@@ -289,7 +289,7 @@
  *   LED_SIGNAL          In a signal handler      No change
  *   LED_ASSERTION       An assertion failed      No change
  *   LED_PANIC           The system has crashed   Blinking
- *   LED_IDLE            STM32 is is sleep mode   Not used
+ *   LED_IDLE            STM32 is in sleep mode   Not used
  */
 
 #define LED_STARTED      0

--- a/boards/arm/stm32/nucleo-g474re/include/board.h
+++ b/boards/arm/stm32/nucleo-g474re/include/board.h
@@ -154,7 +154,7 @@
  * | LED_SIGNAL         | In a signal handler     | No change  |
  * | LED_ASSERTION      | An assertion failed     | No change  |
  * | LED_PANIC          | The system has crashed  | 0 B 0 0    |
- * | LED_IDLE           | STM32 is is sleep mode  | Not used   |
+ * | LED_IDLE           | STM32 is in sleep mode  | Not used   |
  * |--------------------|-------------------------|------------|
  *
  * LED states legend:

--- a/boards/arm/stm32/nucleo-l152re/include/board.h
+++ b/boards/arm/stm32/nucleo-l152re/include/board.h
@@ -174,7 +174,7 @@
  *   LED_SIGNAL          In a signal handler      No change
  *   LED_ASSERTION       An assertion failed      No change
  *   LED_PANIC           The system has crashed   Blinking
- *   LED_IDLE            STM32 is is sleep mode   Not used
+ *   LED_IDLE            STM32 is in sleep mode   Not used
  */
 
 #define LED_STARTED      0

--- a/boards/arm/stm32/olimexino-stm32/include/board.h
+++ b/boards/arm/stm32/olimexino-stm32/include/board.h
@@ -151,7 +151,7 @@
 #define LED_SIGNAL           5 /* In a signal handler      N/C    ON     */
 #define LED_ASSERTION        6 /* An assertion failed      N/C    ON     */
 #define LED_PANIC            7 /* The system has crashed   N/C  Blinking */
-#define LED_IDLE             8 /* MCU is is sleep mode    OFF    N/C    */
+#define LED_IDLE             8 /* MCU is in sleep mode    OFF    N/C    */
 
 /* Thus if the Green is statically on, NuttX has successfully booted and is,
  * apparently, running normally.  If the YellowLED is flashing at

--- a/boards/arm/stm32/photon/include/board.h
+++ b/boards/arm/stm32/photon/include/board.h
@@ -186,7 +186,7 @@
 #define LED_SIGNAL       2 /* In a signal handler     N/C      */
 #define LED_ASSERTION    2 /* An assertion failed     N/C      */
 #define LED_PANIC        3 /* The system has crashed  FLASH    */
-#undef  LED_IDLE           /* MCU is is sleep mode    Not used */
+#undef  LED_IDLE           /* MCU is in sleep mode    Not used */
 
 /* Thus if LED is statically on, NuttX has successfully  booted and is,
  * apparently, running normally.  If LED is flashing at approximately

--- a/boards/arm/stm32/stm32butterfly2/include/board.h
+++ b/boards/arm/stm32/stm32butterfly2/include/board.h
@@ -134,7 +134,7 @@
 #define LED_SIGNAL        6  /* In a signal handler      N/C  N/C  N/C  GLOW  */
 #define LED_ASSERTION     7  /* An assertion failed      N/C  N/C  N/C  GLOW  */
 #define LED_PANIC         8  /* The system has crashed   N/C  N/C  N/C  FLASH */
-#undef  LED_IDLE             /* MCU is is sleep mode         Not used         */
+#undef  LED_IDLE             /* MCU is in sleep mode         Not used         */
 
 /* After booting, LED1-3 are not longer used by the system and can be used
  * for other purposes by the application (Of course, all LEDs are available

--- a/boards/arm/stm32/stm32f3discovery/include/board.h
+++ b/boards/arm/stm32/stm32f3discovery/include/board.h
@@ -185,7 +185,7 @@
  *   LED_ASSERTION        An assertion failed      LD9 ON while handling
  *                                                 the assertion
  *   LED_PANIC            The system has crashed   LD10 Blinking at 2Hz
- *   LED_IDLE             STM32 is is sleep mode   (Optional, not used)
+ *   LED_IDLE             STM32 is in sleep mode   (Optional, not used)
  */
 
 #define LED_STARTED       0

--- a/boards/arm/stm32/stm32f401rc-rs485/include/board.h
+++ b/boards/arm/stm32/stm32f401rc-rs485/include/board.h
@@ -394,7 +394,7 @@ extern "C"
  *   LED_SIGNAL           In a signal handler        No change
  *   LED_ASSERTION        An assertion failed        No change
  *   LED_PANIC            The system has crashed     Blinking
- *   LED_IDLE             MCU is is sleep mode       Not used
+ *   LED_IDLE             MCU is in sleep mode       Not used
  *
  * Thus if LD2, NuttX has successfully booted and is, apparently, running
  * normally.  If LD2 is flashing at approximately 2Hz, then a fatal error

--- a/boards/arm/stm32/stm32ldiscovery/include/board.h
+++ b/boards/arm/stm32/stm32ldiscovery/include/board.h
@@ -197,7 +197,7 @@
  *   LED_SIGNAL           In a signal handler          No change
  *   LED_ASSERTION        An assertion failed          No change
  *   LED_PANIC            The system has crashed     OFF      Blinking
- *   LED_IDLE             STM32 is is sleep mode       Not used
+ *   LED_IDLE             STM32 is in sleep mode       Not used
  */
 
 #define LED_STARTED              0

--- a/boards/arm/stm32/stm32ldiscovery/src/stm32_autoleds.c
+++ b/boards/arm/stm32/stm32ldiscovery/src/stm32_autoleds.c
@@ -58,7 +58,7 @@
  *   LED_SIGNAL           In a signal handler          No change
  *   LED_ASSERTION        An assertion failed          No change
  *   LED_PANIC            The system has crashed     OFF      Blinking
- *   LED_IDLE             STM32 is is sleep mode       Not used
+ *   LED_IDLE             STM32 is in sleep mode       Not used
  */
 
 /****************************************************************************

--- a/boards/arm/stm32/viewtool-stm32f107/include/board.h
+++ b/boards/arm/stm32/viewtool-stm32f107/include/board.h
@@ -91,7 +91,7 @@
 #define LED_SIGNAL        4  /* In a signal handler      N/C  N/C  N/C  GLOW  */
 #define LED_ASSERTION     4  /* An assertion failed      N/C  N/C  N/C  GLOW  */
 #define LED_PANIC         4  /* The system has crashed   N/C  N/C  N/C  FLASH */
-#undef  LED_IDLE             /* MCU is is sleep mode         Not used         */
+#undef  LED_IDLE             /* MCU is in sleep mode         Not used         */
 
 /* After booting, LED1-3 are not longer used by the system and can be used
  * for other purposes by the application (Of course, all LEDs are available

--- a/boards/arm/stm32/viewtool-stm32f107/src/stm32_leds.c
+++ b/boards/arm/stm32/viewtool-stm32f107/src/stm32_leds.c
@@ -141,7 +141,7 @@ void stm32_led_initialize(void)
  *   LED_SIGNAL         4   In a signal handler       N/C  N/C  N/C  GLOW
  *   LED_ASSERTION      4   An assertion failed       N/C  N/C  N/C  GLOW
  *   LED_PANIC          4   The system has crashed    N/C  N/C  N/C  FLASH
- *   ED_IDLE                MCU is is sleep mode         Not used
+ *   ED_IDLE                MCU is in sleep mode         Not used
  *
  ****************************************************************************/
 
@@ -194,7 +194,7 @@ void board_autoled_on(int led)
  *   LED_SIGNAL         4   In a signal handler       N/C  N/C  N/C  GLOW
  *   LED_ASSERTION      4   An assertion failed       N/C  N/C  N/C  GLOW
  *   LED_PANIC          4   The system has crashed    N/C  N/C  N/C  FLASH
- *   ED_IDLE                MCU is is sleep mode         Not used
+ *   ED_IDLE                MCU is in sleep mode         Not used
  *
  ****************************************************************************/
 

--- a/boards/arm/stm32f0l0g0/b-l072z-lrwan1/include/board.h
+++ b/boards/arm/stm32f0l0g0/b-l072z-lrwan1/include/board.h
@@ -137,7 +137,7 @@
  *   LED_SIGNAL          In a signal handler      No change
  *   LED_ASSERTION       An assertion failed      No change
  *   LED_PANIC           The system has crashed   Blinking
- *   LED_IDLE            STM32 is is sleep mode   Not used
+ *   LED_IDLE            STM32 is in sleep mode   Not used
  */
 
 #define LED_STARTED      0

--- a/boards/arm/stm32f0l0g0/nucleo-c071rb/include/board.h
+++ b/boards/arm/stm32f0l0g0/nucleo-c071rb/include/board.h
@@ -108,7 +108,7 @@
  *   LED_SIGNAL          In a signal handler      No change
  *   LED_ASSERTION       An assertion failed      No change
  *   LED_PANIC           The system has crashed   Blinking
- *   LED_IDLE            STM32 is is sleep mode   Not used
+ *   LED_IDLE            STM32 is in sleep mode   Not used
  */
 
 #define LED_STARTED      0

--- a/boards/arm/stm32f0l0g0/nucleo-c092rc/include/board.h
+++ b/boards/arm/stm32f0l0g0/nucleo-c092rc/include/board.h
@@ -113,7 +113,7 @@
  *   LED_SIGNAL          In a signal handler      No change
  *   LED_ASSERTION       An assertion failed      No change
  *   LED_PANIC           The system has crashed   Blinking
- *   LED_IDLE            STM32 is is sleep mode   Not used
+ *   LED_IDLE            STM32 is in sleep mode   Not used
  */
 
 #define LED_STARTED      0

--- a/boards/arm/stm32f0l0g0/nucleo-f072rb/include/board.h
+++ b/boards/arm/stm32f0l0g0/nucleo-f072rb/include/board.h
@@ -187,7 +187,7 @@
  *   LED_SIGNAL           In a signal handler        No change
  *   LED_ASSERTION        An assertion failed        No change
  *   LED_PANIC            The system has crashed     Blinking
- *   LED_IDLE             MCU is is sleep mode       Not used
+ *   LED_IDLE             MCU is in sleep mode       Not used
  *
  * Thus if LD2, NuttX has successfully booted and is, apparently, running
  * normally.  If LD2 is flashing at approximately 2Hz, then a fatal error

--- a/boards/arm/stm32f0l0g0/nucleo-f091rc/include/board.h
+++ b/boards/arm/stm32f0l0g0/nucleo-f091rc/include/board.h
@@ -187,7 +187,7 @@
  *   LED_SIGNAL           In a signal handler        No change
  *   LED_ASSERTION        An assertion failed        No change
  *   LED_PANIC            The system has crashed     Blinking
- *   LED_IDLE             MCU is is sleep mode       Not used
+ *   LED_IDLE             MCU is in sleep mode       Not used
  *
  * Thus if LD2, NuttX has successfully booted and is, apparently, running
  * normally.  If LD2 is flashing at approximately 2Hz, then a fatal error

--- a/boards/arm/stm32f0l0g0/nucleo-g070rb/include/board.h
+++ b/boards/arm/stm32f0l0g0/nucleo-g070rb/include/board.h
@@ -169,7 +169,7 @@
  *   LED_SIGNAL          In a signal handler      No change
  *   LED_ASSERTION       An assertion failed      No change
  *   LED_PANIC           The system has crashed   Blinking
- *   LED_IDLE            STM32 is is sleep mode   Not used
+ *   LED_IDLE            STM32 is in sleep mode   Not used
  */
 
 #define LED_STARTED      0

--- a/boards/arm/stm32f0l0g0/nucleo-g071rb/include/board.h
+++ b/boards/arm/stm32f0l0g0/nucleo-g071rb/include/board.h
@@ -162,7 +162,7 @@
  *   LED_SIGNAL          In a signal handler      No change
  *   LED_ASSERTION       An assertion failed      No change
  *   LED_PANIC           The system has crashed   Blinking
- *   LED_IDLE            STM32 is is sleep mode   Not used
+ *   LED_IDLE            STM32 is in sleep mode   Not used
  */
 
 #define LED_STARTED      0

--- a/boards/arm/stm32f0l0g0/nucleo-g0b1re/include/board.h
+++ b/boards/arm/stm32f0l0g0/nucleo-g0b1re/include/board.h
@@ -170,7 +170,7 @@
  *   LED_SIGNAL          In a signal handler      No change
  *   LED_ASSERTION       An assertion failed      No change
  *   LED_PANIC           The system has crashed   Blinking
- *   LED_IDLE            STM32 is is sleep mode   Not used
+ *   LED_IDLE            STM32 is in sleep mode   Not used
  */
 
 #define LED_STARTED      0

--- a/boards/arm/stm32f0l0g0/nucleo-l073rz/include/board.h
+++ b/boards/arm/stm32f0l0g0/nucleo-l073rz/include/board.h
@@ -138,7 +138,7 @@
  *   LED_SIGNAL          In a signal handler      No change
  *   LED_ASSERTION       An assertion failed      No change
  *   LED_PANIC           The system has crashed   Blinking
- *   LED_IDLE            STM32 is is sleep mode   Not used
+ *   LED_IDLE            STM32 is in sleep mode   Not used
  */
 
 #define LED_STARTED      0

--- a/boards/arm/stm32f0l0g0/stm32f051-discovery/include/board.h
+++ b/boards/arm/stm32f0l0g0/stm32f051-discovery/include/board.h
@@ -198,7 +198,7 @@
  *   LED_SIGNAL           In a signal handler          No change
  *   LED_ASSERTION        An assertion failed          No change
  *   LED_PANIC            The system has crashed     OFF      Blinking
- *   LED_IDLE             STM32 is is sleep mode       Not used
+ *   LED_IDLE             STM32 is in sleep mode       Not used
  */
 
 #define LED_STARTED              0

--- a/boards/arm/stm32f0l0g0/stm32f051-discovery/src/stm32_autoleds.c
+++ b/boards/arm/stm32f0l0g0/stm32f051-discovery/src/stm32_autoleds.c
@@ -57,7 +57,7 @@
  *   LED_SIGNAL           In a signal handler          No change
  *   LED_ASSERTION        An assertion failed          No change
  *   LED_PANIC            The system has crashed     OFF      Blinking
- *   LED_IDLE             STM32 is is sleep mode       Not used
+ *   LED_IDLE             STM32 is in sleep mode       Not used
  */
 
 /****************************************************************************

--- a/boards/arm/stm32f0l0g0/stm32f072-discovery/include/board.h
+++ b/boards/arm/stm32f0l0g0/stm32f072-discovery/include/board.h
@@ -203,7 +203,7 @@
  *   LED_SIGNAL           In a signal handler          No change
  *   LED_ASSERTION        An assertion failed          No change
  *   LED_PANIC            The system has crashed     OFF      Blinking
- *   LED_IDLE             STM32 is is sleep mode       Not used
+ *   LED_IDLE             STM32 is in sleep mode       Not used
  */
 
 #define LED_STARTED              0

--- a/boards/arm/stm32f0l0g0/stm32f072-discovery/src/stm32_autoleds.c
+++ b/boards/arm/stm32f0l0g0/stm32f072-discovery/src/stm32_autoleds.c
@@ -57,7 +57,7 @@
  *   LED_SIGNAL           In a signal handler          No change
  *   LED_ASSERTION        An assertion failed          No change
  *   LED_PANIC            The system has crashed     OFF      Blinking
- *   LED_IDLE             STM32 is is sleep mode       Not used
+ *   LED_IDLE             STM32 is in sleep mode       Not used
  */
 
 /****************************************************************************

--- a/boards/arm/stm32f0l0g0/stm32l0538-disco/include/board.h
+++ b/boards/arm/stm32f0l0g0/stm32l0538-disco/include/board.h
@@ -133,7 +133,7 @@
  *   LED_SIGNAL          In a signal handler      No change
  *   LED_ASSERTION       An assertion failed      No change
  *   LED_PANIC           The system has crashed   Blinking
- *   LED_IDLE            STM32 is is sleep mode   Not used
+ *   LED_IDLE            STM32 is in sleep mode   Not used
  */
 
 #define LED_STARTED      0

--- a/boards/arm/stm32f7/nucleo-f722ze/include/board.h
+++ b/boards/arm/stm32f7/nucleo-f722ze/include/board.h
@@ -302,7 +302,7 @@
 #define LED_SIGNAL         5 /* In a signal handler      N/C    GLOW  N/C  */
 #define LED_ASSERTION      6 /* An assertion failed      GLOW   N/C   GLOW */
 #define LED_PANIC          7 /* The system has crashed   Blink  OFF   N/C  */
-#define LED_IDLE           8 /* MCU is is sleep mode     ON     OFF   OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     ON     OFF   OFF  */
 
 /* Thus if the Green LED is statically on, NuttX has successfully booted and
  * is, apparently, running normally.  If the Red LED is flashing at

--- a/boards/arm/stm32f7/nucleo-f746zg/include/board.h
+++ b/boards/arm/stm32f7/nucleo-f746zg/include/board.h
@@ -302,7 +302,7 @@
 #define LED_SIGNAL         5 /* In a signal handler      N/C    GLOW  N/C  */
 #define LED_ASSERTION      6 /* An assertion failed      GLOW   N/C   GLOW */
 #define LED_PANIC          7 /* The system has crashed   Blink  OFF   N/C  */
-#define LED_IDLE           8 /* MCU is is sleep mode     ON     OFF   OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     ON     OFF   OFF  */
 
 /* Thus if the Green LED is statically on, NuttX has successfully booted and
  * is, apparently, running normally.  If the Red LED is flashing at

--- a/boards/arm/stm32f7/nucleo-f767zi/include/board.h
+++ b/boards/arm/stm32f7/nucleo-f767zi/include/board.h
@@ -302,7 +302,7 @@
 #define LED_SIGNAL         5 /* In a signal handler      N/C    GLOW  N/C  */
 #define LED_ASSERTION      6 /* An assertion failed      GLOW   N/C   GLOW */
 #define LED_PANIC          7 /* The system has crashed   Blink  OFF   N/C  */
-#define LED_IDLE           8 /* MCU is is sleep mode     ON     OFF   OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     ON     OFF   OFF  */
 
 /* Thus if the Green LED is statically on, NuttX has successfully booted and
  * is, apparently, running normally.  If the Red LED is flashing at

--- a/boards/arm/stm32f7/stm32f777zit6-meadow/include/board.h
+++ b/boards/arm/stm32f7/stm32f777zit6-meadow/include/board.h
@@ -351,7 +351,7 @@
 #define LED_SIGNAL         5 /* In a signal handler      N/C    GLOW  N/C  */
 #define LED_ASSERTION      6 /* An assertion failed      GLOW   N/C   GLOW */
 #define LED_PANIC          7 /* The system has crashed   Blink  OFF   N/C  */
-#define LED_IDLE           8 /* MCU is is sleep mode     ON     OFF   OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     ON     OFF   OFF  */
 
 /* Button definitions *******************************************************/
 

--- a/boards/arm/stm32h5/nucleo-h563zi/include/board.h
+++ b/boards/arm/stm32h5/nucleo-h563zi/include/board.h
@@ -300,7 +300,7 @@
 #define LED_SIGNAL         5 /* In a signal handler      N/C    GLOW  N/C  */
 #define LED_ASSERTION      6 /* An assertion failed      GLOW   N/C   GLOW */
 #define LED_PANIC          7 /* The system has crashed   Blink  OFF   N/C  */
-#define LED_IDLE           8 /* MCU is is sleep mode     ON     OFF   OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     ON     OFF   OFF  */
 
 /* Thus if the Green LED is statically on, NuttX has successfully booted and
  * is, apparently, running normally.  If the Red LED is flashing at

--- a/boards/arm/stm32h7/linum-stm32h753bi/include/board.h
+++ b/boards/arm/stm32h7/linum-stm32h753bi/include/board.h
@@ -337,7 +337,7 @@
 #define LED_SIGNAL         5 /* In a signal handler      N/C    GLOW  N/C  */
 #define LED_ASSERTION      6 /* An assertion failed      GLOW   N/C   GLOW */
 #define LED_PANIC          7 /* The system has crashed   Blink  OFF   N/C  */
-#define LED_IDLE           8 /* MCU is is sleep mode     ON     OFF   OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     ON     OFF   OFF  */
 
 /* Thus if the Green LED is statically on, NuttX has successfully booted and
  * is, apparently, running normally.  If the Red LED is flashing at

--- a/boards/arm/stm32h7/nucleo-h723zg/include/board.h
+++ b/boards/arm/stm32h7/nucleo-h723zg/include/board.h
@@ -338,7 +338,7 @@
 #define LED_SIGNAL         5 /* In a signal handler      GLOW  N/C    N/C   */
 #define LED_ASSERTION      6 /* An assertion failed      N/C   GLOW   GLOW  */
 #define LED_PANIC          7 /* The system has crashed   OFF   N/C    Blink */
-#define LED_IDLE           8 /* MCU is is sleep mode     OFF   OFF    ON    */
+#define LED_IDLE           8 /* MCU is in sleep mode     OFF   OFF    ON    */
 
 /* Thus if the Green LED is statically on, NuttX has successfully booted and
  * is, apparently, running normally.  If the Red LED is flashing at

--- a/boards/arm/stm32h7/nucleo-h743zi/include/board.h
+++ b/boards/arm/stm32h7/nucleo-h743zi/include/board.h
@@ -339,7 +339,7 @@
 #define LED_SIGNAL         5 /* In a signal handler      N/C    GLOW  N/C  */
 #define LED_ASSERTION      6 /* An assertion failed      GLOW   N/C   GLOW */
 #define LED_PANIC          7 /* The system has crashed   Blink  OFF   N/C  */
-#define LED_IDLE           8 /* MCU is is sleep mode     ON     OFF   OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     ON     OFF   OFF  */
 
 /* Thus if the Green LED is statically on, NuttX has successfully booted and
  * is, apparently, running normally.  If the Red LED is flashing at

--- a/boards/arm/stm32h7/nucleo-h743zi2/include/board.h
+++ b/boards/arm/stm32h7/nucleo-h743zi2/include/board.h
@@ -330,7 +330,7 @@
 #define LED_SIGNAL         5 /* In a signal handler      N/C    GLOW  N/C  */
 #define LED_ASSERTION      6 /* An assertion failed      GLOW   N/C   GLOW */
 #define LED_PANIC          7 /* The system has crashed   Blink  OFF   N/C  */
-#define LED_IDLE           8 /* MCU is is sleep mode     ON     OFF   OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     ON     OFF   OFF  */
 
 /* Thus if the Green LED is statically on, NuttX has successfully booted and
  * is, apparently, running normally.  If the Red LED is flashing at

--- a/boards/arm/stm32h7/nucleo-h745zi/include/board.h
+++ b/boards/arm/stm32h7/nucleo-h745zi/include/board.h
@@ -339,7 +339,7 @@
 #define LED_SIGNAL         5 /* In a signal handler      N/C    GLOW  N/C  */
 #define LED_ASSERTION      6 /* An assertion failed      GLOW   N/C   GLOW */
 #define LED_PANIC          7 /* The system has crashed   Blink  OFF   N/C  */
-#define LED_IDLE           8 /* MCU is is sleep mode     ON     OFF   OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     ON     OFF   OFF  */
 
 /* Thus if the Green LED is statically on, NuttX has successfully booted and
  * is, apparently, running normally.  If the Red LED is flashing at

--- a/boards/arm/stm32h7/portenta-h7/include/board.h
+++ b/boards/arm/stm32h7/portenta-h7/include/board.h
@@ -300,7 +300,7 @@
 #define LED_SIGNAL         5 /* In a signal handler      N/C    GLOW  N/C  */
 #define LED_ASSERTION      6 /* An assertion failed      GLOW   N/C   GLOW */
 #define LED_PANIC          7 /* The system has crashed   Blink  OFF   N/C  */
-#define LED_IDLE           8 /* MCU is is sleep mode     ON     OFF   OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     ON     OFF   OFF  */
 
 /* Thus if the Green LED is statically on, NuttX has successfully booted and
  * is, apparently, running normally.  If the Red LED is flashing at

--- a/boards/arm/stm32h7/stm32h745i-disco/include/board.h
+++ b/boards/arm/stm32h7/stm32h745i-disco/include/board.h
@@ -478,7 +478,7 @@
 #define LED_SIGNAL         5 /* In a signal handler      N/C    GLOW  N/C  */
 #define LED_ASSERTION      6 /* An assertion failed      GLOW   N/C   GLOW */
 #define LED_PANIC          7 /* The system has crashed   Blink  OFF   N/C  */
-#define LED_IDLE           8 /* MCU is is sleep mode     ON     OFF   OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     ON     OFF   OFF  */
 
 /* Thus if the Green LED is statically on, NuttX has successfully booted and
  * is, apparently, running normally.  If the Red LED is flashing at

--- a/boards/arm/stm32h7/stm32h750b-dk/include/board.h
+++ b/boards/arm/stm32h7/stm32h750b-dk/include/board.h
@@ -475,7 +475,7 @@
 #define LED_SIGNAL         5 /* In a signal handler      N/C    GLOW  N/C  */
 #define LED_ASSERTION      6 /* An assertion failed      GLOW   N/C   GLOW */
 #define LED_PANIC          7 /* The system has crashed   Blink  OFF   N/C  */
-#define LED_IDLE           8 /* MCU is is sleep mode     ON     OFF   OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     ON     OFF   OFF  */
 
 /* Thus if the Green LED is statically on, NuttX has successfully booted and
  * is, apparently, running normally.  If the Red LED is flashing at

--- a/boards/arm/stm32h7/weact-stm32h743/include/board.h
+++ b/boards/arm/stm32h7/weact-stm32h743/include/board.h
@@ -350,7 +350,7 @@
 #define LED_SIGNAL         5 /* In a signal handler      N/C    GLOW  N/C  */
 #define LED_ASSERTION      6 /* An assertion failed      GLOW   N/C   GLOW */
 #define LED_PANIC          7 /* The system has crashed   Blink  OFF   N/C  */
-#define LED_IDLE           8 /* MCU is is sleep mode     ON     OFF   OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     ON     OFF   OFF  */
 
 /* Thus if the Green LED is statically on, NuttX has successfully booted and
  * is, apparently, running normally.  If the Red LED is flashing at

--- a/boards/arm/stm32h7/weact-stm32h750/include/board.h
+++ b/boards/arm/stm32h7/weact-stm32h750/include/board.h
@@ -350,7 +350,7 @@
 #define LED_SIGNAL         5 /* In a signal handler      N/C    GLOW  N/C  */
 #define LED_ASSERTION      6 /* An assertion failed      GLOW   N/C   GLOW */
 #define LED_PANIC          7 /* The system has crashed   Blink  OFF   N/C  */
-#define LED_IDLE           8 /* MCU is is sleep mode     ON     OFF   OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     ON     OFF   OFF  */
 
 /* Thus if the Green LED is statically on, NuttX has successfully booted and
  * is, apparently, running normally.  If the Red LED is flashing at

--- a/boards/arm/stm32l4/b-l475e-iot01a/include/board.h
+++ b/boards/arm/stm32l4/b-l475e-iot01a/include/board.h
@@ -77,7 +77,7 @@
 #define LED_SIGNAL       2 /* In a signal handler     N/C      */
 #define LED_ASSERTION    2 /* An assertion failed     N/C      */
 #define LED_PANIC        3 /* The system has crashed  FLASH    */
-#undef  LED_IDLE           /* MCU is is sleep mode    Not used */
+#undef  LED_IDLE           /* MCU is in sleep mode    Not used */
 
 /* Thus if LED is statically on, NuttX has successfully  booted and is,
  * apparently, running normally.  If LED is flashing at approximately

--- a/boards/arm/stm32l4/nucleo-l432kc/include/board.h
+++ b/boards/arm/stm32l4/nucleo-l432kc/include/board.h
@@ -211,7 +211,7 @@
  *   LED_SIGNAL           In a signal handler        No change
  *   LED_ASSERTION        An assertion failed        No change
  *   LED_PANIC            The system has crashed     Blinking
- *   LED_IDLE             MCU is is sleep mode       Not used
+ *   LED_IDLE             MCU is in sleep mode       Not used
  *
  * Thus if LD3 NuttX has successfully booted and is, apparently, running
  * normally.  If LD3 is flashing at approximately 2Hz, then a fatal error

--- a/boards/arm/stm32l4/nucleo-l452re/include/board.h
+++ b/boards/arm/stm32l4/nucleo-l452re/include/board.h
@@ -171,7 +171,7 @@
  *   LED_SIGNAL           In a signal handler        No change
  *   LED_ASSERTION        An assertion failed        No change
  *   LED_PANIC            The system has crashed     Blinking
- *   LED_IDLE             MCU is is sleep mode       Not used
+ *   LED_IDLE             MCU is in sleep mode       Not used
  *
  * Thus if LD2, NuttX has successfully booted and is, apparently, running
  * normally.  If LD2 is flashing at approximately 2Hz, then a fatal error

--- a/boards/arm/stm32l4/nucleo-l476rg/include/board.h
+++ b/boards/arm/stm32l4/nucleo-l476rg/include/board.h
@@ -196,7 +196,7 @@
  *   LED_SIGNAL           In a signal handler        No change
  *   LED_ASSERTION        An assertion failed        No change
  *   LED_PANIC            The system has crashed     Blinking
- *   LED_IDLE             MCU is is sleep mode       Not used
+ *   LED_IDLE             MCU is in sleep mode       Not used
  *
  * Thus if LD2, NuttX has successfully booted and is, apparently, running
  * normally.  If LD2 is flashing at approximately 2Hz, then a fatal error

--- a/boards/arm/stm32l4/nucleo-l496zg/include/board.h
+++ b/boards/arm/stm32l4/nucleo-l496zg/include/board.h
@@ -531,7 +531,7 @@
 #define LED_SIGNAL         5 /* In a signal handler      N/C    GLOW  N/C  */
 #define LED_ASSERTION      6 /* An assertion failed      GLOW   N/C   GLOW */
 #define LED_PANIC          7 /* The system has crashed   Blink  OFF   N/C  */
-#define LED_IDLE           8 /* MCU is is sleep mode     ON     OFF   OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     ON     OFF   OFF  */
 
 /* Thus if the Green LED is statically on, NuttX has successfully booted and
  * is, apparently, running normally.  If the Red LED is flashing at

--- a/boards/arm/stm32l4/steval-stlcs01v1/include/board.h
+++ b/boards/arm/stm32l4/steval-stlcs01v1/include/board.h
@@ -315,7 +315,7 @@
  *   LED_SIGNAL           In a signal handler        No change
  *   LED_ASSERTION        An assertion failed        No change
  *   LED_PANIC            The system has crashed     Blinking
- *   LED_IDLE             MCU is is sleep mode       Not used
+ *   LED_IDLE             MCU is in sleep mode       Not used
  *
  * Thus if LD1, NuttX has successfully booted and is, apparently, running
  * normally.  If LD1 is flashing at approximately 2Hz, then a fatal error

--- a/boards/arm/stm32l4/stm32l476-mdk/include/board.h
+++ b/boards/arm/stm32l4/stm32l476-mdk/include/board.h
@@ -164,7 +164,7 @@
 #define LED_SIGNAL       2 /* In a signal handler     N/C      */
 #define LED_ASSERTION    2 /* An assertion failed     N/C      */
 #define LED_PANIC        3 /* The system has crashed  FLASH    */
-#undef  LED_IDLE           /* MCU is is sleep mode    Not used */
+#undef  LED_IDLE           /* MCU is in sleep mode    Not used */
 
 /* Thus if the white LED is statically on, NuttX has successfully  booted and
  * is, apparently, running normally.  If white LED is flashing at

--- a/boards/arm/stm32l4/stm32l476-mdk/src/stm32_autoleds.c
+++ b/boards/arm/stm32l4/stm32l476-mdk/src/stm32_autoleds.c
@@ -51,7 +51,7 @@
  *   LED_SIGNAL         In a signal handler      N/C
  *   LED_ASSERTION      An assertion failed      N/C
  *   LED_PANIC          The system has crashed   FLASH
- *   LED_IDLE           MCU is is sleep mode     Not used
+ *   LED_IDLE           MCU is in sleep mode     Not used
  *
  * Thus if the white LED is statically on, NuttX has successfully booted and
  * is, apparently, running normally.  If white LED is flashing at

--- a/boards/arm/stm32l4/stm32l476vg-disco/include/board.h
+++ b/boards/arm/stm32l4/stm32l476vg-disco/include/board.h
@@ -224,7 +224,7 @@
  *   LED_SIGNAL           In a signal handler
  *   LED_ASSERTION        An assertion failed
  *   LED_PANIC            The system has crashed                  Blinking
- *   LED_IDLE             MCU is is sleep mode       ON
+ *   LED_IDLE             MCU is in sleep mode       ON
  *
  * Thus if BOARD_LED_GRN, NuttX has successfully booted and is, apparently,
  * running normally.  If BOARD_LED_RED is flashing at approximately 2Hz, then

--- a/boards/arm/stm32l4/stm32l4r9ai-disco/include/board.h
+++ b/boards/arm/stm32l4/stm32l4r9ai-disco/include/board.h
@@ -218,7 +218,7 @@
  *   LED_SIGNAL           In a signal handler
  *   LED_ASSERTION        An assertion failed
  *   LED_PANIC            The system has crashed                  Blinking
- *   LED_IDLE             MCU is is sleep mode       ON
+ *   LED_IDLE             MCU is in sleep mode       ON
  *
  * Thus if BOARD_LED_GRN, NuttX has successfully booted and is, apparently,
  * running normally.  If BOARD_LED_RED is flashing at approximately 2Hz, then

--- a/boards/arm/stm32l5/nucleo-l552ze/include/board.h
+++ b/boards/arm/stm32l5/nucleo-l552ze/include/board.h
@@ -223,7 +223,7 @@
 #define LED_SIGNAL         5 /* In a signal handler      N/C    GLOW  N/C  */
 #define LED_ASSERTION      6 /* An assertion failed      GLOW   N/C   GLOW */
 #define LED_PANIC          7 /* The system has crashed   Blink  OFF   N/C  */
-#define LED_IDLE           8 /* MCU is is sleep mode     ON     OFF   OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     ON     OFF   OFF  */
 
 /* Thus if the Green LED is statically on, NuttX has successfully booted and
  * is, apparently, running normally.  If the Red LED is flashing at

--- a/boards/arm/stm32l5/stm32l562e-dk/include/board.h
+++ b/boards/arm/stm32l5/stm32l562e-dk/include/board.h
@@ -147,7 +147,7 @@
 #define LED_SIGNAL         5 /* In a signal handler      GLOW   N/C  */
 #define LED_ASSERTION      6 /* An assertion failed      GLOW   N/C  */
 #define LED_PANIC          7 /* The system has crashed   Blink  OFF  */
-#define LED_IDLE           8 /* MCU is is sleep mode     N/C    ON   */
+#define LED_IDLE           8 /* MCU is in sleep mode     N/C    ON   */
 
 /* Thus if the Green LED is statically on, NuttX has successfully booted and
  * is, apparently, idleing.  If the Red LED is flashing at approximately 2Hz,

--- a/boards/arm/stm32wl5/nucleo-wl55jc/include/board.h
+++ b/boards/arm/stm32wl5/nucleo-wl55jc/include/board.h
@@ -209,7 +209,7 @@
 #define LED_SIGNAL        6  /* In a signal handler      GLOW  N/C  N/C */
 #define LED_ASSERTION     7  /* An assertion failed      GLOW  N/C  N/C */
 #define LED_PANIC         8  /* The system has crashed   ON    ON   ON  */
-#undef  LED_IDLE             /* MCU is is sleep mode        Not used    */
+#undef  LED_IDLE             /* MCU is in sleep mode        Not used    */
 
 /****************************************************************************
  * Public Data

--- a/boards/arm/tiva/launchxl-cc1310/include/board.h
+++ b/boards/arm/tiva/launchxl-cc1310/include/board.h
@@ -84,7 +84,7 @@
 #define LED_SIGNAL       3 /* In a signal handler     N/C  GLOW  */
 #define LED_ASSERTION    3 /* An assertion failed     N/C  GLOW  */
 #define LED_PANIC        4 /* The system has crashed  OFF  BLINK */
-#undef  LED_IDLE           /* MCU is is sleep mode    -Not used- */
+#undef  LED_IDLE           /* MCU is in sleep mode    -Not used- */
 
 /* Thus iF GLED is statically on, NuttX has successfully  booted and is,
  * apparently, running normally.  A soft glow of the RLED means that the

--- a/boards/arm/tiva/launchxl-cc1310/src/cc1310_autoleds.c
+++ b/boards/arm/tiva/launchxl-cc1310/src/cc1310_autoleds.c
@@ -98,7 +98,7 @@ void board_autoled_on(int led)
         return;
     }
 
-  /* Set the new state of the GLED (unless is is N/C) */
+  /* Set the new state of the GLED (unless it is N/C) */
 
   if (gled_change)
     {

--- a/boards/arm/tiva/launchxl-cc1312r1/include/board.h
+++ b/boards/arm/tiva/launchxl-cc1312r1/include/board.h
@@ -84,7 +84,7 @@
 #define LED_SIGNAL       3 /* In a signal handler     N/C  GLOW  */
 #define LED_ASSERTION    3 /* An assertion failed     N/C  GLOW  */
 #define LED_PANIC        4 /* The system has crashed  OFF  BLINK */
-#undef  LED_IDLE           /* MCU is is sleep mode    -Not used- */
+#undef  LED_IDLE           /* MCU is in sleep mode    -Not used- */
 
 /* Thus iF GLED is statically on, NuttX has successfully  booted and is,
  * apparently, running normally.  A soft glow of the RLED means that the

--- a/boards/arm/tiva/launchxl-cc1312r1/src/cc1312_autoleds.c
+++ b/boards/arm/tiva/launchxl-cc1312r1/src/cc1312_autoleds.c
@@ -98,7 +98,7 @@ void board_autoled_on(int led)
         return;
     }
 
-  /* Set the new state of the GLED (unless is is N/C) */
+  /* Set the new state of the GLED (unless it is N/C) */
 
   if (gled_change)
     {

--- a/boards/arm/tms570/launchxl-tms57004/include/board.h
+++ b/boards/arm/tms570/launchxl-tms57004/include/board.h
@@ -218,7 +218,7 @@
 #define LED_SIGNAL          2 /* In a signal handler     N/C      */
 #define LED_ASSERTION       2 /* An assertion failed     N/C      */
 #define LED_PANIC           3 /* The system has crashed  FLASH    */
-#undef  LED_IDLE              /* MCU is is sleep mode    Not used */
+#undef  LED_IDLE              /* MCU is in sleep mode    Not used */
 
 /* Thus if the LED is statically on, NuttX has successfully  booted and is,
  * apparently, running normally.  If the LED is flashing at approximately

--- a/boards/arm/tms570/tms570ls31x-usb-kit/include/board.h
+++ b/boards/arm/tms570/tms570ls31x-usb-kit/include/board.h
@@ -229,7 +229,7 @@
 #define LED_SIGNAL          2 /* In a signal handler     N/C      */
 #define LED_ASSERTION       2 /* An assertion failed     N/C      */
 #define LED_PANIC           3 /* The system has crashed  FLASH    */
-#undef  LED_IDLE              /* MCU is is sleep mode    Not used */
+#undef  LED_IDLE              /* MCU is in sleep mode    Not used */
 
 /* Thus if the LED is statically on, NuttX has successfully  booted and is,
  * apparently, running normally.  If the LED is flashing at approximately

--- a/boards/arm/xmc4/xmc4500-relax/include/board.h
+++ b/boards/arm/xmc4/xmc4500-relax/include/board.h
@@ -278,7 +278,7 @@
 #define LED_SIGNAL        2 /* In a signal handler       No change    */
 #define LED_ASSERTION     2 /* An assertion failed       No change    */
 #define LED_PANIC         3 /* The system has crashed   N/C  Blinking */
-#undef  LED_IDLE            /* MCU is is sleep mode      Not used     */
+#undef  LED_IDLE            /* MCU is in sleep mode      Not used     */
 
 /* Thus if LED1 is statically on, NuttX has successfully booted and is,
  * apparently, running normally.  If LED2 is flashing at approximately

--- a/boards/arm/xmc4/xmc4500-relax/src/xmc4_autoleds.c
+++ b/boards/arm/xmc4/xmc4500-relax/src/xmc4_autoleds.c
@@ -41,7 +41,7 @@
  *   LED_SIGNAL         In a signal handler       No change
  *   LED_ASSERTION      An assertion failed       No change
  *   LED_PANIC          The system has crashed   N/C  Blinking
- *   LED_IDLE           MCU is is sleep mode      Not used
+ *   LED_IDLE           MCU is in sleep mode      Not used
  */
 
 /****************************************************************************

--- a/boards/arm/xmc4/xmc4700-relax/include/board.h
+++ b/boards/arm/xmc4/xmc4700-relax/include/board.h
@@ -275,7 +275,7 @@
 #define LED_SIGNAL        2 /* In a signal handler       No change    */
 #define LED_ASSERTION     2 /* An assertion failed       No change    */
 #define LED_PANIC         3 /* The system has crashed   N/C  Blinking */
-#undef  LED_IDLE            /* MCU is is sleep mode      Not used     */
+#undef  LED_IDLE            /* MCU is in sleep mode      Not used     */
 
 /* Thus if LED1 is statically on, NuttX has successfully booted and is,
  * apparently, running normally.  If LED2 is flashing at approximately

--- a/boards/arm/xmc4/xmc4700-relax/src/xmc4_autoleds.c
+++ b/boards/arm/xmc4/xmc4700-relax/src/xmc4_autoleds.c
@@ -41,7 +41,7 @@
  *   LED_SIGNAL         In a signal handler       No change
  *   LED_ASSERTION      An assertion failed       No change
  *   LED_PANIC          The system has crashed   N/C  Blinking
- *   LED_IDLE           MCU is is sleep mode      Not used
+ *   LED_IDLE           MCU is in sleep mode      Not used
  */
 
 /****************************************************************************

--- a/boards/arm/xmc4/xmc4800-relax/include/board.h
+++ b/boards/arm/xmc4/xmc4800-relax/include/board.h
@@ -284,7 +284,7 @@
 #define LED_SIGNAL        2 /* In a signal handler       No change    */
 #define LED_ASSERTION     2 /* An assertion failed       No change    */
 #define LED_PANIC         3 /* The system has crashed   N/C  Blinking */
-#undef  LED_IDLE            /* MCU is is sleep mode      Not used     */
+#undef  LED_IDLE            /* MCU is in sleep mode      Not used     */
 
 /* Thus if LED1 is statically on, NuttX has successfully booted and is,
  * apparently, running normally.  If LED2 is flashing at approximately

--- a/boards/arm/xmc4/xmc4800-relax/src/xmc4_autoleds.c
+++ b/boards/arm/xmc4/xmc4800-relax/src/xmc4_autoleds.c
@@ -41,7 +41,7 @@
  *   LED_SIGNAL         In a signal handler       No change
  *   LED_ASSERTION      An assertion failed       No change
  *   LED_PANIC          The system has crashed   N/C  Blinking
- *   LED_IDLE           MCU is is sleep mode      Not used
+ *   LED_IDLE           MCU is in sleep mode      Not used
  */
 
 /****************************************************************************

--- a/boards/arm64/a64/pinephone/include/board.h
+++ b/boards/arm64/a64/pinephone/include/board.h
@@ -68,6 +68,6 @@ typedef enum
 #define LED_SIGNAL         5 /* In a signal handler      ON     OFF   ON   */
 #define LED_ASSERTION      6 /* An assertion failed      OFF    ON    ON   */
 #define LED_PANIC          7 /* The system has crashed   FLASH  ON    ON   */
-#define LED_IDLE           8 /* MCU is is sleep mode     OFF    FLASH OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     OFF    FLASH OFF  */
 
 #endif /* __BOARDS_ARM64_A64_PINEPHONE_INCLUDE_BOARD_H */

--- a/boards/arm64/rk3399/pinephonepro/include/board.h
+++ b/boards/arm64/rk3399/pinephonepro/include/board.h
@@ -68,6 +68,6 @@ typedef enum
 #define LED_SIGNAL         5 /* In a signal handler      ON     OFF   ON   */
 #define LED_ASSERTION      6 /* An assertion failed      OFF    ON    ON   */
 #define LED_PANIC          7 /* The system has crashed   FLASH  ON    ON   */
-#define LED_IDLE           8 /* MCU is is sleep mode     OFF    FLASH OFF  */
+#define LED_IDLE           8 /* MCU is in sleep mode     OFF    FLASH OFF  */
 
 #endif /* __BOARDS_ARM64_RK3399_PINEPHONE_PRO_INCLUDE_BOARD_H */

--- a/boards/arm64/zynq-mpsoc/zcu111/include/board.h
+++ b/boards/arm64/zynq-mpsoc/zcu111/include/board.h
@@ -63,7 +63,7 @@
  *   LED_SIGNAL          In a signal handler      No change
  *   LED_ASSERTION       An assertion failed      No change
  *   LED_PANIC           The system has crashed   Blinking
- *   LED_IDLE            STM32 is is sleep mode   Not used
+ *   LED_IDLE            STM32 is in sleep mode   Not used
  */
 
 #define LED_STARTED      0

--- a/boards/mips/pic32mz/chipkit-wifire/include/board.h
+++ b/boards/mips/pic32mz/chipkit-wifire/include/board.h
@@ -206,7 +206,7 @@
 #define LED_SIGNAL       4 /* In a signal handler     ON  ON  ON  ON  */
 #define LED_ASSERTION    4 /* An assertion failed     ON  ON  ON  ON  */
 #define LED_PANIC        4 /* The system has crashed  ON  ON  ON  ON  */
-#undef  LED_IDLE           /* MCU is is sleep mode    ---- Not used - */
+#undef  LED_IDLE           /* MCU is in sleep mode    ---- Not used - */
 
 /* Switch definitions *******************************************************/
 

--- a/boards/mips/pic32mz/chipkit-wifire/src/pic32mz_autoleds.c
+++ b/boards/mips/pic32mz/chipkit-wifire/src/pic32mz_autoleds.c
@@ -68,7 +68,7 @@
  * LED_SIGNAL        In a signal handler     ON  ON  ON  ON
  * LED_ASSERTION     An assertion failed     ON  ON  ON  ON
  * LED_PANIC         The system has crashed  ON  ON  ON  ON
- * LED_IDLE          MCU is is sleep mode    ---- Not used ----
+ * LED_IDLE          MCU is in sleep mode    ---- Not used ----
  */
 
 /* LED indices */

--- a/boards/mips/pic32mz/flipnclick-pic32mz/include/board.h
+++ b/boards/mips/pic32mz/flipnclick-pic32mz/include/board.h
@@ -233,7 +233,7 @@
 #define LED_SIGNAL       4 /* In a signal handler     GLO N/C N/C N/C N/C */
 #define LED_ASSERTION    4 /* An assertion failed     GLO N/C N/C N/C N/C */
 #define LED_PANIC        4 /* The system has crashed  2Hz N/C N/C N/C N/C */
-#undef  LED_IDLE           /* MCU is is sleep mode    ---- Not used ----- */
+#undef  LED_IDLE           /* MCU is in sleep mode    ---- Not used ----- */
 
 /* Thus if LED L is faintly glowing and all other LEDs are off (except LED D
  * which was left on but is no longer controlled by NuttX and so may be

--- a/boards/mips/pic32mz/flipnclick-pic32mz/src/pic32mz_autoleds.c
+++ b/boards/mips/pic32mz/flipnclick-pic32mz/src/pic32mz_autoleds.c
@@ -73,7 +73,7 @@
  *   LED_SIGNAL       In a signal handler     GLO N/C N/C N/C N/C
  *   LED_ASSERTION    An assertion failed     GLO N/C N/C N/C N/C
  *   LED_PANIC        The system has crashed  2Hz N/C N/C N/C N/C
- *   LED_IDLE         MCU is is sleep mode    ---- Not used -----
+ *   LED_IDLE         MCU is in sleep mode    ---- Not used -----
  *
  * Thus if LED L is faintly glowing and all other LEDs are off (except LED
  * D which was left on but is no longer controlled by NuttX and so may be in

--- a/boards/xtensa/esp32s3/esp32s3-xiao/include/board.h
+++ b/boards/xtensa/esp32s3/esp32s3-xiao/include/board.h
@@ -72,7 +72,7 @@
  #define LED_SIGNAL        2  /* In a signal handler      N/C GLOW OFF      */
  #define LED_ASSERTION     2  /* An assertion failed      N/C GLOW OFF      */
  #define LED_PANIC         3  /* The system has crashed   N/C N/C  Blinking */
- #define LED_PANIC         3  /* MCU is is sleep mode    ---- Not used ---- */
+ #define LED_PANIC         3  /* MCU is in sleep mode    ---- Not used ---- */
 
 /* GPIO pins used by the GPIO Subsystem */
 

--- a/boards/xtensa/esp32s3/esp32s3-xiao/src/esp32s3_autoleds.c
+++ b/boards/xtensa/esp32s3/esp32s3-xiao/src/esp32s3_autoleds.c
@@ -64,7 +64,7 @@
  *   LED_SIGNAL           In a signal handler        N/C
  *   LED_ASSERTION        An assertion failed        N/C
  *   LED_PANIC            The system has crashed     N/C
- *   LED_IDLE             MCU is is sleep mode      ------
+ *   LED_IDLE             MCU is in sleep mode      ------
  */
 
 /****************************************************************************

--- a/drivers/audio/wm8904.c
+++ b/drivers/audio/wm8904.c
@@ -2250,7 +2250,7 @@ static void wm8904_audio_output(FAR struct wm8904_dev_s *priv)
    * This value sets TOCLK_RATE_DIV16=0, TOCLK_RATE_X4=0, and MCLK_DIV=0
    * while preserving the state of some undocumented bits (see wm8904.h).
    *
-   *   MCLK_DIV=0           : MCLK is is not divided by 2.
+   *   MCLK_DIV=0           : MCLK is not divided by 2.
    */
 
   wm8904_writereg(priv, WM8904_CLKRATE0, 0x845e);

--- a/drivers/mtd/ftl.c
+++ b/drivers/mtd/ftl.c
@@ -586,7 +586,7 @@ static ssize_t ftl_flush(FAR void *priv, FAR const uint8_t *buffer,
       return ftl_flush_direct(dev, buffer, startblock, nblocks);
     }
 
-  /* Get the aligned block.  Here is is assumed: (1) The number of R/W blocks
+  /* Get the aligned block.  Here it is assumed: (1) The number of R/W blocks
    * per erase block is a power of 2, and (2) the erase begins with that same
    * alignment.
    */

--- a/drivers/mtd/smart.c
+++ b/drivers/mtd/smart.c
@@ -951,7 +951,7 @@ static ssize_t smart_write(FAR struct inode *inode,
 
   /* I think maybe we need to lock on a mutex here */
 
-  /* Get the aligned block.  Here is is assumed: (1) The number of R/W blocks
+  /* Get the aligned block.  Here it is assumed: (1) The number of R/W blocks
    * per erase block is a power of 2, and (2) the erase begins with that same
    * alignment.
    */
@@ -4150,7 +4150,7 @@ errout:
  * Name: smart_write_wearstatus
  *
  * Description:  Writes the wear leveling status bits to sector zero (and
- *               possibly others if it doesn't fit) such that is is persisted
+ *               possibly others if it doesn't fit) such that it is persisted
  *               across OS reboots.
  *
  ****************************************************************************/
@@ -4271,7 +4271,7 @@ errout:
  * Name: smart_read_wearstatus
  *
  * Description:  Reads the wear leveling status bits from sector zero (and
- *               possibly others if it doesn't fit) such that is is persisted
+ *               possibly others if it doesn't fit) such that it is persisted
  *               across OS reboots.
  *
  ****************************************************************************/

--- a/drivers/usbdev/usbmsc.c
+++ b/drivers/usbdev/usbmsc.c
@@ -627,7 +627,7 @@ static int usbmsc_setup(FAR struct usbdevclass_driver_s *driver,
             switch (ctrl->value[1])
               {
                 /* If the mass storage device is used in as part of a
-                 * composite device, then the device descriptor is is
+                 * composite device, then the device descriptor is
                  * provided by logic in the composite device implementation.
                  */
 

--- a/fs/smartfs/smartfs_smart.c
+++ b/fs/smartfs/smartfs_smart.c
@@ -258,7 +258,7 @@ static int smartfs_open(FAR struct file *filep, FAR const char *relpath,
 
   if (ret == OK)
     {
-      /* The name exists -- but is is a file or a directory? */
+      /* The name exists -- but is it a file or a directory? */
 
       if (sf->entry.flags & SMARTFS_DIRENT_TYPE_DIR)
         {

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -1197,7 +1197,7 @@ int fdlist_open(FAR struct fdlist *list,
  * Name: nx_open
  *
  * Description:
- *   nx_open() is similar to the standard 'open' interface except that is is
+ *   nx_open() is similar to the standard 'open' interface except that it is
  *   not a cancellation point and it does not modify the errno variable.
  *
  *   nx_open() is an internal NuttX interface and should not be called

--- a/include/nuttx/page.h
+++ b/include/nuttx/page.h
@@ -412,7 +412,7 @@ int up_allocpage(FAR struct tcb_s *tcb, FAR void **vpage);
  *  but non-cacheable.  No special actions will be required of
  *  up_fillpage() in order to write into this allocated page.  If the
  *  virtual address maps to a text region, however, this function should
- *  remap the region so that is is read/execute only.  It should be made
+ *  remap the region so that it is read/execute only.  It should be made
  *  cache-able in any case.
  *
  * Input Parameters:

--- a/include/nuttx/spi/spi_bitbang.c
+++ b/include/nuttx/spi/spi_bitbang.c
@@ -329,7 +329,7 @@ static uint16_t spi_bitexchange0(uint16_t dataout, uint32_t holdtime)
 {
   uint16_t datain;
 
-  /* Here the clock is is in the resting set (low).  Set MOSI output and wait
+  /* Here the clock is in the resting set (low).  Set MOSI output and wait
    * for the hold time
    */
 
@@ -464,7 +464,7 @@ static uint16_t spi_bitexchange2(uint16_t dataout, uint32_t holdtime)
 {
   uint16_t datain;
 
-  /* Here the clock is is in the resting set (high).  Set MOSI output and
+  /* Here the clock is in the resting set (high).  Set MOSI output and
    * wait for the hold time
    */
 

--- a/libs/libc/time/lib_localtime.c
+++ b/libs/libc/time/lib_localtime.c
@@ -1055,7 +1055,7 @@ static int tzload(FAR const char *name,
         }
     }
 
-  /* If type 0 is is unused in transitions, it's the type to use for early
+  /* If type 0 is unused in transitions, it's the type to use for early
    * times.
    */
 

--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -253,8 +253,8 @@ static int inet_udp_alloc(FAR struct socket *psock)
 
 static int inet_setup(FAR struct socket *psock)
 {
-  /* Allocate the appropriate connection structure.  This reserves the
-   * the connection structure is is unallocated at this point.  It will
+  /* Allocate the appropriate connection structure.  This reserves
+   * the connection structure, which is unallocated at this point.  It will
    * not actually be initialized until the socket is connected.
    *
    * REVISIT:  Only SOCK_STREAM and SOCK_DGRAM are supported.


### PR DESCRIPTION
## Summary

Fix "is is" typo (duplicate "is") across the codebase. This is a pure style/documentation fix that corrects duplicate word typos found in 181 files.

In most cases "is is" was changed to "is", but in contexts like "MCU is is sleep mode" it was corrected to "MCU in sleep mode".

Also fixes a "the the" typo in net/inet/inet_sockif.c.

## Impact

- Impact on user: NO
- Impact on build: NO
- Impact on hardware: NO
- Impact on documentation: YES - Documentation comments are corrected
- Impact on security: NO
- Impact on compatibility: NO

## Testing

No functional testing required - this is a documentation/style-only change that fixes typos in comments and documentation.
