### PR TITLE
stm32h5/adc: fix TROVS bit and watchdog threshold register writes

### DIFF
--- a/arch/arm/src/stm32h5/stm32_adc.c
+++ b/arch/arm/src/stm32h5/stm32_adc.c
@@ -1069,7 +1069,10 @@ static void adc_oversample(struct adc_dev_s *dev)
                      (priv->ovsr << ADC_CFGR2_OVSR_SHIFT) |
                      (priv->ovss << ADC_CFGR2_OVSS_SHIFT);
 
-  setbits |= priv->trovs;
+  if (priv->trovs)
+    {
+      setbits |= ADC_CFGR2_TROVS;
+    }
 
   adc_modifyreg(priv, STM32_ADC_CFGR2_OFFSET, clrbits, setbits);
 }
@@ -1811,7 +1814,8 @@ static int adc_ioctl(struct adc_dev_s *dev, int cmd, unsigned long arg)
 
           /* Set the watchdog threshold register */
 
-          regval = ((arg << ADC_TR1_HT1_SHIFT) & ADC_TR1_HT1_MASK);
+          regval &= ~ADC_TR1_HT1_MASK;
+          regval |= ((arg << ADC_TR1_HT1_SHIFT) & ADC_TR1_HT1_MASK);
           adc_putreg(priv, STM32_ADC_TR1_OFFSET, regval);
 
           /* Ensure analog watchdog is enabled */
@@ -1845,7 +1849,8 @@ static int adc_ioctl(struct adc_dev_s *dev, int cmd, unsigned long arg)
 
           /* Set the watchdog threshold register */
 
-          regval = ((arg << ADC_TR1_LT1_SHIFT) & ADC_TR1_LT1_MASK);
+          regval &= ~ADC_TR1_LT1_MASK;
+          regval |= ((arg << ADC_TR1_LT1_SHIFT) & ADC_TR1_LT1_MASK);
           adc_putreg(priv, STM32_ADC_TR1_OFFSET, regval);
 
           /* Ensure analog watchdog is enabled */


### PR DESCRIPTION
## Summary

Fix two register-level bugs in the STM32H5 ADC driver:

1. **TROVS bit never set**: In `adc_oversample()`, `priv->trovs` (a `bool`, value 0 or 1) was OR'd directly into `setbits`. Since `ADC_CFGR2_TROVS` is `(1 << 9)` (bit 9), OR'ing in `true` (1) only sets bit 0 — which is `ADC_CFGR2_ROVSE`, already set. The TROVS bit was silently never enabled, meaning triggered oversampling could not be activated.

2. **Watchdog ioctl clobbers TR1 register**: Both `ANIOC_WDOG_UPPER` and `ANIOC_WDOG_LOWER` read the TR1 register for threshold validation, but then overwrite `regval` with only the new threshold field before writing back. This zeros out the opposite threshold (LT1 or HT1) and the AWDFILT digital filter bits. Changed to read-modify-write to preserve all other fields.

## Impact

- Fixes incorrect hardware configuration for users of triggered oversampling (`CONFIG_STM32H5_ADCx_TROVS`)
- Fixes data loss in watchdog threshold register when setting upper or lower thresholds via ioctl at runtime
- No impact on users not using these features; no API changes

## Testing

- Build host: Linux (WSL2)
- Target: STM32H563 (Nucleo-H563ZI)
- Code-level review against RM0481 register definitions for ADC_CFGR2 (Section 25.7.5) and ADC_TR1 (Section 25.7.7)