### PR TITLE
{bp-18572} libs/libbuiltin: Fix spacing style in gcov.c

### DIFF
--- a/libs/libbuiltin/libgcc/gcov.c
+++ b/libs/libbuiltin/libgcc/gcov.c
@@ -514,7 +514,7 @@ void __gcov_dump(void)
 
       _NX_CLOSE(fd);
     }
-  else if(S_ISDIR(state.st_mode))
+  else if (S_ISDIR(state.st_mode))
     {
       args.mkdir = gcov_mkdir;
       args.strip = atoi(getenv("GCOV_PREFIX_STRIP"));


### PR DESCRIPTION
## Summary
Add space after 'else if' keyword to follow NuttX coding style guidelines.

## Impact

RELEASE

## Testing

CI