### PR TITLE
CI: install NTFC from PIP

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -184,42 +184,26 @@ jobs:
       - name: Export NuttX Repo SHA
         run: echo "nuttx_sha=`git -C sources/nuttx rev-parse HEAD`" >> $GITHUB_ENV
 
-      - name: Install NTFC
-        uses: ./sources/nuttx/.github/actions/ci-container
-        env:
-          BLOBDIR: /tools/blobs
-        with:
-          run: |
-            # install python venv
-            apt-get update
-            apt-get install -y python3 python3-dev python3-venv
-
-            # get NTFC sources
-            git clone -b release-0.0.1 https://github.com/szafonimateusz-mi/nuttx-ntfc
-            cd /github/workspace/nuttx-ntfc
-
-            # install NTFC with venv
-            python3 -m venv /github/workspace/nuttx-ntfc/venv
-            source /github/workspace/nuttx-ntfc/venv/bin/activate
-            pip3 install .
-            deactivate
-
-            # get NTFC test cases
-            cd external
-            git clone -b release-0.0.1 https://github.com/szafonimateusz-mi/nuttx-testing
-
       - name: Run builds
         uses: ./sources/nuttx/.github/actions/ci-container
         env:
           BLOBDIR: /tools/blobs
         with:
           run: |
+            pip install ntfc==0.0.1
+            mkdir /github/workspace/nuttx-ntfc
+            mkdir /github/workspace/nuttx-ntfc/external
+            cd /github/workspace/nuttx-ntfc
+            # get NTFC test cases
+            cd external
+            git clone -b release-0.0.1 https://github.com/szafonimateusz-mi/nuttx-testing
+
             echo "::add-matcher::sources/nuttx/.github/gcc.json"
             export ARTIFACTDIR=`pwd`/buildartifacts
             export NTFCDIR=/github/workspace/nuttx-ntfc
             git config --global --add safe.directory /github/workspace/sources/nuttx
             git config --global --add safe.directory /github/workspace/sources/apps
-            cd sources/nuttx/tools/ci
+            cd /github/workspace/sources/nuttx/tools/ci
             if [ "X${{matrix.boards}}" = "Xcodechecker" ]; then
                 ./cibuild.sh -c -A -N -R --codechecker testlist/${{matrix.boards}}.dat
             else

--- a/boards/arm/imx6/sabre-6quad/configs/citest/run.sh
+++ b/boards/arm/imx6/sabre-6quad/configs/citest/run.sh
@@ -28,20 +28,14 @@ olddir=$(pwd)
 nuttdir=${CURRENTCONFDIR}/../../../../../../
 cd ${nuttdir}
 
-# enable venv
-source ${NTFCDIR}/venv/bin/activate
-
 # run NTFC
 confpath=${CURRENTCONFDIR}/config.yaml
 jsonconf=${CURRENTCONFDIR}/session.json
 testpath=${NTFCDIR}/external/nuttx-testing
-python3 -m ntfc test --testpath=${testpath} --confpath=${confpath} --jsonconf=${jsonconf}
+ntfc test --testpath=${testpath} --confpath=${confpath} --jsonconf=${jsonconf}
 
 ret="$?"
 echo $ret
-
-# disable venv
-deactivate
 
 # export test results
 artifacts=${ARTIFACTCONFDIR}/ntfc

--- a/boards/arm64/qemu/qemu-armv8a/configs/citest/run.sh
+++ b/boards/arm64/qemu/qemu-armv8a/configs/citest/run.sh
@@ -28,20 +28,14 @@ olddir=$(pwd)
 nuttdir=${CURRENTCONFDIR}/../../../../../../
 cd ${nuttdir}
 
-# enable venv
-source ${NTFCDIR}/venv/bin/activate
-
 # run NTFC
 confpath=${CURRENTCONFDIR}/config.yaml
 jsonconf=${CURRENTCONFDIR}/session.json
 testpath=${NTFCDIR}/external/nuttx-testing
-python3 -m ntfc test --testpath=${testpath} --confpath=${confpath} --jsonconf=${jsonconf}
+ntfc test --testpath=${testpath} --confpath=${confpath} --jsonconf=${jsonconf}
 
 ret="$?"
 echo $ret
-
-# disable venv
-deactivate
 
 # export test results
 artifacts=${ARTIFACTCONFDIR}/ntfc

--- a/boards/arm64/qemu/qemu-armv8a/configs/citest_smp/run.sh
+++ b/boards/arm64/qemu/qemu-armv8a/configs/citest_smp/run.sh
@@ -28,20 +28,14 @@ olddir=$(pwd)
 nuttdir=${CURRENTCONFDIR}/../../../../../../
 cd ${nuttdir}
 
-# enable venv
-source ${NTFCDIR}/venv/bin/activate
-
 # run NTFC
 confpath=${CURRENTCONFDIR}/config.yaml
 jsonconf=${CURRENTCONFDIR}/session.json
 testpath=${NTFCDIR}/external/nuttx-testing
-python3 -m ntfc test --testpath=${testpath} --confpath=${confpath} --jsonconf=${jsonconf}
+ntfc test --testpath=${testpath} --confpath=${confpath} --jsonconf=${jsonconf}
 
 ret="$?"
 echo $ret
-
-# disable venv
-deactivate
 
 # export test results
 artifacts=${ARTIFACTCONFDIR}/ntfc

--- a/boards/risc-v/qemu-rv/rv-virt/configs/citest/run.sh
+++ b/boards/risc-v/qemu-rv/rv-virt/configs/citest/run.sh
@@ -33,20 +33,14 @@ dd if=/dev/zero of=fatfs.img bs=512 count=128K
 mkfs.fat fatfs.img
 chmod 777 ./fatfs.img
 
-# enable venv
-source ${NTFCDIR}/venv/bin/activate
-
 # run NTFC
 confpath=${CURRENTCONFDIR}/config.yaml
 jsonconf=${CURRENTCONFDIR}/session.json
 testpath=${NTFCDIR}/external/nuttx-testing
-python3 -m ntfc test --testpath=${testpath} --confpath=${confpath} --jsonconf=${jsonconf}
+ntfc test --testpath=${testpath} --confpath=${confpath} --jsonconf=${jsonconf}
 
 ret="$?"
 echo $ret
-
-# disable venv
-deactivate
 
 # export test results
 artifacts=${ARTIFACTCONFDIR}/ntfc

--- a/boards/risc-v/qemu-rv/rv-virt/configs/citest64/run.sh
+++ b/boards/risc-v/qemu-rv/rv-virt/configs/citest64/run.sh
@@ -35,7 +35,7 @@ source ${NTFCDIR}/venv/bin/activate
 confpath=${CURRENTCONFDIR}/config.yaml
 jsonconf=${CURRENTCONFDIR}/session.json
 testpath=${NTFCDIR}/external/nuttx-testing
-python3 -m ntfc test --testpath=${testpath} --confpath=${confpath} --jsonconf=${jsonconf}
+ntfc test --testpath=${testpath} --confpath=${confpath} --jsonconf=${jsonconf}
 
 ret="$?"
 echo $ret

--- a/boards/sim/sim/sim/configs/citest/run.sh
+++ b/boards/sim/sim/sim/configs/citest/run.sh
@@ -28,20 +28,14 @@ olddir=$(pwd)
 nuttdir=${CURRENTCONFDIR}/../../../../../../
 cd ${nuttdir}
 
-# enable venv
-source ${NTFCDIR}/venv/bin/activate
-
 # run NTFC
 confpath=${CURRENTCONFDIR}/config.yaml
 jsonconf=${CURRENTCONFDIR}/session.json
 testpath=${NTFCDIR}/external/nuttx-testing
-python3 -m ntfc test --testpath=${testpath} --confpath=${confpath} --jsonconf=${jsonconf}
+ntfc test --testpath=${testpath} --confpath=${confpath} --jsonconf=${jsonconf}
 
 ret="$?"
 echo $ret
-
-# disable venv
-deactivate
 
 # export test results
 artifacts=${ARTIFACTCONFDIR}/ntfc


### PR DESCRIPTION
## Summary

install NTFC package from PIP. With this change we can skip the use of venv and the installation of system dependencies, thus limiting the amount of data downloaded

## Impact
This aproach should be faster and more stable. The next step will be to install NTFC directly into the Docker image.

## Testing

NTFC works correctly my priv fork https://github.com/raiden00pl/nuttx/actions/runs/23595750546/job/68712232540?pr=47#step:10:294

