### PR TITLE
boards/nucleo-c0{71rb|92rc}: fix USART 1 pins

### DIFF
--- a/boards/arm/stm32f0l0g0/nucleo-c071rb/include/board.h
+++ b/boards/arm/stm32f0l0g0/nucleo-c071rb/include/board.h
@@ -139,12 +139,12 @@
 /* USART */
 
 /* USART1 at arduino D0/D1:
- *   USART1_RX - PB6
- *   USART1_TX - PB7
+ *   USART1_RX - PB7
+ *   USART1_TX - PB6
  */
 
-#define GPIO_USART1_RX      (GPIO_USART2_RX_2|GPIO_SPEED_HIGH)    /* PB6 */
-#define GPIO_USART1_TX      (GPIO_USART2_TX_2|GPIO_SPEED_HIGH)    /* PB7 */
+#define GPIO_USART1_RX      (GPIO_USART1_RX_2|GPIO_SPEED_HIGH)    /* PB7 */
+#define GPIO_USART1_TX      (GPIO_USART1_TX_2|GPIO_SPEED_HIGH)    /* PB6 */
 
 /* USART1 RS485_DIR - PA8 (arduino D7)
  * (compatible with RS485 Waveshare shield)

--- a/boards/arm/stm32f0l0g0/nucleo-c092rc/include/board.h
+++ b/boards/arm/stm32f0l0g0/nucleo-c092rc/include/board.h
@@ -144,12 +144,12 @@
 /* USART */
 
 /* USART1 at arduino D0/D1:
- *   USART1_RX - PB6
- *   USART1_TX - PB7
+ *   USART1_RX - PB7
+ *   USART1_TX - PB6
  */
 
-#define GPIO_USART1_RX      (GPIO_USART2_RX_2|GPIO_SPEED_HIGH)    /* PB6 */
-#define GPIO_USART1_TX      (GPIO_USART2_TX_2|GPIO_SPEED_HIGH)    /* PB7 */
+#define GPIO_USART1_RX      (GPIO_USART1_RX_2|GPIO_SPEED_HIGH)    /* PB7 */
+#define GPIO_USART1_TX      (GPIO_USART1_TX_2|GPIO_SPEED_HIGH)    /* PB6 */
 
 /* USART1 RS485_DIR - PA8 (arduino D7)
  * (compatible with RS485 Waveshare shield)


### PR DESCRIPTION

## Summary
boards/nucleo-c0{71rb|92rc}: fix USART 1 pins

<img width="1684" height="176" alt="image" src="https://github.com/user-attachments/assets/594d6c99-98e6-419c-b259-e509d3c02e9c" />

## Impact

fix wrong pins

## Testing

tested with modbus on USART1 pins