### PR TITLE
{bp-18487} serial/uart_rpmsg: Remove redundant CONFIG_RPMSG_UART_CONSOLE macro c…

### DIFF
--- a/drivers/serial/uart_rpmsg.c
+++ b/drivers/serial/uart_rpmsg.c
@@ -458,12 +458,10 @@ int uart_rpmsg_init(FAR const char *cpuname, FAR const char *devname,
            UART_RPMSG_DEV_PREFIX, devname);
   uart_register(name, dev);
 
-  #ifdef CONFIG_RPMSG_UART_CONSOLE
   if (dev->isconsole)
     {
       uart_register(UART_RPMSG_DEV_CONSOLE, dev);
     }
-  #endif
 
   return 0;
 }

--- a/drivers/serial/uart_rpmsg_raw.c
+++ b/drivers/serial/uart_rpmsg_raw.c
@@ -369,12 +369,10 @@ int uart_rpmsg_raw_init(FAR const char *cpuname, FAR const char *devname,
            UART_RPMSG_DEV_PREFIX, devname);
   uart_register(name, dev);
 
-#ifdef CONFIG_RPMSG_UART_RAW_CONSOLE
   if (dev->isconsole)
     {
       uart_register(UART_RPMSG_DEV_CONSOLE, dev);
     }
-#endif
 
   return 0;
 }


### PR DESCRIPTION
## Summary
Remove the unnecessary CONFIG_RPMSG_UART_CONSOLE preprocessor guard around the console registration logic in uart_rpmsg_init().

The uart_rpmsg_init() function already accepts a bool isconsole parameter to dynamically control console registration, which is designed to support flexible console setup in distributed multi-core SOC systems. Adding the macro check on top of this runtime parameter is redundant and negates the dynamic registration capability.

This change fixes a regression introduced by PR #18410, which broke the functionality of sim/rpproxy and sim/rpserver due to the incorrect macro guard preventing proper console registration for the rpmsg UART device.

## Impact

RELEASE

## Testing

CI