### PR TITLE
{bp-18499} boards/arm64/bcm2711/raspberrypi-4b: Fix GPIO

### DIFF
--- a/arch/arm64/include/bcm2711/chip.h
+++ b/arch/arm64/include/bcm2711/chip.h
@@ -75,6 +75,8 @@
 
 #if defined(CONFIG_RPI4B_RAM_4GB) || defined(CONFIG_RPI4B_RAM_8GB)
 #define CONFIG_RAMBANK1_SIZE GB(4) - MB(64)
+#elif defined(CONFIG_RPI4B_RAM_2GB)
+#define CONFIG_RAMBANK1_SIZE GB(2) - MB(64)
 #endif /* defined(CONFIG_RPI4B_RAM_4GB) || defined(CONFIG_RPI4B_RAM_8GB) */
 
 /* The 8GB version begins to use a second RAM bank.

--- a/arch/arm64/src/bcm2711/bcm2711_gpio.c
+++ b/arch/arm64/src/bcm2711/bcm2711_gpio.c
@@ -380,22 +380,22 @@ void bcm2711_gpio_set_func(uint32_t gpio, enum bcm2711_gpio_func_e func)
       value = (g_fsel_map[func] << ((gpio - 10) * 3));
       modreg32(value, value, BCM_GPIO_GPFSEL1);
     }
-  else if (gpio <= 29 && gpio > 20)
+  else if (gpio <= 29 && gpio > 19)
     {
       value = (g_fsel_map[func] << ((gpio - 20) * 3));
       modreg32(value, value, BCM_GPIO_GPFSEL2);
     }
-  else if (gpio <= 39 && gpio > 30)
+  else if (gpio <= 39 && gpio > 29)
     {
       value = (g_fsel_map[func] << ((gpio - 30) * 3));
       modreg32(value, value, BCM_GPIO_GPFSEL3);
     }
-  else if (gpio <= 49 && gpio > 40)
+  else if (gpio <= 49 && gpio > 39)
     {
       value = (g_fsel_map[func] << ((gpio - 40) * 3));
       modreg32(value, value, BCM_GPIO_GPFSEL4);
     }
-  else if (gpio <= 57 && gpio > 50)
+  else if (gpio <= 57 && gpio > 49)
     {
       value = (g_fsel_map[func] << ((gpio - 50) * 3));
       modreg32(value, value, BCM_GPIO_GPFSEL5);
@@ -418,15 +418,8 @@ void bcm2711_gpio_set_func(uint32_t gpio, enum bcm2711_gpio_func_e func)
 void bcm2711_gpio_pin_set(uint32_t gpio, bool set)
 {
   DEBUGASSERT(gpio < BCM_GPIO_NUM);
-
-  if (set)
-    {
-      bcm2711_gpio_help_set(gpio, BCM_GPIO_GPSET0, BCM_GPIO_GPSET0, true);
-    }
-  else
-    {
-      bcm2711_gpio_help_set(gpio, BCM_GPIO_GPCLR0, BCM_GPIO_GPCLR0, true);
-    }
+  bcm2711_gpio_help_set(gpio, BCM_GPIO_GPSET0, BCM_GPIO_GPSET1, set);
+  bcm2711_gpio_help_set(gpio, BCM_GPIO_GPCLR0, BCM_GPIO_GPCLR1, !set);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

* Fix GPIO unspecified behavior on some GPIO ports.
* Fix GPIO undefined behavior caused by uncleared set or reset bits.

## Impact

RELEASE

## Testing

CI