### PR TITLE
ci: split xtensa jobs into three separate jobs (instead of two)

### DIFF
--- a/.github/workflows/arch.yml
+++ b/.github/workflows/arch.yml
@@ -33,7 +33,7 @@ jobs:
       # Get the Arch for the PR: arm, arm64, risc-v, xtensa, ...
       - name: Get arch
         id: get-arch
-        run: |        
+        run: |
 
           # If PR is Not Created or Modified: Build all targets
           pr=${{github.event.pull_request.number}}
@@ -193,7 +193,7 @@ jobs:
             # Fetch the board
             board=$( echo "$boards" | jq ".[$i]" )
             skip_build=0
-            
+
             # For "Arch / Board: arm": Build arm-01, arm-02, ...
             if [[ "$arch_contains_arm" == "1" || "$board_contains_arm" == "1" ]]; then
               if [[ "$board" != *"arm-"* ]]; then
@@ -211,7 +211,7 @@ jobs:
               if [[ "$board" != *"risc-v-"* ]]; then
                 skip_build=1
               fi
-  
+
             # For "Arch / Board: simulator": Build sim-01, sim-02
             elif [[ "$arch_contains_sim" == "1" || "$board_contains_sim" == "1" ]]; then
               if [[ "$board" != *"sim-"* ]]; then
@@ -223,24 +223,24 @@ jobs:
               if [[ "$board" != *"other"* ]]; then
                 skip_build=1
               fi
-  
+
             # For "Arch / Board: x86_64": Build x86_64-01
             elif [[ "$arch_contains_x86_64" == "1" || "$board_contains_x86_64" == "1" ]]; then
               if [[ "$board" != *"x86_64-"* ]]; then
                 skip_build=1
               fi
-  
-            # For "Arch / Board: xtensa": Build xtensa-01, xtensa-02
+
+            # For "Arch / Board: xtensa": Build xtensa-01, xtensa-02, xtensa-03
             elif [[ "$arch_contains_xtensa" == "1" || "$board_contains_xtensa" == "1" ]]; then
               if [[ "$board" != *"xtensa-"* ]]; then
                 skip_build=1
               fi
-  
+
             # For Other Arch: Allow the build
             else
               echo Build by default: $board
             fi
-  
+
             # Add the board to the selected builds
             if [[ "$skip_build" == "0" ]]; then
               echo Add $board to selected_builds

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -131,7 +131,7 @@ jobs:
         [
           "arm-01", "risc-v-01", "sim-01", "xtensa-01", "arm64-01", "x86_64-01", "other",
           "arm-02", "risc-v-02", "sim-02", "xtensa-02",
-          "arm-03", "risc-v-03", "sim-03",
+          "arm-03", "risc-v-03", "sim-03", "xtensa-03",
           "arm-04", "risc-v-04",
           "arm-05", "risc-v-05",
           "arm-06", "risc-v-06",

--- a/tools/ci/testlist/xtensa-00.dat
+++ b/tools/ci/testlist/xtensa-00.dat
@@ -1,0 +1,1 @@
+/xtensa/esp32s3/esp32s3-devkit/configs/python

--- a/tools/ci/testlist/xtensa-02.dat
+++ b/tools/ci/testlist/xtensa-02.dat
@@ -1,9 +1,1 @@
 /xtensa/esp32s2
-
-/xtensa/esp32s3
-
-# Building Python takes too long to be tested automatically
--esp32s3-devkit:python
-
-# We do not set ESPTOOL_BINDIR in this build
--esp32s3-devkit:qemu_openeth

--- a/tools/ci/testlist/xtensa-03.dat
+++ b/tools/ci/testlist/xtensa-03.dat
@@ -1,1 +1,7 @@
-/xtensa/esp32s3/esp32s3-devkit/configs/python
+/xtensa/esp32s3
+
+# Building Python takes too long to be tested automatically
+-esp32s3-devkit:python
+
+# We do not set ESPTOOL_BINDIR in this build
+-esp32s3-devkit:qemu_openeth


### PR DESCRIPTION
## Summary

This is necessary because new defconfigs were recently added to Xtensa-based Espressif SoCs and the build job may exceed 2 hours. In order to avoid increasing job timeout, a specific job for each supported SoC (ESP32, ESP32-S2 and ESP32-S3) was created instead.

## Impact
Impact on user: No.

Impact on build: Yes. CI is expected to run successfully without timing out for Xtensa devices.

Impact on hardware: No.

Impact on documentation: No.

Impact on security: No.

Impact on compatibility: No.

## Testing

This is being tested with https://github.com/apache/nuttx/pull/18614. Please check https://github.com/apache/nuttx/pull/18614/checks : we should expect three xtensa-related jobs: [xtensa-01](https://github.com/apache/nuttx/actions/runs/23646961693/job/68888971610?pr=18614),  [xtensa-02](https://github.com/apache/nuttx/actions/runs/23646961693/job/68888971897?pr=18614) and [xtensa-03](https://github.com/apache/nuttx/actions/runs/23646961693/job/68888971609?pr=18614) jobs.