### PR TITLE
{bp-18584} docs: Fix typos, formatting, and numbering in README.md and CONTRIBUT…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,7 +3,7 @@
 Thank you for your interest in contributing to Apache NuttX RTOS :-)
 
 If you haven't yet read
-[The Inviolable Principles of NuttX]( https://github.com/apache/nuttx/blob/master/INVIOLABLES.md)
+[The Inviolable Principles of NuttX](https://github.com/apache/nuttx/blob/master/INVIOLABLES.md)
 please do so first.
 
 Apache NuttX RTOS supports over 15 different architectures, 360+ boards,
@@ -355,8 +355,8 @@ See: https://github.com/apache/nuttx/blob/master/INVIOLABLES.md
 2. Single company / organization commit, review, and merge is not allowed.
 3. Merge of PRs with unresolved discussions and "change request" marks
    is not allowed.
-3. Self committed code merge with or without review is not allowed.
-4. Direct push to master is not allowed.
+4. Self committed code merge with or without review is not allowed.
+5. Direct push to master is not allowed.
 
 Breaking these rules will be punished.
 
@@ -395,7 +395,7 @@ Add g_ prefix to can_dlc_to_len and len_to_can_dlc to
 follow NuttX coding style conventions for global symbols,
 improving code readability and maintainability.
 * you can also use bullet points.
-* to note different thing briefly.
+* to note different things briefly.
 
 Signed-off-by: AuthorName <Valid@EmailAddress>
 ```

--- a/README.md
+++ b/README.md
@@ -3,11 +3,9 @@
 </p>
 
 ![POSIX Badge](https://img.shields.io/badge/POSIX-Compliant-brightgreen?style=flat&label=POSIX)
-[![License](https://img.shields.io/badge/License-Apache%202.0-blue
-)](https://nuttx.apache.org/docs/latest/introduction/licensing.html)
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue)](https://nuttx.apache.org/docs/latest/introduction/licensing.html)
 ![Issues Tracking Badge](https://img.shields.io/badge/issue_track-github-blue?style=flat&label=Issue%20Tracking)
-[![Contributors](https://img.shields.io/github/contributors/apache/nuttx
-)](https://github.com/apache/nuttx/graphs/contributors)
+[![Contributors](https://img.shields.io/github/contributors/apache/nuttx)](https://github.com/apache/nuttx/graphs/contributors)
 [![GitHub Build Badge](https://github.com/apache/nuttx/workflows/Build/badge.svg)](https://github.com/apache/nuttx/actions/workflows/build.yml)
 [![Documentation Badge](https://github.com/apache/nuttx/workflows/Build%20Documentation/badge.svg)](https://nuttx.apache.org/docs/latest/index.html)
 


### PR DESCRIPTION
## Summary
Fix multiple documentation issues in README.md and CONTRIBUTING.md:
* README.md: Merge multi-line badge markdown into single lines for License and Contributors badges to follow standard markdown format.
* CONTRIBUTING.md: Remove extra space in Inviolable Principles link URL.
* CONTRIBUTING.md: Fix duplicate numbering in section 1.17 Merge rules (two items numbered 3, renumbered to 3, 4, 5).
* CONTRIBUTING.md: Fix typo in section 2.2 commit template example, "different thing" to "different things" (missing plural).

## Impact

RELEASE

## Testing

CI