### PR TITLE
sched/group_foreachchild.c: fix warning

### DIFF
--- a/sched/group/group_foreachchild.c
+++ b/sched/group/group_foreachchild.c
@@ -64,7 +64,7 @@ int group_foreachchild(FAR struct task_group_s *group,
 {
   FAR sq_entry_t *curr;
   FAR sq_entry_t *next;
-  int ret;
+  int ret = OK;
 
   DEBUGASSERT(group);
 


### PR DESCRIPTION
## Summary
fix compilation warning:
```
   group/group_foreachchild.c:85:10: warning: 'ret' may be used uninitialized [-Wmaybe-uninitialized]
   85 |   return ret;
      |          ^~~
   group/group_foreachchild.c:67:7: note: 'ret' was declared here
   67 |   int ret;
```

## Impact

fix waring

## Testing

CI
