### PR TITLE
drivers/net/telnet: Ignore unsupported subnegotiation data

### DIFF
--- a/drivers/net/telnet.c
+++ b/drivers/net/telnet.c
@@ -107,8 +107,8 @@ enum telnet_state_e
   STATE_DO,
   STATE_DONT,
   STATE_SB,
-  STATE_SB_NAWS,
-  STATE_SE
+  STATE_SB_DATA,
+  STATE_SB_NAWS
 };
 
 /* This structure describes the internal state of the driver */
@@ -118,6 +118,7 @@ struct telnet_dev_s
   uint8_t           td_state;     /* (See telnet_state_e) */
   uint8_t           td_crefs;     /* The number of open references to the session */
   uint8_t           td_minor;     /* Minor device number */
+  bool              td_sb_iac;    /* Saw IAC within sub-negotiation payload */
   uint16_t          td_offset;    /* Offset to the valid, pending bytes in the rxbuffer */
   uint16_t          td_pending;   /* Number of valid, pending bytes in the rxbuffer */
 #ifdef CONFIG_TELNET_SUPPORT_NAWS
@@ -372,16 +373,17 @@ static ssize_t telnet_receive(FAR struct telnet_dev_s *priv,
                       priv->td_state = STATE_DONT;
                       break;
 
-#ifdef CONFIG_TELNET_SUPPORT_NAWS
                     case TELNET_SB:
                       priv->td_state = STATE_SB;
+                      priv->td_sb_iac = false;
+#ifdef CONFIG_TELNET_SUPPORT_NAWS
                       priv->td_sb_count = 0;
+#endif
                       break;
 
                     case TELNET_SE:
                       priv->td_state = STATE_NORMAL;
                       break;
-#endif
 
                     default:
                       priv->td_state = STATE_NORMAL;
@@ -458,25 +460,58 @@ static ssize_t telnet_receive(FAR struct telnet_dev_s *priv,
               }
             break;
 
-#ifdef CONFIG_TELNET_SUPPORT_NAWS
-          /* Handle Telnet Sub negotiation request */
+          /* Handle Telnet sub-negotiation requests. */
 
           case STATE_SB:
             switch (ch)
               {
+#ifdef CONFIG_TELNET_SUPPORT_NAWS
                 case TELNET_NAWS:
                   priv->td_state = STATE_SB_NAWS;
                   break;
+#endif
 
                 default:
-                  priv->td_state = STATE_NORMAL;
+                  priv->td_state = STATE_SB_DATA;
                   break;
               }
             break;
 
+          /* Ignore unsupported sub-negotiation payload until IAC SE. */
+
+          case STATE_SB_DATA:
+            if (priv->td_sb_iac)
+              {
+                priv->td_sb_iac = false;
+                if (ch == TELNET_SE)
+                  {
+                    priv->td_state = STATE_NORMAL;
+                  }
+              }
+            else if (ch == TELNET_IAC)
+              {
+                priv->td_sb_iac = true;
+              }
+            break;
+
+#ifdef CONFIG_TELNET_SUPPORT_NAWS
           /* Handle NAWS sub-option negotiation */
 
           case STATE_SB_NAWS:
+            if (priv->td_sb_iac)
+              {
+                priv->td_sb_iac = false;
+                if (ch == TELNET_SE)
+                  {
+                    priv->td_state = STATE_NORMAL;
+                    break;
+                  }
+              }
+            else if (ch == TELNET_IAC)
+              {
+                priv->td_sb_iac = true;
+                break;
+              }
 
             /* Update cols / rows based on received byte count */
 
@@ -500,11 +535,11 @@ static ssize_t telnet_receive(FAR struct telnet_dev_s *priv,
                   break;
               }
 
-            /* Increment SB count and switch to NORMAL when complete */
+            /* Increment SB count and keep discarding until IAC SE. */
 
             if (++priv->td_sb_count == 4)
               {
-                priv->td_state = STATE_NORMAL;
+                priv->td_state = STATE_SB_DATA;
               }
 
             break;


### PR DESCRIPTION
## Summary

  Fix telnet sub-negotiation parsing so unsupported sub-option payload does not
  leak into the first NSH command.

  The issue happens when the telnet client sends `IAC SB ... IAC SE`
  sub-negotiation data and the option is not handled by the current build,
  for example when `CONFIG_TELNET_SUPPORT_NAWS` is disabled or
  some new sub-options. In that case, the previous implementation could
  return to normal input processing and let sub-negotiation payload
  bytes appear as part of the first command read by NSH.

  This change keeps consuming unsupported sub-negotiation payload until
  `IAC SE`, and also handles escaped `IAC IAC` correctly inside
  sub-negotiation payload so a literal `0xFF` data byte is not mistaken for
  the sub-negotiation terminator.

  NAWS handling remains unchanged in functionality, but now follows the
  same sub-negotiation framing rules more strictly.

  Reference:
  * Fixes BUG [#18431]
  * RFC 854   (telnet)
  * RFC 1073 (NAWS)

## Impact
  bugfix
  * Is new feature added? Is existing feature changed? NO 
  * Impact on user (will user need to adapt to change)? NO
  * Impact on build (will build process change)? NO
  * Impact on hardware (will arch(s) / board(s) / driver(s) change)? NO
  * Impact on documentation (is update required / provided)? NO
  * Impact on security (any sort of implications)? NO
  * Impact on compatibility (backward/forward/interoperability)? NO
  * Anything else to consider or add? None

## Testing

  I confirm that changes are verified on local setup and works as intended:
  * Build Host(s): OS (Linux shun-tcubuntu 6.8.0-106-generic), CPU(Intel(R) Xeon(R) Platinum 8255C CPU), compiler(arm-gnu-toolchain-15.2.rel1-x86_64-aarch64-none-elf)
  * Target(s): arch(aarch64), board:qemu-armv8a
  * you can also provide steps on how to reproduce the problem and verify the change.
    * Launch Nuttx and run `telnetd &` from NSH as telnet server
    * Mock sub-negotiation client behavior using python code
    * Tested with and without CONFIG_TELNET_SUPPORT_NAWS config

  Test python pseudo code
  ```
  import socket, time

  s = socket.create_connection(("host", port))

  # IAC SB NAWS WIDTH[1] WIDTH[0] HEIGHT[1] HEIGHT[0] IAC SE
  s.sendall(b"\xff\xfa\x1fwwhh\xff\xf0help\r\n")
  wait
  print(s.recv(8192).decode("latin1", errors="replace"))

  # IAC SB TERMINAL-TYPE SEND IAC SE
  s.sendall(b"\xff\xfa\x18xx\xff\xf0help\r\n")
  wait
  print(s.recv(8192).decode("latin1", errors="replace"))
 
  # No sub-negotiation
  s.sendall(b"help\r\n")
  wait
  print(s.recv(8192).decode("latin1", errors="replace"))

  s.close()
  ```

  Testing logs before change:

  ```
  help command execution error
  NuttShell (NSH) NuttX-12.12.0
  nsh> nsh: wwhhhelp: command not found
  nsh>
  ```

  Testing logs after change with and without CONFIG_TELNET_SUPPORT_NAWS config:

  ```
  ÿý when enable NAWS, should be response here.
  NuttShell (NSH) NuttX-12.12.0
  nsh> help usage:  help [-v] [<cmd>]

    .           cmp         free        mkrd        rmdir       uname
    [           dirname     get         mount       set         umount
    ?           df          help        mv          kill        unset
    alias       dmesg       hexdump     nfsmount    pkill       uptime
    unalias     echo        ifconfig    nslookup    sleep       watch
    arp         env         ifdown      pidof       usleep      wget
    basename    exec        ifup        printf      source      xd
    break       exit        ls          ps          test        wait
    cat         expr        md5         put         time
    cd          false       mkdir       pwd         true
    cp          fdinfo      mkfatfs     rm          truncate

  Builtin Apps:
    dd            hello         nxplayer      ping          telnetd
    fdtdump       iperf         nxrecorder    renew
    getprime      nsh           ostest        sh
  nsh>
  ```