### PR TITLE
arch/espressif: serialize Wi-Fi RX queue access.

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_wlan_netdev.c
+++ b/arch/risc-v/src/common/espressif/esp_wlan_netdev.c
@@ -117,6 +117,7 @@ struct esp_wlan_priv_s
   struct esp_common_wifi_s *common;
   uint32_t mode;
 
+  spinlock_t rx_lock;
   netpkt_queue_t netdev_rx_queue;
   uint8_t flatbuf[CONFIG_NET_ETH_PKTSIZE];
 };
@@ -212,6 +213,7 @@ static int esp_wlan_ifup(struct netdev_lowerhalf_s *dev)
 {
   struct esp_wlan_priv_s *priv = (struct esp_wlan_priv_s *)dev;
   struct net_driver_s *netdev = &priv->dev.netdev;
+  irqstate_t flags;
   int ret = OK;
 
 #ifdef CONFIG_NET_IPv4
@@ -228,7 +230,9 @@ static int esp_wlan_ifup(struct netdev_lowerhalf_s *dev)
 
   /* Clear RX queue */
 
+  flags = spin_lock_irqsave(&priv->rx_lock);
   netpkt_free_queue(&priv->netdev_rx_queue);
+  spin_unlock_irqrestore(&priv->rx_lock, flags);
 
   /* Start Wi-Fi interface */
 
@@ -349,7 +353,13 @@ static int esp_wlan_transmit(struct netdev_lowerhalf_s *dev,
 static netpkt_t *esp_wlan_receive(struct netdev_lowerhalf_s *dev)
 {
   struct esp_wlan_priv_s *priv = (struct esp_wlan_priv_s *)dev;
-  netpkt_t *pkt = netpkt_remove_queue(&priv->netdev_rx_queue);
+  irqstate_t flags;
+  netpkt_t *pkt;
+
+  flags = spin_lock_irqsave(&priv->rx_lock);
+  pkt = netpkt_remove_queue(&priv->netdev_rx_queue);
+  spin_unlock_irqrestore(&priv->rx_lock, flags);
+
   return pkt;
 }
 
@@ -1008,6 +1018,7 @@ void IRAM_ATTR esp_wifi_tx_done_cb(uint8_t ifidx,
 static int wlan_rx_done(struct esp_wlan_priv_s *priv,
                         void *buffer, uint16_t len, void *eb)
 {
+  irqstate_t flags;
   int ret = OK;
   netpkt_t *pkt = NULL;
 
@@ -1025,7 +1036,9 @@ static int wlan_rx_done(struct esp_wlan_priv_s *priv,
       goto out;
     }
 
+  flags = spin_lock_irqsave(&priv->rx_lock);
   ret = netpkt_tryadd_queue(pkt, &priv->netdev_rx_queue);
+  spin_unlock_irqrestore(&priv->rx_lock, flags);
   if (ret < 0)
     {
       wlerr("ERROR: Failed to add packet to queue\n");
@@ -1221,6 +1234,7 @@ static int esp_wlan_initialize(uint32_t mode)
   priv->dev.rxtype           = NETDEV_RX_THREAD;
   priv->dev.priority         = 100;
 
+  spin_lock_init(&priv->rx_lock);
   IOB_QINIT(&priv->netdev_rx_queue);
 
   /* Register RX done callback. Called when the RX packet is received. */

--- a/arch/xtensa/src/common/espressif/esp_wlan_netdev.c
+++ b/arch/xtensa/src/common/espressif/esp_wlan_netdev.c
@@ -117,6 +117,7 @@ struct esp_wlan_priv_s
   struct esp_common_wifi_s *common;
   uint32_t mode;
 
+  spinlock_t rx_lock;
   netpkt_queue_t netdev_rx_queue;
   uint8_t flatbuf[CONFIG_NET_ETH_PKTSIZE];
 };
@@ -212,6 +213,7 @@ static int esp_wlan_ifup(struct netdev_lowerhalf_s *dev)
 {
   struct esp_wlan_priv_s *priv = (struct esp_wlan_priv_s *)dev;
   struct net_driver_s *netdev = &priv->dev.netdev;
+  irqstate_t flags;
   int ret = OK;
 
 #ifdef CONFIG_NET_IPv4
@@ -228,7 +230,9 @@ static int esp_wlan_ifup(struct netdev_lowerhalf_s *dev)
 
   /* Clear RX queue */
 
+  flags = spin_lock_irqsave(&priv->rx_lock);
   netpkt_free_queue(&priv->netdev_rx_queue);
+  spin_unlock_irqrestore(&priv->rx_lock, flags);
 
   /* Start Wi-Fi interface */
 
@@ -349,7 +353,13 @@ static int esp_wlan_transmit(struct netdev_lowerhalf_s *dev,
 static netpkt_t *esp_wlan_receive(struct netdev_lowerhalf_s *dev)
 {
   struct esp_wlan_priv_s *priv = (struct esp_wlan_priv_s *)dev;
-  netpkt_t *pkt = netpkt_remove_queue(&priv->netdev_rx_queue);
+  irqstate_t flags;
+  netpkt_t *pkt;
+
+  flags = spin_lock_irqsave(&priv->rx_lock);
+  pkt = netpkt_remove_queue(&priv->netdev_rx_queue);
+  spin_unlock_irqrestore(&priv->rx_lock, flags);
+
   return pkt;
 }
 
@@ -1008,6 +1018,7 @@ void IRAM_ATTR esp_wifi_tx_done_cb(uint8_t ifidx,
 static int wlan_rx_done(struct esp_wlan_priv_s *priv,
                         void *buffer, uint16_t len, void *eb)
 {
+  irqstate_t flags;
   int ret = OK;
   netpkt_t *pkt = NULL;
 
@@ -1025,7 +1036,9 @@ static int wlan_rx_done(struct esp_wlan_priv_s *priv,
       goto out;
     }
 
+  flags = spin_lock_irqsave(&priv->rx_lock);
   ret = netpkt_tryadd_queue(pkt, &priv->netdev_rx_queue);
+  spin_unlock_irqrestore(&priv->rx_lock, flags);
   if (ret != OK)
     {
       wlerr("ERROR: Failed to add packet to queue\n");
@@ -1224,6 +1237,7 @@ static int esp_wlan_initialize(uint32_t mode)
   priv->dev.rxtype           = NETDEV_RX_THREAD;
   priv->dev.priority         = 100;
 
+  spin_lock_init(&priv->rx_lock);
   IOB_QINIT(&priv->netdev_rx_queue);
 
   /* Register RX done callback. Called when the RX packet is received. */


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This change fixes a race in the common Espressif Wi-Fi lower-half netdev path used by both the Xtensa and RISC-V drivers.

The Wi-Fi RX callback appends packets to `netdev_rx_queue`, while the netdev upper-half RX thread removes packets from that same queue. The queue is backed by the IOB queue helpers, and those helpers do not provide their own internal serialization. Under sustained receive traffic, the enqueue and dequeue sides can run concurrently and corrupt the queue state.

When that happens, RX buffers can become stranded in the queue, available IOBs drop over time, and throughput degrades until the interface no longer recovers cleanly. This matches the behavior reported in issue #16915.

To fix that, this patch:

* adds a dedicated RX spinlock to the shared Espressif Wi-Fi netdev private state
* initializes the lock during device setup
* takes the lock before clearing the RX queue during `ifup`
* takes the lock before enqueueing packets in the Wi-Fi RX callback
* takes the lock before dequeueing packets for the upper half

The change is intentionally limited to the shared Espressif Wi-Fi netdev implementation:

* `arch/risc-v/src/common/espressif/esp_wlan_netdev.c`
* `arch/xtensa/src/common/espressif/esp_wlan_netdev.c`

Issue: #16915

## Impact

This is a targeted bug fix for Espressif Wi-Fi devices using the common netdev-based lower-half driver.

Expected impact:

* prevents RX queue corruption caused by concurrent enqueue/dequeue access
* avoids leaking or stranding IOB-backed RX packets under heavy traffic
* improves long-run Wi-Fi stability during sustained throughput tests such as `iperf`
* applies consistently to both Xtensa and RISC-V Espressif Wi-Fi targets that use the shared implementation

Compatibility impact:

* no API changes
* no Kconfig changes
* no board configuration changes
* no documentation changes required

Build and maintenance impact:

* only two driver source files are touched
* the fix follows the same locking model already used by older Espressif Wi-Fi code paths when protecting RX/TX queues

## Testing

Host machine:

* macOS on Apple Silicon (`CONFIG_HOST_MACOS=y`, `CONFIG_HOST_ARM64=y`)

Repository checks completed locally:

1. Ran style checks directly on the modified files:

   ```sh
   ./tools/checkpatch.sh -f arch/risc-v/src/common/espressif/esp_wlan_netdev.c \
     arch/xtensa/src/common/espressif/esp_wlan_netdev.c
   ```

   Result:

   ```text
   All checks pass.
   ```

2. Re-ran patch-level style checks on the final commit:

   ```sh
   ./tools/checkpatch.sh -g HEAD~1..HEAD
   ```

   Result:

   ```text
   All checks pass.
   ```

3. Verified there are no whitespace or patch formatting issues:

   ```sh
   git diff --check
   ```

   Result: no output

GitHub Actions build verification for this PR completed successfully.

Relevant Espressif Wi-Fi targets built in CI:

* `Linux (xtensa-01)` built `esp32-devkitc/wifi`
* `Linux (risc-v-03)` built `esp32c6-devkitc/wifi`

Representative CI build output:

```text
Linux (xtensa-01)  Configuration/Tool: esp32-devkitc/wifi
Linux (xtensa-01)    Cleaning...
Linux (xtensa-01)    Configuring...
Linux (xtensa-01)    Building NuttX...
Linux (xtensa-01)    [1/1] Normalize esp32-devkitc/wifi
```

```text
Linux (risc-v-03)  Configuration/Tool: esp32c6-devkitc/wifi
Linux (risc-v-03)    Cleaning...
Linux (risc-v-03)    Configuring...
Linux (risc-v-03)    Building NuttX...
Linux (risc-v-03)    [1/1] Normalize esp32c6-devkitc/wifi
```

The full PR CI set also passed, including `check`, `Lint`, `OOT-Build`, `Linux (xtensa-01)`, `Linux (xtensa-03)`, and `Linux (risc-v-03)`.

Local target builds were still limited by the available toolchains on this machine, so I could not run on-device Wi-Fi traffic tests here. The code path and fix were instead verified by:

* tracing the RX ownership path in the common Espressif netdev lower half
* comparing it against the older Espressif Wi-Fi implementation, which already serialized queue access
* confirming that the only shared mutable structure between the RX callback and upper-half RX thread was the unprotected `netdev_rx_queue`
* validating the final patch with repeated style and patch checks

Recommended hardware verification for the PR:

1. Build and flash `esp32-devkitc:wifi` and `esp32c6-devkitc:wifi`
2. Connect to Wi-Fi and confirm normal connectivity with `ping`
3. Run repeated `iperf` sessions and compare `/proc/iobinfo` before and after
4. Confirm IOB counts recover normally and throughput does not collapse after sustained traffic

