### PR TITLE
nucleo-l476rg: fix ADC driver compilation

### DIFF
--- a/boards/arm/stm32l4/nucleo-l476rg/src/stm32_adc.c
+++ b/boards/arm/stm32l4/nucleo-l476rg/src/stm32_adc.c
@@ -35,7 +35,7 @@
 
 #include "chip.h"
 #include "arm_internal.h"
-#include "stm32l4_pwm.h"
+#include "stm32l4_adc.h"
 #include "nucleo-l476rg.h"
 
 #ifdef CONFIG_STM32L4_ADC1
@@ -58,7 +58,6 @@
 
 /* Identifying number of each ADC channel. */
 
-#ifdef CONFIG_INPUT_AJOYSTICK
 #ifdef CONFIG_ADC_DMA
 /* The Itead analog joystick gets inputs on ADC_IN1 and ADC_IN2 */
 
@@ -94,7 +93,6 @@ static const uint32_t g_adc1_pinlist[ADC1_NCHANNELS]  =
 };
 
 #endif /* CONFIG_ADC_DMA */
-#endif /* CONFIG_INPUT_AJOYSTICK */
 
 /****************************************************************************
  * Private Functions


### PR DESCRIPTION
## Summary
The definition of ADC channels should not depend on option `CONFIG_INPUT_AJOYSTICK` at all. Moreover, the include of stm32l4_adc.h file was missing (PWM include was used instead), causing the implicit declaration of `stm32l4_adc_initialize` function.

```
stm32_adc.c:128:9: error: implicit declaration of function 'stm32l4_adc_initialize'; did you mean 'stm32l4_usbinitialize'? [-Wimplicit-function-declaration]
  128 |   adc = stm32l4_adc_initialize(1, g_adc1_chanlist, ADC1_NCHANNELS);
      |         ^~~~~~~~~~~~~~~~~~~~~~
      |         stm32l4_usbinitialize
stm32_adc.c:128:7: error: assignment to 'struct adc_dev_s *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
  128 |   adc = stm32l4_adc_initialize(1, g_adc1_chanlist, ADC1_NCHANNELS);
      |       ^
make[2]: *** [/home/michal/Michal/projects/nuttx/core/boards/Board.mk:83: stm32_adc.o] Error 1
make[1]: *** [Makefile:187: board/libboard.a] Error 2
make: *** [tools/Unix.mk:565: nuttx] Error 2
```

## Impact
ADC now works on Nucleo-L476RG.

## Testing

With standard ADC example application and pin A5 against GDN and 3.3 V:

```
Sample:
1: channel: 1 value: 0
Sample:
1: channel: 1 value: 0
Sample:
1: channel: 1 value: 0
Sample:
1: channel: 1 value: 4090
Sample:
1: channel: 1 value: 4090
Sample:
1: channel: 1 value: 4091
```
