### PR TITLE
arch/risc-v/qemu-rv: Configure PMP before booting secondary harts.

### DIFF
--- a/arch/risc-v/src/qemu-rv/qemu_rv_start.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_start.c
@@ -227,6 +227,9 @@ void qemu_rv_start(int mhartid, const char *dtb)
 cpux:
 
 #ifdef CONFIG_SMP
+#  ifdef CONFIG_BUILD_PROTECTED
+  qemu_rv_configure_mpu();
+#  endif
   riscv_cpu_boot(mhartid);
 #endif
 

--- a/arch/risc-v/src/qemu-rv/qemu_rv_userspace.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_userspace.c
@@ -55,7 +55,7 @@
  ****************************************************************************/
 
 /****************************************************************************
- * Name: configure_mpu
+ * Name: qemu_rv_configure_mpu
  *
  * Description:
  *   This function configures the MPU for for kernel- / userspace separation.
@@ -63,7 +63,7 @@
  *
  ****************************************************************************/
 
-static void configure_mpu(void)
+void qemu_rv_configure_mpu(void)
 {
   int ret;
   ret = riscv_append_pmp_region(UFLASH_F, UFLASH_START, UFLASH_SIZE);
@@ -123,7 +123,7 @@ void qemu_rv_userspace(void)
 
   /* Configure MPU / PMP to grant access to the userspace */
 
-  configure_mpu();
+  qemu_rv_configure_mpu();
 }
 
 #endif /* CONFIG_BUILD_PROTECTED */

--- a/arch/risc-v/src/qemu-rv/qemu_rv_userspace.h
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_userspace.h
@@ -45,6 +45,7 @@
  ****************************************************************************/
 
 #ifdef CONFIG_BUILD_PROTECTED
+void qemu_rv_configure_mpu(void);
 void qemu_rv_userspace(void);
 #endif
 


### PR DESCRIPTION
## Summary

  This change fixes protected SMP startup on `qemu-rv:rv-virt` by
  configuring PMP on the secondary-hart boot path before 
  `riscv_cpu_boot()`.

  In protected SMP builds, PMP is configured for the boot hart during
  userspace bring-up, but not for secondary harts on their boot path.
  As a result, CPU1 can fault when userspace work is first scheduled there.

  This patch exports `qemu_rv_configure_mpu()` from
  `arch/risc-v/src/qemu-rv/qemu_rv_userspace.c` and invokes it from
  the secondary-hart path under `CONFIG_SMP` and
  `CONFIG_BUILD_PROTECTED`.

## Impact

  bugfix

## Testing

  I confirm that the change was built and runtime-tested on a local setup.

  * Build host: Linux x86_64
  * Toolchain: local NuttX RISC-V GCC toolchain
  * Target: `qemu-rv:rv-virt`
  * Build mode: `CONFIG_BUILD_PROTECTED=y`
  * SMP: `CONFIG_SMP=y`, `CONFIG_SMP_NCPUS=2`

### Test command

  smp

### Logs before this change

```
  NuttShell (NSH) NuttX-12.12.0
  nsh> smp
  Main[0]: Running on CPU0
  Main[0]: Initializing barrier
  Main[0]: Thread 1 created
  Main[0]: Thread 2 created
  Main[0]: Thread 3 created
  Main[0]: Thread 4 created
  [ Main[0]: Thread 5 created
  CPU  Main[0]: Thread 6 created
  Main[0]: Thread 7 created
 1] r  Main[0]: Thread 8 created
 iscv_exception: EXCEPTION: Instruction Thread[2]: Started                                                                                                                   accesThread[2]: Running on CPU0
 s fault. MCAUSE: 00000001, EPC: 80000230, MTVAL: 00000000
 [CPU1] riscv_exception: PANIC!!! Exception = 00000001
 [CPU1] dump_assert_info: Current Version: NuttX  12.12.0 c64b95ccbf Mar 28 2026 22:52:44 risc-v
 [CPU1] dump_assert_info: Assertion failed panic: at file: common/riscv_exception.c:134 task(CPU1): smp process: smp 0x8004ecb2
 [CPU1] up_dump_register: EPC: 80000230
 [CPU1] up_dump_register: A0: 8004ecb2 A1: 00000001 A2: 00000000 A3: 00000000
 [CPU1] up_dump_register: A4: 00000000 A5: 00000000 A6: 00000000 A7: 00000000
 [CPU1] up_dump_register: T0: 00000000 T1: 00000000 T2: 00000000 T3: 00000000
 [CPU1] up_dump_register: T4: 00000000 T5: 00000000 T6: 00000000
 [CPU1] up_dump_register: S0: 00000000 S1: 00000000 S2: 00000000 S3: 00000000
 [CPU1] up_dump_register: S4: 00000000 S5: 00000000 S6: 00000000 S7: 00000000
 [CPU1] up_dump_register: S8: 00000000 S9: 00000000 S10: 00000000 S11: 00000000
 [CPU1] up_dump_register: SP: 80207000 FP: 00000000 TP: 00000000 RA: 00000000
```

### Logs after this change

```
NuttShell (NSH) NuttX-12.12.0
nsh> smp
  Main[0]: Running on CPU0
  Main[0]: Initializing barrier
  Main[0]: Thread 1 created
  Main[0]: Thread 2 created
  Thread[1]: Started
  Main[0]: Thread 3 created
  ..
  ..
  Main[0]: Thread 7 completed with result=0
  Main[0]: Thread 8 completed with result=0
```