### PR TITLE
nucleo-l476rg/stm32_gpio.c: fix compilation error

### DIFF
--- a/boards/arm/stm32l4/nucleo-l476rg/src/stm32_gpio.c
+++ b/boards/arm/stm32l4/nucleo-l476rg/src/stm32_gpio.c
@@ -147,7 +147,7 @@ static int stm32gpio_interrupt(int irq, void *context, void *arg)
   gpioinfo("Interrupt! callback=%p\n", stm32gpint->callback);
 
   stm32gpint->callback(&stm32gpint->stm32gpio.gpio,
-                       tm32gpint->stm32gpio.id);
+                       stm32gpint->stm32gpio.id);
   return OK;
 }
 


### PR DESCRIPTION
## Summary
Fixes the following compilation error.

```
stm32_gpio.c: In function 'stm32gpio_interrupt':
stm32_gpio.c:150:24: error: 'tm32gpint' undeclared (first use in this function); did you mean 'stm32gpint'?
  150 |                        tm32gpint->stm32gpio.id);
      |                        ^~~~~~~~~
      |                        stm32gpint
```

## Impact

Fixes the compilation of Nucleo L476RG board with GPIO enabled

## Testing
Code compiles and GPIO works with standard `gpio` example application.