### PR TITLE
drivers/net/telnet: fix typo in telnet.c

### DIFF
--- a/drivers/net/telnet.c
+++ b/drivers/net/telnet.c
@@ -209,9 +209,9 @@ static const struct file_operations g_factory_fops =
   factory_ioctl, /* ioctl */
 };
 
-/* This is an global data set of all of all active Telnet drivers.  This
- * additional logic in included to handle killing of task via control
- * characters received via Telenet (via Ctrl-C SIGINT, in particular).
+/* This is a global data set of all active Telnet drivers. This
+ * additional logic is included to handle killing tasks via control
+ * characters received via Telnet (via Ctrl-C SIGINT, in particular).
  */
 
 static struct telnet_dev_s *g_telnet_clients[CONFIG_TELNET_MAXLCLIENTS];


### PR DESCRIPTION
## Summary

  Fix spelling and grammar in a telnet file comment.

  Correct `Telenet` -> `Telnet` and clean up nearby wording in
  `drivers/net/telnet.c`. This is a comment-only change.

## Impact

  Comments only, no other impact.

## Testing

  I confirm that changes are verified on local setup and works as intended:
  * Build Host(s): OS (Linux shun-tcubuntu 6.8.0-106-generic), CPU(Intel(R) Xeon(R) Platinum 8255C CPU), compiler(arm-gnu-toolchain-15.2.rel1-x86_64-aarch64-none-elf)
  * Target(s): arch(aarch64), board:qemu-armv8a

  Build logs:
  ```
  (nuttx) shun@shun-tcubuntu:~/nuttx$ make -j$(nproc)
  Create version.h
  LD: nuttx
  Memory region         Used Size  Region Size  %age Used
  CP: nuttx.hex
  CP: nuttx.bin

  build passed.
  ```

  Testing logs:
  ```
  Bringup and telnetd log
  [    0.040000] pci_scan_bus: pci_scan_bus for bus 0
  [    0.040000] pci_scan_bus: class = 00000600, hdr_type = 00000000
  [    0.040000] pci_scan_bus: 00:00 [1b36:0008]
  [    0.040000] pci_setup_device: pbar0 set bad mask
  [    0.040000] pci_setup_device: pbar1 set bad mask
  [    0.040000] pci_setup_device: pbar2 set bad mask
  [    0.040000] pci_setup_device: pbar3 set bad mask
  [    0.040000] pci_setup_device: pbar4 set bad mask
  [    0.040000] pci_setup_device: pbar5 set bad mask
  telnetd [4:100]

  telnet client worked.
  Escape character is '^]'.

  NuttShell (NSH) NuttX-12.12.0
  nsh> help
  help usage:  help [-v] [<cmd>]

    .           cmp         free        mkrd        rmdir       uname
    [           dirname     get         mount       set         umount
    ?           df          help        mv          kill        unset
    alias       dmesg       hexdump     nfsmount    pkill       uptime
    unalias     echo        ifconfig    nslookup    sleep       watch
    arp         env         ifdown      pidof       usleep      wget
    basename    exec        ifup        printf      source      xd
    break       exit        ls          ps          test        wait
    cat         expr        md5         put         time
    cd          false       mkdir       pwd         true
    cp          fdinfo      mkfatfs     rm          truncate

  Builtin Apps:
    dd            hello         nxplayer      ping          telnetd
    fdtdump       iperf         nxrecorder    renew
    getprime      nsh           ostest        sh
  nsh> ^^^]
  telnet>
  Connection closed.
  ```