### PR TITLE
{bp-18567} boards/xtensa/esp32s3: fix WiFi init by using CONFIG_ESPRESSIF_WIFI

### DIFF
--- a/boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/esp32s3-box/src/esp32s3_bringup.c
@@ -42,7 +42,7 @@
 #  include "esp32s3_board_tim.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WLAN
+#ifdef CONFIG_ESPRESSIF_WIFI
 #  include "esp32s3_board_wlan.h"
 #endif
 
@@ -211,7 +211,7 @@ int esp32s3_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WLAN
+#ifdef CONFIG_ESPRESSIF_WIFI
   ret = board_wlan_init();
   if (ret < 0)
     {

--- a/boards/xtensa/esp32s3/esp32s3-eye/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/esp32s3-eye/src/esp32s3_bringup.c
@@ -42,7 +42,7 @@
 #  include "esp32s3_board_tim.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WLAN
+#ifdef CONFIG_ESPRESSIF_WIFI
 #  include "esp32s3_board_wlan.h"
 #endif
 
@@ -202,7 +202,7 @@ int esp32s3_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WLAN
+#ifdef CONFIG_ESPRESSIF_WIFI
   ret = board_wlan_init();
   if (ret < 0)
     {

--- a/boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/esp32s3-korvo-2/src/esp32s3_bringup.c
@@ -45,7 +45,7 @@
 #  include "esp32s3_board_tim.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WLAN
+#ifdef CONFIG_ESPRESSIF_WIFI
 #  include "esp32s3_board_wlan.h"
 #endif
 
@@ -412,7 +412,7 @@ int esp32s3_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WLAN
+#ifdef CONFIG_ESPRESSIF_WIFI
   ret = board_wlan_init();
   if (ret < 0)
     {

--- a/boards/xtensa/esp32s3/esp32s3-lcd-ev/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/esp32s3-lcd-ev/src/esp32s3_bringup.c
@@ -45,7 +45,7 @@
 #  include "esp32s3_board_tim.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WLAN
+#ifdef CONFIG_ESPRESSIF_WIFI
 #  include "esp32s3_board_wlan.h"
 #endif
 
@@ -304,7 +304,7 @@ int esp32s3_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WLAN
+#ifdef CONFIG_ESPRESSIF_WIFI
   ret = board_wlan_init();
   if (ret < 0)
     {

--- a/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/lckfb-szpi-esp32s3/src/esp32s3_bringup.c
@@ -45,7 +45,7 @@
 #  include "esp32s3_board_tim.h"
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WLAN
+#ifdef CONFIG_ESPRESSIF_WIFI
 #  include "esp32s3_board_wlan.h"
 #endif
 
@@ -402,7 +402,7 @@ int esp32s3_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESPRESSIF_WLAN
+#ifdef CONFIG_ESPRESSIF_WIFI
   ret = board_wlan_init();
   if (ret < 0)
     {


### PR DESCRIPTION
## Summary
The WiFi driver refactor (662c1e0bbb7) renamed the Kconfig symbol from CONFIG_ESPRESSIF_WLAN to CONFIG_ESPRESSIF_WIFI, but several ESP32-S3 board bringup files were not updated. This caused board_wlan_init() to be compiled out, so the wlan0 interface never appeared.

Update the preprocessor guards in all affected boards:
  - esp32s3-box
  - esp32s3-eye
  - esp32s3-korvo-2
  - esp32s3-lcd-ev
  - lckfb-szpi-esp32s3

## Impact

RELEASE

## Testing

CI