### PR TITLE
{bp-18579} nucleo-l476rg: register userleds device driver if CONFIG_USERLED is set

### DIFF
--- a/boards/arm/stm32l4/nucleo-l476rg/src/stm32_bringup.c
+++ b/boards/arm/stm32l4/nucleo-l476rg/src/stm32_bringup.c
@@ -57,6 +57,10 @@
 #include "stm32_bmp280.h"
 #endif
 
+#ifdef CONFIG_USERLED
+#  include <nuttx/leds/userled.h>
+#endif
+
 #ifdef CONFIG_SENSORS_MPU9250
 #include "stm32_mpu9250.h"
 #endif
@@ -244,6 +248,16 @@ int stm32_bringup(void)
     {
       syslog(LOG_ERR, "Failed to initialize BMP180, error %d\n", ret);
       return ret;
+    }
+#endif
+
+#ifdef CONFIG_USERLED
+  /* Register the LED driver */
+
+  ret = userled_lower_initialize("/dev/userleds");
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);
     }
 #endif
 


### PR DESCRIPTION
## Summary

This enhances the bringup file with /dev/userleds registration if CONFIG_USERLED option is set.

## Impact

RELEASE

## Testing

CI