### PR TITLE
arch/risc-v/espressif: Fix wrong C3 naming

### DIFF
--- a/arch/risc-v/src/common/espressif/Kconfig
+++ b/arch/risc-v/src/common/espressif/Kconfig
@@ -470,7 +470,7 @@ if PM
 
 config PM_EXT1_WAKEUP
 	bool "PM EXT1 Wakeup"
-	depends on !ARCH_CHIP_ESP32C3_GENERIC
+	depends on !ARCH_CHIP_ESP32C3
 	default n
 	---help---
 		Enable EXT1 wakeup functionality.
@@ -754,42 +754,42 @@ config PM_GPIO_WAKEUP_GPIO21
 
 config PM_GPIO_WAKEUP_GPIO22
 	bool "GPIO22"
-	depends on !ARCH_CHIP_ESP32C3_GENERIC
+	depends on !ARCH_CHIP_ESP32C3
 	default n
 	---help---
 		Enable GPIO22 as an GPIO wakeup source.
 
 config PM_GPIO_WAKEUP_GPIO23
 	bool "GPIO23"
-	depends on !ARCH_CHIP_ESP32C3_GENERIC
+	depends on !ARCH_CHIP_ESP32C3
 	default n
 	---help---
 		Enable GPIO23 as an GPIO wakeup source.
 
 config PM_GPIO_WAKEUP_GPIO24
 	bool "GPIO24"
-	depends on !ARCH_CHIP_ESP32C3_GENERIC
+	depends on !ARCH_CHIP_ESP32C3
 	default n
 	---help---
 		Enable GPIO24 as an GPIO wakeup source.
 
 config PM_GPIO_WAKEUP_GPIO25
 	bool "GPIO25"
-	depends on !ARCH_CHIP_ESP32C3_GENERIC
+	depends on !ARCH_CHIP_ESP32C3
 	default n
 	---help---
 		Enable GPIO25 as an GPIO wakeup source.
 
 config PM_GPIO_WAKEUP_GPIO26
 	bool "GPIO26"
-	depends on !ARCH_CHIP_ESP32C3_GENERIC
+	depends on !ARCH_CHIP_ESP32C3
 	default n
 	---help---
 		Enable GPIO26 as an GPIO wakeup source.
 
 config PM_GPIO_WAKEUP_GPIO27
 	bool "GPIO27"
-	depends on !ARCH_CHIP_ESP32C3_GENERIC
+	depends on !ARCH_CHIP_ESP32C3
 	default n
 	---help---
 		Enable GPIO27 as an GPIO wakeup source.
@@ -858,23 +858,23 @@ endchoice # PM_UART_WAKEUP_UART_NUM
 
 choice PM_UART_WAKEUP_MODE
 	prompt "PM UART Wakeup Mode"
-	default PM_UART_WAKEUP_START_BIT_MODE if !ARCH_CHIP_ESP32C3_GENERIC
-	default PM_UART_WAKEUP_ACTIVE_EDGE_THRESHOLD_MODE if ARCH_CHIP_ESP32C3_GENERIC
+	default PM_UART_WAKEUP_START_BIT_MODE if !ARCH_CHIP_ESP32C3
+	default PM_UART_WAKEUP_ACTIVE_EDGE_THRESHOLD_MODE if ARCH_CHIP_ESP32C3
 
 config PM_UART_WAKEUP_ACTIVE_EDGE_THRESHOLD_MODE
 	bool "Wake-up triggered by active edge threshold"
 
 config PM_UART_WAKEUP_FIFO_THRESHOLD_MODE
 	bool "Wake-up triggered by the number of bytes received in the RX FIFO"
-	depends on !ARCH_CHIP_ESP32C3_GENERIC
+	depends on !ARCH_CHIP_ESP32C3
 
 config PM_UART_WAKEUP_START_BIT_MODE
 	bool "Wake-up triggered by the detection of a start bit"
-	depends on !ARCH_CHIP_ESP32C3_GENERIC
+	depends on !ARCH_CHIP_ESP32C3
 
 config PM_UART_WAKEUP_CHAR_SEQ_MODE
 	bool "Wake-up triggered by detecting a specific character sequence"
-	depends on !ARCH_CHIP_ESP32C3_GENERIC
+	depends on !ARCH_CHIP_ESP32C3
 
 endchoice # PM_UART_WAKEUP_MODE
 
@@ -2254,7 +2254,7 @@ config ESPRESSIF_UART1_RS485
 config ESPRESSIF_UART1_RS485_DIR_PIN
 	int "UART1 RS-485 DIR pin"
 	default 4
-	range 0 21 if ARCH_CHIP_ESP32C3_GENERIC
+	range 0 21 if ARCH_CHIP_ESP32C3
 	range 0 30 if ARCH_CHIP_ESP32C6
 	range 0 27 if ARCH_CHIP_ESP32H2
 	range 0 54 if ARCH_CHIP_ESP32P4
@@ -2996,7 +2996,7 @@ config ESPRESSIF_I2S0_SAMPLE_RATE
 config ESPRESSIF_I2S0_BCLKPIN
 	int "I2S0 BCLK pin"
 	default 4
-	range 0 21 if ARCH_CHIP_ESP32C3_GENERIC
+	range 0 21 if ARCH_CHIP_ESP32C3
 	range 0 30 if ARCH_CHIP_ESP32C6
 	range 0 27 if ARCH_CHIP_ESP32H2
 	range 0 54 if ARCH_CHIP_ESP32P4
@@ -3004,7 +3004,7 @@ config ESPRESSIF_I2S0_BCLKPIN
 config ESPRESSIF_I2S0_WSPIN
 	int "I2S0 WS pin"
 	default 5
-	range 0 21 if ARCH_CHIP_ESP32C3_GENERIC
+	range 0 21 if ARCH_CHIP_ESP32C3
 	range 0 30 if ARCH_CHIP_ESP32C6
 	range 0 27 if ARCH_CHIP_ESP32H2
 	range 0 54 if ARCH_CHIP_ESP32P4
@@ -3014,7 +3014,7 @@ config ESPRESSIF_I2S0_DINPIN
 	depends on ESPRESSIF_I2S0_RX
 	default 19 if !ARCH_CHIP_ESP32H2
 	default 11 if ARCH_CHIP_ESP32H2
-	range 0 21 if ARCH_CHIP_ESP32C3_GENERIC
+	range 0 21 if ARCH_CHIP_ESP32C3
 	range 0 30 if ARCH_CHIP_ESP32C6
 	range 0 27 if ARCH_CHIP_ESP32H2
 	range 0 54 if ARCH_CHIP_ESP32P4
@@ -3024,7 +3024,7 @@ config ESPRESSIF_I2S0_DOUTPIN
 	depends on ESPRESSIF_I2S0_TX
 	default 18 if !ARCH_CHIP_ESP32H2
 	default 10 if ARCH_CHIP_ESP32H2
-	range 0 21 if ARCH_CHIP_ESP32C3_GENERIC
+	range 0 21 if ARCH_CHIP_ESP32C3
 	range 0 30 if ARCH_CHIP_ESP32C6
 	range 0 27 if ARCH_CHIP_ESP32H2
 	range 0 54 if ARCH_CHIP_ESP32P4
@@ -3040,7 +3040,7 @@ config ESPRESSIF_I2S0_MCLKPIN
 	int "I2S MCLK pin"
 	depends on ESPRESSIF_I2S0_MCLK
 	default 0
-	range 0 21 if ARCH_CHIP_ESP32C3_GENERIC
+	range 0 21 if ARCH_CHIP_ESP32C3
 	range 0 30 if ARCH_CHIP_ESP32C6
 	range 0 27 if ARCH_CHIP_ESP32H2
 	range 0 54 if ARCH_CHIP_ESP32P4
@@ -3082,7 +3082,7 @@ config ESPRESSIF_I2C0_SCLPIN
 	int "I2C0 SCL Pin"
 	default 6 if !ESPRESSIF_LPI2C
 	default 23 if ESPRESSIF_LPI2C
-	range 0 21 if ARCH_CHIP_ESP32C3_GENERIC
+	range 0 21 if ARCH_CHIP_ESP32C3
 	range 0 30 if ARCH_CHIP_ESP32C6
 	range 0 27 if ARCH_CHIP_ESP32H2
 	range 0 54 if ARCH_CHIP_ESP32P4
@@ -3090,7 +3090,7 @@ config ESPRESSIF_I2C0_SCLPIN
 config ESPRESSIF_I2C0_SDAPIN
 	int "I2C0 SDA Pin"
 	default 5
-	range 0 21 if ARCH_CHIP_ESP32C3_GENERIC
+	range 0 21 if ARCH_CHIP_ESP32C3
 	range 0 30 if ARCH_CHIP_ESP32C6
 	range 0 27 if ARCH_CHIP_ESP32H2
 	range 0 54 if ARCH_CHIP_ESP32P4
@@ -3119,7 +3119,7 @@ endchoice # ESPRESSIF_I2C1_MODE
 config ESPRESSIF_I2C1_SCLPIN
 	int "I2C1 SCL Pin"
 	default 2
-	range 0 21 if ARCH_CHIP_ESP32C3_GENERIC
+	range 0 21 if ARCH_CHIP_ESP32C3
 	range 0 30 if ARCH_CHIP_ESP32C6
 	range 0 27 if ARCH_CHIP_ESP32H2
 	range 0 54 if ARCH_CHIP_ESP32P4
@@ -3127,7 +3127,7 @@ config ESPRESSIF_I2C1_SCLPIN
 config ESPRESSIF_I2C1_SDAPIN
 	int "I2C1 SDA Pin"
 	default 1
-	range 0 21 if ARCH_CHIP_ESP32C3_GENERIC
+	range 0 21 if ARCH_CHIP_ESP32C3
 	range 0 30 if ARCH_CHIP_ESP32C6
 	range 0 27 if ARCH_CHIP_ESP32H2
 	range 0 54 if ARCH_CHIP_ESP32P4
@@ -3172,7 +3172,7 @@ endchoice # ESPRESSIF_I2C_BITBANG_MODE
 config ESPRESSIF_I2C_BITBANG_SCLPIN
 	int "I2C Bitbang SCL Pin"
 	default 0
-	range 0 21 if ARCH_CHIP_ESP32C3_GENERIC
+	range 0 21 if ARCH_CHIP_ESP32C3
 	range 0 30 if ARCH_CHIP_ESP32C6
 	range 0 27 if ARCH_CHIP_ESP32H2
 	range 0 54 if ARCH_CHIP_ESP32P4
@@ -3180,7 +3180,7 @@ config ESPRESSIF_I2C_BITBANG_SCLPIN
 config ESPRESSIF_I2C_BITBANG_SDAPIN
 	int "I2C Bitbang SDA Pin"
 	default 1
-	range 0 21 if ARCH_CHIP_ESP32C3_GENERIC
+	range 0 21 if ARCH_CHIP_ESP32C3
 	range 0 30 if ARCH_CHIP_ESP32C6
 	range 0 27 if ARCH_CHIP_ESP32H2
 	range 0 54 if ARCH_CHIP_ESP32P4
@@ -3200,7 +3200,7 @@ config ESPRESSIF_I2CTIMEOMS
 config ESPRESSIF_I2C_TEST_MODE
 	bool "I2C driver loopback test mode (for testing only)"
 	default n
-	depends on !ARCH_CHIP_ESP32C3_GENERIC
+	depends on !ARCH_CHIP_ESP32C3
 	depends on (ESPRESSIF_I2C_PERIPH_MASTER_MODE && ESPRESSIF_I2C_PERIPH_SLAVE_MODE)
 	---help---
 		This enables a loopback test mode that attaches the master I2C peripheral


### PR DESCRIPTION
## Summary

<!-- This field should contain a summary of the changes. It will be pre-filled with the commit's message and descriptions. Adjust it accordingly -->

* arch/risc-v/espressif: Fix wrong C3 naming

Fix wrong C3 naming in Kconfig

## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: No
<!-- Does it impact user's applications? How? -->

Impact on build: No
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: No
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: No
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: No
<!-- Does it impact NuttX's security? -->

Impact on compatibility: No
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

## Testing
<!-- Please provide all the testing procedure. Consider that upstream reviewers should be able to reproduce the same testing performed internally -->

`esp32c3-devkit:nsh` used to test

### Building
<!-- Provide how to build the test for each SoC being tested -->

Command to build:
```
make distclean && ./tools/configure.sh esp32c3-devkit:nsh && make -j && make download ESPTOOL_PORT=/dev/ttyUSB0
```
### Running
<!-- Provide how to run the test for each SoC being tested -->

Device booting up and `ostest` command run

### Results
<!-- Provide tests' results and runtime logs -->

Output:

```
nsh> ostest
...
ostest_main: Exiting with status 0
nsh> 
```