### PR TITLE
arch: cxd56xx: Fix DMA transfer for large memory size

### DIFF
--- a/arch/arm/src/cxd56xx/cxd56_dmac.c
+++ b/arch/arm/src/cxd56xx/cxd56_dmac.c
@@ -313,13 +313,13 @@ static int ch2dmac(int ch)
 {
   switch (ch)
     {
-    case 0: case 1:
+      case 0 ... 1:
         return 1;
-    case 2: case 3: case 4: case 5: case 6: /* APP IDMAC */
+      case 2 ... 6: /* APP IDMAC */
         return 3;
-    case 7: case 8: /* APP SKDMAC */
+      case 7 ... 8: /* APP SKDMAC */
         return 2;
-    default:
+      default:
         return 0;
     }
 }
@@ -330,9 +330,12 @@ static struct dmac_register_map *get_device(int ch)
 
   switch (id)
     {
-    case 1: return (struct dmac_register_map *)DMAC1_REG_BASE;
-    case 2: return (struct dmac_register_map *)DMAC2_REG_BASE;
-    case 3: return (struct dmac_register_map *)DMAC3_REG_BASE;
+      case 1:
+        return (struct dmac_register_map *)DMAC1_REG_BASE;
+      case 2:
+        return (struct dmac_register_map *)DMAC2_REG_BASE;
+      case 3:
+        return (struct dmac_register_map *)DMAC3_REG_BASE;
     }
 
     return NULL;
@@ -366,13 +369,13 @@ static int get_pmid(int ch)
 {
   switch (ch)
     {
-    case 0: case 1:
+      case 0 ... 1:
         return PM_APP_ADMAC;
-    case 2: case 3: case 4: case 5: case 6:
+      case 2 ... 6:
         return PM_APP_IDMAC;
-    case 7: case 8:
+      case 7 ... 8:
         return PM_APP_SKDMAC;
-    default:
+      default:
         break; /* may not comes here */
     }
 


### PR DESCRIPTION
## Summary
When using a dummy memory address in DMA LLI transfers, do not update the memory address.

## Impact
Only for spresense.

## Testing
* Build Host(s): OS (Linux), CPU(Intel), compiler(GCC),
* Target(s): arch(ARM), board(SPRESENSE), Use spresense:example_lcd
* how to reproduce the problem and verify the change.

This issue occurs when the size of a single SPI DMA transfer is 4 KB or larger.
Add a `putarea` function to the ILI9340 driver to increase the transfer size. The existing `putrun` function has no problem.

In addition to verify the memory address, add a `printf` log for test:

```diff
diff --git a/arch/arm/src/cxd56xx/cxd56_dmac.c b/arch/arm/src/cxd56xx/cxd56_dmac.c
index 1c978c34e1..20bc5e9f3f 100644
--- a/arch/arm/src/cxd56xx/cxd56_dmac.c
+++ b/arch/arm/src/cxd56xx/cxd56_dmac.c
@@ -928,6 +928,7 @@ void cxd56_rxdmasetup(DMA_HANDLE handle, uintptr_t paddr, uintptr_t maddr,
   rest = nbytes;

   list_num = (nbytes + CXD56_DMAC_MAX_SIZE - 1) / CXD56_DMAC_MAX_SIZE;
+  printf("---------------------------------------------------- Rx nbytes=%d\n", nbytes);
   for (i = 0; i < list_num - 1; i++)
     {
       dmach->list[i].src_addr = paddr;
@@ -938,6 +939,11 @@ void cxd56_rxdmasetup(DMA_HANDLE handle, uintptr_t paddr, uintptr_t maddr,
                                config.dest_width, config.src_width,    /* Dest / Src transfer width */
                                CXD56_DMAC_BSIZE4, CXD56_DMAC_BSIZE4,   /* Dest / Src burst size (fixed) */
                                CXD56_DMAC_MAX_SIZE);
+      printf("[%02d] src=%08lx dst=%08lx lli=%08lx control=%08lx\n", i,
+             dmach->list[i].src_addr,
+             dmach->list[i].dest_addr,
+             dmach->list[i].nextlli,
+             dmach->list[i].control);

       if (di)
         {
@@ -955,6 +961,11 @@ void cxd56_rxdmasetup(DMA_HANDLE handle, uintptr_t paddr, uintptr_t maddr,
                                config.dest_width, config.src_width,    /* Dest / Src transfer width */
                                CXD56_DMAC_BSIZE4, CXD56_DMAC_BSIZE4,   /* Dest / Src burst size (fixed) */
                                rest);
+  printf("[%02d] src=%08lx dst=%08lx lli=%08lx control=%08lx\n", i,
+         dmach->list[i].src_addr,
+         dmach->list[i].dest_addr,
+         dmach->list[i].nextlli,
+         dmach->list[i].control);

   peri = config.channel_cfg & CXD56_DMA_PERIPHERAL_MASK;
   dma_setconfig(dmach->chan, 1, 1, CXD56_DMAC_P2M, 0, peri);
@@ -1003,6 +1014,7 @@ void cxd56_txdmasetup(DMA_HANDLE handle, uintptr_t paddr, uintptr_t maddr,
   rest = nbytes;

   list_num = (nbytes + CXD56_DMAC_MAX_SIZE - 1) / CXD56_DMAC_MAX_SIZE;
+  printf("---------------------------------------------------- Tx nbytes=%d\n", nbytes);
   for (i = 0; i < list_num - 1; i++)
     {
       dmach->list[i].src_addr = src;
@@ -1013,6 +1025,11 @@ void cxd56_txdmasetup(DMA_HANDLE handle, uintptr_t paddr, uintptr_t maddr,
                                    config.dest_width, config.src_width,    /* Dest / Src transfer width (fixed) */
                                    CXD56_DMAC_BSIZE1, CXD56_DMAC_BSIZE1,   /* Dest / Src burst size (fixed) */
                                    CXD56_DMAC_MAX_SIZE);
+      printf("[%02d] src=%08lx dst=%08lx lli=%08lx control=%08lx\n", i,
+             dmach->list[i].src_addr,
+             dmach->list[i].dest_addr,
+             dmach->list[i].nextlli,
+             dmach->list[i].control);

       if (si)
         {
@@ -1030,6 +1047,11 @@ void cxd56_txdmasetup(DMA_HANDLE handle, uintptr_t paddr, uintptr_t maddr,
                                    config.dest_width, config.src_width,    /* Dest / Src transfer width (fixed) */
                                    CXD56_DMAC_BSIZE4, CXD56_DMAC_BSIZE4,   /* Dest / Src burst size (fixed) */
                                    rest);
+  printf("[%02d] src=%08lx dst=%08lx lli=%08lx control=%08lx\n", i,
+         dmach->list[i].src_addr,
+         dmach->list[i].dest_addr,
+         dmach->list[i].nextlli,
+         dmach->list[i].control);

   peri = config.channel_cfg & CXD56_DMA_PERIPHERAL_MASK;
   dma_setconfig(dmach->chan, 1, 1, CXD56_DMAC_M2P, peri, 0);
```

Testing logs before change:

Failure: the destination address `dst` in Rx has been incremented and points to an invalid address.


```
---------------------------------------------------- Rx nbytes=115200
[00] src=02103408 dst=0d05a6bc lli=0d0730f8 control=0aa80fff
[01] src=02103408 dst=0d05b6bb lli=0d073108 control=0aa80fff
[02] src=02103408 dst=0d05c6ba lli=0d073118 control=0aa80fff
[03] src=02103408 dst=0d05d6b9 lli=0d073128 control=0aa80fff
[04] src=02103408 dst=0d05e6b8 lli=0d073138 control=0aa80fff
[05] src=02103408 dst=0d05f6b7 lli=0d073148 control=0aa80fff
[06] src=02103408 dst=0d0606b6 lli=0d073158 control=0aa80fff
[07] src=02103408 dst=0d0616b5 lli=0d073168 control=0aa80fff
[08] src=02103408 dst=0d0626b4 lli=0d073178 control=0aa80fff
[09] src=02103408 dst=0d0636b3 lli=0d073188 control=0aa80fff
[10] src=02103408 dst=0d0646b2 lli=0d073198 control=0aa80fff
[11] src=02103408 dst=0d0656b1 lli=0d0731a8 control=0aa80fff
[12] src=02103408 dst=0d0666b0 lli=0d0731b8 control=0aa80fff
[13] src=02103408 dst=0d0676af lli=0d0731c8 control=0aa80fff
[14] src=02103408 dst=0d0686ae lli=0d0731d8 control=0aa80fff
[15] src=02103408 dst=0d0696ad lli=0d0731e8 control=0aa80fff
[16] src=02103408 dst=0d06a6ac lli=0d0731f8 control=0aa80fff
[17] src=02103408 dst=0d06b6ab lli=0d073208 control=0aa80fff
[18] src=02103408 dst=0d06c6aa lli=0d073218 control=0aa80fff
[19] src=02103408 dst=0d06d6a9 lli=0d073228 control=0aa80fff
[20] src=02103408 dst=0d06e6a8 lli=0d073238 control=0aa80fff
[21] src=02103408 dst=0d06f6a7 lli=0d073248 control=0aa80fff
[22] src=02103408 dst=0d0706a6 lli=0d073258 control=0aa80fff
[23] src=02103408 dst=0d0716a5 lli=0d073268 control=0aa80fff
[24] src=02103408 dst=0d0726a4 lli=0d073278 control=0aa80fff
[25] src=02103408 dst=0d0736a3 lli=0d073288 control=0aa80fff
[26] src=02103408 dst=0d0746a2 lli=0d073298 control=0aa80fff
[27] src=02103408 dst=0d0756a1 lli=0d0732a8 control=0aa80fff
[28] src=02103408 dst=0d0766a0 lli=00000000 control=8aa8021c
```

Testing logs after change:

Success: the Rx destination address `dst` points to a fixed address.


```
---------------------------------------------------- Rx nbytes=115200
[00] src=02103408 dst=0d05a6bc lli=0d0730f8 control=0aa80fff
[01] src=02103408 dst=0d05a6bc lli=0d073108 control=0aa80fff
[02] src=02103408 dst=0d05a6bc lli=0d073118 control=0aa80fff
[03] src=02103408 dst=0d05a6bc lli=0d073128 control=0aa80fff
[04] src=02103408 dst=0d05a6bc lli=0d073138 control=0aa80fff
[05] src=02103408 dst=0d05a6bc lli=0d073148 control=0aa80fff
[06] src=02103408 dst=0d05a6bc lli=0d073158 control=0aa80fff
[07] src=02103408 dst=0d05a6bc lli=0d073168 control=0aa80fff
[08] src=02103408 dst=0d05a6bc lli=0d073178 control=0aa80fff
[09] src=02103408 dst=0d05a6bc lli=0d073188 control=0aa80fff
[10] src=02103408 dst=0d05a6bc lli=0d073198 control=0aa80fff
[11] src=02103408 dst=0d05a6bc lli=0d0731a8 control=0aa80fff
[12] src=02103408 dst=0d05a6bc lli=0d0731b8 control=0aa80fff
[13] src=02103408 dst=0d05a6bc lli=0d0731c8 control=0aa80fff
[14] src=02103408 dst=0d05a6bc lli=0d0731d8 control=0aa80fff
[15] src=02103408 dst=0d05a6bc lli=0d0731e8 control=0aa80fff
[16] src=02103408 dst=0d05a6bc lli=0d0731f8 control=0aa80fff
[17] src=02103408 dst=0d05a6bc lli=0d073208 control=0aa80fff
[18] src=02103408 dst=0d05a6bc lli=0d073218 control=0aa80fff
[19] src=02103408 dst=0d05a6bc lli=0d073228 control=0aa80fff
[20] src=02103408 dst=0d05a6bc lli=0d073238 control=0aa80fff
[21] src=02103408 dst=0d05a6bc lli=0d073248 control=0aa80fff
[22] src=02103408 dst=0d05a6bc lli=0d073258 control=0aa80fff
[23] src=02103408 dst=0d05a6bc lli=0d073268 control=0aa80fff
[24] src=02103408 dst=0d05a6bc lli=0d073278 control=0aa80fff
[25] src=02103408 dst=0d05a6bc lli=0d073288 control=0aa80fff
[26] src=02103408 dst=0d05a6bc lli=0d073298 control=0aa80fff
[27] src=02103408 dst=0d05a6bc lli=0d0732a8 control=0aa80fff
[28] src=02103408 dst=0d05a6bc lli=00000000 control=8aa8021c
```

