### PR TITLE
arch/arm/stm32*:  Use PRIx32 format specifier where appropriate

### DIFF
--- a/arch/arm/src/stm32/stm32_adc.c
+++ b/arch/arm/src/stm32/stm32_adc.c
@@ -2144,7 +2144,7 @@ static void adc_power_down_delay(struct stm32_dev_s *priv, bool pdd_high)
 static void adc_dels_after_conversion(struct stm32_dev_s *priv,
                                       uint32_t delay)
 {
-  ainfo("Delay selected: 0x%08x\n", delay);
+  ainfo("Delay selected: 0x%08" PRIx32 "\n", delay);
 
   adc_modifyreg(priv, STM32_ADC_CR2_OFFSET, ADC_CR2_DELS_MASK, delay);
 }

--- a/arch/arm/src/stm32/stm32_dma2d.c
+++ b/arch/arm/src/stm32/stm32_dma2d.c
@@ -332,7 +332,7 @@ static int stm32_dma2dirq(int irq, void *context, void *arg)
   uint32_t regval = getreg32(STM32_DMA2D_ISR);
   struct stm32_interrupt_s *priv = &g_interrupt;
 
-  reginfo("irq = %d, regval = %08x\n", irq, regval);
+  reginfo("irq = %d, regval = %08" PRIx32 "\n", irq, regval);
 
   if (regval & DMA2D_ISR_TCIF)
     {
@@ -471,9 +471,9 @@ static int stm32_dma2d_loadclut(uintptr_t pfcreg)
 
   regval  = getreg32(pfcreg);
   regval |= DMA2D_XGPFCCR_START;
-  reginfo("set regval=%08x\n", regval);
+  reginfo("set regval=%08" PRIx32 "\n", regval);
   putreg32(regval, pfcreg);
-  reginfo("configured regval=%08x\n", getreg32(pfcreg));
+  reginfo("configured regval=%08" PRIx32 "\n", getreg32(pfcreg));
 
   /* Wait until clut is finished */
 

--- a/arch/arm/src/stm32/stm32_dma_v1.c
+++ b/arch/arm/src/stm32/stm32_dma_v1.c
@@ -847,19 +847,19 @@ void stm32_dmadump(DMA_HANDLE handle, const struct stm32_dmaregs_s *regs,
   uint32_t dmabase = DMA_BASE(dmach->base);
 
   dmainfo("DMA Registers: %s\n", msg);
-  dmainfo("   ISRC[%08x]: %08x\n",
+  dmainfo("   ISRC[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmabase + STM32_DMA_ISR_OFFSET, regs->isr);
 #ifdef DMA_HAVE_CSELR
-  dmainfo("  CSELR[%08x]: %08x\n",
+  dmainfo("  CSELR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmabase + STM32_DMA_CSELR_OFFSET, regs->cselr);
 #endif
-  dmainfo("    CCR[%08x]: %08x\n",
+  dmainfo("    CCR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmach->base + STM32_DMACHAN_CCR_OFFSET, regs->ccr);
-  dmainfo("  CNDTR[%08x]: %08x\n",
+  dmainfo("  CNDTR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmach->base + STM32_DMACHAN_CNDTR_OFFSET, regs->cndtr);
-  dmainfo("   CPAR[%08x]: %08x\n",
+  dmainfo("   CPAR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmach->base + STM32_DMACHAN_CPAR_OFFSET, regs->cpar);
-  dmainfo("   CMAR[%08x]: %08x\n",
+  dmainfo("   CMAR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmach->base + STM32_DMACHAN_CMAR_OFFSET, regs->cmar);
 }
 #endif

--- a/arch/arm/src/stm32/stm32_dma_v1mux.c
+++ b/arch/arm/src/stm32/stm32_dma_v1mux.c
@@ -907,19 +907,19 @@ static void stm32_dma12_dump(DMA_HANDLE handle,
   dmainfo("DMA%d Registers: %s\n",
           dmachan->ctrl + 1,
           msg);
-  dmainfo("    ISR[%08x]: %08x\n",
+  dmainfo("    ISR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmabase + STM32_DMA_ISR_OFFSET,
           regs->isr);
-  dmainfo("    CCR[%08x]: %08x\n",
+  dmainfo("    CCR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmachan->base + STM32_DMACHAN_CCR_OFFSET,
           regs->ccr);
-  dmainfo("  CNDTR[%08x]: %08x\n",
+  dmainfo("  CNDTR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmachan->base + STM32_DMACHAN_CNDTR_OFFSET,
           regs->cndtr);
-  dmainfo("   CPAR[%08x]: %08x\n",
+  dmainfo("   CPAR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmachan->base + STM32_DMACHAN_CPAR_OFFSET,
           regs->cpar);
-  dmainfo("   CMAR[%08x]: %08x\n",
+  dmainfo("   CMAR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmachan->base + STM32_DMACHAN_CMAR_OFFSET,
           regs->cmar);
 
@@ -958,20 +958,20 @@ static void stm32_dmamux_dump(DMA_MUX dmamux, uint8_t channel,
                               const struct stm32_dmaregs_s *regs)
 {
   dmainfo("DMAMUX%d CH=%d\n", dmamux->id, channel);
-  dmainfo("    CCR[%08x]: %08x\n",
+  dmainfo("    CCR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmamux->base + STM32_DMAMUX_CXCR_OFFSET(channel),
           regs->dmamux.ccr);
-  dmainfo("    CSR[%08x]: %08x\n",
+  dmainfo("    CSR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmamux->base + STM32_DMAMUX_CSR_OFFSET, regs->dmamux.csr);
-  dmainfo("  RG0CR[%08x]: %08x\n",
+  dmainfo("  RG0CR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmamux->base + STM32_DMAMUX_RG0CR_OFFSET, regs->dmamux.rg0cr);
-  dmainfo("  RG1CR[%08x]: %08x\n",
+  dmainfo("  RG1CR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmamux->base + STM32_DMAMUX_RG1CR_OFFSET, regs->dmamux.rg1cr);
-  dmainfo("  RG2CR[%08x]: %08x\n",
+  dmainfo("  RG2CR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmamux->base + STM32_DMAMUX_RG2CR_OFFSET, regs->dmamux.rg2cr);
-  dmainfo("  RG3CR[%08x]: %08x\n",
+  dmainfo("  RG3CR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmamux->base + STM32_DMAMUX_RG3CR_OFFSET, regs->dmamux.rg3cr);
-  dmainfo("   RGSR[%08x]: %08x\n",
+  dmainfo("   RGSR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmamux->base + STM32_DMAMUX_RGSR_OFFSET, regs->dmamux.rgsr);
 };
 #endif

--- a/arch/arm/src/stm32/stm32_dma_v2.c
+++ b/arch/arm/src/stm32/stm32_dma_v2.c
@@ -1069,21 +1069,21 @@ void stm32_dmadump(DMA_HANDLE handle, const struct stm32_dmaregs_s *regs,
   uint32_t dmabase = DMA_BASE(dmast->base);
 
   dmainfo("DMA Registers: %s\n", msg);
-  dmainfo("   LISR[%08x]: %08x\n",
+  dmainfo("   LISR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmabase + STM32_DMA_LISR_OFFSET, regs->lisr);
-  dmainfo("   HISR[%08x]: %08x\n",
+  dmainfo("   HISR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmabase + STM32_DMA_HISR_OFFSET, regs->hisr);
-  dmainfo("    SCR[%08x]: %08x\n",
+  dmainfo("    SCR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmast->base + STM32_DMA_SCR_OFFSET, regs->scr);
-  dmainfo("  SNDTR[%08x]: %08x\n",
+  dmainfo("  SNDTR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmast->base + STM32_DMA_SNDTR_OFFSET, regs->sndtr);
-  dmainfo("   SPAR[%08x]: %08x\n",
+  dmainfo("   SPAR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmast->base + STM32_DMA_SPAR_OFFSET, regs->spar);
-  dmainfo("  SM0AR[%08x]: %08x\n",
+  dmainfo("  SM0AR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmast->base + STM32_DMA_SM0AR_OFFSET, regs->sm0ar);
-  dmainfo("  SM1AR[%08x]: %08x\n",
+  dmainfo("  SM1AR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmast->base + STM32_DMA_SM1AR_OFFSET, regs->sm1ar);
-  dmainfo("   SFCR[%08x]: %08x\n",
+  dmainfo("   SFCR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmast->base + STM32_DMA_SFCR_OFFSET, regs->sfcr);
 }
 #endif

--- a/arch/arm/src/stm32/stm32_dumpgpio.c
+++ b/arch/arm/src/stm32/stm32_dumpgpio.c
@@ -138,7 +138,7 @@ int stm32_dumpgpio(uint32_t pinset, const char *msg)
 #elif defined(CONFIG_STM32_STM32L15XX)
   DEBUGASSERT(port < STM32_NGPIO_PORTS);
 
-  _info("GPIO%c pinset: %08x base: %08x -- %s\n",
+  _info("GPIO%c pinset: %08" PRIx32 " base: %08" PRIx32 " -- %s\n",
         g_portchar[port], pinset, base, msg);
 
   if ((getreg32(STM32_RCC_AHBENR) & RCC_AHBENR_GPIOEN(port)) != 0)
@@ -217,7 +217,7 @@ int stm32_dumpgpio(uint32_t pinset, const char *msg)
     }
   else
     {
-      _info("  GPIO%c not enabled: AHB1ENR: %08x\n",
+      _info("  GPIO%c not enabled: AHB1ENR: %08" PRIx32 "\n",
             g_portchar[port], getreg32(STM32_RCC_AHB1ENR));
     }
 

--- a/arch/arm/src/stm32/stm32_eth.c
+++ b/arch/arm/src/stm32/stm32_eth.c
@@ -846,7 +846,7 @@ static uint32_t stm32_getreg(uint32_t addr)
 
   /* Show the register value read */
 
-  ninfo("%08x->%08x\n", addr, val);
+  ninfo("%08" PRIx32 "->%08" PRIx32 "\n", addr, val);
   return val;
 }
 #endif
@@ -873,7 +873,7 @@ static void stm32_putreg(uint32_t val, uint32_t addr)
 {
   /* Show the register value being written */
 
-  ninfo("%08x<-%08x\n", addr, val);
+  ninfo("%08" PRIx32 "<-%08" PRIx32 "\n", addr, val);
 
   /* Write the value */
 

--- a/arch/arm/src/stm32/stm32_hrtim.c
+++ b/arch/arm/src/stm32/stm32_hrtim.c
@@ -2023,24 +2023,27 @@ static void hrtim_dumpregs(struct stm32_hrtim_s *priv, uint8_t timer,
     {
       case HRTIM_TIMER_MASTER:
         {
-          tmrinfo("\tCR:\t0x%08x\tISR:\t0x%08x\tICR:\t0x%08x\n",
+          tmrinfo("\tCR:\t0x%08" PRIx32 "\tISR:\t0x%08" PRIx32
+                  "\tICR:\t0x%08" PRIx32 "\n",
                   hrtim_tim_getreg(priv, timer, STM32_HRTIM_TIM_CR_OFFSET),
                   hrtim_tim_getreg(priv, timer, STM32_HRTIM_TIM_ISR_OFFSET),
                   hrtim_tim_getreg(priv, timer, STM32_HRTIM_TIM_ICR_OFFSET));
 
-          tmrinfo("\tDIER:\t0x%08x\tCNTR:\t0x%08x\tPER:\t0x%08x\n",
+          tmrinfo("\tDIER:\t0x%08" PRIx32 "\tCNTR:\t0x%08" PRIx32
+                  "\tPER:\t0x%08" PRIx32 "\n",
                   hrtim_tim_getreg(priv, timer, STM32_HRTIM_TIM_DIER_OFFSET),
                   hrtim_tim_getreg(priv, timer, STM32_HRTIM_TIM_CNTR_OFFSET),
                   hrtim_tim_getreg(priv, timer, STM32_HRTIM_TIM_PER_OFFSET));
 
-          tmrinfo("\tREP:\t0x%08x\tCMP1:\t0x%08x\tCMP2:\t0x%08x\n",
+          tmrinfo("\tREP:\t0x%08" PRIx32 "\tCMP1:\t0x%08" PRIx32
+                  "\tCMP2:\t0x%08" PRIx32 "\n",
                   hrtim_tim_getreg(priv, timer, STM32_HRTIM_TIM_REPR_OFFSET),
                   hrtim_tim_getreg(priv, timer,
                                    STM32_HRTIM_TIM_CMP1R_OFFSET),
                   hrtim_tim_getreg(priv, timer,
                                    STM32_HRTIM_TIM_CMP2R_OFFSET));
 
-          tmrinfo("\tCMP3:\t0x%08x\tCMP4:\t0x%08x\n",
+          tmrinfo("\tCMP3:\t0x%08" PRIx32 "\tCMP4:\t0x%08" PRIx32 "\n",
                   hrtim_tim_getreg(priv, timer,
                                    STM32_HRTIM_TIM_CMP3R_OFFSET),
                   hrtim_tim_getreg(priv, timer,
@@ -2064,24 +2067,28 @@ static void hrtim_dumpregs(struct stm32_hrtim_s *priv, uint8_t timer,
       case HRTIM_TIMER_TIME:
 #endif
         {
-          tmrinfo("\tCR:\t0x%08x\tISR:\t0x%08x\tICR:\t0x%08x\n",
+          tmrinfo("\tCR:\t0x%08" PRIx32 "\tISR:\t0x%08" PRIx32
+                  "\tICR:\t0x%08" PRIx32 "\n",
                   hrtim_tim_getreg(priv, timer, STM32_HRTIM_TIM_CR_OFFSET),
                   hrtim_tim_getreg(priv, timer, STM32_HRTIM_TIM_ISR_OFFSET),
                   hrtim_tim_getreg(priv, timer, STM32_HRTIM_TIM_ICR_OFFSET));
 
-          tmrinfo("\tDIER:\t0x%08x\tCNTR:\t0x%08x\tPER:\t0x%08x\n",
+          tmrinfo("\tDIER:\t0x%08" PRIx32 "\tCNTR:\t0x%08" PRIx32
+                  "\tPER:\t0x%08" PRIx32 "\n",
                   hrtim_tim_getreg(priv, timer, STM32_HRTIM_TIM_DIER_OFFSET),
                   hrtim_tim_getreg(priv, timer, STM32_HRTIM_TIM_CNTR_OFFSET),
                   hrtim_tim_getreg(priv, timer, STM32_HRTIM_TIM_PER_OFFSET));
 
-          tmrinfo("\tREP:\t0x%08x\tCMP1:\t0x%08x\tCMP1C:\t0x%08x\n",
+          tmrinfo("\tREP:\t0x%08" PRIx32 "\tCMP1:\t0x%08" PRIx32
+                  "\tCMP1C:\t0x%08" PRIx32 "\n",
                   hrtim_tim_getreg(priv, timer, STM32_HRTIM_TIM_REPR_OFFSET),
                   hrtim_tim_getreg(priv, timer,
                                    STM32_HRTIM_TIM_CMP1R_OFFSET),
                   hrtim_tim_getreg(priv, timer,
                                    STM32_HRTIM_TIM_CMP1CR_OFFSET));
 
-          tmrinfo("\tCMP2:\t0x%08x\tCMP3:\t0x%08x\tCMP4:\t0x%08x\n",
+          tmrinfo("\tCMP2:\t0x%08" PRIx32 "\tCMP3:\t0x%08" PRIx32
+                  "\tCMP4:\t0x%08" PRIx32 "\n",
                   hrtim_tim_getreg(priv, timer,
                                    STM32_HRTIM_TIM_CMP2R_OFFSET),
                   hrtim_tim_getreg(priv, timer,
@@ -2089,14 +2096,16 @@ static void hrtim_dumpregs(struct stm32_hrtim_s *priv, uint8_t timer,
                   hrtim_tim_getreg(priv, timer,
                                    STM32_HRTIM_TIM_CMP4R_OFFSET));
 
-          tmrinfo("\tCPT1:\t0x%08x\tCPT2:\t0x%08x\tDTR:\t0x%08x\n",
+          tmrinfo("\tCPT1:\t0x%08" PRIx32 "\tCPT2:\t0x%08" PRIx32
+                  "\tDTR:\t0x%08" PRIx32 "\n",
                   hrtim_tim_getreg(priv, timer,
                                    STM32_HRTIM_TIM_CPT1R_OFFSET),
                   hrtim_tim_getreg(priv, timer,
                                    STM32_HRTIM_TIM_CPT2R_OFFSET),
                   hrtim_tim_getreg(priv, timer, STM32_HRTIM_TIM_DTR_OFFSET));
 
-          tmrinfo("\tSET1:\t0x%08x\tRST1:\t0x%08x\tSET2:\t0x%08x\n",
+          tmrinfo("\tSET1:\t0x%08" PRIx32 "\tRST1:\t0x%08" PRIx32
+                  "\tSET2:\t0x%08" PRIx32 "\n",
                   hrtim_tim_getreg(priv, timer,
                                    STM32_HRTIM_TIM_SET1R_OFFSET),
                   hrtim_tim_getreg(priv, timer,
@@ -2104,7 +2113,8 @@ static void hrtim_dumpregs(struct stm32_hrtim_s *priv, uint8_t timer,
                   hrtim_tim_getreg(priv, timer,
                                    STM32_HRTIM_TIM_SET2R_OFFSET));
 
-          tmrinfo("\tRST2:\t0x%08x\tEEF1:\t0x%08x\tEEF2:\t0x%08x\n",
+          tmrinfo("\tRST2:\t0x%08" PRIx32 "\tEEF1:\t0x%08" PRIx32
+                  "\tEEF2:\t0x%08" PRIx32 "\n",
                   hrtim_tim_getreg(priv, timer,
                                    STM32_HRTIM_TIM_RST2R_OFFSET),
                   hrtim_tim_getreg(priv, timer,
@@ -2112,13 +2122,15 @@ static void hrtim_dumpregs(struct stm32_hrtim_s *priv, uint8_t timer,
                   hrtim_tim_getreg(priv, timer,
                                    STM32_HRTIM_TIM_EEFR2_OFFSET));
 
-          tmrinfo("\tRSTR:\t0x%08x\tCHPR:\t0x%08x\tCPT1C:\t0x%08x\n",
+          tmrinfo("\tRSTR:\t0x%08" PRIx32 "\tCHPR:\t0x%08" PRIx32
+                  "\tCPT1C:\t0x%08" PRIx32 "\n",
                   hrtim_tim_getreg(priv, timer, STM32_HRTIM_TIM_RSTR_OFFSET),
                   hrtim_tim_getreg(priv, timer, STM32_HRTIM_TIM_CHPR_OFFSET),
                   hrtim_tim_getreg(priv, timer,
                                    STM32_HRTIM_TIM_CPT1CR_OFFSET));
 
-          tmrinfo("\tCPT2C:\t0x%08x\tOUT:\t0x%08x\tFLT:\t0x%08x\n",
+          tmrinfo("\tCPT2C:\t0x%08" PRIx32 "\tOUT:\t0x%08" PRIx32
+                  "\tFLT:\t0x%08" PRIx32 "\n",
                   hrtim_tim_getreg(priv, timer,
                                    STM32_HRTIM_TIM_CPT2CR_OFFSET),
                   hrtim_tim_getreg(priv, timer, STM32_HRTIM_TIM_OUTR_OFFSET),
@@ -2130,47 +2142,55 @@ static void hrtim_dumpregs(struct stm32_hrtim_s *priv, uint8_t timer,
 
       case HRTIM_TIMER_COMMON:
         {
-          tmrinfo("\tCR1:\t0x%08x\tCR2:\t0x%08x\tISR:\t0x%08x\n",
+          tmrinfo("\tCR1:\t0x%08" PRIx32 "\tCR2:\t0x%08" PRIx32
+                  "\tISR:\t0x%08" PRIx32 "\n",
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_CR1_OFFSET),
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_CR2_OFFSET),
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_ISR_OFFSET));
 
-          tmrinfo("\tICR:\t0x%08x\tIER:\t0x%08x\tOENR:\t0x%08x\n",
+          tmrinfo("\tICR:\t0x%08" PRIx32 "\tIER:\t0x%08" PRIx32
+                  "\tOENR:\t0x%08" PRIx32 "\n",
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_ICR_OFFSET),
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_IER_OFFSET),
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_OENR_OFFSET));
 
-          tmrinfo("\tODISR:\t0x%08x\tODSR:\t0x%08x\tBMCR:\t0x%08x\n",
+          tmrinfo("\tODISR:\t0x%08" PRIx32 "\tODSR:\t0x%08" PRIx32
+                  "\tBMCR:\t0x%08" PRIx32 "\n",
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_ODISR_OFFSET),
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_ODSR_OFFSET),
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_BMCR_OFFSET));
 
-          tmrinfo("\tBMTRG:\t0x%08x\tBMCMPR:\t0x%08x\tBMPER:\t0x%08x\n",
+          tmrinfo("\tBMTRG:\t0x%08" PRIx32 "\tBMCMPR:\t0x%08" PRIx32
+                  "\tBMPER:\t0x%08" PRIx32 "\n",
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_BMTRGR_OFFSET),
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_BMCMPR_OFFSET),
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_BMPER_OFFSET));
 
-          tmrinfo("\tADC1R:\t0x%08x\tADC2R:\t0x%08x\tADC3R:\t0x%08x\n",
+          tmrinfo("\tADC1R:\t0x%08" PRIx32 "\tADC2R:\t0x%08" PRIx32
+                  "\tADC3R:\t0x%08" PRIx32 "\n",
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_ADC1R_OFFSET),
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_ADC2R_OFFSET),
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_ADC3R_OFFSET));
 
-          tmrinfo("\tADC4R:\t0x%08x\tDLLCR:\t0x%08x\tFLTIN1:\t0x%08x\n",
+          tmrinfo("\tADC4R:\t0x%08" PRIx32 "\tDLLCR:\t0x%08" PRIx32
+                  "\tFLTIN1:\t0x%08" PRIx32 "\n",
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_ADC4R_OFFSET),
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_DLLCR_OFFSET),
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_FLTINR1_OFFSET));
 
-          tmrinfo("\tFLTIN2:\t0x%08x\tBDMUPD:\t0x%08x\tBDTAUP:\t0x%08x\n",
+          tmrinfo("\tFLTIN2:\t0x%08" PRIx32 "\tBDMUPD:\t0x%08" PRIx32
+                  "\tBDTAUP:\t0x%08" PRIx32 "\n",
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_FLTINR2_OFFSET),
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_BDMUPDR_OFFSET),
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_BDTAUPR_OFFSET));
 
-          tmrinfo("\tBDTBUP: 0x%08x\tBDTCUP:\t0x%08x\tBDTDUP:\t0x%08x\n",
+          tmrinfo("\tBDTBUP: 0x%08" PRIx32 "\tBDTCUP:\t0x%08" PRIx32
+                  "\tBDTDUP:\t0x%08" PRIx32 "\n",
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_BDTBUPR_OFFSET),
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_BDTCUPR_OFFSET),
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_BDTDUPR_OFFSET));
 
-          tmrinfo("\tBDTEUP:\t0x%08x\tBDMAD:\t0x%08x\n",
+          tmrinfo("\tBDTEUP:\t0x%08" PRIx32 "\tBDMAD:\t0x%08" PRIx32 "\n",
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_BDTEUPR_OFFSET),
                   hrtim_cmn_getreg(priv, STM32_HRTIM_CMN_BDMADR_OFFSET));
 

--- a/arch/arm/src/stm32/stm32_i2c.c
+++ b/arch/arm/src/stm32/stm32_i2c.c
@@ -96,11 +96,11 @@
  ****************************************************************************/
 
 #if STM32_PCLK1_FREQUENCY < 4000000
-#  warning STM32_I2C: Peripheral clock must be at least 4 MHz to support 400 kHz operation.
+#  warning "STM32_I2C: Periph clk must be at least 4MHz to support 400kHz."
 #endif
 
 #if STM32_PCLK1_FREQUENCY < 2000000
-#  error STM32_I2C: Peripheral clock must be at least 2 MHz to support 100 kHz operation.
+#  error "STM32_I2C: Periph clk must be at least 2MHz to support 100kHz."
 #endif
 
 /* Configuration ************************************************************/
@@ -832,7 +832,8 @@ static void stm32_i2c_tracedump(struct stm32_i2c_priv_s *priv)
     {
       trace = &priv->trace[i];
       syslog(LOG_DEBUG,
-         "%2d. STATUS: %08x COUNT: %3d EVENT: %s(%2d) PARM: %08x TIME: %d\n",
+         "%2d. STATUS: %08" PRIx32 " COUNT: %3d EVENT: %s(%2d) PARM:"
+             " %08" PRIx32 " TIME: %d\n",
              i + 1, trace->status, trace->count, g_trace_names[trace->event],
              trace->event, trace->parm, trace->time - priv->start_time);
     }

--- a/arch/arm/src/stm32/stm32_i2c_alt.c
+++ b/arch/arm/src/stm32/stm32_i2c_alt.c
@@ -857,7 +857,8 @@ static void stm32_i2c_tracedump(struct stm32_i2c_priv_s *priv)
     {
       trace = &priv->trace[i];
       syslog(LOG_DEBUG,
-             "%2d. STATUS: %08x COUNT: %4d EVENT: %4d PARM: %08x TIME: %d\n",
+             "%2d. STATUS: %08" PRIx32 " COUNT: %4d EVENT: %4d PARM:"
+             " %08" PRIx32 " TIME: %d\n",
              i + 1, trace->status, trace->count,  trace->event, trace->parm,
              trace->time - priv->start_time);
     }

--- a/arch/arm/src/stm32/stm32_i2c_v2.c
+++ b/arch/arm/src/stm32/stm32_i2c_v2.c
@@ -886,7 +886,8 @@ static inline int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
 
   while (priv->intstate != INTSTATE_DONE && elapsed < timeout);
 
-  i2cinfo("intstate: %d elapsed: %ld threshold: %ld status: 0x%08x\n",
+  i2cinfo("intstate: %d elapsed: %ld threshold: %ld status:"
+          " 0x%08" PRIx32 "\n",
           priv->intstate, (long)elapsed, (long)timeout, priv->status);
 
   /* Set the interrupt state back to IDLE */
@@ -1149,7 +1150,8 @@ static void stm32_i2c_tracedump(struct stm32_i2c_priv_s *priv)
     {
       trace = &priv->trace[i];
       syslog(LOG_DEBUG,
-             "%2d. STATUS: %08x COUNT: %3d EVENT: %2d PARM: %08x TIME: %d\n",
+             "%2d. STATUS: %08" PRIx32 " COUNT: %3d EVENT: %2d PARM:"
+             " %08" PRIx32 " TIME: %d\n",
              i + 1, trace->status, trace->count,  trace->event, trace->parm,
              (int)(trace->time - priv->start_time));
     }

--- a/arch/arm/src/stm32/stm32_i2s.c
+++ b/arch/arm/src/stm32/stm32_i2s.c
@@ -535,7 +535,7 @@ static inline uint16_t i2s_getreg(struct stm32_i2s_s *priv,
 #ifdef CONFIG_STM32_I2S_REGDEBUG
   if (i2s_checkreg(priv, false, regval, regaddr))
     {
-      i2sinfo("%08x->%04x\n", regaddr, regval);
+      i2sinfo("%08" PRIx32 "->%04x\n", regaddr, regval);
     }
 #endif
 
@@ -566,7 +566,7 @@ static inline void i2s_putreg(struct stm32_i2s_s *priv, uint8_t offset,
 #ifdef CONFIG_STM32_I2S_REGDEBUG
   if (i2s_checkreg(priv, true, regval, regaddr))
     {
-      i2sinfo("%08x<-%04x\n", regaddr, regval);
+      i2sinfo("%08" PRIx32 "<-%04x\n", regaddr, regval);
     }
 #endif
 

--- a/arch/arm/src/stm32/stm32_iwdg.c
+++ b/arch/arm/src/stm32/stm32_iwdg.c
@@ -229,7 +229,7 @@ static uint16_t stm32_getreg(uint32_t addr)
 
   /* Show the register value read */
 
-  wdinfo("%08x->%04x\n", addr, val);
+  wdinfo("%08" PRIx32 "->%04x\n", addr, val);
   return val;
 }
 #endif
@@ -247,7 +247,7 @@ static void stm32_putreg(uint16_t val, uint32_t addr)
 {
   /* Show the register value being written */
 
-  wdinfo("%08x<-%04x\n", addr, val);
+  wdinfo("%08" PRIx32 "<-%04x\n", addr, val);
 
   /* Write the value */
 

--- a/arch/arm/src/stm32/stm32_ltdc.c
+++ b/arch/arm/src/stm32/stm32_ltdc.c
@@ -1251,7 +1251,7 @@ static void stm32_ltdc_gpioconfig(void)
 
   for (i = 0; i < STM32_LTDC_NPINCONFIGS; i++)
     {
-      reginfo("set gpio%d = %08x\n", i, g_ltdcpins[i]);
+      reginfo("set gpio%d = %08" PRIx32 "\n", i, g_ltdcpins[i]);
       stm32_configgpio(g_ltdcpins[i]);
     }
 }
@@ -1275,43 +1275,46 @@ static void stm32_ltdc_periphconfig(void)
 
   /* Configure APB2 LTDC clock external */
 
-  reginfo("configured RCC_APB2ENR=%08x\n", getreg32(STM32_RCC_APB2ENR));
+  reginfo("configured RCC_APB2ENR=%08" PRIx32 "\n",
+          getreg32(STM32_RCC_APB2ENR));
 
   /* Configure the SAI PLL external to provide the LCD_CLK */
 
-  reginfo("configured RCC_PLLSAI=%08x\n", getreg32(STM32_RCC_PLLSAICFGR));
+  reginfo("configured RCC_PLLSAI=%08" PRIx32 "\n",
+          getreg32(STM32_RCC_PLLSAICFGR));
 
   /* Configure dedicated clock external */
 
-  reginfo("configured RCC_DCKCFGR=%08x\n", getreg32(STM32_RCC_DCKCFGR));
+  reginfo("configured RCC_DCKCFGR=%08" PRIx32 "\n",
+          getreg32(STM32_RCC_DCKCFGR));
 
   /* Configure LTDC_SSCR */
 
   regval = (STM32_LTDC_SSCR_VSH | STM32_LTDC_SSCR_HSW);
-  reginfo("set LTDC_SSCR=%08x\n", regval);
+  reginfo("set LTDC_SSCR=%08" PRIx32 "\n", regval);
   putreg32(regval, STM32_LTDC_SSCR);
-  reginfo("configured LTDC_SSCR=%08x\n", getreg32(STM32_LTDC_SSCR));
+  reginfo("configured LTDC_SSCR=%08" PRIx32 "\n", getreg32(STM32_LTDC_SSCR));
 
   /* Configure LTDC_BPCR */
 
   regval = (STM32_LTDC_BPCR_AVBP | STM32_LTDC_BPCR_AHBP);
-  reginfo("set LTDC_BPCR=%08x\n", regval);
+  reginfo("set LTDC_BPCR=%08" PRIx32 "\n", regval);
   putreg32(regval, STM32_LTDC_BPCR);
-  reginfo("configured LTDC_BPCR=%08x\n", getreg32(STM32_LTDC_BPCR));
+  reginfo("configured LTDC_BPCR=%08" PRIx32 "\n", getreg32(STM32_LTDC_BPCR));
 
   /* Configure LTDC_AWCR */
 
   regval = (STM32_LTDC_AWCR_AAH | STM32_LTDC_AWCR_AAW);
-  reginfo("set LTDC_AWCR=%08x\n", regval);
+  reginfo("set LTDC_AWCR=%08" PRIx32 "\n", regval);
   putreg32(regval, STM32_LTDC_AWCR);
-  reginfo("configured LTDC_AWCR=%08x\n", getreg32(STM32_LTDC_AWCR));
+  reginfo("configured LTDC_AWCR=%08" PRIx32 "\n", getreg32(STM32_LTDC_AWCR));
 
   /* Configure LTDC_TWCR */
 
   regval = (STM32_LTDC_TWCR_TOTALH | STM32_LTDC_TWCR_TOTALW);
-  reginfo("set LTDC_TWCR=%08x\n", regval);
+  reginfo("set LTDC_TWCR=%08" PRIx32 "\n", regval);
   putreg32(regval, STM32_LTDC_TWCR);
-  reginfo("configured LTDC_TWCR=%08x\n", getreg32(STM32_LTDC_TWCR));
+  reginfo("configured LTDC_TWCR=%08" PRIx32 "\n", getreg32(STM32_LTDC_TWCR));
 
   /* Configure LTDC_GCR */
 
@@ -1321,9 +1324,9 @@ static void stm32_ltdc_periphconfig(void)
   regval |= (STM32_LTDC_GCR_PCPOL | STM32_LTDC_GCR_DEPOL |
              STM32_LTDC_GCR_VSPOL | STM32_LTDC_GCR_HSPOL);
 
-  reginfo("set LTDC_GCR=%08x\n", regval);
+  reginfo("set LTDC_GCR=%08" PRIx32 "\n", regval);
   putreg32(regval, STM32_LTDC_GCR);
-  reginfo("configured LTDC_GCR=%08x\n", getreg32(STM32_LTDC_GCR));
+  reginfo("configured LTDC_GCR=%08" PRIx32 "\n", getreg32(STM32_LTDC_GCR));
 }
 
 /****************************************************************************
@@ -1342,7 +1345,7 @@ static void stm32_ltdc_ldefaultcolor(struct stm32_ltdc_s *layer,
                                      uint32_t rgb)
 {
   DEBUGASSERT(layer->layerno < LTDC_NLAYERS);
-  reginfo("set LTDC_L%dDCCR=%08x\n", layer->layerno + 1, rgb);
+  reginfo("set LTDC_L%dDCCR=%08" PRIx32 "\n", layer->layerno + 1, rgb);
 
   putreg32(rgb, stm32_dccr_layer_t[layer->layerno]);
 
@@ -1350,7 +1353,7 @@ static void stm32_ltdc_ldefaultcolor(struct stm32_ltdc_s *layer,
 
   stm32_ltdc_reload(LTDC_SRCR_IMR, false);
 
-  reginfo("configured LTDC_L%dDCCR=%08x\n", layer->layerno + 1,
+  reginfo("configured LTDC_L%dDCCR=%08" PRIx32 "\n", layer->layerno + 1,
           getreg32(STM32_LTDC_BCCR));
 }
 
@@ -1367,9 +1370,9 @@ static void stm32_ltdc_ldefaultcolor(struct stm32_ltdc_s *layer,
 
 static void stm32_ltdc_bgcolor(uint32_t rgb)
 {
-  reginfo("set LTDC_BCCR=%08x\n", rgb);
+  reginfo("set LTDC_BCCR=%08" PRIx32 "\n", rgb);
   putreg32(rgb, STM32_LTDC_BCCR);
-  reginfo("configured LTDC_BCCR=%08x\n", getreg32(STM32_LTDC_BCCR));
+  reginfo("configured LTDC_BCCR=%08" PRIx32 "\n", getreg32(STM32_LTDC_BCCR));
 }
 
 /****************************************************************************
@@ -1405,9 +1408,10 @@ static void stm32_ltdc_dither(bool enable, uint8_t red,
   regval &= ~(LTDC_GCR_DBW_MASK | LTDC_GCR_DGW_MASK | LTDC_GCR_DRW_MASK);
   regval |= (LTDC_GCR_DRW(red) | LTDC_GCR_DGW(green) | LTDC_GCR_DBW(blue));
 
-  reginfo("set LTDC_GCR=%08x\n", regval);
+  reginfo("set LTDC_GCR=%08" PRIx32 "\n", regval);
   putreg32(regval, STM32_LTDC_GCR);
-  reginfo("configured LTDC_GCR=%08x\n", getreg32(STM32_LTDC_GCR));
+  reginfo("configured LTDC_GCR=%08" PRIx32 "\n",
+          getreg32(STM32_LTDC_GCR));
 }
 
 /****************************************************************************
@@ -1424,7 +1428,8 @@ static void stm32_ltdc_linepos(void)
 
   reginfo("set LTDC_LIPCR=%08x\n", STM32_LTDC_LIPCR_LIPOS);
   putreg32(STM32_LTDC_LIPCR_LIPOS, STM32_LTDC_LIPCR);
-  reginfo("configured LTDC_LIPCR=%08x\n", getreg32(STM32_LTDC_LIPCR));
+  reginfo("configured LTDC_LIPCR=%08" PRIx32 "\n",
+          getreg32(STM32_LTDC_LIPCR));
 }
 
 /****************************************************************************
@@ -1446,9 +1451,9 @@ static void stm32_ltdc_irqctrl(uint32_t setirqs, uint32_t clrirqs)
   regval = getreg32(STM32_LTDC_IER);
   regval &= ~clrirqs;
   regval |= setirqs;
-  reginfo("set LTDC_IER=%08x\n", regval);
+  reginfo("set LTDC_IER=%08" PRIx32 "\n", regval);
   putreg32(regval, STM32_LTDC_IER);
-  reginfo("configured LTDC_IER=%08x\n", getreg32(STM32_LTDC_IER));
+  reginfo("configured LTDC_IER=%08" PRIx32 "\n", getreg32(STM32_LTDC_IER));
 }
 
 /****************************************************************************
@@ -1465,7 +1470,7 @@ static int stm32_ltdcirq(int irq, void *context, void *arg)
   struct stm32_interrupt_s *priv = &g_interrupt;
   uint32_t regval = getreg32(STM32_LTDC_ISR);
 
-  reginfo("irq = %d, regval = %08x\n", irq, regval);
+  reginfo("irq = %d, regval = %08" PRIx32 "\n", irq, regval);
 
   if (regval & LTDC_ISR_RRIF)
     {
@@ -1579,7 +1584,7 @@ static int stm32_ltdc_reload(uint8_t value, bool waitvblank)
 
   reginfo("set LTDC_SRCR=%08x\n", value);
   putreg32(value, STM32_LTDC_SRCR);
-  reginfo("configured LTDC_SRCR=%08x\n", getreg32(STM32_LTDC_SRCR));
+  reginfo("configured LTDC_SRCR=%08" PRIx32 "\n", getreg32(STM32_LTDC_SRCR));
 
   if (value == LTDC_SRCR_VBR && waitvblank)
     {
@@ -1671,7 +1676,7 @@ static void stm32_ltdc_enable(bool enable)
   uint32_t    regval;
 
   regval = getreg32(STM32_LTDC_GCR);
-  reginfo("get LTDC_GCR=%08x\n", regval);
+  reginfo("get LTDC_GCR=%08" PRIx32 "\n", regval);
 
   if (enable == true)
     {
@@ -1682,9 +1687,9 @@ static void stm32_ltdc_enable(bool enable)
       regval &= ~LTDC_GCR_LTDCEN;
     }
 
-  reginfo("set LTDC_GCR=%08x\n", regval);
+  reginfo("set LTDC_GCR=%08" PRIx32 "\n", regval);
   putreg32(regval, STM32_LTDC_GCR);
-  reginfo("configured LTDC_GCR=%08x\n", getreg32(STM32_LTDC_GCR));
+  reginfo("configured LTDC_GCR=%08" PRIx32 "\n", getreg32(STM32_LTDC_GCR));
 }
 
 /****************************************************************************
@@ -1707,7 +1712,7 @@ static void stm32_ltdc_lpixelformat(struct stm32_ltdc_s *layer)
 
   /* Configure PFCR register */
 
-  reginfo("set LTDC_L%dPFCR=%08x\n", overlay + 1,
+  reginfo("set LTDC_L%dPFCR=%08" PRIx32 "\n", overlay + 1,
           stm32_fmt_layer_t[overlay]);
   putreg32(stm32_fmt_layer_t[overlay], stm32_pfcr_layer_t[overlay]);
 
@@ -1759,14 +1764,14 @@ static void stm32_ltdc_lframebuffer(struct stm32_ltdc_s *layer)
 
   /* Configure LxWHPCR / LxWVPCR register */
 
-  reginfo("set LTDC_L%dWHPCR=%08x\n", layerno + 1, whpcr);
+  reginfo("set LTDC_L%dWHPCR=%08" PRIx32 "\n", layerno + 1, whpcr);
   putreg32(whpcr, stm32_whpcr_layer_t[layerno]);
-  reginfo("set LTDC_L%dWVPCR=%08x\n", layerno + 1, wvpcr);
+  reginfo("set LTDC_L%dWVPCR=%08" PRIx32 "\n", layerno + 1, wvpcr);
   putreg32(wvpcr, stm32_wvpcr_layer_t[layerno]);
 
   /* Configure LxCFBAR register */
 
-  reginfo("set LTDC_L%dCFBAR=%08x\n", layerno + 1,
+  reginfo("set LTDC_L%dCFBAR=%08" PRIx32 "\n", layerno + 1,
           stm32_fbmem_layer_t[layerno]);
   putreg32(stm32_fbmem_layer_t[layerno], stm32_cfbar_layer_t[layerno]);
 
@@ -1778,12 +1783,12 @@ static void stm32_ltdc_lframebuffer(struct stm32_ltdc_s *layer)
           LTDC_LXCFBLR_CFBLL(stm32_width_layer_t[layerno] *
           STM32_LTDC_LX_BYPP(stm32_bpp_layer_t[layerno]) + 3);
 
-  reginfo("set LTDC_L%dCFBLR=%08x\n", layerno + 1, cfblr);
+  reginfo("set LTDC_L%dCFBLR=%08" PRIx32 "\n", layerno + 1, cfblr);
   putreg32(cfblr, stm32_cfblr_layer_t[layerno]);
 
   /* Configure LxCFBLNR register */
 
-  reginfo("set LTDC_L%dCFBLNR=%08x\n", layerno + 1,
+  reginfo("set LTDC_L%dCFBLNR=%08" PRIx32 "\n", layerno + 1,
           stm32_height_layer_t[layerno]);
   putreg32(stm32_height_layer_t[layerno], stm32_cfblnr_layer_t[layerno]);
 
@@ -1824,7 +1829,7 @@ static void stm32_ltdc_lenable(struct stm32_ltdc_s *layer, bool enable)
 
   /* Enable/Disable layer */
 
-  reginfo("set LTDC_L%dCR=%08x\n", layer->layerno + 1, regval);
+  reginfo("set LTDC_L%dCR=%08" PRIx32 "\n", layer->layerno + 1, regval);
   putreg32(regval, stm32_cr_layer_t[layer->layerno]);
 
   /* Reload shadow register */
@@ -1872,7 +1877,7 @@ static void stm32_ltdc_ltransp(struct stm32_ltdc_s *layer,
   bf2 = LTDC_BF2_CONST_ALPHA;
 #endif
 
-  reginfo("set LTDC_L%dBFCR=%08x\n", layer->layerno + 1,
+  reginfo("set LTDC_L%dBFCR=%08" PRIx32 "\n", layer->layerno + 1,
           (LTDC_LXBFCR_BF1(bf1) | LTDC_LXBFCR_BF2(bf2)));
 
   /* Set blendmode */
@@ -1910,7 +1915,7 @@ static void stm32_ltdc_lchromakey(struct stm32_ltdc_s *layer,
   uint32_t rgb;
   DEBUGASSERT(layer->layerno < LTDC_NLAYERS);
 
-  reginfo("%08x\n", getreg32(stm32_cr_layer_t[layer->layerno]));
+  reginfo("%08" PRIx32 "\n", getreg32(stm32_cr_layer_t[layer->layerno]));
 
   /* Set chromakey */
 
@@ -1923,7 +1928,7 @@ static void stm32_ltdc_lchromakey(struct stm32_ltdc_s *layer,
   rgb = ARGB8888(chroma);
 #endif
 
-  reginfo("set LTDC_L%dCKCR=%08x\n", layer->layerno + 1, rgb);
+  reginfo("set LTDC_L%dCKCR=%08" PRIx32 "\n", layer->layerno + 1, rgb);
   putreg32(rgb, stm32_ckcr_layer_t[layer->layerno]);
 
   /* Reload shadow register */
@@ -1964,7 +1969,7 @@ static void stm32_ltdc_lchromakeyenable(struct stm32_ltdc_s *layer,
       regval &= ~LTDC_LXCR_COLKEN;
     }
 
-  reginfo("set LTDC_L%dCR=%08x\n", layer->layerno + 1, regval);
+  reginfo("set LTDC_L%dCR=%08" PRIx32 "\n", layer->layerno + 1, regval);
   putreg32(regval, stm32_cr_layer_t[layer->layerno]);
 
   /* Reload shadow register */
@@ -1991,7 +1996,8 @@ static void stm32_ltdc_lclutenable(struct stm32_ltdc_s *layer,
   uint32_t    regval;
 
   regval = getreg32(stm32_cr_layer_t[layer->oinfo.overlay]);
-  reginfo("get LTDC_L%dCR=%08x\n", layer->oinfo.overlay + 1, regval);
+  reginfo("get LTDC_L%dCR=%08" PRIx32 "\n",
+          layer->oinfo.overlay + 1, regval);
 
   /* Disable the clut support during update the color table */
 
@@ -2004,7 +2010,7 @@ static void stm32_ltdc_lclutenable(struct stm32_ltdc_s *layer,
       regval &= ~LTDC_LXCR_CLUTEN;
     }
 
-  reginfo("set LTDC_L%dCR=%08x\n", layer->oinfo.overlay, regval);
+  reginfo("set LTDC_L%dCR=%08" PRIx32 "\n", layer->oinfo.overlay, regval);
   putreg32(regval, stm32_cr_layer_t[layer->oinfo.overlay]);
 
   /* Reload shadow register */
@@ -2050,7 +2056,7 @@ static void stm32_ltdc_lputclut(struct stm32_ltdc_s *layer,
                (uint32_t)LTDC_CLUT_GREEN(cmap->green[n]) |
                (uint32_t)LTDC_CLUT_BLUE(cmap->blue[n]);
 
-      reginfo("set LTDC_L%dCLUTWR = %08x, first = %d, len = %d\n",
+      reginfo("set LTDC_L%dCLUTWR = %08" PRIx32 ", first = %d, len = %d\n",
               layer->oinfo.overlay + 1, regval, cmap->first, cmap->len);
       putreg32(regval, stm32_clutwr_layer_t[layer->oinfo.overlay]);
     }

--- a/arch/arm/src/stm32/stm32_otgfsdev.c
+++ b/arch/arm/src/stm32/stm32_otgfsdev.c
@@ -886,7 +886,7 @@ static uint32_t stm32_getreg(uint32_t addr)
 
   /* Show the register value read */
 
-  uinfo("%08x->%08x\n", addr, val);
+  uinfo("%08" PRIx32 "->%08" PRIx32 "\n", addr, val);
   return val;
 }
 #endif
@@ -904,7 +904,7 @@ static void stm32_putreg(uint32_t val, uint32_t addr)
 {
   /* Show the register value being written */
 
-  uinfo("%08x<-%08x\n", addr, val);
+  uinfo("%08" PRIx32 "<-%08" PRIx32 "\n", addr, val);
 
   /* Write the value */
 

--- a/arch/arm/src/stm32/stm32_otgfshost.c
+++ b/arch/arm/src/stm32/stm32_otgfshost.c
@@ -502,7 +502,7 @@ static struct usbhost_connection_s g_usbconn =
 #ifdef CONFIG_STM32_USBHOST_REGDEBUG
 static void stm32_printreg(uint32_t addr, uint32_t val, bool iswrite)
 {
-  uinfo("%08x%s%08x\n", addr, iswrite ? "<-" : "->", val);
+  uinfo("%08" PRIx32 "%s%08" PRIx32 "\n", addr, iswrite ? "<-" : "->", val);
 }
 #endif
 

--- a/arch/arm/src/stm32/stm32_otghsdev.c
+++ b/arch/arm/src/stm32/stm32_otghsdev.c
@@ -835,7 +835,7 @@ static uint32_t stm32_getreg(uint32_t addr)
 
   /* Show the register value read */
 
-  uinfo("%08x->%08x\n", addr, val);
+  uinfo("%08" PRIx32 "->%08" PRIx32 "\n", addr, val);
   return val;
 }
 #endif
@@ -853,7 +853,7 @@ static void stm32_putreg(uint32_t val, uint32_t addr)
 {
   /* Show the register value being written */
 
-  uinfo("%08x<-%08x\n", addr, val);
+  uinfo("%08" PRIx32 "<-%08" PRIx32 "\n", addr, val);
 
   /* Write the value */
 

--- a/arch/arm/src/stm32/stm32_otghshost.c
+++ b/arch/arm/src/stm32/stm32_otghshost.c
@@ -507,7 +507,7 @@ static struct usbhost_connection_s g_usbconn =
 #ifdef CONFIG_STM32_USBHOST_REGDEBUG
 static void stm32_printreg(uint32_t addr, uint32_t val, bool iswrite)
 {
-  uinfo("%08x%s%08x\n", addr, iswrite ? "<-" : "->", val);
+  uinfo("%08" PRIx32 "%s%08" PRIx32 "\n", addr, iswrite ? "<-" : "->", val);
 }
 #endif
 

--- a/arch/arm/src/stm32/stm32_rtcc.c
+++ b/arch/arm/src/stm32/stm32_rtcc.c
@@ -100,26 +100,26 @@ volatile bool g_rtc_enabled = false;
 static void rtc_dumpregs(const char *msg)
 {
   rtcinfo("%s:\n", msg);
-  rtcinfo("      TR: %08x\n", getreg32(STM32_RTC_TR));
-  rtcinfo("      DR: %08x\n", getreg32(STM32_RTC_DR));
-  rtcinfo("      CR: %08x\n", getreg32(STM32_RTC_CR));
-  rtcinfo("     ISR: %08x\n", getreg32(STM32_RTC_ISR));
-  rtcinfo("    PRER: %08x\n", getreg32(STM32_RTC_PRER));
-  rtcinfo("    WUTR: %08x\n", getreg32(STM32_RTC_WUTR));
+  rtcinfo("      TR: %08" PRIx32 "\n", getreg32(STM32_RTC_TR));
+  rtcinfo("      DR: %08" PRIx32 "\n", getreg32(STM32_RTC_DR));
+  rtcinfo("      CR: %08" PRIx32 "\n", getreg32(STM32_RTC_CR));
+  rtcinfo("     ISR: %08" PRIx32 "\n", getreg32(STM32_RTC_ISR));
+  rtcinfo("    PRER: %08" PRIx32 "\n", getreg32(STM32_RTC_PRER));
+  rtcinfo("    WUTR: %08" PRIx32 "\n", getreg32(STM32_RTC_WUTR));
 #ifndef CONFIG_STM32_STM32F30XX
-  rtcinfo("  CALIBR: %08x\n", getreg32(STM32_RTC_CALIBR));
+  rtcinfo("  CALIBR: %08" PRIx32 "\n", getreg32(STM32_RTC_CALIBR));
 #endif
-  rtcinfo("  ALRMAR: %08x\n", getreg32(STM32_RTC_ALRMAR));
-  rtcinfo("  ALRMBR: %08x\n", getreg32(STM32_RTC_ALRMBR));
-  rtcinfo("  SHIFTR: %08x\n", getreg32(STM32_RTC_SHIFTR));
-  rtcinfo("    TSTR: %08x\n", getreg32(STM32_RTC_TSTR));
-  rtcinfo("    TSDR: %08x\n", getreg32(STM32_RTC_TSDR));
-  rtcinfo("   TSSSR: %08x\n", getreg32(STM32_RTC_TSSSR));
-  rtcinfo("    CALR: %08x\n", getreg32(STM32_RTC_CALR));
-  rtcinfo("   TAFCR: %08x\n", getreg32(STM32_RTC_TAFCR));
-  rtcinfo("ALRMASSR: %08x\n", getreg32(STM32_RTC_ALRMASSR));
-  rtcinfo("ALRMBSSR: %08x\n", getreg32(STM32_RTC_ALRMBSSR));
-  rtcinfo("MAGICREG: %08x\n", getreg32(RTC_MAGIC_REG));
+  rtcinfo("  ALRMAR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMAR));
+  rtcinfo("  ALRMBR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMBR));
+  rtcinfo("  SHIFTR: %08" PRIx32 "\n", getreg32(STM32_RTC_SHIFTR));
+  rtcinfo("    TSTR: %08" PRIx32 "\n", getreg32(STM32_RTC_TSTR));
+  rtcinfo("    TSDR: %08" PRIx32 "\n", getreg32(STM32_RTC_TSDR));
+  rtcinfo("   TSSSR: %08" PRIx32 "\n", getreg32(STM32_RTC_TSSSR));
+  rtcinfo("    CALR: %08" PRIx32 "\n", getreg32(STM32_RTC_CALR));
+  rtcinfo("   TAFCR: %08" PRIx32 "\n", getreg32(STM32_RTC_TAFCR));
+  rtcinfo("ALRMASSR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMASSR));
+  rtcinfo("ALRMBSSR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMBSSR));
+  rtcinfo("MAGICREG: %08" PRIx32 "\n", getreg32(RTC_MAGIC_REG));
 }
 #else
 #  define rtc_dumpregs(msg)

--- a/arch/arm/src/stm32/stm32_sdadc.c
+++ b/arch/arm/src/stm32/stm32_sdadc.c
@@ -916,16 +916,18 @@ static void sdadc_reset(struct adc_dev_s *dev)
 
   leave_critical_section(flags);
 
-  ainfo("CR1:  0x%08x CR2:  0x%08x\n",
+  ainfo("CR1:  0x%08" PRIx32 " CR2:  0x%08" PRIx32 "\n",
         sdadc_getreg(priv, STM32_SDADC_CR1_OFFSET),
         sdadc_getreg(priv, STM32_SDADC_CR2_OFFSET));
 
-  ainfo("CONF0R: 0x%08x CONF1R: 0x%08x CONF3R: 0x%08x\n",
+  ainfo("CONF0R: 0x%08" PRIx32 " CONF1R: 0x%08" PRIx32
+        " CONF3R: 0x%08" PRIx32 "\n",
         sdadc_getreg(priv, STM32_SDADC_CONF0R_OFFSET),
         sdadc_getreg(priv, STM32_SDADC_CONF1R_OFFSET),
         sdadc_getreg(priv, STM32_SDADC_CONF2R_OFFSET));
 
-  ainfo("CONFCHR1: 0x%08x CONFCHR2: 0x%08x JCHGR: 0x%08x\n",
+  ainfo("CONFCHR1: 0x%08" PRIx32 " CONFCHR2: 0x%08" PRIx32
+        " JCHGR: 0x%08" PRIx32 "\n",
         sdadc_getreg(priv, STM32_SDADC_CONFCHR1_OFFSET),
         sdadc_getreg(priv, STM32_SDADC_CONFCHR2_OFFSET),
         sdadc_getreg(priv, STM32_SDADC_JCHGR_OFFSET));

--- a/arch/arm/src/stm32/stm32_sdio.c
+++ b/arch/arm/src/stm32/stm32_sdio.c
@@ -810,12 +810,18 @@ static void stm32_sdiodump(struct stm32_sdioregs_s *regs, const char *msg)
   mcinfo("  POWER[%08x]: %08x\n", STM32_SDIO_POWER,   regs->power);
   mcinfo("  CLKCR[%08x]: %08x\n", STM32_SDIO_CLKCR,   regs->clkcr);
   mcinfo("  DCTRL[%08x]: %08x\n", STM32_SDIO_DCTRL,   regs->dctrl);
-  mcinfo(" DTIMER[%08x]: %08x\n", STM32_SDIO_DTIMER,  regs->dtimer);
-  mcinfo("   DLEN[%08x]: %08x\n", STM32_SDIO_DLEN,    regs->dlen);
-  mcinfo(" DCOUNT[%08x]: %08x\n", STM32_SDIO_DCOUNT,  regs->dcount);
-  mcinfo("    STA[%08x]: %08x\n", STM32_SDIO_STA,     regs->sta);
-  mcinfo("   MASK[%08x]: %08x\n", STM32_SDIO_MASK,    regs->mask);
-  mcinfo("FIFOCNT[%08x]: %08x\n", STM32_SDIO_FIFOCNT, regs->fifocnt);
+  mcinfo(" DTIMER[%08x]: %08" PRIx32 "\n",
+         STM32_SDIO_DTIMER,  regs->dtimer);
+  mcinfo("   DLEN[%08x]: %08" PRIx32 "\n",
+         STM32_SDIO_DLEN,    regs->dlen);
+  mcinfo(" DCOUNT[%08x]: %08" PRIx32 "\n",
+         STM32_SDIO_DCOUNT,  regs->dcount);
+  mcinfo("    STA[%08x]: %08" PRIx32 "\n",
+         STM32_SDIO_STA,     regs->sta);
+  mcinfo("   MASK[%08x]: %08" PRIx32 "\n",
+         STM32_SDIO_MASK,    regs->mask);
+  mcinfo("FIFOCNT[%08x]: %08" PRIx32 "\n",
+         STM32_SDIO_FIFOCNT, regs->fifocnt);
 }
 #endif
 
@@ -2250,7 +2256,7 @@ static int stm32_recvshortcrc(struct sdio_dev_s *dev, uint32_t cmd,
            (cmd & MMCSD_RESPONSE_MASK) != MMCSD_R5_RESPONSE &&
            (cmd & MMCSD_RESPONSE_MASK) != MMCSD_R6_RESPONSE)
     {
-      mcerr("ERROR: Wrong response CMD=%08x\n", cmd);
+      mcerr("ERROR: Wrong response CMD=%08" PRIx32 "\n", cmd);
       ret = -EINVAL;
     }
   else
@@ -2315,7 +2321,7 @@ static int stm32_recvlong(struct sdio_dev_s *dev, uint32_t cmd,
 
   if ((cmd & MMCSD_RESPONSE_MASK) != MMCSD_R2_RESPONSE)
     {
-      mcerr("ERROR: Wrong response CMD=%08x\n", cmd);
+      mcerr("ERROR: Wrong response CMD=%08" PRIx32 "\n", cmd);
       ret = -EINVAL;
     }
   else
@@ -2372,7 +2378,7 @@ static int stm32_recvshort(struct sdio_dev_s *dev, uint32_t cmd,
       (cmd & MMCSD_RESPONSE_MASK) != MMCSD_R4_RESPONSE &&
       (cmd & MMCSD_RESPONSE_MASK) != MMCSD_R7_RESPONSE)
     {
-      mcerr("ERROR: Wrong response CMD=%08x\n", cmd);
+      mcerr("ERROR: Wrong response CMD=%08" PRIx32 "\n", cmd);
       ret = -EINVAL;
     }
   else

--- a/arch/arm/src/stm32/stm32_usbdev.c
+++ b/arch/arm/src/stm32/stm32_usbdev.c
@@ -681,7 +681,7 @@ static uint16_t stm32_getreg(uint32_t addr)
 
   /* Show the register value read */
 
-  uinfo("%08x->%04x\n", addr, val);
+  uinfo("%08" PRIx32 "->%04x\n", addr, val);
   return val;
 }
 #endif
@@ -695,7 +695,7 @@ static void stm32_putreg(uint16_t val, uint32_t addr)
 {
   /* Show the register value being written */
 
-  uinfo("%08x<-%04x\n", addr, val);
+  uinfo("%08" PRIx32 "<-%04x\n", addr, val);
 
   /* Write the value */
 
@@ -723,26 +723,26 @@ static void stm32_dumpep(int epno)
   /* Endpoint register */
 
   addr = STM32_USB_EPR(epno);
-  uinfo("EPR%d:   [%08x] %04x\n", epno, addr, getreg16(addr));
+  uinfo("EPR%d:   [%08" PRIx32 "] %04x\n", epno, addr, getreg16(addr));
 
   /* Endpoint descriptor */
 
   addr = STM32_USB_BTABLE_ADDR(epno, 0);
-  uinfo("DESC:   %08x\n", addr);
+  uinfo("DESC:   %08" PRIx32 "\n", addr);
 
   /* Endpoint buffer descriptor */
 
   addr = STM32_USB_ADDR_TX(epno);
-  uinfo("  TX ADDR:  [%08x] %04x\n",  addr, getreg16(addr));
+  uinfo("  TX ADDR:  [%08" PRIx32 "] %04x\n",  addr, getreg16(addr));
 
   addr = STM32_USB_COUNT_TX(epno);
-  uinfo("     COUNT: [%08x] %04x\n",  addr, getreg16(addr));
+  uinfo("     COUNT: [%08" PRIx32 "] %04x\n",  addr, getreg16(addr));
 
   addr = STM32_USB_ADDR_RX(epno);
-  uinfo("  RX ADDR:  [%08x] %04x\n",  addr, getreg16(addr));
+  uinfo("  RX ADDR:  [%08" PRIx32 "] %04x\n",  addr, getreg16(addr));
 
   addr = STM32_USB_COUNT_RX(epno);
-  uinfo("     COUNT: [%08x] %04x\n",  addr, getreg16(addr));
+  uinfo("     COUNT: [%08" PRIx32 "] %04x\n",  addr, getreg16(addr));
 }
 #endif
 
@@ -757,8 +757,9 @@ static void stm32_checksetup(void)
   uint32_t apb1rstr = getreg32(STM32_RCC_APB1RSTR);
   uint32_t apb1enr  = getreg32(STM32_RCC_APB1ENR);
 
-  uinfo("CFGR: %08x APB1RSTR: %08x APB1ENR: %08x\n",
-         cfgr, apb1rstr, apb1enr);
+  uinfo("CFGR: %08" PRIx32 " APB1RSTR: %08" PRIx32
+        " APB1ENR: %08" PRIx32 "\n",
+        cfgr, apb1rstr, apb1enr);
 
   if ((apb1rstr & RCC_APB1RSTR_USBRST) != 0 ||
       (apb1enr & RCC_APB1ENR_USBEN) == 0)

--- a/arch/arm/src/stm32/stm32_usbfs.c
+++ b/arch/arm/src/stm32/stm32_usbfs.c
@@ -662,7 +662,7 @@ static uint16_t stm32_getreg(uint32_t addr)
 
   /* Show the register value read */
 
-  uinfo("%08x->%04x\n", addr, val);
+  uinfo("%08" PRIx32 "->%04" PRIx32 "\n", addr, val);
   return val;
 }
 #endif
@@ -676,7 +676,7 @@ static void stm32_putreg(uint16_t val, uint32_t addr)
 {
   /* Show the register value being written */
 
-  uinfo("%08x<-%04x\n", addr, val);
+  uinfo("%08" PRIx32 "<-%04" PRIx32 "\n", addr, val);
 
   /* Write the value */
 
@@ -704,26 +704,26 @@ static void stm32_dumpep(int epno)
   /* Endpoint register */
 
   addr = STM32_USB_EPR(epno);
-  uinfo("EPR%d:   [%08x] %04x\n", epno, addr, getreg16(addr));
+  uinfo("EPR%d:   [%08" PRIx32 "] %04x\n", epno, addr, getreg16(addr));
 
   /* Endpoint descriptor */
 
   addr = STM32_USB_BTABLE_ADDR(epno, 0);
-  uinfo("DESC:   %08x\n", addr);
+  uinfo("DESC:   %08" PRIx32 "\n", addr);
 
   /* Endpoint buffer descriptor */
 
   addr = STM32_USB_ADDR_TX(epno);
-  uinfo("  TX ADDR:  [%08x] %04x\n",  addr, getreg16(addr));
+  uinfo("  TX ADDR:  [%08" PRIx32 "] %04x\n",  addr, getreg16(addr));
 
   addr = STM32_USB_COUNT_TX(epno);
-  uinfo("     COUNT: [%08x] %04x\n",  addr, getreg16(addr));
+  uinfo("     COUNT: [%08" PRIx32 "] %04x\n",  addr, getreg16(addr));
 
   addr = STM32_USB_ADDR_RX(epno);
-  uinfo("  RX ADDR:  [%08x] %04x\n",  addr, getreg16(addr));
+  uinfo("  RX ADDR:  [%08" PRIx32 "] %04x\n",  addr, getreg16(addr));
 
   addr = STM32_USB_COUNT_RX(epno);
-  uinfo("     COUNT: [%08x] %04x\n",  addr, getreg16(addr));
+  uinfo("     COUNT: [%08" PRIx32 "] %04x\n",  addr, getreg16(addr));
 }
 #endif
 
@@ -738,7 +738,8 @@ static void stm32_checksetup(void)
   uint32_t apb1rstr = getreg32(STM32_RCC_APB1RSTR1);
   uint32_t apb1enr  = getreg32(STM32_RCC_APB1ENR1);
 
-  uinfo("CFGR: %08x APB1RSTR: %08x APB1ENR: %08x\n",
+  uinfo("CFGR: %08" PRIx32 " APB1RSTR: %08" PRIx32
+        " APB1ENR: %08" PRIx32 "\n",
          cfgr, apb1rstr, apb1enr);
 
   if ((apb1rstr & RCC_APB1RSTR1_USBRST) != 0 ||

--- a/arch/arm/src/stm32/stm32_wwdg.c
+++ b/arch/arm/src/stm32/stm32_wwdg.c
@@ -212,7 +212,7 @@ static uint16_t stm32_getreg(uint32_t addr)
 
   /* Show the register value read */
 
-  wdinfo("%08x->%04x\n", addr, val);
+  wdinfo("%08" PRIx32 "->%04x\n", addr, val);
   return val;
 }
 #endif
@@ -230,7 +230,7 @@ static void stm32_putreg(uint16_t val, uint32_t addr)
 {
   /* Show the register value being written */
 
-  wdinfo("%08x<-%04x\n", addr, val);
+  wdinfo("%08" PRIx32 "<-%04x\n", addr, val);
 
   /* Write the value */
 

--- a/arch/arm/src/stm32/stm32f40xxx_i2c.c
+++ b/arch/arm/src/stm32/stm32f40xxx_i2c.c
@@ -885,7 +885,8 @@ static void stm32_i2c_tracedump(struct stm32_i2c_priv_s *priv)
     {
       trace = &priv->trace[i];
       syslog(LOG_DEBUG,
-             "%2d. STATUS: %08x COUNT: %3d EVENT: %2d PARM: %08x TIME: %d\n",
+             "%2d. STATUS: %08" PRIx32 " COUNT: %3d EVENT: %2d"
+             " PARM: %08" PRIx32 " TIME: %d\n",
              i + 1, trace->status, trace->count, trace->event, trace->parm,
              (int)(trace->time - priv->start_time));
     }

--- a/arch/arm/src/stm32/stm32f40xxx_rtcc.c
+++ b/arch/arm/src/stm32/stm32f40xxx_rtcc.c
@@ -164,23 +164,23 @@ static void rtc_dumpregs(const char *msg)
   int rtc_state;
 
   rtcinfo("%s:\n", msg);
-  rtcinfo("      TR: %08x\n", getreg32(STM32_RTC_TR));
-  rtcinfo("      DR: %08x\n", getreg32(STM32_RTC_DR));
-  rtcinfo("      CR: %08x\n", getreg32(STM32_RTC_CR));
-  rtcinfo("     ISR: %08x\n", getreg32(STM32_RTC_ISR));
-  rtcinfo("    PRER: %08x\n", getreg32(STM32_RTC_PRER));
-  rtcinfo("    WUTR: %08x\n", getreg32(STM32_RTC_WUTR));
-  rtcinfo("  ALRMAR: %08x\n", getreg32(STM32_RTC_ALRMAR));
-  rtcinfo("  ALRMBR: %08x\n", getreg32(STM32_RTC_ALRMBR));
-  rtcinfo("  SHIFTR: %08x\n", getreg32(STM32_RTC_SHIFTR));
-  rtcinfo("    TSTR: %08x\n", getreg32(STM32_RTC_TSTR));
-  rtcinfo("    TSDR: %08x\n", getreg32(STM32_RTC_TSDR));
-  rtcinfo("   TSSSR: %08x\n", getreg32(STM32_RTC_TSSSR));
-  rtcinfo("    CALR: %08x\n", getreg32(STM32_RTC_CALR));
-  rtcinfo("   TAFCR: %08x\n", getreg32(STM32_RTC_TAFCR));
-  rtcinfo("ALRMASSR: %08x\n", getreg32(STM32_RTC_ALRMASSR));
-  rtcinfo("ALRMBSSR: %08x\n", getreg32(STM32_RTC_ALRMBSSR));
-  rtcinfo("MAGICREG: %08x\n", getreg32(RTC_MAGIC_REG));
+  rtcinfo("      TR: %08" PRIx32 "\n", getreg32(STM32_RTC_TR));
+  rtcinfo("      DR: %08" PRIx32 "\n", getreg32(STM32_RTC_DR));
+  rtcinfo("      CR: %08" PRIx32 "\n", getreg32(STM32_RTC_CR));
+  rtcinfo("     ISR: %08" PRIx32 "\n", getreg32(STM32_RTC_ISR));
+  rtcinfo("    PRER: %08" PRIx32 "\n", getreg32(STM32_RTC_PRER));
+  rtcinfo("    WUTR: %08" PRIx32 "\n", getreg32(STM32_RTC_WUTR));
+  rtcinfo("  ALRMAR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMAR));
+  rtcinfo("  ALRMBR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMBR));
+  rtcinfo("  SHIFTR: %08" PRIx32 "\n", getreg32(STM32_RTC_SHIFTR));
+  rtcinfo("    TSTR: %08" PRIx32 "\n", getreg32(STM32_RTC_TSTR));
+  rtcinfo("    TSDR: %08" PRIx32 "\n", getreg32(STM32_RTC_TSDR));
+  rtcinfo("   TSSSR: %08" PRIx32 "\n", getreg32(STM32_RTC_TSSSR));
+  rtcinfo("    CALR: %08" PRIx32 "\n", getreg32(STM32_RTC_CALR));
+  rtcinfo("   TAFCR: %08" PRIx32 "\n", getreg32(STM32_RTC_TAFCR));
+  rtcinfo("ALRMASSR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMASSR));
+  rtcinfo("ALRMBSSR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMBSSR));
+  rtcinfo("MAGICREG: %08" PRIx32 "\n", getreg32(RTC_MAGIC_REG));
 
   rtc_state =
     ((getreg32(STM32_EXTI_RTSR) & EXTI_RTC_ALARM) ? 0x1000 : 0) |
@@ -771,7 +771,7 @@ static int rtchw_set_alrmbr(rtc_alarmreg_t alarmreg)
   /* Set the RTC Alarm register */
 
   putreg32(alarmreg, STM32_RTC_ALRMBR);
-  rtcinfo("  ALRMBR: %08x\n", getreg32(STM32_RTC_ALRMBR));
+  rtcinfo("  ALRMBR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMBR));
 
   /* Enable RTC alarm B */
 

--- a/arch/arm/src/stm32/stm32l15xxx_rtcc.c
+++ b/arch/arm/src/stm32/stm32l15xxx_rtcc.c
@@ -163,24 +163,24 @@ static inline void rtc_enable_alarm(void);
 static void rtc_dumpregs(const char *msg)
 {
   rtcinfo("%s:\n", msg);
-  rtcinfo("      TR: %08x\n", getreg32(STM32_RTC_TR));
-  rtcinfo("      DR: %08x\n", getreg32(STM32_RTC_DR));
-  rtcinfo("      CR: %08x\n", getreg32(STM32_RTC_CR));
-  rtcinfo("     ISR: %08x\n", getreg32(STM32_RTC_ISR));
-  rtcinfo("    PRER: %08x\n", getreg32(STM32_RTC_PRER));
-  rtcinfo("    WUTR: %08x\n", getreg32(STM32_RTC_WUTR));
-  rtcinfo("  CALIBR: %08x\n", getreg32(STM32_RTC_CALIBR));
-  rtcinfo("  ALRMAR: %08x\n", getreg32(STM32_RTC_ALRMAR));
-  rtcinfo("  ALRMBR: %08x\n", getreg32(STM32_RTC_ALRMBR));
-  rtcinfo("  SHIFTR: %08x\n", getreg32(STM32_RTC_SHIFTR));
-  rtcinfo("    TSTR: %08x\n", getreg32(STM32_RTC_TSTR));
-  rtcinfo("    TSDR: %08x\n", getreg32(STM32_RTC_TSDR));
-  rtcinfo("   TSSSR: %08x\n", getreg32(STM32_RTC_TSSSR));
-  rtcinfo("    CALR: %08x\n", getreg32(STM32_RTC_CALR));
-  rtcinfo("   TAFCR: %08x\n", getreg32(STM32_RTC_TAFCR));
-  rtcinfo("ALRMASSR: %08x\n", getreg32(STM32_RTC_ALRMASSR));
-  rtcinfo("ALRMBSSR: %08x\n", getreg32(STM32_RTC_ALRMBSSR));
-  rtcinfo("MAGICREG: %08x\n", getreg32(RTC_MAGIC_REG));
+  rtcinfo("      TR: %08" PRIx32 "\n", getreg32(STM32_RTC_TR));
+  rtcinfo("      DR: %08" PRIx32 "\n", getreg32(STM32_RTC_DR));
+  rtcinfo("      CR: %08" PRIx32 "\n", getreg32(STM32_RTC_CR));
+  rtcinfo("     ISR: %08" PRIx32 "\n", getreg32(STM32_RTC_ISR));
+  rtcinfo("    PRER: %08" PRIx32 "\n", getreg32(STM32_RTC_PRER));
+  rtcinfo("    WUTR: %08" PRIx32 "\n", getreg32(STM32_RTC_WUTR));
+  rtcinfo("  CALIBR: %08" PRIx32 "\n", getreg32(STM32_RTC_CALIBR));
+  rtcinfo("  ALRMAR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMAR));
+  rtcinfo("  ALRMBR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMBR));
+  rtcinfo("  SHIFTR: %08" PRIx32 "\n", getreg32(STM32_RTC_SHIFTR));
+  rtcinfo("    TSTR: %08" PRIx32 "\n", getreg32(STM32_RTC_TSTR));
+  rtcinfo("    TSDR: %08" PRIx32 "\n", getreg32(STM32_RTC_TSDR));
+  rtcinfo("   TSSSR: %08" PRIx32 "\n", getreg32(STM32_RTC_TSSSR));
+  rtcinfo("    CALR: %08" PRIx32 "\n", getreg32(STM32_RTC_CALR));
+  rtcinfo("   TAFCR: %08" PRIx32 "\n", getreg32(STM32_RTC_TAFCR));
+  rtcinfo("ALRMASSR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMASSR));
+  rtcinfo("ALRMBSSR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMBSSR));
+  rtcinfo("MAGICREG: %08" PRIx32 "\n", getreg32(RTC_MAGIC_REG));
 }
 #else
 #  define rtc_dumpregs(msg)
@@ -678,7 +678,7 @@ static int rtchw_set_alrmar(rtc_alarmreg_t alarmreg)
 
   putreg32(alarmreg, STM32_RTC_ALRMAR);
   putreg32(0, STM32_RTC_ALRMASSR);
-  rtcinfo("  ALRMAR: %08x\n", getreg32(STM32_RTC_ALRMAR));
+  rtcinfo("  ALRMAR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMAR));
 
   /* Enable RTC alarm A */
 
@@ -721,7 +721,7 @@ static int rtchw_set_alrmbr(rtc_alarmreg_t alarmreg)
 
   putreg32(alarmreg, STM32_RTC_ALRMBR);
   putreg32(0, STM32_RTC_ALRMBSSR);
-  rtcinfo("  ALRMBR: %08x\n", getreg32(STM32_RTC_ALRMBR));
+  rtcinfo("  ALRMBR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMBR));
 
   /* Enable RTC alarm B */
 

--- a/arch/arm/src/stm32f0l0g0/stm32_adc.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_adc.c
@@ -2091,7 +2091,7 @@ static void adc_enable_vbat_channel(struct adc_dev_s *dev, bool enable)
       adccmn_modifyreg(priv, STM32_ADC_CCR_OFFSET, ADC_CCR_VBATEN, 0);
     }
 
-  ainfo("STM32_ADC_CCR value: 0x%08x\n",
+  ainfo("STM32_ADC_CCR value: 0x%08" PRIx32 "\n",
         adccmn_getreg(priv, STM32_ADC_CCR_OFFSET));
 }
 #endif

--- a/arch/arm/src/stm32f0l0g0/stm32_dma_v1.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_dma_v1.c
@@ -744,19 +744,19 @@ void stm32_dmadump(DMA_HANDLE handle, const struct stm32_dmaregs_s *regs,
   uint32_t dmabase = DMA_BASE(dmach->base);
 
   dmainfo("DMA Registers: %s\n", msg);
-  dmainfo("   ISRC[%08x]: %08x\n",
+  dmainfo("   ISRC[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmabase + STM32_DMA_ISR_OFFSET, regs->isr);
 #ifdef DMA_HAVE_CSELR
-  dmainfo("  CSELR[%08x]: %08x\n",
+  dmainfo("  CSELR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmabase + STM32_DMA_CSELR_OFFSET, regs->cselr);
 #endif
-  dmainfo("    CCR[%08x]: %08x\n",
+  dmainfo("    CCR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmach->base + STM32_DMACHAN_CCR_OFFSET, regs->ccr);
-  dmainfo("  CNDTR[%08x]: %08x\n",
+  dmainfo("  CNDTR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmach->base + STM32_DMACHAN_CNDTR_OFFSET, regs->cndtr);
-  dmainfo("   CPAR[%08x]: %08x\n",
+  dmainfo("   CPAR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmach->base + STM32_DMACHAN_CPAR_OFFSET, regs->cpar);
-  dmainfo("   CMAR[%08x]: %08x\n",
+  dmainfo("   CMAR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmach->base + STM32_DMACHAN_CMAR_OFFSET, regs->cmar);
 }
 #endif

--- a/arch/arm/src/stm32f0l0g0/stm32_dma_v1mux.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_dma_v1mux.c
@@ -971,20 +971,20 @@ static void stm32_dmamux_dump(DMA_MUX dmamux, uint8_t channel,
                               const struct stm32_dmaregs_s *regs)
 {
   dmainfo("DMAMUX%d CH=%d\n", dmamux->id, channel);
-  dmainfo("    CCR[%08x]: %08x\n",
+  dmainfo("    CCR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmamux->base + STM32_DMAMUX_CXCR_OFFSET(channel),
           regs->dmamux.ccr);
-  dmainfo("    CSR[%08x]: %08x\n",
+  dmainfo("    CSR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmamux->base + STM32_DMAMUX_CSR_OFFSET, regs->dmamux.csr);
-  dmainfo("  RG0CR[%08x]: %08x\n",
+  dmainfo("  RG0CR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmamux->base + STM32_DMAMUX_RG0CR_OFFSET, regs->dmamux.rg0cr);
-  dmainfo("  RG1CR[%08x]: %08x\n",
+  dmainfo("  RG1CR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmamux->base + STM32_DMAMUX_RG1CR_OFFSET, regs->dmamux.rg1cr);
-  dmainfo("  RG2CR[%08x]: %08x\n",
+  dmainfo("  RG2CR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmamux->base + STM32_DMAMUX_RG2CR_OFFSET, regs->dmamux.rg2cr);
-  dmainfo("  RG3CR[%08x]: %08x\n",
+  dmainfo("  RG3CR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmamux->base + STM32_DMAMUX_RG3CR_OFFSET, regs->dmamux.rg3cr);
-  dmainfo("   RGSR[%08x]: %08x\n",
+  dmainfo("   RGSR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmamux->base + STM32_DMAMUX_RGSR_OFFSET, regs->dmamux.rgsr);
 };
 #endif

--- a/arch/arm/src/stm32f0l0g0/stm32_i2c.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_i2c.c
@@ -872,7 +872,8 @@ static inline int stm32_i2c_sem_waitdone(struct stm32_i2c_priv_s *priv)
 
   while (priv->intstate != INTSTATE_DONE && elapsed < timeout);
 
-  i2cinfo("intstate: %d elapsed: %ld threshold: %ld status: 0x%08x\n",
+  i2cinfo("intstate: %d elapsed: %ld threshold: %ld"
+          " status: 0x%08" PRIx32 "\n",
           priv->intstate, (long)elapsed, (long)timeout, priv->status);
 
   /* Set the interrupt state back to IDLE */
@@ -1136,7 +1137,8 @@ static void stm32_i2c_tracedump(struct stm32_i2c_priv_s *priv)
     {
       trace = &priv->trace[i];
       syslog(LOG_DEBUG,
-             "%2d. STATUS: %08x COUNT: %3d EVENT: %2d PARM: %08x TIME: %d\n",
+             "%2d. STATUS: %08" PRIx32 " COUNT: %3d EVENT: %2d"
+             " PARM: %08" PRIx32 " TIME: %d\n",
              i + 1, trace->status, trace->count,  trace->event, trace->parm,
              (int)(trace->time - priv->start_time));
     }

--- a/arch/arm/src/stm32f0l0g0/stm32_usbdev.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_usbdev.c
@@ -647,7 +647,7 @@ static uint16_t stm32_getreg(uint32_t addr)
 
   /* Show the register value read */
 
-  uinfo("%08x->%04x\n", addr, val);
+  uinfo("%08" PRIx32 "->%04x\n", addr, val);
   return val;
 }
 #endif
@@ -661,7 +661,7 @@ static void stm32_putreg(uint16_t val, uint32_t addr)
 {
   /* Show the register value being written */
 
-  uinfo("%08x<-%04x\n", addr, val);
+  uinfo("%08" PRIx32 "<-%04x\n", addr, val);
 
   /* Write the value */
 
@@ -689,26 +689,26 @@ static void stm32_dumpep(int epno)
   /* Endpoint register */
 
   addr = STM32_USB_EPR(epno);
-  uinfo("EPR%d:   [%08x] %04x\n", epno, addr, getreg16(addr));
+  uinfo("EPR%d:   [%08" PRIx32 "] %04x\n", epno, addr, getreg16(addr));
 
   /* Endpoint descriptor */
 
   addr = STM32_USB_BTABLE_ADDR(epno, 0);
-  uinfo("DESC:   %08x\n", addr);
+  uinfo("DESC:   %08" PRIx32 "\n", addr);
 
   /* Endpoint buffer descriptor */
 
   addr = STM32_USB_ADDR_TX(epno);
-  uinfo("  TX ADDR:  [%08x] %04x\n",  addr, getreg16(addr));
+  uinfo("  TX ADDR:  [%08" PRIx32 "] %04x\n",  addr, getreg16(addr));
 
   addr = STM32_USB_COUNT_TX(epno);
-  uinfo("     COUNT: [%08x] %04x\n",  addr, getreg16(addr));
+  uinfo("     COUNT: [%08" PRIx32 "] %04x\n",  addr, getreg16(addr));
 
   addr = STM32_USB_ADDR_RX(epno);
-  uinfo("  RX ADDR:  [%08x] %04x\n",  addr, getreg16(addr));
+  uinfo("  RX ADDR:  [%08" PRIx32 "] %04x\n",  addr, getreg16(addr));
 
   addr = STM32_USB_COUNT_RX(epno);
-  uinfo("     COUNT: [%08x] %04x\n",  addr, getreg16(addr));
+  uinfo("     COUNT: [%08" PRIx32 "] %04x\n",  addr, getreg16(addr));
 }
 #endif
 

--- a/arch/arm/src/stm32f7/stm32_dma.c
+++ b/arch/arm/src/stm32f7/stm32_dma.c
@@ -1102,21 +1102,21 @@ void stm32_dmadump(DMA_HANDLE handle, const struct stm32_dmaregs_s *regs,
   uint32_t dmabase = DMA_BASE(dmast->base);
 
   dmainfo("DMA Registers: %s\n", msg);
-  dmainfo("   LISR[%08x]: %08x\n",
+  dmainfo("   LISR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmabase + STM32_DMA_LISR_OFFSET, regs->lisr);
-  dmainfo("   HISR[%08x]: %08x\n",
+  dmainfo("   HISR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmabase + STM32_DMA_HISR_OFFSET, regs->hisr);
-  dmainfo("    SCR[%08x]: %08x\n",
+  dmainfo("    SCR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmast->base + STM32_DMA_SCR_OFFSET, regs->scr);
-  dmainfo("  SNDTR[%08x]: %08x\n",
+  dmainfo("  SNDTR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmast->base + STM32_DMA_SNDTR_OFFSET, regs->sndtr);
-  dmainfo("   SPAR[%08x]: %08x\n",
+  dmainfo("   SPAR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmast->base + STM32_DMA_SPAR_OFFSET, regs->spar);
-  dmainfo("  SM0AR[%08x]: %08x\n",
+  dmainfo("  SM0AR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmast->base + STM32_DMA_SM0AR_OFFSET, regs->sm0ar);
-  dmainfo("  SM1AR[%08x]: %08x\n",
+  dmainfo("  SM1AR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmast->base + STM32_DMA_SM1AR_OFFSET, regs->sm1ar);
-  dmainfo("   SFCR[%08x]: %08x\n",
+  dmainfo("   SFCR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmast->base + STM32_DMA_SFCR_OFFSET, regs->sfcr);
 }
 #endif

--- a/arch/arm/src/stm32f7/stm32_dma2d.c
+++ b/arch/arm/src/stm32f7/stm32_dma2d.c
@@ -307,13 +307,14 @@ static void stm32_dma2d_control(uint32_t setbits, uint32_t clrbits)
 {
   uint32_t   cr;
 
-  lcdinfo("setbits=%08x, clrbits=%08x\n", setbits, clrbits);
+  lcdinfo("setbits=%08" PRIx32 ", clrbits=%08" PRIx32 "\n",
+          setbits, clrbits);
 
   cr = getreg32(STM32_DMA2D_CR);
   cr &= ~clrbits;
   cr |= setbits;
 
-  lcdinfo("cr=%08x\n", cr);
+  lcdinfo("cr=%08" PRIx32 "\n", cr);
   putreg32(cr, STM32_DMA2D_CR);
 }
 
@@ -331,7 +332,7 @@ static int stm32_dma2dirq(int irq, void *context, void *arg)
   uint32_t regval = getreg32(STM32_DMA2D_ISR);
   struct stm32_interrupt_s *priv = &g_interrupt;
 
-  reginfo("irq = %d, regval = %08x\n", irq, regval);
+  reginfo("irq = %d, regval = %08" PRIx32 "\n", irq, regval);
 
   if (regval & DMA2D_ISR_TCIF)
     {
@@ -470,9 +471,9 @@ static int stm32_dma2d_loadclut(uintptr_t pfcreg)
 
   regval  = getreg32(pfcreg);
   regval |= DMA2D_XGPFCCR_START;
-  reginfo("set regval=%08x\n", regval);
+  reginfo("set regval=%08" PRIx32 "\n", regval);
   putreg32(regval, pfcreg);
-  reginfo("configured regval=%08x\n", getreg32(pfcreg));
+  reginfo("configured regval=%08" PRIx32 "\n", getreg32(pfcreg));
 
   /* Wait until clut is finished */
 
@@ -607,7 +608,7 @@ static void stm32_dma2d_lfifo(struct stm32_dma2d_overlay_s *oinfo,
 
 static void stm32_dma2d_lcolor(int lid, uint32_t argb)
 {
-  lcdinfo("lid=%d, argb=%08x\n", lid, argb);
+  lcdinfo("lid=%d, argb=%08" PRIx32 "\n", lid, argb);
   putreg32(argb, stm32_color_layer_t[lid]);
 }
 
@@ -673,8 +674,8 @@ static void stm32_dma2d_lpfc(int lid, uint32_t blendmode, uint8_t alpha,
 {
   uint32_t   pfccrreg;
 
-  lcdinfo("lid=%d, blendmode=%08x, alpha=%02x, fmt=%d\n", lid, blendmode,
-          alpha, fmt);
+  lcdinfo("lid=%d, blendmode=%08" PRIx32 ", alpha=%02x, fmt=%d\n",
+          lid, blendmode, alpha, fmt);
 
   /* Set color format */
 
@@ -819,7 +820,7 @@ static int stm32_dma2d_fillcolor(struct stm32_dma2d_overlay_s *oinfo,
   struct stm32_dma2d_s *priv = &g_dma2ddev;
   DEBUGASSERT(oinfo != NULL && oinfo->oinfo != NULL && area != NULL);
 
-  lcdinfo("oinfo=%p, argb=%08x\n", oinfo, argb);
+  lcdinfo("oinfo=%p, argb=%08" PRIx32 "\n", oinfo, argb);
 
 #ifdef CONFIG_STM32F7_FB_CMAP
   if (oinfo->fmt == DMA2D_PF_L8)

--- a/arch/arm/src/stm32f7/stm32_dumpgpio.c
+++ b/arch/arm/src/stm32f7/stm32_dumpgpio.c
@@ -114,27 +114,29 @@ int stm32_dumpgpio(uint32_t pinset, const char *msg)
 
   DEBUGASSERT(port < STM32F7_NGPIO);
 
-  gpioinfo("GPIO%c pinset: %08x base: %08x -- %s\n",
+  gpioinfo("GPIO%c pinset: %08" PRIx32 " base: %08" PRIx32 " -- %s\n",
         g_portchar[port], pinset, base, msg);
 
   if ((getreg32(STM32_RCC_AHB1ENR) & RCC_AHB1ENR_GPIOEN(port)) != 0)
     {
-      gpioinfo(" MODE: %08x OTYPE: %04x     OSPEED: %08x PUPDR: %08x\n",
+      gpioinfo(" MODE: %08" PRIx32 " OTYPE: %04" PRIx32
+               "     OSPEED: %08" PRIx32 " PUPDR: %08" PRIx32 "\n",
                getreg32(base + STM32_GPIO_MODER_OFFSET),
                getreg32(base + STM32_GPIO_OTYPER_OFFSET),
                getreg32(base + STM32_GPIO_OSPEED_OFFSET),
                getreg32(base + STM32_GPIO_PUPDR_OFFSET));
-      gpioinfo("  IDR: %04x       ODR: %04x       LCKR: %05x\n",
+      gpioinfo("  IDR: %04" PRIx32 "       ODR: %04" PRIx32
+               "       LCKR: %05" PRIx32 "\n",
                getreg32(base + STM32_GPIO_IDR_OFFSET),
                getreg32(base + STM32_GPIO_ODR_OFFSET),
                getreg32(base + STM32_GPIO_LCKR_OFFSET));
-      gpioinfo(" AFRH: %08x  AFRL: %08x\n",
+      gpioinfo(" AFRH: %08" PRIx32 "  AFRL: %08" PRIx32 "\n",
                getreg32(base + STM32_GPIO_AFRH_OFFSET),
                getreg32(base + STM32_GPIO_AFRL_OFFSET));
     }
   else
     {
-      gpioinfo("  GPIO%c not enabled: AHB1ENR: %08x\n",
+      gpioinfo("  GPIO%c not enabled: AHB1ENR: %08" PRIx32 "\n",
                g_portchar[port], getreg32(STM32_RCC_AHB1ENR));
     }
 

--- a/arch/arm/src/stm32f7/stm32_ethernet.c
+++ b/arch/arm/src/stm32f7/stm32_ethernet.c
@@ -837,7 +837,7 @@ static uint32_t stm32_getreg(uint32_t addr)
 
   /* Show the register value read */
 
-  ninfo("%08x->%08x\n", addr, val);
+  ninfo("%08" PRIx32 "->%08" PRIx32 "\n", addr, val);
   return val;
 }
 #endif
@@ -864,7 +864,7 @@ static void stm32_putreg(uint32_t val, uint32_t addr)
 {
   /* Show the register value being written */
 
-  ninfo("%08x<-%08x\n", addr, val);
+  ninfo("%08" PRIx32 "<-%08" PRIx32 "\n", addr, val);
 
   /* Write the value */
 

--- a/arch/arm/src/stm32f7/stm32_i2c.c
+++ b/arch/arm/src/stm32f7/stm32_i2c.c
@@ -1176,7 +1176,8 @@ static void stm32_i2c_tracedump(struct stm32_i2c_priv_s *priv)
     {
       trace = &priv->trace[i];
       syslog(LOG_DEBUG,
-             "%2d. STATUS: %08x COUNT: %3d EVENT: %2d PARM: %08x TIME: %d\n",
+             "%2d. STATUS: %08" PRIx32 " COUNT: %3d EVENT: %2d"
+             " PARM: %08" PRIx32 " TIME: %d\n",
              i + 1, trace->status, trace->count,  trace->event, trace->parm,
              (int)(trace->time - priv->start_time));
     }

--- a/arch/arm/src/stm32f7/stm32_i2s.c
+++ b/arch/arm/src/stm32f7/stm32_i2s.c
@@ -582,7 +582,7 @@ static inline uint16_t i2s_getreg(struct stm32_i2s_s *priv,
 #ifdef CONFIG_STM32F7_I2S_REGDEBUG
   if (i2s_checkreg(priv, false, regval, regaddr))
     {
-      i2sinfo("%08x->%04x\n", regaddr, regval);
+      i2sinfo("%08" PRIx32 "->%04x\n", regaddr, regval);
     }
 #endif
 
@@ -613,7 +613,7 @@ static inline void i2s_putreg(struct stm32_i2s_s *priv, uint8_t offset,
 #ifdef CONFIG_STM32F7_I2S_REGDEBUG
   if (i2s_checkreg(priv, true, regval, regaddr))
     {
-      i2sinfo("%08x<-%04x\n", regaddr, regval);
+      i2sinfo("%08" PRIx32 "<-%04x\n", regaddr, regval);
     }
 #endif
 
@@ -647,7 +647,7 @@ static void i2s_dump_regs(struct stm32_i2s_s *priv, const char *msg)
   i2sinfo("    I2SCFGR:%04x    I2SPR:%04x\n",
           i2s_getreg(priv, STM32_SPI_I2SCFGR_OFFSET),
           i2s_getreg(priv, STM32_SPI_I2SPR_OFFSET));
-  i2sinfo("    PLLI2SCFGR:%08x\n", getreg32(STM32_RCC_PLLI2SCFGR));
+  i2sinfo("    PLLI2SCFGR:%08" PRIx32 "\n", getreg32(STM32_RCC_PLLI2SCFGR));
 }
 #endif
 

--- a/arch/arm/src/stm32f7/stm32_ltdc.c
+++ b/arch/arm/src/stm32f7/stm32_ltdc.c
@@ -1252,7 +1252,7 @@ static void stm32_ltdc_gpioconfig(void)
 
   for (i = 0; i < STM32_LTDC_NPINCONFIGS; i++)
     {
-      reginfo("set gpio%d = %08x\n", i, g_ltdcpins[i]);
+      reginfo("set gpio%d = %08" PRIx32 "\n", i, g_ltdcpins[i]);
       stm32_configgpio(g_ltdcpins[i]);
     }
 }
@@ -1276,45 +1276,48 @@ static void stm32_ltdc_periphconfig(void)
 
   /* Configure APB2 LTDC clock external */
 
-  reginfo("configured RCC_APB2ENR=%08x\n", getreg32(STM32_RCC_APB2ENR));
+  reginfo("configured RCC_APB2ENR=%08" PRIx32 "\n",
+          getreg32(STM32_RCC_APB2ENR));
 
   /* Configure the SAI PLL external to provide the LCD_CLK */
 
-  reginfo("configured RCC_PLLSAI=%08x\n", getreg32(STM32_RCC_PLLSAICFGR));
+  reginfo("configured RCC_PLLSAI=%08" PRIx32 "\n",
+          getreg32(STM32_RCC_PLLSAICFGR));
 
   /* Configure dedicated clock external.
    * Division factor for LCD_CLK in DCKCFGR1
    */
 
-  reginfo("configured RCC_DCKCFGR1=%08x\n", getreg32(STM32_RCC_DCKCFGR1));
+  reginfo("configured RCC_DCKCFGR1=%08" PRIx32 "\n",
+          getreg32(STM32_RCC_DCKCFGR1));
 
   /* Configure LTDC_SSCR */
 
   regval = (STM32_LTDC_SSCR_VSH | STM32_LTDC_SSCR_HSW);
-  reginfo("set LTDC_SSCR=%08x\n", regval);
+  reginfo("set LTDC_SSCR=%08" PRIx32 "\n", regval);
   putreg32(regval, STM32_LTDC_SSCR);
-  reginfo("configured LTDC_SSCR=%08x\n", getreg32(STM32_LTDC_SSCR));
+  reginfo("configured LTDC_SSCR=%08" PRIx32 "\n", getreg32(STM32_LTDC_SSCR));
 
   /* Configure LTDC_BPCR */
 
   regval = (STM32_LTDC_BPCR_AVBP | STM32_LTDC_BPCR_AHBP);
-  reginfo("set LTDC_BPCR=%08x\n", regval);
+  reginfo("set LTDC_BPCR=%08" PRIx32 "\n", regval);
   putreg32(regval, STM32_LTDC_BPCR);
-  reginfo("configured LTDC_BPCR=%08x\n", getreg32(STM32_LTDC_BPCR));
+  reginfo("configured LTDC_BPCR=%08" PRIx32 "\n", getreg32(STM32_LTDC_BPCR));
 
   /* Configure LTDC_AWCR */
 
   regval = (STM32_LTDC_AWCR_AAH | STM32_LTDC_AWCR_AAW);
-  reginfo("set LTDC_AWCR=%08x\n", regval);
+  reginfo("set LTDC_AWCR=%08" PRIx32 "\n", regval);
   putreg32(regval, STM32_LTDC_AWCR);
-  reginfo("configured LTDC_AWCR=%08x\n", getreg32(STM32_LTDC_AWCR));
+  reginfo("configured LTDC_AWCR=%08" PRIx32 "\n", getreg32(STM32_LTDC_AWCR));
 
   /* Configure LTDC_TWCR */
 
   regval = (STM32_LTDC_TWCR_TOTALH | STM32_LTDC_TWCR_TOTALW);
-  reginfo("set LTDC_TWCR=%08x\n", regval);
+  reginfo("set LTDC_TWCR=%08" PRIx32 "\n", regval);
   putreg32(regval, STM32_LTDC_TWCR);
-  reginfo("configured LTDC_TWCR=%08x\n", getreg32(STM32_LTDC_TWCR));
+  reginfo("configured LTDC_TWCR=%08" PRIx32 "\n", getreg32(STM32_LTDC_TWCR));
 
   /* Configure LTDC_GCR */
 
@@ -1324,9 +1327,9 @@ static void stm32_ltdc_periphconfig(void)
   regval |= (STM32_LTDC_GCR_PCPOL | STM32_LTDC_GCR_DEPOL |
              STM32_LTDC_GCR_VSPOL | STM32_LTDC_GCR_HSPOL);
 
-  reginfo("set LTDC_GCR=%08x\n", regval);
+  reginfo("set LTDC_GCR=%08" PRIx32 "\n", regval);
   putreg32(regval, STM32_LTDC_GCR);
-  reginfo("configured LTDC_GCR=%08x\n", getreg32(STM32_LTDC_GCR));
+  reginfo("configured LTDC_GCR=%08" PRIx32 "\n", getreg32(STM32_LTDC_GCR));
 }
 
 /****************************************************************************
@@ -1345,7 +1348,7 @@ static void stm32_ltdc_ldefaultcolor(struct stm32_ltdc_s *layer,
                                      uint32_t rgb)
 {
   DEBUGASSERT(layer->layerno < LTDC_NLAYERS);
-  reginfo("set LTDC_L%dDCCR=%08x\n", layer->layerno + 1, rgb);
+  reginfo("set LTDC_L%dDCCR=%08" PRIx32 "\n", layer->layerno + 1, rgb);
 
   putreg32(rgb, stm32_dccr_layer_t[layer->layerno]);
 
@@ -1353,7 +1356,7 @@ static void stm32_ltdc_ldefaultcolor(struct stm32_ltdc_s *layer,
 
   stm32_ltdc_reload(LTDC_SRCR_IMR, false);
 
-  reginfo("configured LTDC_L%dDCCR=%08x\n", layer->layerno + 1,
+  reginfo("configured LTDC_L%dDCCR=%08" PRIx32 "\n", layer->layerno + 1,
           getreg32(STM32_LTDC_BCCR));
 }
 
@@ -1370,9 +1373,9 @@ static void stm32_ltdc_ldefaultcolor(struct stm32_ltdc_s *layer,
 
 static void stm32_ltdc_bgcolor(uint32_t rgb)
 {
-  reginfo("set LTDC_BCCR=%08x\n", rgb);
+  reginfo("set LTDC_BCCR=%08" PRIx32 "\n", rgb);
   putreg32(rgb, STM32_LTDC_BCCR);
-  reginfo("configured LTDC_BCCR=%08x\n", getreg32(STM32_LTDC_BCCR));
+  reginfo("configured LTDC_BCCR=%08" PRIx32 "\n", getreg32(STM32_LTDC_BCCR));
 }
 
 /****************************************************************************
@@ -1408,9 +1411,9 @@ static void stm32_ltdc_dither(bool enable, uint8_t red,
   regval &= ~(LTDC_GCR_DBW_MASK | LTDC_GCR_DGW_MASK | LTDC_GCR_DRW_MASK);
   regval |= (LTDC_GCR_DRW(red) | LTDC_GCR_DGW(green) | LTDC_GCR_DBW(blue));
 
-  reginfo("set LTDC_GCR=%08x\n", regval);
+  reginfo("set LTDC_GCR=%08" PRIx32 "\n", regval);
   putreg32(regval, STM32_LTDC_GCR);
-  reginfo("configured LTDC_GCR=%08x\n", getreg32(STM32_LTDC_GCR));
+  reginfo("configured LTDC_GCR=%08" PRIx32 "\n", getreg32(STM32_LTDC_GCR));
 }
 
 /****************************************************************************
@@ -1425,9 +1428,10 @@ static void stm32_ltdc_linepos(void)
 {
   /* Configure LTDC_LIPCR */
 
-  reginfo("set LTDC_LIPCR=%08x\n", STM32_LTDC_LIPCR_LIPOS);
+  reginfo("set LTDC_LIPCR=%08" PRIx32 "\n", STM32_LTDC_LIPCR_LIPOS);
   putreg32(STM32_LTDC_LIPCR_LIPOS, STM32_LTDC_LIPCR);
-  reginfo("configured LTDC_LIPCR=%08x\n", getreg32(STM32_LTDC_LIPCR));
+  reginfo("configured LTDC_LIPCR=%08" PRIx32 "\n",
+          getreg32(STM32_LTDC_LIPCR));
 }
 
 /****************************************************************************
@@ -1449,9 +1453,9 @@ static void stm32_ltdc_irqctrl(uint32_t setirqs, uint32_t clrirqs)
   regval = getreg32(STM32_LTDC_IER);
   regval &= ~clrirqs;
   regval |= setirqs;
-  reginfo("set LTDC_IER=%08x\n", regval);
+  reginfo("set LTDC_IER=%08" PRIx32 "\n", regval);
   putreg32(regval, STM32_LTDC_IER);
-  reginfo("configured LTDC_IER=%08x\n", getreg32(STM32_LTDC_IER));
+  reginfo("configured LTDC_IER=%08" PRIx32 "\n", getreg32(STM32_LTDC_IER));
 }
 
 /****************************************************************************
@@ -1468,7 +1472,7 @@ static int stm32_ltdcirq(int irq, void *context, void *arg)
   struct stm32_interrupt_s *priv = &g_interrupt;
   uint32_t regval = getreg32(STM32_LTDC_ISR);
 
-  reginfo("irq = %d, regval = %08x\n", irq, regval);
+  reginfo("irq = %d, regval = %08" PRIx32 "\n", irq, regval);
 
   if (regval & LTDC_ISR_RRIF)
     {
@@ -1582,7 +1586,7 @@ static int stm32_ltdc_reload(uint8_t value, bool waitvblank)
 
   reginfo("set LTDC_SRCR=%08x\n", value);
   putreg32(value, STM32_LTDC_SRCR);
-  reginfo("configured LTDC_SRCR=%08x\n", getreg32(STM32_LTDC_SRCR));
+  reginfo("configured LTDC_SRCR=%08" PRIx32 "\n", getreg32(STM32_LTDC_SRCR));
 
   if (value == LTDC_SRCR_VBR && waitvblank)
     {
@@ -1674,7 +1678,7 @@ static void stm32_ltdc_enable(bool enable)
   uint32_t    regval;
 
   regval = getreg32(STM32_LTDC_GCR);
-  reginfo("get LTDC_GCR=%08x\n", regval);
+  reginfo("get LTDC_GCR=%08" PRIx32 "\n", regval);
 
   if (enable == true)
     {
@@ -1685,9 +1689,9 @@ static void stm32_ltdc_enable(bool enable)
       regval &= ~LTDC_GCR_LTDCEN;
     }
 
-  reginfo("set LTDC_GCR=%08x\n", regval);
+  reginfo("set LTDC_GCR=%08" PRIx32 "\n", regval);
   putreg32(regval, STM32_LTDC_GCR);
-  reginfo("configured LTDC_GCR=%08x\n", getreg32(STM32_LTDC_GCR));
+  reginfo("configured LTDC_GCR=%08" PRIx32 "\n", getreg32(STM32_LTDC_GCR));
 }
 
 /****************************************************************************
@@ -1710,7 +1714,7 @@ static void stm32_ltdc_lpixelformat(struct stm32_ltdc_s *layer)
 
   /* Configure PFCR register */
 
-  reginfo("set LTDC_L%dPFCR=%08x\n", overlay + 1,
+  reginfo("set LTDC_L%dPFCR=%08" PRIx32 "\n", overlay + 1,
           stm32_fmt_layer_t[overlay]);
   putreg32(stm32_fmt_layer_t[overlay], stm32_pfcr_layer_t[overlay]);
 
@@ -1762,14 +1766,14 @@ static void stm32_ltdc_lframebuffer(struct stm32_ltdc_s *layer)
 
   /* Configure LxWHPCR / LxWVPCR register */
 
-  reginfo("set LTDC_L%dWHPCR=%08x\n", layerno + 1, whpcr);
+  reginfo("set LTDC_L%dWHPCR=%08" PRIx32 "\n", layerno + 1, whpcr);
   putreg32(whpcr, stm32_whpcr_layer_t[layerno]);
-  reginfo("set LTDC_L%dWVPCR=%08x\n", layerno + 1, wvpcr);
+  reginfo("set LTDC_L%dWVPCR=%08" PRIx32 "\n", layerno + 1, wvpcr);
   putreg32(wvpcr, stm32_wvpcr_layer_t[layerno]);
 
   /* Configure LxCFBAR register */
 
-  reginfo("set LTDC_L%dCFBAR=%08x\n", layerno + 1,
+  reginfo("set LTDC_L%dCFBAR=%08" PRIx32 "\n", layerno + 1,
           stm32_fbmem_layer_t[layerno]);
   putreg32(stm32_fbmem_layer_t[layerno], stm32_cfbar_layer_t[layerno]);
 
@@ -1781,12 +1785,12 @@ static void stm32_ltdc_lframebuffer(struct stm32_ltdc_s *layer)
           LTDC_LXCFBLR_CFBLL(stm32_width_layer_t[layerno] *
           STM32_LTDC_LX_BYPP(stm32_bpp_layer_t[layerno]) + 3);
 
-  reginfo("set LTDC_L%dCFBLR=%08x\n", layerno + 1, cfblr);
+  reginfo("set LTDC_L%dCFBLR=%08" PRIx32 "\n", layerno + 1, cfblr);
   putreg32(cfblr, stm32_cfblr_layer_t[layerno]);
 
   /* Configure LxCFBLNR register */
 
-  reginfo("set LTDC_L%dCFBLNR=%08x\n", layerno + 1,
+  reginfo("set LTDC_L%dCFBLNR=%08" PRIx32 "\n", layerno + 1,
           stm32_height_layer_t[layerno]);
   putreg32(stm32_height_layer_t[layerno], stm32_cfblnr_layer_t[layerno]);
 
@@ -1827,7 +1831,7 @@ static void stm32_ltdc_lenable(struct stm32_ltdc_s *layer, bool enable)
 
   /* Enable/Disable layer */
 
-  reginfo("set LTDC_L%dCR=%08x\n", layer->layerno + 1, regval);
+  reginfo("set LTDC_L%dCR=%08" PRIx32 "\n", layer->layerno + 1, regval);
   putreg32(regval, stm32_cr_layer_t[layer->layerno]);
 
   /* Reload shadow register */
@@ -1874,7 +1878,7 @@ static void stm32_ltdc_ltransp(struct stm32_ltdc_s *layer,
   bf2 = LTDC_BF2_CONST_ALPHA;
 #endif
 
-  reginfo("set LTDC_L%dBFCR=%08x\n", layer->layerno + 1,
+  reginfo("set LTDC_L%dBFCR=%08" PRIx32 "\n", layer->layerno + 1,
           (LTDC_LXBFCR_BF1(bf1) | LTDC_LXBFCR_BF2(bf2)));
 
   /* Set blendmode */
@@ -1912,7 +1916,7 @@ static void stm32_ltdc_lchromakey(struct stm32_ltdc_s *layer,
   uint32_t rgb;
   DEBUGASSERT(layer->layerno < LTDC_NLAYERS);
 
-  reginfo("%08x\n", getreg32(stm32_cr_layer_t[layer->layerno]));
+  reginfo("%08" PRIx32 "\n", getreg32(stm32_cr_layer_t[layer->layerno]));
 
   /* Set chromakey */
 
@@ -1925,7 +1929,7 @@ static void stm32_ltdc_lchromakey(struct stm32_ltdc_s *layer,
   rgb = ARGB8888(chroma);
 #endif
 
-  reginfo("set LTDC_L%dCKCR=%08x\n", layer->layerno + 1, rgb);
+  reginfo("set LTDC_L%dCKCR=%08" PRIx32 "\n", layer->layerno + 1, rgb);
   putreg32(rgb, stm32_ckcr_layer_t[layer->layerno]);
 
   /* Reload shadow register */
@@ -1966,7 +1970,7 @@ static void stm32_ltdc_lchromakeyenable(struct stm32_ltdc_s *layer,
       regval &= ~LTDC_LXCR_COLKEN;
     }
 
-  reginfo("set LTDC_L%dCR=%08x\n", layer->layerno + 1, regval);
+  reginfo("set LTDC_L%dCR=%08" PRIx32 "\n", layer->layerno + 1, regval);
   putreg32(regval, stm32_cr_layer_t[layer->layerno]);
 
   /* Reload shadow register */
@@ -1993,7 +1997,8 @@ static void stm32_ltdc_lclutenable(struct stm32_ltdc_s *layer,
   uint32_t    regval;
 
   regval = getreg32(stm32_cr_layer_t[layer->oinfo.overlay]);
-  reginfo("get LTDC_L%dCR=%08x\n", layer->oinfo.overlay + 1, regval);
+  reginfo("get LTDC_L%dCR=%08" PRIx32 "\n",
+          layer->oinfo.overlay + 1, regval);
 
   /* Disable the clut support during update the color table */
 
@@ -2006,7 +2011,7 @@ static void stm32_ltdc_lclutenable(struct stm32_ltdc_s *layer,
       regval &= ~LTDC_LXCR_CLUTEN;
     }
 
-  reginfo("set LTDC_L%dCR=%08x\n", layer->oinfo.overlay, regval);
+  reginfo("set LTDC_L%dCR=%08" PRIx32 "\n", layer->oinfo.overlay, regval);
   putreg32(regval, stm32_cr_layer_t[layer->oinfo.overlay]);
 
   /* Reload shadow register */
@@ -2052,7 +2057,7 @@ static void stm32_ltdc_lputclut(struct stm32_ltdc_s *layer,
                (uint32_t)LTDC_CLUT_GREEN(cmap->green[n]) |
                (uint32_t)LTDC_CLUT_BLUE(cmap->blue[n]);
 
-      reginfo("set LTDC_L%dCLUTWR = %08x, first = %d, len = %d\n",
+      reginfo("set LTDC_L%dCLUTWR = %08" PRIx32 ", first = %d, len = %d\n",
               layer->oinfo.overlay + 1, regval, cmap->first, cmap->len);
       putreg32(regval, stm32_clutwr_layer_t[layer->oinfo.overlay]);
     }

--- a/arch/arm/src/stm32f7/stm32_otgdev.c
+++ b/arch/arm/src/stm32f7/stm32_otgdev.c
@@ -948,7 +948,7 @@ static uint32_t stm32_getreg(uint32_t addr)
 
   /* Show the register value read */
 
-  uinfo("%08x->%08x\n", addr, val);
+  uinfo("%08" PRIx32 "->%08" PRIx32 "\n", addr, val);
   return val;
 }
 #  endif
@@ -966,7 +966,7 @@ static void stm32_putreg(uint32_t val, uint32_t addr)
 {
   /* Show the register value being written */
 
-  uinfo("%08x<-%08x\n", addr, val);
+  uinfo("%08" PRIx32 "<-%08" PRIx32 "\n", addr, val);
 
   /* Write the value */
 

--- a/arch/arm/src/stm32f7/stm32_otghost.c
+++ b/arch/arm/src/stm32f7/stm32_otghost.c
@@ -499,7 +499,7 @@ static struct usbhost_connection_s g_usbconn =
 #ifdef CONFIG_STM32F7_USBHOST_REGDEBUG
 static void stm32_printreg(uint32_t addr, uint32_t val, bool iswrite)
 {
-  uinfo("%08x%s%08x\n", addr, iswrite ? "<-" : "->", val);
+  uinfo("%08" PRIx32 "%s%08" PRIx32 "\n", addr, iswrite ? "<-" : "->", val);
 }
 #endif
 

--- a/arch/arm/src/stm32f7/stm32_qspi.c
+++ b/arch/arm/src/stm32f7/stm32_qspi.c
@@ -423,7 +423,7 @@ static inline uint32_t qspi_getreg(struct stm32f7_qspidev_s *priv,
 #ifdef CONFIG_STM32F7_QSPI_REGDEBUG
   if (qspi_checkreg(priv, false, value, address))
     {
-      spiinfo("%08x->%08x\n", address, value);
+      spiinfo("%08" PRIx32 "->%08" PRIx32 "\n", address, value);
     }
 #endif
 
@@ -446,7 +446,7 @@ static inline void qspi_putreg(struct stm32f7_qspidev_s *priv,
 #ifdef CONFIG_STM32F7_QSPI_REGDEBUG
   if (qspi_checkreg(priv, true, value, address))
     {
-      spiinfo("%08x<-%08x\n", address, value);
+      spiinfo("%08" PRIx32 "<-%08" PRIx32 "\n", address, value);
     }
 #endif
 
@@ -481,7 +481,7 @@ static void qspi_dumpregs(struct stm32f7_qspidev_s *priv, const char *msg)
    */
 
   regval = getreg32(priv->base + STM32_QUADSPI_CR_OFFSET);    /* Control Register */
-  spiinfo("CR:%08x\n", regval);
+  spiinfo("CR:%08" PRIx32 "\n", regval);
   spiinfo("  EN:%1d ABORT:%1d DMAEN:%1d TCEN:%1d SSHIFT:%1d\n"
           "  FTHRES: %d\n"
           "  TEIE:%1d TCIE:%1d FTIE:%1d SMIE:%1d TOIE:%1d APMS:%1d PMM:%1d\n"
@@ -502,14 +502,14 @@ static void qspi_dumpregs(struct stm32f7_qspidev_s *priv, const char *msg)
           (regval & QSPI_CR_PRESCALER_MASK) >> QSPI_CR_PRESCALER_SHIFT);
 
   regval = getreg32(priv->base + STM32_QUADSPI_DCR_OFFSET);   /* Device Configuration Register */
-  spiinfo("DCR:%08x\n", regval);
+  spiinfo("DCR:%08" PRIx32 "\n", regval);
   spiinfo("  CKMODE:%1d CSHT:%d FSIZE:%d\n",
           (regval & QSPI_DCR_CKMODE) ? 1 : 0,
           (regval & QSPI_DCR_CSHT_MASK) >> QSPI_DCR_CSHT_SHIFT,
           (regval & QSPI_DCR_FSIZE_MASK) >> QSPI_DCR_FSIZE_SHIFT);
 
   regval = getreg32(priv->base + STM32_QUADSPI_CCR_OFFSET);   /* Communication Configuration Register */
-  spiinfo("CCR:%08x\n", regval);
+  spiinfo("CCR:%08" PRIx32 "\n", regval);
   spiinfo("   INST:%02x IMODE:%d ADMODE:%d ADSIZE:%d ABMODE:%d\n"
           "   ABSIZE:%d DCYC:%d DMODE:%d FMODE:%d\n"
           "   SIOO:%1d DDRM:%1d\n",
@@ -526,7 +526,7 @@ static void qspi_dumpregs(struct stm32f7_qspidev_s *priv, const char *msg)
           (regval & QSPI_CCR_DDRM) ? 1 : 0);
 
   regval = getreg32(priv->base + STM32_QUADSPI_SR_OFFSET);    /* Status Register */
-  spiinfo("SR:%08x\n", regval);
+  spiinfo("SR:%08" PRIx32 "\n", regval);
   spiinfo("  TEF:%1d TCF:%1d FTF:%1d SMF:%1d TOF:%1d BUSY:%1d FLEVEL:%d\n",
           (regval & QSPI_SR_TEF) ? 1 : 0,
           (regval & QSPI_SR_TCF) ? 1 : 0,
@@ -537,17 +537,19 @@ static void qspi_dumpregs(struct stm32f7_qspidev_s *priv, const char *msg)
           (regval & QSPI_SR_FLEVEL_MASK) >> QSPI_SR_FLEVEL_SHIFT);
 
 #else
-  spiinfo("    CR:%08x   DCR:%08x   CCR:%08x    SR:%08x\n",
+  spiinfo("    CR:%08" PRIx32 "   DCR:%08" PRIx32
+          "   CCR:%08" PRIx32 "    SR:%08" PRIx32 "\n",
           getreg32(priv->base + STM32_QUADSPI_CR_OFFSET),     /* Control Register */
           getreg32(priv->base + STM32_QUADSPI_DCR_OFFSET),    /* Device Configuration Register */
           getreg32(priv->base + STM32_QUADSPI_CCR_OFFSET),    /* Communication Configuration Register */
           getreg32(priv->base + STM32_QUADSPI_SR_OFFSET));    /* Status Register */
-  spiinfo("   DLR:%08x   ABR:%08x PSMKR:%08x PSMAR:%08x\n",
+  spiinfo("   DLR:%08" PRIx32 "   ABR:%08" PRIx32
+          " PSMKR:%08" PRIx32 " PSMAR:%08" PRIx32 "\n",
           getreg32(priv->base + STM32_QUADSPI_DLR_OFFSET),    /* Data Length Register */
           getreg32(priv->base + STM32_QUADSPI_ABR_OFFSET),    /* Alternate Bytes Register */
           getreg32(priv->base + STM32_QUADSPI_PSMKR_OFFSET),  /* Polling Status mask Register */
           getreg32(priv->base + STM32_QUADSPI_PSMAR_OFFSET)); /* Polling Status match Register */
-  spiinfo("   PIR:%08x  LPTR:%08x\n",
+  spiinfo("   PIR:%08" PRIx32 "  LPTR:%08" PRIx32 "\n",
           getreg32(priv->base + STM32_QUADSPI_PIR_OFFSET),    /* Polling Interval Register */
           getreg32(priv->base + STM32_QUADSPI_LPTR_OFFSET));  /* Low-Power Timeout Register */
   UNUSED(regval);
@@ -564,62 +566,62 @@ static void qspi_dumpgpioconfig(const char *msg)
   /* Port B */
 
   regval = getreg32(STM32_GPIOB_MODER);
-  spiinfo("B_MODER:%08x\n", regval);
+  spiinfo("B_MODER:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOB_OTYPER);
-  spiinfo("B_OTYPER:%08x\n", regval);
+  spiinfo("B_OTYPER:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOB_OSPEED);
-  spiinfo("B_OSPEED:%08x\n", regval);
+  spiinfo("B_OSPEED:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOB_PUPDR);
-  spiinfo("B_PUPDR:%08x\n", regval);
+  spiinfo("B_PUPDR:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOB_AFRL);
-  spiinfo("B_AFRL:%08x\n", regval);
+  spiinfo("B_AFRL:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOB_AFRH);
-  spiinfo("B_AFRH:%08x\n", regval);
+  spiinfo("B_AFRH:%08" PRIx32 "\n", regval);
 
   /* Port D */
 
   regval = getreg32(STM32_GPIOD_MODER);
-  spiinfo("D_MODER:%08x\n", regval);
+  spiinfo("D_MODER:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOD_OTYPER);
-  spiinfo("D_OTYPER:%08x\n", regval);
+  spiinfo("D_OTYPER:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOD_OSPEED);
-  spiinfo("D_OSPEED:%08x\n", regval);
+  spiinfo("D_OSPEED:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOD_PUPDR);
-  spiinfo("D_PUPDR:%08x\n", regval);
+  spiinfo("D_PUPDR:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOD_AFRL);
-  spiinfo("D_AFRL:%08x\n", regval);
+  spiinfo("D_AFRL:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOD_AFRH);
-  spiinfo("D_AFRH:%08x\n", regval);
+  spiinfo("D_AFRH:%08" PRIx32 "\n", regval);
 
   /* Port E */
 
   regval = getreg32(STM32_GPIOE_MODER);
-  spiinfo("E_MODER:%08x\n", regval);
+  spiinfo("E_MODER:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOE_OTYPER);
-  spiinfo("E_OTYPER:%08x\n", regval);
+  spiinfo("E_OTYPER:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOE_OSPEED);
-  spiinfo("E_OSPEED:%08x\n", regval);
+  spiinfo("E_OSPEED:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOE_PUPDR);
-  spiinfo("E_PUPDR:%08x\n", regval);
+  spiinfo("E_PUPDR:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOE_AFRL);
-  spiinfo("E_AFRL:%08x\n", regval);
+  spiinfo("E_AFRL:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOE_AFRH);
-  spiinfo("E_AFRH:%08x\n", regval);
+  spiinfo("E_AFRH:%08" PRIx32 "\n", regval);
 }
 #endif
 

--- a/arch/arm/src/stm32f7/stm32_rtc.c
+++ b/arch/arm/src/stm32f7/stm32_rtc.c
@@ -165,23 +165,23 @@ static void rtc_dumpregs(const char *msg)
   int rtc_state;
 
   rtcinfo("%s:\n", msg);
-  rtcinfo("      TR: %08x\n", getreg32(STM32_RTC_TR));
-  rtcinfo("      DR: %08x\n", getreg32(STM32_RTC_DR));
-  rtcinfo("      CR: %08x\n", getreg32(STM32_RTC_CR));
-  rtcinfo("     ISR: %08x\n", getreg32(STM32_RTC_ISR));
-  rtcinfo("    PRER: %08x\n", getreg32(STM32_RTC_PRER));
-  rtcinfo("    WUTR: %08x\n", getreg32(STM32_RTC_WUTR));
-  rtcinfo("  ALRMAR: %08x\n", getreg32(STM32_RTC_ALRMAR));
-  rtcinfo("  ALRMBR: %08x\n", getreg32(STM32_RTC_ALRMBR));
-  rtcinfo("  SHIFTR: %08x\n", getreg32(STM32_RTC_SHIFTR));
-  rtcinfo("    TSTR: %08x\n", getreg32(STM32_RTC_TSTR));
-  rtcinfo("    TSDR: %08x\n", getreg32(STM32_RTC_TSDR));
-  rtcinfo("   TSSSR: %08x\n", getreg32(STM32_RTC_TSSSR));
-  rtcinfo("    CALR: %08x\n", getreg32(STM32_RTC_CALR));
-  rtcinfo("  TAMPCR: %08x\n", getreg32(STM32_RTC_TAMPCR));
-  rtcinfo("ALRMASSR: %08x\n", getreg32(STM32_RTC_ALRMASSR));
-  rtcinfo("ALRMBSSR: %08x\n", getreg32(STM32_RTC_ALRMBSSR));
-  rtcinfo("MAGICREG: %08x\n", getreg32(RTC_MAGIC_REG));
+  rtcinfo("      TR: %08" PRIx32 "\n", getreg32(STM32_RTC_TR));
+  rtcinfo("      DR: %08" PRIx32 "\n", getreg32(STM32_RTC_DR));
+  rtcinfo("      CR: %08" PRIx32 "\n", getreg32(STM32_RTC_CR));
+  rtcinfo("     ISR: %08" PRIx32 "\n", getreg32(STM32_RTC_ISR));
+  rtcinfo("    PRER: %08" PRIx32 "\n", getreg32(STM32_RTC_PRER));
+  rtcinfo("    WUTR: %08" PRIx32 "\n", getreg32(STM32_RTC_WUTR));
+  rtcinfo("  ALRMAR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMAR));
+  rtcinfo("  ALRMBR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMBR));
+  rtcinfo("  SHIFTR: %08" PRIx32 "\n", getreg32(STM32_RTC_SHIFTR));
+  rtcinfo("    TSTR: %08" PRIx32 "\n", getreg32(STM32_RTC_TSTR));
+  rtcinfo("    TSDR: %08" PRIx32 "\n", getreg32(STM32_RTC_TSDR));
+  rtcinfo("   TSSSR: %08" PRIx32 "\n", getreg32(STM32_RTC_TSSSR));
+  rtcinfo("    CALR: %08" PRIx32 "\n", getreg32(STM32_RTC_CALR));
+  rtcinfo("  TAMPCR: %08" PRIx32 "\n", getreg32(STM32_RTC_TAMPCR));
+  rtcinfo("ALRMASSR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMASSR));
+  rtcinfo("ALRMBSSR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMBSSR));
+  rtcinfo("MAGICREG: %08" PRIx32 "\n", getreg32(RTC_MAGIC_REG));
 
   rtc_state =
     ((getreg32(STM32_EXTI_RTSR) & EXTI_RTC_ALARM) ? 0x1000 : 0) |
@@ -803,7 +803,7 @@ static int rtchw_set_alrmbr(rtc_alarmreg_t alarmreg)
 
   putreg32(alarmreg, STM32_RTC_ALRMBR);
   putreg32(0, STM32_RTC_ALRMBSSR);
-  rtcinfo("  ALRMBR: %08x\n", getreg32(STM32_RTC_ALRMBR));
+  rtcinfo("  ALRMBR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMBR));
 
   /* Enable RTC alarm B */
 

--- a/arch/arm/src/stm32f7/stm32_sai.c
+++ b/arch/arm/src/stm32f7/stm32_sai.c
@@ -477,12 +477,14 @@ static void sai_dump_regs(struct stm32f7_sai_s *priv, const char *msg)
       i2sinfo("%s\n", msg);
 
 #if 0
-  i2sinfo("CR1:%08x CR2:%08x  FRCR:%08x SLOTR:%08x\n",
+  i2sinfo("CR1:%08" PRIx32 " CR2:%08" PRIx32
+          "  FRCR:%08" PRIx32 " SLOTR:%08" PRIx32 "\n",
           sai_getreg(priv, STM32F7_SAI_CR1_OFFSET),
           sai_getreg(priv, STM32F7_SAI_CR2_OFFSET),
           sai_getreg(priv, STM32F7_SAI_FRCR_OFFSET),
           sai_getreg(priv, STM32F7_SAI_SLOTR_OFFSET));
-  i2sinfo(" IM:%08x  SR:%08x CLRFR:%08x\n",
+  i2sinfo(" IM:%08" PRIx32 "  SR:%08" PRIx32
+          " CLRFR:%08" PRIx32 "\n",
           sai_getreg(priv, STM32F7_SAI_IM_OFFSET),
           sai_getreg(priv, STM32F7_SAI_SR_OFFSET),
           sai_getreg(priv, STM32F7_SAI_CLRFR_OFFSET));
@@ -491,16 +493,16 @@ static void sai_dump_regs(struct stm32f7_sai_s *priv, const char *msg)
 
 #ifdef CONFIG_STM32F7_SAI1
   uint32_t gcr = getreg32(STM32F7_SAI1_GCR);
-  i2sinfo("GCR: *%08x = %08x\n", STM32F7_SAI1_GCR, gcr);
+  i2sinfo("GCR: *%08x = %08" PRIx32 "\n", STM32F7_SAI1_GCR, gcr);
 #else
   uint32_t gcr = getreg32(STM32F7_SAI2_GCR);
-  i2sinfo("GCR: *%08x = %08x\n", STM32F7_SAI2_GCR, gcr);
+  i2sinfo("GCR: *%08x = %08" PRIx32 "\n", STM32F7_SAI2_GCR, gcr);
 #endif
 
   /* CR1 */
 
   uint32_t cr1 = sai_getreg(priv, STM32F7_SAI_CR1_OFFSET);
-  i2sinfo("CR1: *%08x = %08x\n", STM32F7_SAI_CR1_OFFSET, cr1);
+  i2sinfo("CR1: *%08" PRIx32 " = %08x\n", STM32F7_SAI_CR1_OFFSET, cr1);
 
   uint32_t mode = (cr1 & SAI_CR1_MODE_MASK) >> SAI_CR1_MODE_SHIFT;
   const char *mode_string[] =
@@ -583,7 +585,7 @@ static void sai_dump_regs(struct stm32f7_sai_s *priv, const char *msg)
   /* CR2 */
 
   uint32_t cr2 = sai_getreg(priv, STM32F7_SAI_CR2_OFFSET);
-  i2sinfo("CR2: *%08x = %08x\n", STM32F7_SAI_CR2_OFFSET, cr2);
+  i2sinfo("CR2: *%08x = %08" PRIx32 "\n", STM32F7_SAI_CR2_OFFSET, cr2);
   uint32_t fth = (cr2 & SAI_CR2_FTH_MASK) >> SAI_CR2_FTH_SHIFT;
   const char *fth_string[] =
   { "FIFO empty",
@@ -637,7 +639,7 @@ static void sai_dump_regs(struct stm32f7_sai_s *priv, const char *msg)
   /* FRCR */
 
   uint32_t frcr = sai_getreg(priv, STM32F7_SAI_FRCR_OFFSET);
-  i2sinfo("FRCR: *%08x = %08x\n", STM32F7_SAI_FRCR_OFFSET, frcr);
+  i2sinfo("FRCR: *%08x = %08" PRIx32 "\n", STM32F7_SAI_FRCR_OFFSET, frcr);
 
   uint32_t frl = (frcr & SAI_FRCR_FRL_MASK) >> SAI_FRCR_FRL_SHIFT;
   i2sinfo("\t\tFRCR: FRL[7:0] = %d\n", frl);
@@ -661,7 +663,7 @@ static void sai_dump_regs(struct stm32f7_sai_s *priv, const char *msg)
   /* SLOTR */
 
   uint32_t slotr = sai_getreg(priv, STM32F7_SAI_SLOTR_OFFSET);
-  i2sinfo("SLOTR: *%08x = %08x\n", STM32F7_SAI_SLOTR_OFFSET, slotr);
+  i2sinfo("SLOTR: *%08x = %08" PRIx32 "\n", STM32F7_SAI_SLOTR_OFFSET, slotr);
 
   uint32_t fboff = (slotr & SAI_SLOTR_FBOFF_MASK) >> SAI_SLOTR_FBOFF_SHIFT;
   i2sinfo("\t\tSLOTR: FBOFF[4:0] = %d\n", fboff);
@@ -683,7 +685,7 @@ static void sai_dump_regs(struct stm32f7_sai_s *priv, const char *msg)
 
   uint32_t sloten = (slotr & SAI_SLOTR_SLOTEN_MASK) >>
                       SAI_SLOTR_SLOTEN_SHIFT;
-  i2sinfo("\t\tSLOTR: SLOTEN[31:16] = %08x\n", sloten + 1);
+  i2sinfo("\t\tSLOTR: SLOTEN[31:16] = %08" PRIx32 "\n", sloten + 1);
 #endif
 }
 #endif

--- a/arch/arm/src/stm32f7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32f7/stm32_sdmmc.c
@@ -1023,12 +1023,18 @@ static void stm32_sdiodump(struct stm32_sdioregs_s *regs, const char *msg)
   mcinfo("  POWER[%08x]: %08x\n", STM32_SDMMC_POWER_OFFSET,   regs->power);
   mcinfo("  CLKCR[%08x]: %08x\n", STM32_SDMMC_CLKCR_OFFSET,   regs->clkcr);
   mcinfo("  DCTRL[%08x]: %08x\n", STM32_SDMMC_DCTRL_OFFSET,   regs->dctrl);
-  mcinfo(" DTIMER[%08x]: %08x\n", STM32_SDMMC_DTIMER_OFFSET,  regs->dtimer);
-  mcinfo("   DLEN[%08x]: %08x\n", STM32_SDMMC_DLEN_OFFSET,    regs->dlen);
-  mcinfo(" DCOUNT[%08x]: %08x\n", STM32_SDMMC_DCOUNT_OFFSET,  regs->dcount);
-  mcinfo("    STA[%08x]: %08x\n", STM32_SDMMC_STA_OFFSET,     regs->sta);
-  mcinfo("   MASK[%08x]: %08x\n", STM32_SDMMC_MASK_OFFSET,    regs->mask);
-  mcinfo("FIFOCNT[%08x]: %08x\n", STM32_SDMMC_FIFOCNT_OFFSET, regs->fifocnt);
+  mcinfo(" DTIMER[%08x]: %08" PRIx32 "\n",
+         STM32_SDMMC_DTIMER_OFFSET,  regs->dtimer);
+  mcinfo("   DLEN[%08x]: %08" PRIx32 "\n",
+         STM32_SDMMC_DLEN_OFFSET,    regs->dlen);
+  mcinfo(" DCOUNT[%08x]: %08" PRIx32 "\n",
+         STM32_SDMMC_DCOUNT_OFFSET,  regs->dcount);
+  mcinfo("    STA[%08x]: %08" PRIx32 "\n",
+         STM32_SDMMC_STA_OFFSET,     regs->sta);
+  mcinfo("   MASK[%08x]: %08" PRIx32 "\n",
+         STM32_SDMMC_MASK_OFFSET,    regs->mask);
+  mcinfo("FIFOCNT[%08x]: %08" PRIx32 "\n",
+         STM32_SDMMC_FIFOCNT_OFFSET, regs->fifocnt);
 }
 #endif
 

--- a/arch/arm/src/stm32h5/stm32_ethernet.c
+++ b/arch/arm/src/stm32h5/stm32_ethernet.c
@@ -843,7 +843,7 @@ static uint32_t stm32_getreg(uint32_t addr)
 
   /* Show the register value read */
 
-  ninfo("%08x->%08x\n", addr, val);
+  ninfo("%08" PRIx32 "->%08" PRIx32 "\n", addr, val);
   return val;
 }
 #endif
@@ -870,7 +870,7 @@ static void stm32_putreg(uint32_t val, uint32_t addr)
 {
   /* Show the register value being written */
 
-  ninfo("%08x<-%08x\n", addr, val);
+  ninfo("%08" PRIx32 "<-%08" PRIx32 "\n", addr, val);
 
   /* Write the value */
 

--- a/arch/arm/src/stm32h5/stm32_i2c.c
+++ b/arch/arm/src/stm32h5/stm32_i2c.c
@@ -1141,7 +1141,8 @@ static void stm32_i2c_tracedump(struct stm32_i2c_priv_s *priv)
     {
       trace = &priv->trace[i];
       syslog(LOG_DEBUG,
-             "%2d. STATUS: %08x COUNT: %3d EVENT: %2d PARM: %08x TIME: %d\n",
+             "%2d. STATUS: %08" PRIx32 " COUNT: %3d EVENT: %2d"
+             " PARM: %08" PRIx32 " TIME: %d\n",
              i + 1, trace->status, trace->count,  trace->event, trace->parm,
              (int)(trace->time - priv->start_time));
     }

--- a/arch/arm/src/stm32h5/stm32_irq.c
+++ b/arch/arm/src/stm32h5/stm32_irq.c
@@ -79,30 +79,35 @@ static void stm32_dumpnvic(const char *msg, int irq)
   flags = enter_critical_section();
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
-  irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
+  irqinfo("  INTCTRL:    %08" PRIx32 " VECTAB:  %08" PRIx32 "\n",
           getreg32(NVIC_INTCTRL), getreg32(NVIC_VECTAB));
-  irqinfo("  IRQ ENABLE: %08x %08x %08x\n",
+  irqinfo("  IRQ ENABLE: %08" PRIx32 " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ0_31_ENABLE), getreg32(NVIC_IRQ32_63_ENABLE),
           getreg32(NVIC_IRQ64_95_ENABLE));
-  irqinfo("  SYSH_PRIO:  %08x %08x %08x\n",
-          getreg32(NVIC_SYSH4_7_PRIORITY), getreg32(NVIC_SYSH8_11_PRIORITY),
+  irqinfo("  SYSH_PRIO:  %08" PRIx32 " %08" PRIx32 " %08" PRIx32 "\n",
+          getreg32(NVIC_SYSH4_7_PRIORITY),
+          getreg32(NVIC_SYSH8_11_PRIORITY),
           getreg32(NVIC_SYSH12_15_PRIORITY));
-  irqinfo("  IRQ PRIO:   %08x %08x %08x %08x\n",
+  irqinfo("  IRQ PRIO:   %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ0_3_PRIORITY), getreg32(NVIC_IRQ4_7_PRIORITY),
           getreg32(NVIC_IRQ8_11_PRIORITY), getreg32(NVIC_IRQ12_15_PRIORITY));
-  irqinfo("              %08x %08x %08x %08x\n",
+  irqinfo("              %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ16_19_PRIORITY), getreg32(NVIC_IRQ20_23_PRIORITY),
           getreg32(NVIC_IRQ24_27_PRIORITY),
           getreg32(NVIC_IRQ28_31_PRIORITY));
-  irqinfo("              %08x %08x %08x %08x\n",
+  irqinfo("              %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ32_35_PRIORITY), getreg32(NVIC_IRQ36_39_PRIORITY),
           getreg32(NVIC_IRQ40_43_PRIORITY),
           getreg32(NVIC_IRQ44_47_PRIORITY));
-  irqinfo("              %08x %08x %08x %08x\n",
+  irqinfo("              %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ48_51_PRIORITY), getreg32(NVIC_IRQ52_55_PRIORITY),
           getreg32(NVIC_IRQ56_59_PRIORITY),
           getreg32(NVIC_IRQ60_63_PRIORITY));
-  irqinfo("              %08x\n",
+  irqinfo("              %08" PRIx32 "\n",
           getreg32(NVIC_IRQ64_67_PRIORITY));
 
   leave_critical_section(flags);

--- a/arch/arm/src/stm32h5/stm32_qspi.c
+++ b/arch/arm/src/stm32h5/stm32_qspi.c
@@ -441,7 +441,7 @@ static inline uint32_t qspi_getreg(struct stm32_qspidev_s *priv,
 #ifdef CONFIG_STM32H5_QSPI_REGDEBUG
   if (qspi_checkreg(priv, false, value, address))
     {
-      spiinfo("%08x->%08x\n", address, value);
+      spiinfo("%08" PRIx32 "->%08" PRIx32 "\n", address, value);
     }
 #endif
 
@@ -464,7 +464,7 @@ static inline void qspi_putreg(struct stm32_qspidev_s *priv,
 #ifdef CONFIG_STM32H5_QSPI_REGDEBUG
   if (qspi_checkreg(priv, true, value, address))
     {
-      spiinfo("%08x<-%08x\n", address, value);
+      spiinfo("%08" PRIx32 "<-%08" PRIx32 "\n", address, value);
     }
 #endif
 
@@ -491,22 +491,25 @@ static void qspi_dumpregs(struct stm32_qspidev_s *priv, const char *msg)
 {
   spiinfo("%s:\n", msg);
 
-  spiinfo("    CR:%08x   TCR:%08x   CCR:%08x    SR:%08x\n",
+  spiinfo("    CR:%08" PRIx32 "   TCR:%08" PRIx32
+          "   CCR:%08" PRIx32 "    SR:%08" PRIx32 "\n",
           getreg32(priv->base + STM32_QUADSPI_CR_OFFSET),     /* Control Register */
           getreg32(priv->base + STM32_QUADSPI_TCR_OFFSET),    /* Device Configuration Register 1 */
           getreg32(priv->base + STM32_QUADSPI_CCR_OFFSET),    /* Communication Configuration Register */
           getreg32(priv->base + STM32_QUADSPI_SR_OFFSET));    /* Status Register */
-  spiinfo("   DLR:%08x   ABR:%08x PSMKR:%08x PSMAR:%08x\n",
+  spiinfo("   DLR:%08" PRIx32 "   ABR:%08" PRIx32
+          " PSMKR:%08" PRIx32 " PSMAR:%08" PRIx32 "\n",
           getreg32(priv->base + STM32_QUADSPI_DLR_OFFSET),    /* Data Length Register */
           getreg32(priv->base + STM32_QUADSPI_ABR_OFFSET),    /* Alternate Bytes Register */
           getreg32(priv->base + STM32_QUADSPI_PSMKR_OFFSET),  /* Polling Status mask Register */
           getreg32(priv->base + STM32_QUADSPI_PSMAR_OFFSET)); /* Polling Status match Register */
-  spiinfo("   PIR:%08x  LPTR:%08x DCR1:%08x DCR2:%08x\n",
+  spiinfo("   PIR:%08" PRIx32 "  LPTR:%08" PRIx32
+          " DCR1:%08" PRIx32 " DCR2:%08" PRIx32 "\n",
           getreg32(priv->base + STM32_QUADSPI_PIR_OFFSET),    /* Polling Interval Register */
           getreg32(priv->base + STM32_QUADSPI_LPTR_OFFSET),   /* Low-Power Timeout Register */
           getreg32(priv->base + STM32_QUADSPI_DCR1_OFFSET),   /* Device Configuration Register 1 */
           getreg32(priv->base + STM32_QUADSPI_DCR2_OFFSET));  /* Device Configuration Register 2 */
-  spiinfo("   DCR3:%08x  DCR4:%08x\n",
+  spiinfo("   DCR3:%08" PRIx32 "  DCR4:%08" PRIx32 "\n",
           getreg32(priv->base + STM32_QUADSPI_DCR3_OFFSET),   /* Device Configuration Register 3 */
           getreg32(priv->base + STM32_QUADSPI_DCR4_OFFSET));  /* Device Configuration Register 4 */
 }
@@ -521,62 +524,62 @@ static void qspi_dumpgpioconfig(const char *msg)
   /* Port B */
 
   regval = getreg32(STM32_GPIOB_MODER);
-  spiinfo("B_MODER:%08x\n", regval);
+  spiinfo("B_MODER:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOB_OTYPER);
-  spiinfo("B_OTYPER:%08x\n", regval);
+  spiinfo("B_OTYPER:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOB_OSPEED);
-  spiinfo("B_OSPEED:%08x\n", regval);
+  spiinfo("B_OSPEED:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOB_PUPDR);
-  spiinfo("B_PUPDR:%08x\n", regval);
+  spiinfo("B_PUPDR:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOB_AFRL);
-  spiinfo("B_AFRL:%08x\n", regval);
+  spiinfo("B_AFRL:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOB_AFRH);
-  spiinfo("B_AFRH:%08x\n", regval);
+  spiinfo("B_AFRH:%08" PRIx32 "\n", regval);
 
   /* Port D */
 
   regval = getreg32(STM32_GPIOD_MODER);
-  spiinfo("D_MODER:%08x\n", regval);
+  spiinfo("D_MODER:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOD_OTYPER);
-  spiinfo("D_OTYPER:%08x\n", regval);
+  spiinfo("D_OTYPER:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOD_OSPEED);
-  spiinfo("D_OSPEED:%08x\n", regval);
+  spiinfo("D_OSPEED:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOD_PUPDR);
-  spiinfo("D_PUPDR:%08x\n", regval);
+  spiinfo("D_PUPDR:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOD_AFRL);
-  spiinfo("D_AFRL:%08x\n", regval);
+  spiinfo("D_AFRL:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOD_AFRH);
-  spiinfo("D_AFRH:%08x\n", regval);
+  spiinfo("D_AFRH:%08" PRIx32 "\n", regval);
 
   /* Port E */
 
   regval = getreg32(STM32_GPIOE_MODER);
-  spiinfo("E_MODER:%08x\n", regval);
+  spiinfo("E_MODER:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOE_OTYPER);
-  spiinfo("E_OTYPER:%08x\n", regval);
+  spiinfo("E_OTYPER:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOE_OSPEED);
-  spiinfo("E_OSPEED:%08x\n", regval);
+  spiinfo("E_OSPEED:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOE_PUPDR);
-  spiinfo("E_PUPDR:%08x\n", regval);
+  spiinfo("E_PUPDR:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOE_AFRL);
-  spiinfo("E_AFRL:%08x\n", regval);
+  spiinfo("E_AFRL:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOE_AFRH);
-  spiinfo("E_AFRH:%08x\n", regval);
+  spiinfo("E_AFRH:%08" PRIx32 "\n", regval);
 }
 #endif
 

--- a/arch/arm/src/stm32h5/stm32_usbfs.c
+++ b/arch/arm/src/stm32h5/stm32_usbfs.c
@@ -659,7 +659,7 @@ static uint32_t stm32_getreg(uint32_t addr)
 
   /* Show the register value read */
 
-  uinfo("%08x->%04x\n", addr, val);
+  uinfo("%08" PRIx32 "->%04" PRIx32 "\n", addr, val);
   return val;
 }
 #endif
@@ -673,7 +673,7 @@ static void stm32_putreg(uint32_t val, uint32_t addr)
 {
   /* Show the register value being written */
 
-  uinfo("%08x<-%04x\n", addr, val);
+  uinfo("%08" PRIx32 "<-%04" PRIx32 "\n", addr, val);
 
   /* Write the value */
 
@@ -692,29 +692,30 @@ static void stm32_dumpep(int epno)
 
   /* Common registers */
 
-  uinfo("CNTR:   %04x\n", getreg32(STM32_USB_CNTR));
-  uinfo("ISTR:   %04x\n", getreg32(STM32_USB_ISTR));
-  uinfo("FNR:    %04x\n", getreg32(STM32_USB_FNR));
-  uinfo("DADDR:  %04x\n", getreg32(STM32_USB_DADDR));
-  uinfo("BTABLE: %04x\n", getreg32(STM32_USB_BTABLE));
+  uinfo("CNTR:   %04" PRIx32 "\n", getreg32(STM32_USB_CNTR));
+  uinfo("ISTR:   %04" PRIx32 "\n", getreg32(STM32_USB_ISTR));
+  uinfo("FNR:    %04" PRIx32 "\n", getreg32(STM32_USB_FNR));
+  uinfo("DADDR:  %04" PRIx32 "\n", getreg32(STM32_USB_DADDR));
+  uinfo("BTABLE: %04" PRIx32 "\n", getreg32(STM32_USB_BTABLE));
 
   /* Endpoint register */
 
   addr = STM32_USB_EPR(epno);
-  uinfo("EPR%d:   [%08x] %04x\n", epno, addr, getreg32(addr));
+  uinfo("EPR%d:   [%08" PRIx32 "] %04" PRIx32 "\n",
+        epno, addr, getreg32(addr));
 
   /* Endpoint descriptor */
 
   addr = STM32_USB_BTABLE_ADDR(epno, 0);
-  uinfo("DESC:   %08x\n", addr);
+  uinfo("DESC:   %08" PRIx32 "\n", addr);
 
   /* Endpoint buffer descriptor */
 
   addr = STM32_USB_TX(epno);
-  uinfo("  TX BUF:  [%08x] %04x\n",  addr, getreg32(addr));
+  uinfo("  TX BUF:  [%08" PRIx32 "] %04" PRIx32 "\n",  addr, getreg32(addr));
 
   addr = STM32_USB_RX(epno);
-  uinfo("  RX BUF:  [%08x] %04x\n",  addr, getreg32(addr));
+  uinfo("  RX BUF:  [%08" PRIx32 "] %04" PRIx32 "\n",  addr, getreg32(addr));
 }
 #endif
 
@@ -729,7 +730,8 @@ static void stm32_checksetup(void)
   uint32_t apb1rstr = getreg32(STM32_RCC_APB1RSTR1);
   uint32_t apb1enr  = getreg32(STM32_RCC_APB1ENR1);
 
-  uinfo("CFGR: %08x APB1RSTR: %08x APB1ENR: %08x\n",
+  uinfo("CFGR: %08" PRIx32 " APB1RSTR: %08" PRIx32
+        " APB1ENR: %08" PRIx32 "\n",
          cfgr, apb1rstr, apb1enr);
 
   if ((apb1rstr & RCC_APB1RSTR1_USBRST) != 0 ||

--- a/arch/arm/src/stm32h7/stm32_i2c.c
+++ b/arch/arm/src/stm32h7/stm32_i2c.c
@@ -1136,7 +1136,8 @@ static void stm32_i2c_tracedump(struct stm32_i2c_priv_s *priv)
     {
       trace = &priv->trace[i];
       syslog(LOG_DEBUG,
-             "%2d. STATUS: %08x COUNT: %3d EVENT: %2d PARM: %08x TIME: %d\n",
+             "%2d. STATUS: %08" PRIx32 " COUNT: %3d EVENT: %2d"
+             " PARM: %08" PRIx32 " TIME: %d\n",
              i + 1, trace->status, trace->count,  trace->event, trace->parm,
              (int)(trace->time - priv->start_time));
     }

--- a/arch/arm/src/stm32h7/stm32_iwdg.c
+++ b/arch/arm/src/stm32h7/stm32_iwdg.c
@@ -227,7 +227,7 @@ static uint16_t stm32_getreg(uint32_t addr)
 
   /* Show the register value read */
 
-  wdinfo("%08x->%04x\n", addr, val);
+  wdinfo("%08" PRIx32 "->%04x\n", addr, val);
   return val;
 }
 #endif
@@ -245,7 +245,7 @@ static void stm32_putreg(uint16_t val, uint32_t addr)
 {
   /* Show the register value being written */
 
-  wdinfo("%08x<-%04x\n", addr, val);
+  wdinfo("%08" PRIx32 "<-%04x\n", addr, val);
 
   /* Write the value */
 

--- a/arch/arm/src/stm32h7/stm32_ltdc.c
+++ b/arch/arm/src/stm32h7/stm32_ltdc.c
@@ -1276,7 +1276,7 @@ static void stm32_ltdc_gpioconfig(void)
 
   for (i = 0; i < STM32_LTDC_NPINCONFIGS; i++)
     {
-      reginfo("set gpio%d = %08x\n", i, g_ltdcpins[i]);
+      reginfo("set gpio%d = %08" PRIx32 "\n", i, g_ltdcpins[i]);
       stm32_configgpio(g_ltdcpins[i]);
     }
 }
@@ -1300,35 +1300,40 @@ static void stm32_ltdc_periphconfig(void)
 
   /* Configure APB3 LTDC clock external */
 
-  reginfo("configured RCC_APB3ENR=%08x\n", getreg32(STM32_RCC_APB3ENR));
+  reginfo("configured RCC_APB3ENR=%08" PRIx32 "\n",
+          getreg32(STM32_RCC_APB3ENR));
 
   /* Configure LTDC_SSCR */
 
   regval = (STM32_LTDC_SSCR_VSH | STM32_LTDC_SSCR_HSW);
-  reginfo("set LTDC_SSCR=%08x\n", regval);
+  reginfo("set LTDC_SSCR=%08" PRIx32 "\n", regval);
   putreg32(regval, STM32_LTDC_SSCR);
-  reginfo("configured LTDC_SSCR=%08x\n", getreg32(STM32_LTDC_SSCR));
+  reginfo("configured LTDC_SSCR=%08" PRIx32 "\n",
+          getreg32(STM32_LTDC_SSCR));
 
   /* Configure LTDC_BPCR */
 
   regval = (STM32_LTDC_BPCR_AVBP | STM32_LTDC_BPCR_AHBP);
-  reginfo("set LTDC_BPCR=%08x\n", regval);
+  reginfo("set LTDC_BPCR=%08" PRIx32 "\n", regval);
   putreg32(regval, STM32_LTDC_BPCR);
-  reginfo("configured LTDC_BPCR=%08x\n", getreg32(STM32_LTDC_BPCR));
+  reginfo("configured LTDC_BPCR=%08" PRIx32 "\n",
+          getreg32(STM32_LTDC_BPCR));
 
   /* Configure LTDC_AWCR */
 
   regval = (STM32_LTDC_AWCR_AAH | STM32_LTDC_AWCR_AAW);
-  reginfo("set LTDC_AWCR=%08x\n", regval);
+  reginfo("set LTDC_AWCR=%08" PRIx32 "\n", regval);
   putreg32(regval, STM32_LTDC_AWCR);
-  reginfo("configured LTDC_AWCR=%08x\n", getreg32(STM32_LTDC_AWCR));
+  reginfo("configured LTDC_AWCR=%08" PRIx32 "\n",
+          getreg32(STM32_LTDC_AWCR));
 
   /* Configure LTDC_TWCR */
 
   regval = (STM32_LTDC_TWCR_TOTALH | STM32_LTDC_TWCR_TOTALW);
-  reginfo("set LTDC_TWCR=%08x\n", regval);
+  reginfo("set LTDC_TWCR=%08" PRIx32 "\n", regval);
   putreg32(regval, STM32_LTDC_TWCR);
-  reginfo("configured LTDC_TWCR=%08x\n", getreg32(STM32_LTDC_TWCR));
+  reginfo("configured LTDC_TWCR=%08" PRIx32 "\n",
+          getreg32(STM32_LTDC_TWCR));
 
   /* Configure LTDC_GCR */
 
@@ -1338,9 +1343,10 @@ static void stm32_ltdc_periphconfig(void)
   regval |= (STM32_LTDC_GCR_PCPOL | STM32_LTDC_GCR_DEPOL |
              STM32_LTDC_GCR_VSPOL | STM32_LTDC_GCR_HSPOL);
 
-  reginfo("set LTDC_GCR=%08x\n", regval);
+  reginfo("set LTDC_GCR=%08" PRIx32 "\n", regval);
   putreg32(regval, STM32_LTDC_GCR);
-  reginfo("configured LTDC_GCR=%08x\n", getreg32(STM32_LTDC_GCR));
+  reginfo("configured LTDC_GCR=%08" PRIx32 "\n",
+          getreg32(STM32_LTDC_GCR));
 }
 
 /****************************************************************************
@@ -1359,7 +1365,7 @@ static void stm32_ltdc_ldefaultcolor(struct stm32_ltdc_s *layer,
                                      uint32_t rgb)
 {
   DEBUGASSERT(layer->layerno < LTDC_NLAYERS);
-  reginfo("set LTDC_L%dDCCR=%08x\n", layer->layerno + 1, rgb);
+  reginfo("set LTDC_L%dDCCR=%08" PRIx32 "\n", layer->layerno + 1, rgb);
 
   putreg32(rgb, stm32_dccr_layer_t[layer->layerno]);
 
@@ -1367,7 +1373,7 @@ static void stm32_ltdc_ldefaultcolor(struct stm32_ltdc_s *layer,
 
   stm32_ltdc_reload(LTDC_SRCR_IMR, false);
 
-  reginfo("configured LTDC_L%dDCCR=%08x\n", layer->layerno + 1,
+  reginfo("configured LTDC_L%dDCCR=%08" PRIx32 "\n", layer->layerno + 1,
           getreg32(STM32_LTDC_BCCR));
 }
 
@@ -1384,9 +1390,9 @@ static void stm32_ltdc_ldefaultcolor(struct stm32_ltdc_s *layer,
 
 static void stm32_ltdc_bgcolor(uint32_t rgb)
 {
-  reginfo("set LTDC_BCCR=%08x\n", rgb);
+  reginfo("set LTDC_BCCR=%08" PRIx32 "\n", rgb);
   putreg32(rgb, STM32_LTDC_BCCR);
-  reginfo("configured LTDC_BCCR=%08x\n", getreg32(STM32_LTDC_BCCR));
+  reginfo("configured LTDC_BCCR=%08" PRIx32 "\n", getreg32(STM32_LTDC_BCCR));
 }
 
 /****************************************************************************
@@ -1422,9 +1428,9 @@ static void stm32_ltdc_dither(bool enable, uint8_t red,
   regval &= ~(LTDC_GCR_DBW_MASK | LTDC_GCR_DGW_MASK | LTDC_GCR_DRW_MASK);
   regval |= (LTDC_GCR_DRW(red) | LTDC_GCR_DGW(green) | LTDC_GCR_DBW(blue));
 
-  reginfo("set LTDC_GCR=%08x\n", regval);
+  reginfo("set LTDC_GCR=%08" PRIx32 "\n", regval);
   putreg32(regval, STM32_LTDC_GCR);
-  reginfo("configured LTDC_GCR=%08x\n", getreg32(STM32_LTDC_GCR));
+  reginfo("configured LTDC_GCR=%08" PRIx32 "\n", getreg32(STM32_LTDC_GCR));
 }
 
 /****************************************************************************
@@ -1441,7 +1447,8 @@ static void stm32_ltdc_linepos(void)
 
   reginfo("set LTDC_LIPCR=%08x\n", STM32_LTDC_LIPCR_LIPOS);
   putreg32(STM32_LTDC_LIPCR_LIPOS, STM32_LTDC_LIPCR);
-  reginfo("configured LTDC_LIPCR=%08x\n", getreg32(STM32_LTDC_LIPCR));
+  reginfo("configured LTDC_LIPCR=%08" PRIx32 "\n",
+          getreg32(STM32_LTDC_LIPCR));
 }
 
 /****************************************************************************
@@ -1463,9 +1470,9 @@ static void stm32_ltdc_irqctrl(uint32_t setirqs, uint32_t clrirqs)
   regval = getreg32(STM32_LTDC_IER);
   regval &= ~clrirqs;
   regval |= setirqs;
-  reginfo("set LTDC_IER=%08x\n", regval);
+  reginfo("set LTDC_IER=%08" PRIx32 "\n", regval);
   putreg32(regval, STM32_LTDC_IER);
-  reginfo("configured LTDC_IER=%08x\n", getreg32(STM32_LTDC_IER));
+  reginfo("configured LTDC_IER=%08" PRIx32 "\n", getreg32(STM32_LTDC_IER));
 }
 
 /****************************************************************************
@@ -1482,7 +1489,7 @@ static int stm32_ltdcirq(int irq, void *context, void *arg)
   struct stm32_interrupt_s *priv = &g_interrupt;
   uint32_t regval = getreg32(STM32_LTDC_ISR);
 
-  reginfo("irq = %d, regval = %08x\n", irq, regval);
+  reginfo("irq = %d, regval = %08" PRIx32 "\n", irq, regval);
 
   if (regval & LTDC_ISR_RRIF)
     {
@@ -1600,7 +1607,7 @@ static int stm32_ltdc_reload(uint8_t value, bool waitvblank)
 
   reginfo("set LTDC_SRCR=%08x\n", value);
   putreg32(value, STM32_LTDC_SRCR);
-  reginfo("configured LTDC_SRCR=%08x\n", getreg32(STM32_LTDC_SRCR));
+  reginfo("configured LTDC_SRCR=%08" PRIx32 "\n", getreg32(STM32_LTDC_SRCR));
 
   if (value == LTDC_SRCR_VBR && waitvblank)
     {
@@ -1704,7 +1711,7 @@ static void stm32_ltdc_enable(bool enable)
   uint32_t regval;
 
   regval = getreg32(STM32_LTDC_GCR);
-  reginfo("get LTDC_GCR=%08x\n", regval);
+  reginfo("get LTDC_GCR=%08" PRIx32 "\n", regval);
 
   if (enable == true)
     {
@@ -1715,9 +1722,9 @@ static void stm32_ltdc_enable(bool enable)
       regval &= ~LTDC_GCR_LTDCEN;
     }
 
-  reginfo("set LTDC_GCR=%08x\n", regval);
+  reginfo("set LTDC_GCR=%08" PRIx32 "\n", regval);
   putreg32(regval, STM32_LTDC_GCR);
-  reginfo("configured LTDC_GCR=%08x\n", getreg32(STM32_LTDC_GCR));
+  reginfo("configured LTDC_GCR=%08" PRIx32 "\n", getreg32(STM32_LTDC_GCR));
 }
 
 /****************************************************************************
@@ -1740,7 +1747,7 @@ static void stm32_ltdc_lpixelformat(struct stm32_ltdc_s *layer)
 
   /* Configure PFCR register */
 
-  reginfo("set LTDC_L%dPFCR=%08x\n", overlay + 1,
+  reginfo("set LTDC_L%dPFCR=%08" PRIx32 "\n", overlay + 1,
           stm32_fmt_layer_t[overlay]);
   putreg32(stm32_fmt_layer_t[overlay], stm32_pfcr_layer_t[overlay]);
 
@@ -1792,14 +1799,14 @@ static void stm32_ltdc_lframebuffer(struct stm32_ltdc_s *layer)
 
   /* Configure LxWHPCR / LxWVPCR register */
 
-  reginfo("set LTDC_L%dWHPCR=%08x\n", layerno + 1, whpcr);
+  reginfo("set LTDC_L%dWHPCR=%08" PRIx32 "\n", layerno + 1, whpcr);
   putreg32(whpcr, stm32_whpcr_layer_t[layerno]);
-  reginfo("set LTDC_L%dWVPCR=%08x\n", layerno + 1, wvpcr);
+  reginfo("set LTDC_L%dWVPCR=%08" PRIx32 "\n", layerno + 1, wvpcr);
   putreg32(wvpcr, stm32_wvpcr_layer_t[layerno]);
 
   /* Configure LxCFBAR register */
 
-  reginfo("set LTDC_L%dCFBAR=%08x\n", layerno + 1,
+  reginfo("set LTDC_L%dCFBAR=%08" PRIx32 "\n", layerno + 1,
           stm32_fbmem_layer_t[layerno]);
   putreg32(stm32_fbmem_layer_t[layerno], stm32_cfbar_layer_t[layerno]);
 
@@ -1811,12 +1818,12 @@ static void stm32_ltdc_lframebuffer(struct stm32_ltdc_s *layer)
           LTDC_LXCFBLR_CFBLL(stm32_width_layer_t[layerno] *
           STM32_LTDC_LX_BYPP(stm32_bpp_layer_t[layerno]) + 3);
 
-  reginfo("set LTDC_L%dCFBLR=%08x\n", layerno + 1, cfblr);
+  reginfo("set LTDC_L%dCFBLR=%08" PRIx32 "\n", layerno + 1, cfblr);
   putreg32(cfblr, stm32_cfblr_layer_t[layerno]);
 
   /* Configure LxCFBLNR register */
 
-  reginfo("set LTDC_L%dCFBLNR=%08x\n", layerno + 1,
+  reginfo("set LTDC_L%dCFBLNR=%08" PRIx32 "\n", layerno + 1,
           stm32_height_layer_t[layerno]);
   putreg32(stm32_height_layer_t[layerno], stm32_cfblnr_layer_t[layerno]);
 
@@ -1857,7 +1864,7 @@ static void stm32_ltdc_lenable(struct stm32_ltdc_s *layer, bool enable)
 
   /* Enable/Disable layer */
 
-  reginfo("set LTDC_L%dCR=%08x\n", layer->layerno + 1, regval);
+  reginfo("set LTDC_L%dCR=%08" PRIx32 "\n", layer->layerno + 1, regval);
   putreg32(regval, stm32_cr_layer_t[layer->layerno]);
 
   /* Reload shadow register */
@@ -1904,7 +1911,7 @@ static void stm32_ltdc_ltransp(struct stm32_ltdc_s *layer,
   bf2 = LTDC_BF2_CONST_ALPHA;
 #endif
 
-  reginfo("set LTDC_L%dBFCR=%08x\n", layer->layerno + 1,
+  reginfo("set LTDC_L%dBFCR=%08" PRIx32 "\n", layer->layerno + 1,
           (LTDC_LXBFCR_BF1(bf1) | LTDC_LXBFCR_BF2(bf2)));
 
   /* Set blendmode */
@@ -1942,7 +1949,7 @@ static void stm32_ltdc_lchromakey(struct stm32_ltdc_s *layer,
   uint32_t rgb;
   DEBUGASSERT(layer->layerno < LTDC_NLAYERS);
 
-  reginfo("%08x\n", getreg32(stm32_cr_layer_t[layer->layerno]));
+  reginfo("%08" PRIx32 "\n", getreg32(stm32_cr_layer_t[layer->layerno]));
 
   /* Set chromakey */
 
@@ -1955,7 +1962,7 @@ static void stm32_ltdc_lchromakey(struct stm32_ltdc_s *layer,
   rgb = ARGB8888(chroma);
 #endif
 
-  reginfo("set LTDC_L%dCKCR=%08x\n", layer->layerno + 1, rgb);
+  reginfo("set LTDC_L%dCKCR=%08" PRIx32 "\n", layer->layerno + 1, rgb);
   putreg32(rgb, stm32_ckcr_layer_t[layer->layerno]);
 
   /* Reload shadow register */
@@ -1996,7 +2003,7 @@ static void stm32_ltdc_lchromakeyenable(struct stm32_ltdc_s *layer,
       regval &= ~LTDC_LXCR_COLKEN;
     }
 
-  reginfo("set LTDC_L%dCR=%08x\n", layer->layerno + 1, regval);
+  reginfo("set LTDC_L%dCR=%08" PRIx32 "\n", layer->layerno + 1, regval);
   putreg32(regval, stm32_cr_layer_t[layer->layerno]);
 
   /* Reload shadow register */
@@ -2022,7 +2029,8 @@ static void stm32_ltdc_lclutenable(struct stm32_ltdc_s *layer, bool enable)
   uint32_t regval;
 
   regval = getreg32(stm32_cr_layer_t[layer->oinfo.overlay]);
-  reginfo("get LTDC_L%dCR=%08x\n", layer->oinfo.overlay + 1, regval);
+  reginfo("get LTDC_L%dCR=%08" PRIx32 "\n",
+          layer->oinfo.overlay + 1, regval);
 
   /* Disable the clut support during update the color table */
 
@@ -2035,7 +2043,7 @@ static void stm32_ltdc_lclutenable(struct stm32_ltdc_s *layer, bool enable)
       regval &= ~LTDC_LXCR_CLUTEN;
     }
 
-  reginfo("set LTDC_L%dCR=%08x\n", layer->oinfo.overlay, regval);
+  reginfo("set LTDC_L%dCR=%08" PRIx32 "\n", layer->oinfo.overlay, regval);
   putreg32(regval, stm32_cr_layer_t[layer->oinfo.overlay]);
 
   /* Reload shadow register */
@@ -2081,7 +2089,7 @@ static void stm32_ltdc_lputclut(struct stm32_ltdc_s *layer,
                (uint32_t)LTDC_CLUT_GREEN(cmap->green[n]) |
                (uint32_t)LTDC_CLUT_BLUE(cmap->blue[n]);
 
-      reginfo("set LTDC_L%dCLUTWR = %08x, first = %d, len = %d\n",
+      reginfo("set LTDC_L%dCLUTWR = %08" PRIx32 ", first = %d, len = %d\n",
               layer->oinfo.overlay + 1, regval, cmap->first, cmap->len);
       putreg32(regval, stm32_clutwr_layer_t[layer->oinfo.overlay]);
     }

--- a/arch/arm/src/stm32h7/stm32_otghost.c
+++ b/arch/arm/src/stm32h7/stm32_otghost.c
@@ -526,7 +526,7 @@ static struct usbhost_connection_s g_usbconn =
 #ifdef CONFIG_STM32H7_USBHOST_REGDEBUG
 static void stm32_printreg(uint32_t addr, uint32_t val, bool iswrite)
 {
-  uinfo("%08x%s%08x\n", addr, iswrite ? "<-" : "->", val);
+  uinfo("%08" PRIx32 "%s%08" PRIx32 "\n", addr, iswrite ? "<-" : "->", val);
 }
 #endif
 

--- a/arch/arm/src/stm32h7/stm32_qspi.c
+++ b/arch/arm/src/stm32h7/stm32_qspi.c
@@ -448,7 +448,7 @@ static inline uint32_t qspi_getreg(struct stm32h7_qspidev_s *priv,
 #ifdef CONFIG_STM32H7_QSPI_REGDEBUG
   if (qspi_checkreg(priv, false, value, address))
     {
-      spiinfo("%08x->%08x\n", address, value);
+      spiinfo("%08" PRIx32 "->%08" PRIx32 "\n", address, value);
     }
 #endif
 
@@ -471,7 +471,7 @@ static inline void qspi_putreg(struct stm32h7_qspidev_s *priv,
 #ifdef CONFIG_STM32H7_QSPI_REGDEBUG
   if (qspi_checkreg(priv, true, value, address))
     {
-      spiinfo("%08x<-%08x\n", address, value);
+      spiinfo("%08" PRIx32 "<-%08" PRIx32 "\n", address, value);
     }
 #endif
 
@@ -506,7 +506,7 @@ static void qspi_dumpregs(struct stm32h7_qspidev_s *priv, const char *msg)
    */
 
   regval = getreg32(priv->base + STM32_QUADSPI_CR_OFFSET);    /* Control Register */
-  spiinfo("CR:%08x\n", regval);
+  spiinfo("CR:%08" PRIx32 "\n", regval);
   spiinfo("  EN:%1d ABORT:%1d DMAEN:%1d TCEN:%1d SSHIFT:%1d\n"
           "  FTHRES: %d\n"
           "  TEIE:%1d TCIE:%1d FTIE:%1d SMIE:%1d TOIE:%1d APMS:%1d PMM:%1d\n"
@@ -527,14 +527,14 @@ static void qspi_dumpregs(struct stm32h7_qspidev_s *priv, const char *msg)
           (regval & QSPI_CR_PRESCALER_MASK) >> QSPI_CR_PRESCALER_SHIFT);
 
   regval = getreg32(priv->base + STM32_QUADSPI_DCR_OFFSET);   /* Device Configuration Register */
-  spiinfo("DCR:%08x\n", regval);
+  spiinfo("DCR:%08" PRIx32 "\n", regval);
   spiinfo("  CKMODE:%1d CSHT:%d FSIZE:%d\n",
           (regval & QSPI_DCR_CKMODE) ? 1 : 0,
           (regval & QSPI_DCR_CSHT_MASK) >> QSPI_DCR_CSHT_SHIFT,
           (regval & QSPI_DCR_FSIZE_MASK) >> QSPI_DCR_FSIZE_SHIFT);
 
   regval = getreg32(priv->base + STM32_QUADSPI_CCR_OFFSET);   /* Communication Configuration Register */
-  spiinfo("CCR:%08x\n", regval);
+  spiinfo("CCR:%08" PRIx32 "\n", regval);
   spiinfo("   INST:%02x IMODE:%d ADMODE:%d ADSIZE:%d ABMODE:%d\n"
           "   ABSIZE:%d DCYC:%d DMODE:%d FMODE:%d\n"
           "   SIOO:%1d DDRM:%1d\n",
@@ -551,7 +551,7 @@ static void qspi_dumpregs(struct stm32h7_qspidev_s *priv, const char *msg)
           (regval & QSPI_CCR_DDRM) ? 1 : 0);
 
   regval = getreg32(priv->base + STM32_QUADSPI_SR_OFFSET);    /* Status Register */
-  spiinfo("SR:%08x\n", regval);
+  spiinfo("SR:%08" PRIx32 "\n", regval);
   spiinfo("  TEF:%1d TCF:%1d FTF:%1d SMF:%1d TOF:%1d BUSY:%1d FLEVEL:%d\n",
           (regval & QSPI_SR_TEF) ? 1 : 0,
           (regval & QSPI_SR_TCF) ? 1 : 0,
@@ -562,17 +562,19 @@ static void qspi_dumpregs(struct stm32h7_qspidev_s *priv, const char *msg)
           (regval & QSPI_SR_FLEVEL_MASK) >> QSPI_SR_FLEVEL_SHIFT);
 
 #else
-  spiinfo("    CR:%08x   DCR:%08x   CCR:%08x    SR:%08x\n",
+  spiinfo("    CR:%08" PRIx32 "   DCR:%08" PRIx32
+          "   CCR:%08" PRIx32 "    SR:%08" PRIx32 "\n",
           getreg32(priv->base + STM32_QUADSPI_CR_OFFSET),     /* Control Register */
           getreg32(priv->base + STM32_QUADSPI_DCR_OFFSET),    /* Device Configuration Register */
           getreg32(priv->base + STM32_QUADSPI_CCR_OFFSET),    /* Communication Configuration Register */
           getreg32(priv->base + STM32_QUADSPI_SR_OFFSET));    /* Status Register */
-  spiinfo("   DLR:%08x   ABR:%08x PSMKR:%08x PSMAR:%08x\n",
+  spiinfo("   DLR:%08" PRIx32 "   ABR:%08" PRIx32
+          " PSMKR:%08" PRIx32 " PSMAR:%08" PRIx32 "\n",
           getreg32(priv->base + STM32_QUADSPI_DLR_OFFSET),    /* Data Length Register */
           getreg32(priv->base + STM32_QUADSPI_ABR_OFFSET),    /* Alternate Bytes Register */
           getreg32(priv->base + STM32_QUADSPI_PSMKR_OFFSET),  /* Polling Status mask Register */
           getreg32(priv->base + STM32_QUADSPI_PSMAR_OFFSET)); /* Polling Status match Register */
-  spiinfo("   PIR:%08x  LPTR:%08x\n",
+  spiinfo("   PIR:%08" PRIx32 "  LPTR:%08" PRIx32 "\n",
           getreg32(priv->base + STM32_QUADSPI_PIR_OFFSET),    /* Polling Interval Register */
           getreg32(priv->base + STM32_QUADSPI_LPTR_OFFSET));  /* Low-Power Timeout Register */
 #endif
@@ -588,62 +590,62 @@ static void qspi_dumpgpioconfig(const char *msg)
   /* Port B */
 
   regval = getreg32(STM32_GPIOB_MODER);
-  spiinfo("B_MODER:%08x\n", regval);
+  spiinfo("B_MODER:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOB_OTYPER);
-  spiinfo("B_OTYPER:%08x\n", regval);
+  spiinfo("B_OTYPER:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOB_OSPEED);
-  spiinfo("B_OSPEED:%08x\n", regval);
+  spiinfo("B_OSPEED:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOB_PUPDR);
-  spiinfo("B_PUPDR:%08x\n", regval);
+  spiinfo("B_PUPDR:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOB_AFRL);
-  spiinfo("B_AFRL:%08x\n", regval);
+  spiinfo("B_AFRL:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOB_AFRH);
-  spiinfo("B_AFRH:%08x\n", regval);
+  spiinfo("B_AFRH:%08" PRIx32 "\n", regval);
 
   /* Port D */
 
   regval = getreg32(STM32_GPIOD_MODER);
-  spiinfo("D_MODER:%08x\n", regval);
+  spiinfo("D_MODER:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOD_OTYPER);
-  spiinfo("D_OTYPER:%08x\n", regval);
+  spiinfo("D_OTYPER:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOD_OSPEED);
-  spiinfo("D_OSPEED:%08x\n", regval);
+  spiinfo("D_OSPEED:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOD_PUPDR);
-  spiinfo("D_PUPDR:%08x\n", regval);
+  spiinfo("D_PUPDR:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOD_AFRL);
-  spiinfo("D_AFRL:%08x\n", regval);
+  spiinfo("D_AFRL:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOD_AFRH);
-  spiinfo("D_AFRH:%08x\n", regval);
+  spiinfo("D_AFRH:%08" PRIx32 "\n", regval);
 
   /* Port E */
 
   regval = getreg32(STM32_GPIOE_MODER);
-  spiinfo("E_MODER:%08x\n", regval);
+  spiinfo("E_MODER:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOE_OTYPER);
-  spiinfo("E_OTYPER:%08x\n", regval);
+  spiinfo("E_OTYPER:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOE_OSPEED);
-  spiinfo("E_OSPEED:%08x\n", regval);
+  spiinfo("E_OSPEED:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOE_PUPDR);
-  spiinfo("E_PUPDR:%08x\n", regval);
+  spiinfo("E_PUPDR:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOE_AFRL);
-  spiinfo("E_AFRL:%08x\n", regval);
+  spiinfo("E_AFRL:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32_GPIOE_AFRH);
-  spiinfo("E_AFRH:%08x\n", regval);
+  spiinfo("E_AFRH:%08" PRIx32 "\n", regval);
 }
 #endif
 

--- a/arch/arm/src/stm32h7/stm32_rtc.c
+++ b/arch/arm/src/stm32h7/stm32_rtc.c
@@ -165,23 +165,23 @@ static void rtc_dumpregs(const char *msg)
   int rtc_state;
 
   rtcinfo("%s:\n", msg);
-  rtcinfo("      TR: %08x\n", getreg32(STM32_RTC_TR));
-  rtcinfo("      DR: %08x\n", getreg32(STM32_RTC_DR));
-  rtcinfo("      CR: %08x\n", getreg32(STM32_RTC_CR));
-  rtcinfo("     ISR: %08x\n", getreg32(STM32_RTC_ISR));
-  rtcinfo("    PRER: %08x\n", getreg32(STM32_RTC_PRER));
-  rtcinfo("    WUTR: %08x\n", getreg32(STM32_RTC_WUTR));
-  rtcinfo("  ALRMAR: %08x\n", getreg32(STM32_RTC_ALRMAR));
-  rtcinfo("  ALRMBR: %08x\n", getreg32(STM32_RTC_ALRMBR));
-  rtcinfo("  SHIFTR: %08x\n", getreg32(STM32_RTC_SHIFTR));
-  rtcinfo("    TSTR: %08x\n", getreg32(STM32_RTC_TSTR));
-  rtcinfo("    TSDR: %08x\n", getreg32(STM32_RTC_TSDR));
-  rtcinfo("   TSSSR: %08x\n", getreg32(STM32_RTC_TSSSR));
-  rtcinfo("    CALR: %08x\n", getreg32(STM32_RTC_CALR));
-  rtcinfo("  TAMPCR: %08x\n", getreg32(STM32_RTC_TAMPCR));
-  rtcinfo("ALRMASSR: %08x\n", getreg32(STM32_RTC_ALRMASSR));
-  rtcinfo("ALRMBSSR: %08x\n", getreg32(STM32_RTC_ALRMBSSR));
-  rtcinfo("MAGICREG: %08x\n", getreg32(RTC_MAGIC_REG));
+  rtcinfo("      TR: %08" PRIx32 "\n", getreg32(STM32_RTC_TR));
+  rtcinfo("      DR: %08" PRIx32 "\n", getreg32(STM32_RTC_DR));
+  rtcinfo("      CR: %08" PRIx32 "\n", getreg32(STM32_RTC_CR));
+  rtcinfo("     ISR: %08" PRIx32 "\n", getreg32(STM32_RTC_ISR));
+  rtcinfo("    PRER: %08" PRIx32 "\n", getreg32(STM32_RTC_PRER));
+  rtcinfo("    WUTR: %08" PRIx32 "\n", getreg32(STM32_RTC_WUTR));
+  rtcinfo("  ALRMAR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMAR));
+  rtcinfo("  ALRMBR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMBR));
+  rtcinfo("  SHIFTR: %08" PRIx32 "\n", getreg32(STM32_RTC_SHIFTR));
+  rtcinfo("    TSTR: %08" PRIx32 "\n", getreg32(STM32_RTC_TSTR));
+  rtcinfo("    TSDR: %08" PRIx32 "\n", getreg32(STM32_RTC_TSDR));
+  rtcinfo("   TSSSR: %08" PRIx32 "\n", getreg32(STM32_RTC_TSSSR));
+  rtcinfo("    CALR: %08" PRIx32 "\n", getreg32(STM32_RTC_CALR));
+  rtcinfo("  TAMPCR: %08" PRIx32 "\n", getreg32(STM32_RTC_TAMPCR));
+  rtcinfo("ALRMASSR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMASSR));
+  rtcinfo("ALRMBSSR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMBSSR));
+  rtcinfo("MAGICREG: %08" PRIx32 "\n", getreg32(RTC_MAGIC_REG));
 
   rtc_state =
     ((getreg32(STM32_EXTI_RTSR1)   & EXTI_RTC_ALARM) ? 0x1000 : 0) |
@@ -803,7 +803,7 @@ static int rtchw_set_alrmbr(rtc_alarmreg_t alarmreg)
 
   putreg32(alarmreg, STM32_RTC_ALRMBR);
   putreg32(0, STM32_RTC_ALRMBSSR);
-  rtcinfo("  ALRMBR: %08x\n", getreg32(STM32_RTC_ALRMBR));
+  rtcinfo("  ALRMBR: %08" PRIx32 "\n", getreg32(STM32_RTC_ALRMBR));
 
   /* Enable RTC alarm B */
 

--- a/arch/arm/src/stm32h7/stm32_spi_slave.c
+++ b/arch/arm/src/stm32h7/stm32_spi_slave.c
@@ -664,11 +664,13 @@ static inline void spi_writebyte(struct stm32_spidev_s *priv,
 #ifdef CONFIG_DEBUG_SPI_INFO
 static void spi_dumpregs(struct stm32_spidev_s *priv)
 {
-  spiinfo("CR1: 0x%08x CFG1: 0x%08x CFG2: 0x%08x\n",
+  spiinfo("CR1: 0x%08" PRIx32 " CFG1: 0x%08" PRIx32
+          " CFG2: 0x%08" PRIx32 "\n",
           spi_getreg(priv, STM32_SPI_CR1_OFFSET),
           spi_getreg(priv, STM32_SPI_CFG1_OFFSET),
           spi_getreg(priv, STM32_SPI_CFG2_OFFSET));
-  spiinfo("IER: 0x%08x SR: 0x%08x I2SCFGR: 0x%08x\n",
+  spiinfo("IER: 0x%08" PRIx32 " SR: 0x%08" PRIx32
+          " I2SCFGR: 0x%08" PRIx32 "\n",
           spi_getreg(priv, STM32_SPI_IER_OFFSET),
           spi_getreg(priv, STM32_SPI_SR_OFFSET),
           spi_getreg(priv, STM32_SPI_I2SCFGR_OFFSET));

--- a/arch/arm/src/stm32h7/stm32_wwdg.c
+++ b/arch/arm/src/stm32h7/stm32_wwdg.c
@@ -211,7 +211,7 @@ static uint16_t stm32_getreg(uint32_t addr)
 
   /* Show the register value read */
 
-  wdinfo("%08x->%04x\n", addr, val);
+  wdinfo("%08" PRIx32 "->%04x\n", addr, val);
   return val;
 }
 #endif
@@ -229,7 +229,7 @@ static void stm32_putreg(uint16_t val, uint32_t addr)
 {
   /* Show the register value being written */
 
-  wdinfo("%08x<-%04x\n", addr, val);
+  wdinfo("%08" PRIx32 "<-%04x\n", addr, val);
 
   /* Write the value */
 
@@ -462,7 +462,7 @@ static int stm32_getstatus(struct watchdog_lowerhalf_s *lower,
   status->timeleft = (priv->timeout * elapsed) / (priv->reload + 1);
 
   wdinfo("Status     :\n");
-  wdinfo("  flags    : %08x\n", status->flags);
+  wdinfo("  flags    : %08" PRIx32 "\n", status->flags);
   wdinfo("  timeout  : %d\n", status->timeout);
   wdinfo("  timeleft : %d\n", status->timeleft);
   return OK;

--- a/arch/arm/src/stm32l4/stm32l4_can.c
+++ b/arch/arm/src/stm32l4/stm32l4_can.c
@@ -267,7 +267,7 @@ static uint32_t stm32l4can_vgetreg(uint32_t addr)
 
   /* Show the register value read */
 
-  caninfo("%08x->%08x\n", addr, val);
+  caninfo("%08" PRIx32 "->%08" PRIx32 "\n", addr, val);
   return val;
 }
 
@@ -318,7 +318,7 @@ static void stm32l4can_vputreg(uint32_t addr, uint32_t value)
 {
   /* Show the register value being written */
 
-  caninfo("%08x<-%08x\n", addr, value);
+  caninfo("%08" PRIx32 "<-%08" PRIx32 "\n", addr, value);
 
   /* Write the value */
 
@@ -380,16 +380,16 @@ static void stm32l4can_dumpctrlregs(struct stm32l4_can_s *priv,
 
   /* CAN control and status registers */
 
-  caninfo("  MCR: %08x   MSR: %08x   TSR: %08x\n",
+  caninfo("  MCR: %08" PRIx32 "   MSR: %08" PRIx32 "   TSR: %08" PRIx32 "\n",
           getreg32(priv->base + STM32L4_CAN_MCR_OFFSET),
           getreg32(priv->base + STM32L4_CAN_MSR_OFFSET),
           getreg32(priv->base + STM32L4_CAN_TSR_OFFSET));
 
-  caninfo(" RF0R: %08x  RF1R: %08x\n",
+  caninfo(" RF0R: %08" PRIx32 "  RF1R: %08" PRIx32 "\n",
           getreg32(priv->base + STM32L4_CAN_RF0R_OFFSET),
           getreg32(priv->base + STM32L4_CAN_RF1R_OFFSET));
 
-  caninfo("  IER: %08x   ESR: %08x   BTR: %08x\n",
+  caninfo("  IER: %08" PRIx32 "   ESR: %08" PRIx32 "   BTR: %08" PRIx32 "\n",
           getreg32(priv->base + STM32L4_CAN_IER_OFFSET),
           getreg32(priv->base + STM32L4_CAN_ESR_OFFSET),
           getreg32(priv->base + STM32L4_CAN_BTR_OFFSET));
@@ -425,31 +425,36 @@ static void stm32l4can_dumpmbregs(struct stm32l4_can_s *priv,
 
   /* CAN mailbox registers (3 TX and 2 RX) */
 
-  caninfo(" TI0R: %08x TDT0R: %08x TDL0R: %08x TDH0R: %08x\n",
+  caninfo(" TI0R: %08" PRIx32 " TDT0R: %08" PRIx32
+          " TDL0R: %08" PRIx32 " TDH0R: %08" PRIx32 "\n",
           getreg32(priv->base + STM32L4_CAN_TI0R_OFFSET),
           getreg32(priv->base + STM32L4_CAN_TDT0R_OFFSET),
           getreg32(priv->base + STM32L4_CAN_TDL0R_OFFSET),
           getreg32(priv->base + STM32L4_CAN_TDH0R_OFFSET));
 
-  caninfo(" TI1R: %08x TDT1R: %08x TDL1R: %08x TDH1R: %08x\n",
+  caninfo(" TI1R: %08" PRIx32 " TDT1R: %08" PRIx32
+          " TDL1R: %08" PRIx32 " TDH1R: %08" PRIx32 "\n",
           getreg32(priv->base + STM32L4_CAN_TI1R_OFFSET),
           getreg32(priv->base + STM32L4_CAN_TDT1R_OFFSET),
           getreg32(priv->base + STM32L4_CAN_TDL1R_OFFSET),
           getreg32(priv->base + STM32L4_CAN_TDH1R_OFFSET));
 
-  caninfo(" TI2R: %08x TDT2R: %08x TDL2R: %08x TDH2R: %08x\n",
+  caninfo(" TI2R: %08" PRIx32 " TDT2R: %08" PRIx32
+          " TDL2R: %08" PRIx32 " TDH2R: %08" PRIx32 "\n",
           getreg32(priv->base + STM32L4_CAN_TI2R_OFFSET),
           getreg32(priv->base + STM32L4_CAN_TDT2R_OFFSET),
           getreg32(priv->base + STM32L4_CAN_TDL2R_OFFSET),
           getreg32(priv->base + STM32L4_CAN_TDH2R_OFFSET));
 
-  caninfo(" RI0R: %08x RDT0R: %08x RDL0R: %08x RDH0R: %08x\n",
+  caninfo(" RI0R: %08" PRIx32 " RDT0R: %08" PRIx32
+          " RDL0R: %08" PRIx32 " RDH0R: %08" PRIx32 "\n",
           getreg32(priv->base + STM32L4_CAN_RI0R_OFFSET),
           getreg32(priv->base + STM32L4_CAN_RDT0R_OFFSET),
           getreg32(priv->base + STM32L4_CAN_RDL0R_OFFSET),
           getreg32(priv->base + STM32L4_CAN_RDH0R_OFFSET));
 
-  caninfo(" RI1R: %08x RDT1R: %08x RDL1R: %08x RDH1R: %08x\n",
+  caninfo(" RI1R: %08" PRIx32 " RDT1R: %08" PRIx32
+          " RDL1R: %08" PRIx32 " RDH1R: %08" PRIx32 "\n",
           getreg32(priv->base + STM32L4_CAN_RI1R_OFFSET),
           getreg32(priv->base + STM32L4_CAN_RDT1R_OFFSET),
           getreg32(priv->base + STM32L4_CAN_RDL1R_OFFSET),
@@ -486,7 +491,9 @@ static void stm32l4can_dumpfiltregs(struct stm32l4_can_s *priv,
       caninfo("Filter Registers:\n");
     }
 
-  caninfo(" FMR: %08x   FM1R: %08x  FS1R: %08x FFA1R: %08x  FA1R: %08x\n",
+  caninfo(" FMR: %08" PRIx32 "   FM1R: %08" PRIx32
+          "  FS1R: %08" PRIx32 " FFA1R: %08" PRIx32
+          "  FA1R: %08" PRIx32 "\n",
           getreg32(priv->base + STM32L4_CAN_FMR_OFFSET),
           getreg32(priv->base + STM32L4_CAN_FM1R_OFFSET),
           getreg32(priv->base + STM32L4_CAN_FS1R_OFFSET),
@@ -495,7 +502,7 @@ static void stm32l4can_dumpfiltregs(struct stm32l4_can_s *priv,
 
   for (i = 0; i < CAN_NFILTERS; i++)
     {
-      caninfo(" F%dR1: %08x F%dR2: %08x\n",
+      caninfo(" F%dR1: %08" PRIx32 " F%dR2: %08" PRIx32 "\n",
               i, getreg32(priv->base + STM32L4_CAN_FIR_OFFSET(i, 1)),
               i, getreg32(priv->base + STM32L4_CAN_FIR_OFFSET(i, 2)));
     }
@@ -1332,7 +1339,7 @@ static bool stm32l4can_txready(struct can_dev_s *dev)
   /* Return true if any mailbox is available */
 
   regval = stm32l4can_getreg(priv, STM32L4_CAN_TSR_OFFSET);
-  caninfo("CAN%d TSR: %08x\n", priv->port, regval);
+  caninfo("CAN%d TSR: %08" PRIx32 "\n", priv->port, regval);
 
   return (regval & CAN_ALL_MAILBOXES) != 0;
 }
@@ -1363,7 +1370,7 @@ static bool stm32l4can_txempty(struct can_dev_s *dev)
   /* Return true if all mailboxes are available */
 
   regval = stm32l4can_getreg(priv, STM32L4_CAN_TSR_OFFSET);
-  caninfo("CAN%d TSR: %08x\n", priv->port, regval);
+  caninfo("CAN%d TSR: %08" PRIx32 "\n", priv->port, regval);
 
   return (regval & CAN_ALL_MAILBOXES) == CAN_ALL_MAILBOXES;
 }
@@ -1854,7 +1861,8 @@ static int stm32l4can_exitinitmode(struct stm32l4_can_s *priv)
 
   if (timeout < 1)
     {
-      canerr("ERROR: Timed out waiting to exit initialization mode: %08x\n",
+      canerr("ERROR: Timed out waiting to exit"
+             " initialization mode: %08" PRIx32 "\n",
              regval);
       return -ETIMEDOUT;
     }

--- a/arch/arm/src/stm32l4/stm32l4_dfsdm.c
+++ b/arch/arm/src/stm32l4/stm32l4_dfsdm.c
@@ -670,7 +670,7 @@ static int dfsdm_timinit(struct stm32_dev_s *priv)
    *   position.
    */
 
-  ainfo("Initializing timers extsel = 0x%08x\n", priv->extsel);
+  ainfo("Initializing timers extsel = 0x%08" PRIx32 "\n", priv->extsel);
 
   dfsdm_modifyreg(priv, FLTCR2_OFFSET(priv),
                 DFSDM_FLTCR1_JEXTEN_MASK | DFSDM_FLTCR1_JEXTSEL_MASK,
@@ -1241,7 +1241,8 @@ static int dfsdm_setup(struct adc_dev_s *dev)
 
   leave_critical_section(flags);
 
-  ainfo("ISR:   0x%08x FCR:    0x%08x CR1:  0x%08x CR2: 0x%08x\n",
+  ainfo("ISR:   0x%08" PRIx32 " FCR:    0x%08" PRIx32
+        " CR1:  0x%08" PRIx32 " CR2: 0x%08" PRIx32 "\n",
         dfsdm_getreg(priv, FLTISR_OFFSET(priv)),
         dfsdm_getreg(priv, FLTFCR_OFFSET(priv)),
         dfsdm_getreg(priv, FLTCR1_OFFSET(priv)),

--- a/arch/arm/src/stm32l4/stm32l4_dumpgpio.c
+++ b/arch/arm/src/stm32l4/stm32l4_dumpgpio.c
@@ -110,28 +110,30 @@ int stm32l4_dumpgpio(uint32_t pinset, const char *msg)
 
   DEBUGASSERT(port < STM32L4_NPORTS);
 
-  _info("GPIO%c pinset: %08x base: %08x -- %s\n",
+  _info("GPIO%c pinset: %08" PRIx32 " base: %08" PRIx32 " -- %s\n",
         g_portchar[port], pinset, base, msg);
 
   if ((getreg32(STM32L4_RCC_AHB2ENR) & RCC_AHB2ENR_GPIOEN(port)) != 0)
     {
-      _info(" MODE: %08x OTYPE: %04x     OSPEED: %08x PUPDR: %08x\n",
+      _info(" MODE: %08" PRIx32 " OTYPE: %04" PRIx32
+            "     OSPEED: %08" PRIx32 " PUPDR: %08" PRIx32 "\n",
             getreg32(base + STM32L4_GPIO_MODER_OFFSET),
             getreg32(base + STM32L4_GPIO_OTYPER_OFFSET),
             getreg32(base + STM32L4_GPIO_OSPEED_OFFSET),
             getreg32(base + STM32L4_GPIO_PUPDR_OFFSET));
-      _info("  IDR: %04x       ODR: %04x       BSRR: %08x  LCKR: %04x\n",
+      _info("  IDR: %04" PRIx32 "       ODR: %04" PRIx32
+            "       BSRR: %08" PRIx32 "  LCKR: %04x\n",
             getreg32(base + STM32L4_GPIO_IDR_OFFSET),
             getreg32(base + STM32L4_GPIO_ODR_OFFSET),
             getreg32(base + STM32L4_GPIO_BSRR_OFFSET),
             getreg32(base + STM32L4_GPIO_LCKR_OFFSET));
-      _info(" AFRH: %08x  AFRL: %08x\n",
+      _info(" AFRH: %08" PRIx32 "  AFRL: %08" PRIx32 "\n",
             getreg32(base + STM32L4_GPIO_AFRH_OFFSET),
             getreg32(base + STM32L4_GPIO_AFRL_OFFSET));
     }
   else
     {
-      _info("  GPIO%c not enabled: AHB2ENR: %08x\n",
+      _info("  GPIO%c not enabled: AHB2ENR: %08" PRIx32 "\n",
             g_portchar[port], getreg32(STM32L4_RCC_AHB2ENR));
     }
 

--- a/arch/arm/src/stm32l4/stm32l4_i2c.c
+++ b/arch/arm/src/stm32l4/stm32l4_i2c.c
@@ -908,7 +908,8 @@ int stm32l4_i2c_sem_waitdone(struct stm32l4_i2c_priv_s *priv)
 
   while (priv->intstate != INTSTATE_DONE && elapsed < timeout);
 
-  i2cinfo("intstate: %d elapsed: %ld threshold: %ld status: 0x%08x\n",
+  i2cinfo("intstate: %d elapsed: %ld threshold: %ld"
+          " status: 0x%08" PRIx32 "\n",
           priv->intstate, (long)elapsed, (long)timeout, priv->status);
 
   /* Set the interrupt state back to IDLE */
@@ -1175,7 +1176,8 @@ static void stm32l4_i2c_tracedump(struct stm32l4_i2c_priv_s *priv)
     {
       trace = &priv->trace[i];
       syslog(LOG_DEBUG,
-             "%2d. STATUS: %08x COUNT: %3d EVENT: %2d PARM: %08x TIME: %d\n",
+             "%2d. STATUS: %08" PRIx32 " COUNT: %3d EVENT: %2d"
+             " PARM: %08" PRIx32 " TIME: %d\n",
              i + 1, trace->status, trace->count,  trace->event, trace->parm,
              (int)(trace->time - priv->start_time));
     }

--- a/arch/arm/src/stm32l4/stm32l4_irq.c
+++ b/arch/arm/src/stm32l4/stm32l4_irq.c
@@ -79,45 +79,50 @@ static void stm32l4_dumpnvic(const char *msg, int irq)
   flags = enter_critical_section();
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
-  irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
+  irqinfo("  INTCTRL:    %08" PRIx32 " VECTAB:  %08" PRIx32 "\n",
           getreg32(NVIC_INTCTRL), getreg32(NVIC_VECTAB));
 #if 0
-  irqinfo("  SYSH ENABLE MEMFAULT: %08x BUSFAULT: %08x USGFAULT: %08x "
-          "SYSTICK: %08x\n",
+  irqinfo("  SYSH ENABLE MEMFAULT: %08" PRIx32
+          " BUSFAULT: %08" PRIx32 " USGFAULT: %08" PRIx32 " "
+          "SYSTICK: %08" PRIx32 "\n",
           getreg32(NVIC_SYSHCON_MEMFAULTENA),
           getreg32(NVIC_SYSHCON_BUSFAULTENA),
           getreg32(NVIC_SYSHCON_USGFAULTENA),
           getreg32(NVIC_SYSTICK_CTRL_ENABLE));
 #endif
-  irqinfo("  IRQ ENABLE: %08x %08x %08x\n",
+  irqinfo("  IRQ ENABLE: %08" PRIx32 " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ0_31_ENABLE),
           getreg32(NVIC_IRQ32_63_ENABLE),
           getreg32(NVIC_IRQ64_95_ENABLE));
-  irqinfo("  SYSH_PRIO:  %08x %08x %08x\n",
+  irqinfo("  SYSH_PRIO:  %08" PRIx32 " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_SYSH4_7_PRIORITY),
           getreg32(NVIC_SYSH8_11_PRIORITY),
           getreg32(NVIC_SYSH12_15_PRIORITY));
-  irqinfo("  IRQ PRIO:   %08x %08x %08x %08x\n",
+  irqinfo("  IRQ PRIO:   %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ0_3_PRIORITY),
           getreg32(NVIC_IRQ4_7_PRIORITY),
           getreg32(NVIC_IRQ8_11_PRIORITY),
           getreg32(NVIC_IRQ12_15_PRIORITY));
-  irqinfo("              %08x %08x %08x %08x\n",
+  irqinfo("              %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ16_19_PRIORITY),
           getreg32(NVIC_IRQ20_23_PRIORITY),
           getreg32(NVIC_IRQ24_27_PRIORITY),
           getreg32(NVIC_IRQ28_31_PRIORITY));
-  irqinfo("              %08x %08x %08x %08x\n",
+  irqinfo("              %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ32_35_PRIORITY),
           getreg32(NVIC_IRQ36_39_PRIORITY),
           getreg32(NVIC_IRQ40_43_PRIORITY),
           getreg32(NVIC_IRQ44_47_PRIORITY));
-  irqinfo("              %08x %08x %08x %08x\n",
+  irqinfo("              %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ48_51_PRIORITY),
           getreg32(NVIC_IRQ52_55_PRIORITY),
           getreg32(NVIC_IRQ56_59_PRIORITY),
           getreg32(NVIC_IRQ60_63_PRIORITY));
-  irqinfo("              %08x\n",
+  irqinfo("              %08" PRIx32 "\n",
           getreg32(NVIC_IRQ64_67_PRIORITY));
 
   leave_critical_section(flags);

--- a/arch/arm/src/stm32l4/stm32l4_iwdg.c
+++ b/arch/arm/src/stm32l4/stm32l4_iwdg.c
@@ -208,7 +208,7 @@ static uint16_t stm32l4_getreg(uint32_t addr)
 
   /* Show the register value read */
 
-  wdinfo("%08x->%04x\n", addr, val);
+  wdinfo("%08" PRIx32 "->%04x\n", addr, val);
   return val;
 }
 #endif
@@ -226,7 +226,7 @@ static void stm32l4_putreg(uint16_t val, uint32_t addr)
 {
   /* Show the register value being written */
 
-  wdinfo("%08x<-%04x\n", addr, val);
+  wdinfo("%08" PRIx32 "<-%04x\n", addr, val);
 
   /* Write the value */
 

--- a/arch/arm/src/stm32l4/stm32l4_otgfsdev.c
+++ b/arch/arm/src/stm32l4/stm32l4_otgfsdev.c
@@ -943,7 +943,7 @@ static uint32_t stm32l4_getreg(uint32_t addr)
 
   /* Show the register value read */
 
-  uinfo("%08x->%08x\n", addr, val);
+  uinfo("%08" PRIx32 "->%08" PRIx32 "\n", addr, val);
   return val;
 }
 #endif
@@ -961,7 +961,7 @@ static void stm32l4_putreg(uint32_t val, uint32_t addr)
 {
   /* Show the register value being written */
 
-  uinfo("%08x<-%08x\n", addr, val);
+  uinfo("%08" PRIx32 "<-%08" PRIx32 "\n", addr, val);
 
   /* Write the value */
 

--- a/arch/arm/src/stm32l4/stm32l4_otgfshost.c
+++ b/arch/arm/src/stm32l4/stm32l4_otgfshost.c
@@ -507,7 +507,7 @@ static struct usbhost_connection_s g_usbconn =
 #ifdef CONFIG_STM32L4_USBHOST_REGDEBUG
 static void stm32l4_printreg(uint32_t addr, uint32_t val, bool iswrite)
 {
-  lldbg("%08x%s%08x\n", addr, iswrite ? "<-" : "->", val);
+  lldbg("%08" PRIx32 "%s%08" PRIx32 "\n", addr, iswrite ? "<-" : "->", val);
 }
 #endif
 
@@ -2471,7 +2471,8 @@ static inline void stm32l4_gint_hcinisr(struct stm32l4_usbhost_s *priv,
   /* AND the two to get the set of enabled, pending HC interrupts */
 
   pending &= regval;
-  uinfo("HCINTMSK%d: %08x pending: %08x\n", chidx, regval, pending);
+  uinfo("HCINTMSK%d: %08" PRIx32 " pending: %08" PRIx32 "\n",
+        chidx, regval, pending);
 
   /* Check for a pending ACK response received/transmitted interrupt */
 
@@ -2728,7 +2729,8 @@ static inline void stm32l4_gint_hcoutisr(struct stm32l4_usbhost_s *priv,
   /* AND the two to get the set of enabled, pending HC interrupts */
 
   pending &= regval;
-  uinfo("HCINTMSK%d: %08x pending: %08x\n", chidx, regval, pending);
+  uinfo("HCINTMSK%d: %08" PRIx32 " pending: %08" PRIx32 "\n",
+        chidx, regval, pending);
 
   /* Check for a pending ACK response received/transmitted interrupt */
 
@@ -3050,7 +3052,7 @@ static inline void stm32l4_gint_rxflvlisr(struct stm32l4_usbhost_s *priv)
   /* Read and pop the next status from the Rx FIFO */
 
   grxsts = stm32l4_getreg(STM32L4_OTGFS_GRXSTSP);
-  uinfo("GRXSTS: %08x\n", grxsts);
+  uinfo("GRXSTS: %08" PRIx32 "\n", grxsts);
 
   /* Isolate the channel number/index in the status word */
 
@@ -3205,7 +3207,7 @@ static inline void stm32l4_gint_nptxfeisr(struct stm32l4_usbhost_s *priv)
 
   /* Write the next group of packets into the Tx FIFO */
 
-  uinfo("HNPTXSTS: %08x chidx: %d avail: %d buflen: %d xfrd: %d "
+  uinfo("HNPTXSTS: %08" PRIx32 " chidx: %d avail: %d buflen: %d xfrd: %d "
         "wrsize: %d\n",
         regval, chidx, avail, chan->buflen, chan->xfrd, wrsize);
 
@@ -3295,8 +3297,9 @@ static inline void stm32l4_gint_ptxfeisr(struct stm32l4_usbhost_s *priv)
 
   /* Write the next group of packets into the Tx FIFO */
 
-  uinfo("HPTXSTS: %08x chidx: %d avail: %d buflen: %d xfrd: %d wrsize: %d\n",
-           regval, chidx, avail, chan->buflen, chan->xfrd, wrsize);
+  uinfo("HPTXSTS: %08" PRIx32 " chidx: %d avail: %d"
+        " buflen: %d xfrd: %d wrsize: %d\n",
+        regval, chidx, avail, chan->buflen, chan->xfrd, wrsize);
 
   stm32l4_gint_wrpacket(priv, chan->buffer, chidx, wrsize);
 }

--- a/arch/arm/src/stm32l4/stm32l4_qencoder.c
+++ b/arch/arm/src/stm32l4/stm32l4_qencoder.c
@@ -530,25 +530,27 @@ static void stm32l4_dumpregs(struct stm32l4_lowerhalf_s *priv,
                              const char *msg)
 {
   sninfo("%s:\n", msg);
-  sninfo("  CR1: %04x CR2:  %04x SMCR:  %08x DIER:  %04x\n",
+  sninfo("  CR1: %04x CR2:  %04x SMCR:  %08" PRIx32 " DIER:  %04x\n",
          stm32l4_getreg16(priv, STM32L4_GTIM_CR1_OFFSET),
          stm32l4_getreg16(priv, STM32L4_GTIM_CR2_OFFSET),
          stm32l4_getreg32(priv, STM32L4_GTIM_SMCR_OFFSET),
          stm32l4_getreg16(priv, STM32L4_GTIM_DIER_OFFSET));
-  sninfo("   SR: %04x EGR:  %04x CCMR1: %08x CCMR2: %08x\n",
+  sninfo("   SR: %04x EGR:  %04x CCMR1: %08" PRIx32
+         " CCMR2: %08" PRIx32 "\n",
          stm32l4_getreg16(priv, STM32L4_GTIM_SR_OFFSET),
          stm32l4_getreg16(priv, STM32L4_GTIM_EGR_OFFSET),
          stm32l4_getreg32(priv, STM32L4_GTIM_CCMR1_OFFSET),
          stm32l4_getreg32(priv, STM32L4_GTIM_CCMR2_OFFSET));
-  sninfo(" CCER: %04x CNT:  %08x PSC:   %04x ARR:   %08x\n",
+  sninfo(" CCER: %04x CNT:  %08" PRIx32 " PSC:   %04x"
+         " ARR:   %08" PRIx32 "\n",
          stm32l4_getreg16(priv, STM32L4_GTIM_CCER_OFFSET),
          stm32l4_getreg32(priv, STM32L4_GTIM_CNT_OFFSET),
          stm32l4_getreg16(priv, STM32L4_GTIM_PSC_OFFSET),
          stm32l4_getreg32(priv, STM32L4_GTIM_ARR_OFFSET));
-  sninfo(" CCR1: %08x CCR2: %08x\n",
+  sninfo(" CCR1: %08" PRIx32 " CCR2: %08" PRIx32 "\n",
          stm32l4_getreg32(priv, STM32L4_GTIM_CCR1_OFFSET),
          stm32l4_getreg32(priv, STM32L4_GTIM_CCR2_OFFSET));
-  sninfo(" CCR3: %08x CCR4: %08x\n",
+  sninfo(" CCR3: %08" PRIx32 " CCR4: %08" PRIx32 "\n",
          stm32l4_getreg32(priv, STM32L4_GTIM_CCR3_OFFSET),
          stm32l4_getreg32(priv, STM32L4_GTIM_CCR4_OFFSET));
 #if defined(CONFIG_STM32L4_TIM1_QE) || defined(CONFIG_STM32L4_TIM8_QE)
@@ -1001,7 +1003,8 @@ static int stm32l4_shutdown(struct qe_lowerhalf_s *lower)
   putreg32(regval, regaddr);
   leave_critical_section(flags);
 
-  sninfo("regaddr: %08x resetbit: %08x\n", regaddr, resetbit);
+  sninfo("regaddr: %08" PRIx32 " resetbit: %08" PRIx32 "\n",
+         regaddr, resetbit);
   stm32l4_dumpregs(priv, "After stop");
 
   /* Put the TI1 GPIO pin back to its default state */

--- a/arch/arm/src/stm32l4/stm32l4_qspi.c
+++ b/arch/arm/src/stm32l4/stm32l4_qspi.c
@@ -421,7 +421,7 @@ static inline uint32_t qspi_getreg(struct stm32l4_qspidev_s *priv,
 #ifdef CONFIG_STM32L4_QSPI_REGDEBUG
   if (qspi_checkreg(priv, false, value, address))
     {
-      spiinfo("%08x->%08x\n", address, value);
+      spiinfo("%08" PRIx32 "->%08" PRIx32 "\n", address, value);
     }
 #endif
 
@@ -444,7 +444,7 @@ static inline void qspi_putreg(struct stm32l4_qspidev_s *priv,
 #ifdef CONFIG_STM32L4_QSPI_REGDEBUG
   if (qspi_checkreg(priv, true, value, address))
     {
-      spiinfo("%08x<-%08x\n", address, value);
+      spiinfo("%08" PRIx32 "<-%08" PRIx32 "\n", address, value);
     }
 #endif
 
@@ -479,7 +479,7 @@ static void qspi_dumpregs(struct stm32l4_qspidev_s *priv, const char *msg)
    */
 
   regval = getreg32(priv->base + STM32L4_QUADSPI_CR_OFFSET);    /* Control Register */
-  spiinfo("CR:%08x\n", regval);
+  spiinfo("CR:%08" PRIx32 "\n", regval);
   spiinfo("  EN:%1d ABORT:%1d DMAEN:%1d TCEN:%1d SSHIFT:%1d\n"
           "  FTHRES: %d\n"
           "  TEIE:%1d TCIE:%1d FTIE:%1d SMIE:%1d TOIE:%1d APMS:%1d PMM:%1d\n"
@@ -500,14 +500,14 @@ static void qspi_dumpregs(struct stm32l4_qspidev_s *priv, const char *msg)
           (regval & QSPI_CR_PRESCALER_MASK) >> QSPI_CR_PRESCALER_SHIFT);
 
   regval = getreg32(priv->base + STM32L4_QUADSPI_DCR_OFFSET);   /* Device Configuration Register */
-  spiinfo("DCR:%08x\n", regval);
+  spiinfo("DCR:%08" PRIx32 "\n", regval);
   spiinfo("  CKMODE:%1d CSHT:%d FSIZE:%d\n",
           (regval & QSPI_DCR_CKMODE) ? 1 : 0,
           (regval & QSPI_DCR_CSHT_MASK) >> QSPI_DCR_CSHT_SHIFT,
           (regval & QSPI_DCR_FSIZE_MASK) >> QSPI_DCR_FSIZE_SHIFT);
 
   regval = getreg32(priv->base + STM32L4_QUADSPI_CCR_OFFSET);   /* Communication Configuration Register */
-  spiinfo("CCR:%08x\n", regval);
+  spiinfo("CCR:%08" PRIx32 "\n", regval);
   spiinfo("   INST:%02x IMODE:%d ADMODE:%d ADSIZE:%d ABMODE:%d\n"
           "   ABSIZE:%d DCYC:%d DMODE:%d FMODE:%d\n"
           "   SIOO:%1d DDRM:%1d\n",
@@ -524,7 +524,7 @@ static void qspi_dumpregs(struct stm32l4_qspidev_s *priv, const char *msg)
           (regval & QSPI_CCR_DDRM) ? 1 : 0);
 
   regval = getreg32(priv->base + STM32L4_QUADSPI_SR_OFFSET);    /* Status Register */
-  spiinfo("SR:%08x\n", regval);
+  spiinfo("SR:%08" PRIx32 "\n", regval);
   spiinfo("  TEF:%1d TCF:%1d FTF:%1d SMF:%1d TOF:%1d BUSY:%1d FLEVEL:%d\n",
           (regval & QSPI_SR_TEF) ? 1 : 0,
           (regval & QSPI_SR_TCF) ? 1 : 0,
@@ -535,17 +535,19 @@ static void qspi_dumpregs(struct stm32l4_qspidev_s *priv, const char *msg)
           (regval & QSPI_SR_FLEVEL_MASK) >> QSPI_SR_FLEVEL_SHIFT);
 
 #else
-  spiinfo("    CR:%08x   DCR:%08x   CCR:%08x    SR:%08x\n",
+  spiinfo("    CR:%08" PRIx32 "   DCR:%08" PRIx32
+          "   CCR:%08" PRIx32 "    SR:%08" PRIx32 "\n",
           getreg32(priv->base + STM32L4_QUADSPI_CR_OFFSET),     /* Control Register */
           getreg32(priv->base + STM32L4_QUADSPI_DCR_OFFSET),    /* Device Configuration Register */
           getreg32(priv->base + STM32L4_QUADSPI_CCR_OFFSET),    /* Communication Configuration Register */
           getreg32(priv->base + STM32L4_QUADSPI_SR_OFFSET));    /* Status Register */
-  spiinfo("   DLR:%08x   ABR:%08x PSMKR:%08x PSMAR:%08x\n",
+  spiinfo("   DLR:%08" PRIx32 "   ABR:%08" PRIx32
+          " PSMKR:%08" PRIx32 " PSMAR:%08" PRIx32 "\n",
           getreg32(priv->base + STM32L4_QUADSPI_DLR_OFFSET),    /* Data Length Register */
           getreg32(priv->base + STM32L4_QUADSPI_ABR_OFFSET),    /* Alternate Bytes Register */
           getreg32(priv->base + STM32L4_QUADSPI_PSMKR_OFFSET),  /* Polling Status mask Register */
           getreg32(priv->base + STM32L4_QUADSPI_PSMAR_OFFSET)); /* Polling Status match Register */
-  spiinfo("   PIR:%08x  LPTR:%08x\n",
+  spiinfo("   PIR:%08" PRIx32 "  LPTR:%08" PRIx32 "\n",
           getreg32(priv->base + STM32L4_QUADSPI_PIR_OFFSET),    /* Polling Interval Register */
           getreg32(priv->base + STM32L4_QUADSPI_LPTR_OFFSET));  /* Low-Power Timeout Register */
   UNUSED(regval);
@@ -560,22 +562,22 @@ static void qspi_dumpgpioconfig(const char *msg)
   spiinfo("%s:\n", msg);
 
   regval = getreg32(STM32L4_GPIOE_MODER);
-  spiinfo("E_MODER:%08x\n", regval);
+  spiinfo("E_MODER:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32L4_GPIOE_OTYPER);
-  spiinfo("E_OTYPER:%08x\n", regval);
+  spiinfo("E_OTYPER:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32L4_GPIOE_OSPEED);
-  spiinfo("E_OSPEED:%08x\n", regval);
+  spiinfo("E_OSPEED:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32L4_GPIOE_PUPDR);
-  spiinfo("E_PUPDR:%08x\n", regval);
+  spiinfo("E_PUPDR:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32L4_GPIOE_AFRL);
-  spiinfo("E_AFRL:%08x\n", regval);
+  spiinfo("E_AFRL:%08" PRIx32 "\n", regval);
 
   regval = getreg32(STM32L4_GPIOE_AFRH);
-  spiinfo("E_AFRH:%08x\n", regval);
+  spiinfo("E_AFRH:%08" PRIx32 "\n", regval);
 }
 #endif
 

--- a/arch/arm/src/stm32l4/stm32l4_rtc.c
+++ b/arch/arm/src/stm32l4/stm32l4_rtc.c
@@ -142,24 +142,24 @@ static inline void rtc_enable_alarm(void);
 static void rtc_dumpregs(const char *msg)
 {
   rtcinfo("%s:\n", msg);
-  rtcinfo("      TR: %08x\n", getreg32(STM32L4_RTC_TR));
-  rtcinfo("      DR: %08x\n", getreg32(STM32L4_RTC_DR));
-  rtcinfo("      CR: %08x\n", getreg32(STM32L4_RTC_CR));
-  rtcinfo("     ISR: %08x\n", getreg32(STM32L4_RTC_ISR));
-  rtcinfo("    PRER: %08x\n", getreg32(STM32L4_RTC_PRER));
-  rtcinfo("    WUTR: %08x\n", getreg32(STM32L4_RTC_WUTR));
+  rtcinfo("      TR: %08" PRIx32 "\n", getreg32(STM32L4_RTC_TR));
+  rtcinfo("      DR: %08" PRIx32 "\n", getreg32(STM32L4_RTC_DR));
+  rtcinfo("      CR: %08" PRIx32 "\n", getreg32(STM32L4_RTC_CR));
+  rtcinfo("     ISR: %08" PRIx32 "\n", getreg32(STM32L4_RTC_ISR));
+  rtcinfo("    PRER: %08" PRIx32 "\n", getreg32(STM32L4_RTC_PRER));
+  rtcinfo("    WUTR: %08" PRIx32 "\n", getreg32(STM32L4_RTC_WUTR));
 
-  rtcinfo("  ALRMAR: %08x\n", getreg32(STM32L4_RTC_ALRMAR));
-  rtcinfo("  ALRMBR: %08x\n", getreg32(STM32L4_RTC_ALRMBR));
-  rtcinfo("  SHIFTR: %08x\n", getreg32(STM32L4_RTC_SHIFTR));
-  rtcinfo("    TSTR: %08x\n", getreg32(STM32L4_RTC_TSTR));
-  rtcinfo("    TSDR: %08x\n", getreg32(STM32L4_RTC_TSDR));
-  rtcinfo("   TSSSR: %08x\n", getreg32(STM32L4_RTC_TSSSR));
-  rtcinfo("    CALR: %08x\n", getreg32(STM32L4_RTC_CALR));
-  rtcinfo("  TAMPCR: %08x\n", getreg32(STM32L4_RTC_TAMPCR));
-  rtcinfo("ALRMASSR: %08x\n", getreg32(STM32L4_RTC_ALRMASSR));
-  rtcinfo("ALRMBSSR: %08x\n", getreg32(STM32L4_RTC_ALRMBSSR));
-  rtcinfo("MAGICREG: %08x\n", getreg32(RTC_MAGIC_REG));
+  rtcinfo("  ALRMAR: %08" PRIx32 "\n", getreg32(STM32L4_RTC_ALRMAR));
+  rtcinfo("  ALRMBR: %08" PRIx32 "\n", getreg32(STM32L4_RTC_ALRMBR));
+  rtcinfo("  SHIFTR: %08" PRIx32 "\n", getreg32(STM32L4_RTC_SHIFTR));
+  rtcinfo("    TSTR: %08" PRIx32 "\n", getreg32(STM32L4_RTC_TSTR));
+  rtcinfo("    TSDR: %08" PRIx32 "\n", getreg32(STM32L4_RTC_TSDR));
+  rtcinfo("   TSSSR: %08" PRIx32 "\n", getreg32(STM32L4_RTC_TSSSR));
+  rtcinfo("    CALR: %08" PRIx32 "\n", getreg32(STM32L4_RTC_CALR));
+  rtcinfo("  TAMPCR: %08" PRIx32 "\n", getreg32(STM32L4_RTC_TAMPCR));
+  rtcinfo("ALRMASSR: %08" PRIx32 "\n", getreg32(STM32L4_RTC_ALRMASSR));
+  rtcinfo("ALRMBSSR: %08" PRIx32 "\n", getreg32(STM32L4_RTC_ALRMBSSR));
+  rtcinfo("MAGICREG: %08" PRIx32 "\n", getreg32(RTC_MAGIC_REG));
 }
 #else
 #  define rtc_dumpregs(msg)

--- a/arch/arm/src/stm32l4/stm32l4_sai.c
+++ b/arch/arm/src/stm32l4/stm32l4_sai.c
@@ -431,12 +431,13 @@ static void sai_dump_regs(struct stm32l4_sai_s *priv, const char *msg)
   if (msg)
       i2sinfo("%s\n", msg);
 
-  i2sinfo("CR1:%08x CR2:%08x  FRCR:%08x SLOTR:%08x\n",
+  i2sinfo("CR1:%08" PRIx32 " CR2:%08" PRIx32
+          "  FRCR:%08" PRIx32 " SLOTR:%08" PRIx32 "\n",
           sai_getreg(priv, STM32L4_SAI_CR1_OFFSET),
           sai_getreg(priv, STM32L4_SAI_CR2_OFFSET),
           sai_getreg(priv, STM32L4_SAI_FRCR_OFFSET),
           sai_getreg(priv, STM32L4_SAI_SLOTR_OFFSET));
-  i2sinfo(" IM:%08x  SR:%08x CLRFR:%08x\n",
+  i2sinfo(" IM:%08" PRIx32 "  SR:%08" PRIx32 " CLRFR:%08" PRIx32 "\n",
           sai_getreg(priv, STM32L4_SAI_IM_OFFSET),
           sai_getreg(priv, STM32L4_SAI_SR_OFFSET),
           sai_getreg(priv, STM32L4_SAI_CLRFR_OFFSET));

--- a/arch/arm/src/stm32l4/stm32l4_sdmmc.c
+++ b/arch/arm/src/stm32l4/stm32l4_sdmmc.c
@@ -714,7 +714,7 @@ static inline void stm32_setclkcr(struct stm32_dev_s *priv, uint32_t clkcr)
   regval |=  clkcr;
   sdmmc_putreg32(priv, regval, STM32_SDMMC_CLKCR_OFFSET);
 
-  mcinfo("CLKCR: %08x PWR: %08x\n",
+  mcinfo("CLKCR: %08" PRIx32 " PWR: %08" PRIx32 "\n",
         sdmmc_getreg32(priv, STM32_SDMMC_CLKCR_OFFSET),
         sdmmc_getreg32(priv, STM32_SDMMC_POWER_OFFSET));
 }
@@ -918,12 +918,18 @@ static void stm32_sdiodump(struct stm32_sdioregs_s *regs, const char *msg)
   mcinfo("  POWER[%08x]: %08x\n", STM32_SDMMC_POWER_OFFSET,   regs->power);
   mcinfo("  CLKCR[%08x]: %08x\n", STM32_SDMMC_CLKCR_OFFSET,   regs->clkcr);
   mcinfo("  DCTRL[%08x]: %08x\n", STM32_SDMMC_DCTRL_OFFSET,   regs->dctrl);
-  mcinfo(" DTIMER[%08x]: %08x\n", STM32_SDMMC_DTIMER_OFFSET,  regs->dtimer);
-  mcinfo("   DLEN[%08x]: %08x\n", STM32_SDMMC_DLEN_OFFSET,    regs->dlen);
-  mcinfo(" DCOUNT[%08x]: %08x\n", STM32_SDMMC_DCOUNT_OFFSET,  regs->dcount);
-  mcinfo("    STA[%08x]: %08x\n", STM32_SDMMC_STA_OFFSET,     regs->sta);
-  mcinfo("   MASK[%08x]: %08x\n", STM32_SDMMC_MASK_OFFSET,    regs->mask);
-  mcinfo("FIFOCNT[%08x]: %08x\n", STM32_SDMMC_FIFOCNT_OFFSET, regs->fifocnt);
+  mcinfo(" DTIMER[%08x]: %08" PRIx32 "\n",
+         STM32_SDMMC_DTIMER_OFFSET,  regs->dtimer);
+  mcinfo("   DLEN[%08x]: %08" PRIx32 "\n",
+         STM32_SDMMC_DLEN_OFFSET,    regs->dlen);
+  mcinfo(" DCOUNT[%08x]: %08" PRIx32 "\n",
+         STM32_SDMMC_DCOUNT_OFFSET,  regs->dcount);
+  mcinfo("    STA[%08x]: %08" PRIx32 "\n",
+         STM32_SDMMC_STA_OFFSET,     regs->sta);
+  mcinfo("   MASK[%08x]: %08" PRIx32 "\n",
+         STM32_SDMMC_MASK_OFFSET,    regs->mask);
+  mcinfo("FIFOCNT[%08x]: %08" PRIx32 "\n",
+         STM32_SDMMC_FIFOCNT_OFFSET, regs->fifocnt);
 }
 #endif
 
@@ -1704,7 +1710,7 @@ static void stm32_reset(struct sdio_dev_s *dev)
   stm32_setpwrctrl(priv, STM32_SDMMC_POWER_PWRCTRL_ON);
   leave_critical_section(flags);
 
-  mcinfo("CLCKR: %08x POWER: %08x\n",
+  mcinfo("CLCKR: %08" PRIx32 " POWER: %08" PRIx32 "\n",
         sdmmc_getreg32(priv, STM32_SDMMC_CLKCR_OFFSET),
         sdmmc_getreg32(priv, STM32_SDMMC_POWER_OFFSET));
 }
@@ -1950,7 +1956,8 @@ static int stm32_sendcmd(struct sdio_dev_s *dev, uint32_t cmd,
   cmdidx  = (cmd & MMCSD_CMDIDX_MASK) >> MMCSD_CMDIDX_SHIFT;
   regval |= cmdidx | STM32_SDMMC_CMD_CPSMEN;
 
-  mcinfo("cmd: %08x arg: %08x regval: %08x\n", cmd, arg, regval);
+  mcinfo("cmd: %08" PRIx32 " arg: %08" PRIx32 " regval: %08" PRIx32 "\n",
+         cmd, arg, regval);
 
   /* Write the SDIO CMD */
 
@@ -2186,7 +2193,8 @@ static int stm32_waitresponse(struct sdio_dev_s *dev, uint32_t cmd)
     {
       if (--timeout <= 0)
         {
-           mcerr("ERROR: Timeout cmd: %08x events: %08x STA: %08x\n",
+           mcerr("ERROR: Timeout cmd: %08" PRIx32
+                 " events: %08" PRIx32 " STA: %08" PRIx32 "\n",
                cmd, events, sdmmc_getreg32(priv, STM32_SDMMC_STA_OFFSET));
 
           return -ETIMEDOUT;
@@ -2264,7 +2272,7 @@ static int stm32_recvshortcrc(struct sdio_dev_s *dev, uint32_t cmd,
            (cmd & MMCSD_RESPONSE_MASK) != MMCSD_R1B_RESPONSE &&
            (cmd & MMCSD_RESPONSE_MASK) != MMCSD_R6_RESPONSE)
     {
-      mcerr("ERROR: Wrong response CMD=%08x\n", cmd);
+      mcerr("ERROR: Wrong response CMD=%08" PRIx32 "\n", cmd);
       ret = -EINVAL;
     }
   else
@@ -2275,12 +2283,12 @@ static int stm32_recvshortcrc(struct sdio_dev_s *dev, uint32_t cmd,
       regval = sdmmc_getreg32(priv, STM32_SDMMC_STA_OFFSET);
       if ((regval & STM32_SDMMC_STA_CTIMEOUT) != 0)
         {
-          mcerr("ERROR: Command timeout: %08x\n", regval);
+          mcerr("ERROR: Command timeout: %08" PRIx32 "\n", regval);
           ret = -ETIMEDOUT;
         }
       else if ((regval & STM32_SDMMC_STA_CCRCFAIL) != 0)
         {
-          mcerr("ERROR: CRC failure: %08x\n", regval);
+          mcerr("ERROR: CRC failure: %08" PRIx32 "\n", regval);
           ret = -EIO;
         }
 #ifdef CONFIG_DEBUG_FEATURES
@@ -2292,7 +2300,7 @@ static int stm32_recvshortcrc(struct sdio_dev_s *dev, uint32_t cmd,
           if ((uint8_t)(respcmd & STM32_SDMMC_RESPCMD_MASK) !=
               (cmd & MMCSD_CMDIDX_MASK))
             {
-              mcerr("ERROR: RESCMD=%02x CMD=%08x\n", respcmd, cmd);
+              mcerr("ERROR: RESCMD=%02x CMD=%08" PRIx32 "\n", respcmd, cmd);
               ret = -EINVAL;
             }
         }
@@ -2330,7 +2338,7 @@ static int stm32_recvlong(struct sdio_dev_s *dev, uint32_t cmd,
 
   if ((cmd & MMCSD_RESPONSE_MASK) != MMCSD_R2_RESPONSE)
     {
-      mcerr("ERROR: Wrong response CMD=%08x\n", cmd);
+      mcerr("ERROR: Wrong response CMD=%08" PRIx32 "\n", cmd);
       ret = -EINVAL;
     }
   else
@@ -2341,12 +2349,12 @@ static int stm32_recvlong(struct sdio_dev_s *dev, uint32_t cmd,
       regval = sdmmc_getreg32(priv, STM32_SDMMC_STA_OFFSET);
       if (regval & STM32_SDMMC_STA_CTIMEOUT)
         {
-          mcerr("ERROR: Timeout STA: %08x\n", regval);
+          mcerr("ERROR: Timeout STA: %08" PRIx32 "\n", regval);
           ret = -ETIMEDOUT;
         }
       else if (regval & STM32_SDMMC_STA_CCRCFAIL)
         {
-          mcerr("ERROR: CRC fail STA: %08x\n", regval);
+          mcerr("ERROR: CRC fail STA: %08" PRIx32 "\n", regval);
           ret = -EIO;
         }
     }
@@ -2388,7 +2396,7 @@ static int stm32_recvshort(struct sdio_dev_s *dev, uint32_t cmd,
   if ((cmd & MMCSD_RESPONSE_MASK) != MMCSD_R3_RESPONSE &&
       (cmd & MMCSD_RESPONSE_MASK) != MMCSD_R7_RESPONSE)
     {
-      mcerr("ERROR: Wrong response CMD=%08x\n", cmd);
+      mcerr("ERROR: Wrong response CMD=%08" PRIx32 "\n", cmd);
       ret = -EINVAL;
     }
   else
@@ -2401,7 +2409,7 @@ static int stm32_recvshort(struct sdio_dev_s *dev, uint32_t cmd,
       regval = sdmmc_getreg32(priv, STM32_SDMMC_STA_OFFSET);
       if (regval & STM32_SDMMC_STA_CTIMEOUT)
         {
-          mcerr("ERROR: Timeout STA: %08x\n", regval);
+          mcerr("ERROR: Timeout STA: %08" PRIx32 "\n", regval);
           ret = -ETIMEDOUT;
         }
     }

--- a/arch/arm/src/stm32l4/stm32l4_usbdev.c
+++ b/arch/arm/src/stm32l4/stm32l4_usbdev.c
@@ -668,7 +668,7 @@ static uint16_t stm32l4_getreg(uint32_t addr)
 
   /* Show the register value read */
 
-  uinfo("%08x->%04x\n", addr, val);
+  uinfo("%08" PRIx32 "->%04x\n", addr, val);
   return val;
 }
 #endif
@@ -682,7 +682,7 @@ static void stm32l4_putreg(uint16_t val, uint32_t addr)
 {
   /* Show the register value being written */
 
-  uinfo("%08x<-%04x\n", addr, val);
+  uinfo("%08" PRIx32 "<-%04x\n", addr, val);
 
   /* Write the value */
 
@@ -710,26 +710,26 @@ static void stm32l4_dumpep(int epno)
   /* Endpoint register */
 
   addr = STM32L4_USB_EPR(epno);
-  uinfo("EPR%d:   [%08x] %04x\n", epno, addr, getreg16(addr));
+  uinfo("EPR%d:   [%08" PRIx32 "] %04x\n", epno, addr, getreg16(addr));
 
   /* Endpoint descriptor */
 
   addr = STM32L4_USB_BTABLE_ADDR(epno, 0);
-  uinfo("DESC:   %08x\n", addr);
+  uinfo("DESC:   %08" PRIx32 "\n", addr);
 
   /* Endpoint buffer descriptor */
 
   addr = STM32L4_USB_ADDR_TX(epno);
-  uinfo("  TX ADDR:  [%08x] %04x\n",  addr, getreg16(addr));
+  uinfo("  TX ADDR:  [%08" PRIx32 "] %04x\n",  addr, getreg16(addr));
 
   addr = STM32L4_USB_COUNT_TX(epno);
-  uinfo("     COUNT: [%08x] %04x\n",  addr, getreg16(addr));
+  uinfo("     COUNT: [%08" PRIx32 "] %04x\n",  addr, getreg16(addr));
 
   addr = STM32L4_USB_ADDR_RX(epno);
-  uinfo("  RX ADDR:  [%08x] %04x\n",  addr, getreg16(addr));
+  uinfo("  RX ADDR:  [%08" PRIx32 "] %04x\n",  addr, getreg16(addr));
 
   addr = STM32L4_USB_COUNT_RX(epno);
-  uinfo("     COUNT: [%08x] %04x\n",  addr, getreg16(addr));
+  uinfo("     COUNT: [%08" PRIx32 "] %04x\n",  addr, getreg16(addr));
 }
 #endif
 
@@ -744,7 +744,8 @@ static void stm32l4_checksetup(void)
   uint32_t apb1rstr = getreg32(STM32L4_RCC_APB1RSTR1);
   uint32_t apb1enr  = getreg32(STM32L4_RCC_APB1ENR1);
 
-  uinfo("CFGR: %08x APB1RSTR1: %08x APB1ENR1: %08x\n", cfgr, apb1rstr,
+  uinfo("CFGR: %08" PRIx32 " APB1RSTR1: %08" PRIx32
+        " APB1ENR1: %08" PRIx32 "\n", cfgr, apb1rstr,
         apb1enr);
 
   if ((apb1rstr & RCC_APB1RSTR1_USBFSRST) != 0 ||

--- a/arch/arm/src/stm32l4/stm32l4x6xx_dma.c
+++ b/arch/arm/src/stm32l4/stm32l4x6xx_dma.c
@@ -744,17 +744,17 @@ void stm32l4_dmadump(DMA_HANDLE handle, const struct stm32l4_dmaregs_s *regs,
   uint32_t dmabase = DMA_BASE(dmach->base);
 
   dmainfo("DMA Registers: %s\n", msg);
-  dmainfo("    ISR[%08x]: %08x\n",
+  dmainfo("    ISR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmabase + STM32L4_DMA_ISR_OFFSET, regs->isr);
-  dmainfo("  CSELR[%08x]: %08x\n",
+  dmainfo("  CSELR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmabase + STM32L4_DMA_CSELR_OFFSET, regs->cselr);
-  dmainfo("    CCR[%08x]: %08x\n",
+  dmainfo("    CCR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmach->base + STM32L4_DMACHAN_CCR_OFFSET, regs->ccr);
-  dmainfo("  CNDTR[%08x]: %08x\n",
+  dmainfo("  CNDTR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmach->base + STM32L4_DMACHAN_CNDTR_OFFSET, regs->cndtr);
-  dmainfo("   CPAR[%08x]: %08x\n",
+  dmainfo("   CPAR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmach->base + STM32L4_DMACHAN_CPAR_OFFSET, regs->cpar);
-  dmainfo("   CMAR[%08x]: %08x\n",
+  dmainfo("   CMAR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmach->base + STM32L4_DMACHAN_CMAR_OFFSET, regs->cmar);
 }
 #endif

--- a/arch/arm/src/stm32l4/stm32l4xrxx_dma.c
+++ b/arch/arm/src/stm32l4/stm32l4xrxx_dma.c
@@ -863,19 +863,19 @@ static void stm32l4_dma12_dump(DMA_HANDLE handle,
   dmainfo("DMA%d Registers: %s\n",
           dmachan->ctrl + 1,
           msg);
-  dmainfo("    ISR[%08x]: %08x\n",
+  dmainfo("    ISR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmabase + STM32L4_DMA_ISR_OFFSET,
           regs->isr);
-  dmainfo("    CCR[%08x]: %08x\n",
+  dmainfo("    CCR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmachan->base + STM32L4_DMACHAN_CCR_OFFSET,
           regs->ccr);
-  dmainfo("  CNDTR[%08x]: %08x\n",
+  dmainfo("  CNDTR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmachan->base + STM32L4_DMACHAN_CNDTR_OFFSET,
           regs->cndtr);
-  dmainfo("   CPAR[%08x]: %08x\n",
+  dmainfo("   CPAR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmachan->base + STM32L4_DMACHAN_CPAR_OFFSET,
           regs->cpar);
-  dmainfo("   CMAR[%08x]: %08x\n",
+  dmainfo("   CMAR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmachan->base + STM32L4_DMACHAN_CMAR_OFFSET,
           regs->cmar);
 
@@ -914,20 +914,20 @@ static void stm32l4_dmamux_dump(DMA_MUX dmamux, uint8_t channel,
                                 const struct stm32l4_dmaregs_s *regs)
 {
   dmainfo("DMAMUX%d CH=%d\n", dmamux->id, channel);
-  dmainfo("    CCR[%08x]: %08x\n",
+  dmainfo("    CCR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmamux->base + STM32L4_DMAMUX_CXCR_OFFSET(channel),
           regs->dmamux.ccr);
-  dmainfo("    CSR[%08x]: %08x\n",
+  dmainfo("    CSR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmamux->base + STM32L4_DMAMUX_CSR_OFFSET, regs->dmamux.csr);
-  dmainfo("  RG0CR[%08x]: %08x\n",
+  dmainfo("  RG0CR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmamux->base + STM32L4_DMAMUX_RG0CR_OFFSET, regs->dmamux.rg0cr);
-  dmainfo("  RG1CR[%08x]: %08x\n",
+  dmainfo("  RG1CR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmamux->base + STM32L4_DMAMUX_RG1CR_OFFSET, regs->dmamux.rg1cr);
-  dmainfo("  RG2CR[%08x]: %08x\n",
+  dmainfo("  RG2CR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmamux->base + STM32L4_DMAMUX_RG2CR_OFFSET, regs->dmamux.rg2cr);
-  dmainfo("  RG3CR[%08x]: %08x\n",
+  dmainfo("  RG3CR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmamux->base + STM32L4_DMAMUX_RG3CR_OFFSET, regs->dmamux.rg3cr);
-  dmainfo("   RGSR[%08x]: %08x\n",
+  dmainfo("   RGSR[%08" PRIx32 "]: %08" PRIx32 "\n",
           dmamux->base + STM32L4_DMAMUX_RGSR_OFFSET, regs->dmamux.rgsr);
 };
 #endif

--- a/arch/arm/src/stm32l5/stm32l5_dumpgpio.c
+++ b/arch/arm/src/stm32l5/stm32l5_dumpgpio.c
@@ -110,28 +110,30 @@ int stm32l5_dumpgpio(uint32_t pinset, const char *msg)
 
   DEBUGASSERT(port < STM32L5_NPORTS);
 
-  _info("GPIO%c pinset: %08x base: %08x -- %s\n",
+  _info("GPIO%c pinset: %08" PRIx32 " base: %08" PRIx32 " -- %s\n",
         g_portchar[port], pinset, base, msg);
 
   if ((getreg32(STM32L5_RCC_AHB2ENR) & RCC_AHB2ENR_GPIOEN(port)) != 0)
     {
-      _info(" MODE: %08x OTYPE: %04x     OSPEED: %08x PUPDR: %08x\n",
+      _info(" MODE: %08" PRIx32 " OTYPE: %04" PRIx32
+            "     OSPEED: %08" PRIx32 " PUPDR: %08" PRIx32 "\n",
             getreg32(base + STM32L5_GPIO_MODER_OFFSET),
             getreg32(base + STM32L5_GPIO_OTYPER_OFFSET),
             getreg32(base + STM32L5_GPIO_OSPEED_OFFSET),
             getreg32(base + STM32L5_GPIO_PUPDR_OFFSET));
-      _info("  IDR: %04x       ODR: %04x       BSRR: %08x  LCKR: %04x\n",
+      _info("  IDR: %04" PRIx32 "       ODR: %04" PRIx32
+            "       BSRR: %08" PRIx32 "  LCKR: %04" PRIx32 "\n",
             getreg32(base + STM32L5_GPIO_IDR_OFFSET),
             getreg32(base + STM32L5_GPIO_ODR_OFFSET),
             getreg32(base + STM32L5_GPIO_BSRR_OFFSET),
             getreg32(base + STM32L5_GPIO_LCKR_OFFSET));
-      _info(" AFRH: %08x  AFRL: %08x\n",
+      _info(" AFRH: %08" PRIx32 "  AFRL: %08" PRIx32 "\n",
             getreg32(base + STM32L5_GPIO_AFRH_OFFSET),
             getreg32(base + STM32L5_GPIO_AFRL_OFFSET));
     }
   else
     {
-      _info("  GPIO%c not enabled: AHB2ENR: %08x\n",
+      _info("  GPIO%c not enabled: AHB2ENR: %08" PRIx32 "\n",
             g_portchar[port], getreg32(STM32L5_RCC_AHB2ENR));
     }
 

--- a/arch/arm/src/stm32l5/stm32l5_irq.c
+++ b/arch/arm/src/stm32l5/stm32l5_irq.c
@@ -79,30 +79,34 @@ static void stm32l5_dumpnvic(const char *msg, int irq)
   flags = enter_critical_section();
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
-  irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
+  irqinfo("  INTCTRL:    %08" PRIx32 " VECTAB:  %08" PRIx32 "\n",
           getreg32(NVIC_INTCTRL), getreg32(NVIC_VECTAB));
-  irqinfo("  IRQ ENABLE: %08x %08x %08x\n",
+  irqinfo("  IRQ ENABLE: %08" PRIx32 " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ0_31_ENABLE), getreg32(NVIC_IRQ32_63_ENABLE),
           getreg32(NVIC_IRQ64_95_ENABLE));
-  irqinfo("  SYSH_PRIO:  %08x %08x %08x\n",
+  irqinfo("  SYSH_PRIO:  %08" PRIx32 " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_SYSH4_7_PRIORITY), getreg32(NVIC_SYSH8_11_PRIORITY),
           getreg32(NVIC_SYSH12_15_PRIORITY));
-  irqinfo("  IRQ PRIO:   %08x %08x %08x %08x\n",
+  irqinfo("  IRQ PRIO:   %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ0_3_PRIORITY), getreg32(NVIC_IRQ4_7_PRIORITY),
           getreg32(NVIC_IRQ8_11_PRIORITY), getreg32(NVIC_IRQ12_15_PRIORITY));
-  irqinfo("              %08x %08x %08x %08x\n",
+  irqinfo("              %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ16_19_PRIORITY), getreg32(NVIC_IRQ20_23_PRIORITY),
           getreg32(NVIC_IRQ24_27_PRIORITY),
           getreg32(NVIC_IRQ28_31_PRIORITY));
-  irqinfo("              %08x %08x %08x %08x\n",
+  irqinfo("              %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ32_35_PRIORITY), getreg32(NVIC_IRQ36_39_PRIORITY),
           getreg32(NVIC_IRQ40_43_PRIORITY),
           getreg32(NVIC_IRQ44_47_PRIORITY));
-  irqinfo("              %08x %08x %08x %08x\n",
+  irqinfo("              %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ48_51_PRIORITY), getreg32(NVIC_IRQ52_55_PRIORITY),
           getreg32(NVIC_IRQ56_59_PRIORITY),
           getreg32(NVIC_IRQ60_63_PRIORITY));
-  irqinfo("              %08x\n",
+  irqinfo("              %08" PRIx32 "\n",
           getreg32(NVIC_IRQ64_67_PRIORITY));
 
   leave_critical_section(flags);

--- a/arch/arm/src/stm32u5/stm32_dumpgpio.c
+++ b/arch/arm/src/stm32u5/stm32_dumpgpio.c
@@ -110,28 +110,30 @@ int stm32_dumpgpio(uint32_t pinset, const char *msg)
 
   DEBUGASSERT(port < STM32_NPORTS);
 
-  _info("GPIO%c pinset: %08x base: %08x -- %s\n",
+  _info("GPIO%c pinset: %08" PRIx32 " base: %08" PRIx32 " -- %s\n",
         g_portchar[port], pinset, base, msg);
 
   if ((getreg32(STM32_RCC_AHB2ENR1) & RCC_AHB2ENR1_GPIOEN(port)) != 0)
     {
-      _info(" MODE: %08x OTYPE: %04x     OSPEED: %08x PUPDR: %08x\n",
+      _info(" MODE: %08" PRIx32 " OTYPE: %04" PRIx32
+            "     OSPEED: %08" PRIx32 " PUPDR: %08" PRIx32 "\n",
             getreg32(base + STM32_GPIO_MODER_OFFSET),
             getreg32(base + STM32_GPIO_OTYPER_OFFSET),
             getreg32(base + STM32_GPIO_OSPEED_OFFSET),
             getreg32(base + STM32_GPIO_PUPDR_OFFSET));
-      _info("  IDR: %04x       ODR: %04x       BSRR: %08x  LCKR: %04x\n",
+      _info("  IDR: %04" PRIx32 "       ODR: %04" PRIx32
+            "       BSRR: %08" PRIx32 "  LCKR: %04" PRIx32 "\n",
             getreg32(base + STM32_GPIO_IDR_OFFSET),
             getreg32(base + STM32_GPIO_ODR_OFFSET),
             getreg32(base + STM32_GPIO_BSRR_OFFSET),
             getreg32(base + STM32_GPIO_LCKR_OFFSET));
-      _info(" AFRH: %08x  AFRL: %08x\n",
+      _info(" AFRH: %08" PRIx32 "  AFRL: %08" PRIx32 "\n",
             getreg32(base + STM32_GPIO_AFRH_OFFSET),
             getreg32(base + STM32_GPIO_AFRL_OFFSET));
     }
   else
     {
-      _info("  GPIO%c not enabled: AHB2ENR: %08x\n",
+      _info("  GPIO%c not enabled: AHB2ENR: %08" PRIx32 "\n",
             g_portchar[port], getreg32(STM32_RCC_AHB2ENR1));
     }
 

--- a/arch/arm/src/stm32u5/stm32_irq.c
+++ b/arch/arm/src/stm32u5/stm32_irq.c
@@ -79,30 +79,34 @@ static void stm32_dumpnvic(const char *msg, int irq)
   flags = enter_critical_section();
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
-  irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
+  irqinfo("  INTCTRL:    %08" PRIx32 " VECTAB:  %08" PRIx32 "\n",
           getreg32(NVIC_INTCTRL), getreg32(NVIC_VECTAB));
-  irqinfo("  IRQ ENABLE: %08x %08x %08x\n",
+  irqinfo("  IRQ ENABLE: %08" PRIx32 " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ0_31_ENABLE), getreg32(NVIC_IRQ32_63_ENABLE),
           getreg32(NVIC_IRQ64_95_ENABLE));
-  irqinfo("  SYSH_PRIO:  %08x %08x %08x\n",
+  irqinfo("  SYSH_PRIO:  %08" PRIx32 " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_SYSH4_7_PRIORITY), getreg32(NVIC_SYSH8_11_PRIORITY),
           getreg32(NVIC_SYSH12_15_PRIORITY));
-  irqinfo("  IRQ PRIO:   %08x %08x %08x %08x\n",
+  irqinfo("  IRQ PRIO:   %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ0_3_PRIORITY), getreg32(NVIC_IRQ4_7_PRIORITY),
           getreg32(NVIC_IRQ8_11_PRIORITY), getreg32(NVIC_IRQ12_15_PRIORITY));
-  irqinfo("              %08x %08x %08x %08x\n",
+  irqinfo("              %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ16_19_PRIORITY), getreg32(NVIC_IRQ20_23_PRIORITY),
           getreg32(NVIC_IRQ24_27_PRIORITY),
           getreg32(NVIC_IRQ28_31_PRIORITY));
-  irqinfo("              %08x %08x %08x %08x\n",
+  irqinfo("              %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ32_35_PRIORITY), getreg32(NVIC_IRQ36_39_PRIORITY),
           getreg32(NVIC_IRQ40_43_PRIORITY),
           getreg32(NVIC_IRQ44_47_PRIORITY));
-  irqinfo("              %08x %08x %08x %08x\n",
+  irqinfo("              %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ48_51_PRIORITY), getreg32(NVIC_IRQ52_55_PRIORITY),
           getreg32(NVIC_IRQ56_59_PRIORITY),
           getreg32(NVIC_IRQ60_63_PRIORITY));
-  irqinfo("              %08x\n",
+  irqinfo("              %08" PRIx32 "\n",
           getreg32(NVIC_IRQ64_67_PRIORITY));
 
   leave_critical_section(flags);

--- a/arch/arm/src/stm32wb/stm32wb_irq.c
+++ b/arch/arm/src/stm32wb/stm32wb_irq.c
@@ -80,45 +80,50 @@ static void stm32wb_dumpnvic(const char *msg, int irq)
   flags = enter_critical_section();
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
-  irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
+  irqinfo("  INTCTRL:    %08" PRIx32 " VECTAB:  %08" PRIx32 "\n",
           getreg32(NVIC_INTCTRL), getreg32(NVIC_VECTAB));
 #if 0
-  irqinfo("  SYSH ENABLE MEMFAULT: %08x BUSFAULT: %08x USGFAULT: %08x "
-          "SYSTICK: %08x\n",
+  irqinfo("  SYSH ENABLE MEMFAULT: %08" PRIx32
+          " BUSFAULT: %08" PRIx32 " USGFAULT: %08" PRIx32 " "
+          "SYSTICK: %08" PRIx32 "\n",
           getreg32(NVIC_SYSHCON_MEMFAULTENA),
           getreg32(NVIC_SYSHCON_BUSFAULTENA),
           getreg32(NVIC_SYSHCON_USGFAULTENA),
           getreg32(NVIC_SYSTICK_CTRL_ENABLE));
 #endif
-  irqinfo("  IRQ ENABLE: %08x %08x %08x\n",
+  irqinfo("  IRQ ENABLE: %08" PRIx32 " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ0_31_ENABLE),
           getreg32(NVIC_IRQ32_63_ENABLE),
           getreg32(NVIC_IRQ64_95_ENABLE));
-  irqinfo("  SYSH_PRIO:  %08x %08x %08x\n",
+  irqinfo("  SYSH_PRIO:  %08" PRIx32 " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_SYSH4_7_PRIORITY),
           getreg32(NVIC_SYSH8_11_PRIORITY),
           getreg32(NVIC_SYSH12_15_PRIORITY));
-  irqinfo("  IRQ PRIO:   %08x %08x %08x %08x\n",
+  irqinfo("  IRQ PRIO:   %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ0_3_PRIORITY),
           getreg32(NVIC_IRQ4_7_PRIORITY),
           getreg32(NVIC_IRQ8_11_PRIORITY),
           getreg32(NVIC_IRQ12_15_PRIORITY));
-  irqinfo("              %08x %08x %08x %08x\n",
+  irqinfo("              %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ16_19_PRIORITY),
           getreg32(NVIC_IRQ20_23_PRIORITY),
           getreg32(NVIC_IRQ24_27_PRIORITY),
           getreg32(NVIC_IRQ28_31_PRIORITY));
-  irqinfo("              %08x %08x %08x %08x\n",
+  irqinfo("              %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ32_35_PRIORITY),
           getreg32(NVIC_IRQ36_39_PRIORITY),
           getreg32(NVIC_IRQ40_43_PRIORITY),
           getreg32(NVIC_IRQ44_47_PRIORITY));
-  irqinfo("              %08x %08x %08x %08x\n",
+  irqinfo("              %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ48_51_PRIORITY),
           getreg32(NVIC_IRQ52_55_PRIORITY),
           getreg32(NVIC_IRQ56_59_PRIORITY),
           getreg32(NVIC_IRQ60_63_PRIORITY));
-  irqinfo("              %08x\n",
+  irqinfo("              %08" PRIx32 "\n",
           getreg32(NVIC_IRQ64_67_PRIORITY));
 
   leave_critical_section(flags);

--- a/arch/arm/src/stm32wb/stm32wb_rtc.c
+++ b/arch/arm/src/stm32wb/stm32wb_rtc.c
@@ -139,24 +139,24 @@ static inline void rtc_enable_alarm(void);
 static void rtc_dumpregs(const char *msg)
 {
   rtcinfo("%s:\n", msg);
-  rtcinfo("      TR: %08x\n", getreg32(STM32WB_RTC_TR));
-  rtcinfo("      DR: %08x\n", getreg32(STM32WB_RTC_DR));
-  rtcinfo("      CR: %08x\n", getreg32(STM32WB_RTC_CR));
-  rtcinfo("     ISR: %08x\n", getreg32(STM32WB_RTC_ISR));
-  rtcinfo("    PRER: %08x\n", getreg32(STM32WB_RTC_PRER));
-  rtcinfo("    WUTR: %08x\n", getreg32(STM32WB_RTC_WUTR));
-  rtcinfo("  ALRMAR: %08x\n", getreg32(STM32WB_RTC_ALRMAR));
-  rtcinfo("  ALRMBR: %08x\n", getreg32(STM32WB_RTC_ALRMBR));
-  rtcinfo("  SHIFTR: %08x\n", getreg32(STM32WB_RTC_SHIFTR));
-  rtcinfo("    TSTR: %08x\n", getreg32(STM32WB_RTC_TSTR));
-  rtcinfo("    TSDR: %08x\n", getreg32(STM32WB_RTC_TSDR));
-  rtcinfo("   TSSSR: %08x\n", getreg32(STM32WB_RTC_TSSSR));
-  rtcinfo("    CALR: %08x\n", getreg32(STM32WB_RTC_CALR));
-  rtcinfo("  TAMPCR: %08x\n", getreg32(STM32WB_RTC_TAMPCR));
-  rtcinfo("ALRMASSR: %08x\n", getreg32(STM32WB_RTC_ALRMASSR));
-  rtcinfo("ALRMBSSR: %08x\n", getreg32(STM32WB_RTC_ALRMBSSR));
-  rtcinfo("      OR: %08x\n", getreg32(STM32WB_RTC_OR));
-  rtcinfo("MAGICREG: %08x\n", getreg32(RTC_MAGIC_REG));
+  rtcinfo("      TR: %08" PRIx32 "\n", getreg32(STM32WB_RTC_TR));
+  rtcinfo("      DR: %08" PRIx32 "\n", getreg32(STM32WB_RTC_DR));
+  rtcinfo("      CR: %08" PRIx32 "\n", getreg32(STM32WB_RTC_CR));
+  rtcinfo("     ISR: %08" PRIx32 "\n", getreg32(STM32WB_RTC_ISR));
+  rtcinfo("    PRER: %08" PRIx32 "\n", getreg32(STM32WB_RTC_PRER));
+  rtcinfo("    WUTR: %08" PRIx32 "\n", getreg32(STM32WB_RTC_WUTR));
+  rtcinfo("  ALRMAR: %08" PRIx32 "\n", getreg32(STM32WB_RTC_ALRMAR));
+  rtcinfo("  ALRMBR: %08" PRIx32 "\n", getreg32(STM32WB_RTC_ALRMBR));
+  rtcinfo("  SHIFTR: %08" PRIx32 "\n", getreg32(STM32WB_RTC_SHIFTR));
+  rtcinfo("    TSTR: %08" PRIx32 "\n", getreg32(STM32WB_RTC_TSTR));
+  rtcinfo("    TSDR: %08" PRIx32 "\n", getreg32(STM32WB_RTC_TSDR));
+  rtcinfo("   TSSSR: %08" PRIx32 "\n", getreg32(STM32WB_RTC_TSSSR));
+  rtcinfo("    CALR: %08" PRIx32 "\n", getreg32(STM32WB_RTC_CALR));
+  rtcinfo("  TAMPCR: %08" PRIx32 "\n", getreg32(STM32WB_RTC_TAMPCR));
+  rtcinfo("ALRMASSR: %08" PRIx32 "\n", getreg32(STM32WB_RTC_ALRMASSR));
+  rtcinfo("ALRMBSSR: %08" PRIx32 "\n", getreg32(STM32WB_RTC_ALRMBSSR));
+  rtcinfo("      OR: %08" PRIx32 "\n", getreg32(STM32WB_RTC_OR));
+  rtcinfo("MAGICREG: %08" PRIx32 "\n", getreg32(RTC_MAGIC_REG));
 }
 #else
 #  define rtc_dumpregs(msg)

--- a/arch/arm/src/stm32wl5/stm32wl5_irq.c
+++ b/arch/arm/src/stm32wl5/stm32wl5_irq.c
@@ -79,45 +79,50 @@ static void stm32wl5_dumpnvic(const char *msg, int irq)
   flags = enter_critical_section();
 
   irqinfo("NVIC (%s, irq=%d):\n", msg, irq);
-  irqinfo("  INTCTRL:    %08x VECTAB:  %08x\n",
+  irqinfo("  INTCTRL:    %08" PRIx32 " VECTAB:  %08" PRIx32 "\n",
           getreg32(NVIC_INTCTRL), getreg32(NVIC_VECTAB));
 #if 0
-  irqinfo("  SYSH ENABLE MEMFAULT: %08x BUSFAULT: %08x USGFAULT: %08x "
-          "SYSTICK: %08x\n",
+  irqinfo("  SYSH ENABLE MEMFAULT: %08" PRIx32
+          " BUSFAULT: %08" PRIx32 " USGFAULT: %08" PRIx32 " "
+          "SYSTICK: %08" PRIx32 "\n",
           getreg32(NVIC_SYSHCON_MEMFAULTENA),
           getreg32(NVIC_SYSHCON_BUSFAULTENA),
           getreg32(NVIC_SYSHCON_USGFAULTENA),
           getreg32(NVIC_SYSTICK_CTRL_ENABLE));
 #endif
-  irqinfo("  IRQ ENABLE: %08x %08x %08x\n",
+  irqinfo("  IRQ ENABLE: %08" PRIx32 " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ0_31_ENABLE),
           getreg32(NVIC_IRQ32_63_ENABLE),
           getreg32(NVIC_IRQ64_95_ENABLE));
-  irqinfo("  SYSH_PRIO:  %08x %08x %08x\n",
+  irqinfo("  SYSH_PRIO:  %08" PRIx32 " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_SYSH4_7_PRIORITY),
           getreg32(NVIC_SYSH8_11_PRIORITY),
           getreg32(NVIC_SYSH12_15_PRIORITY));
-  irqinfo("  IRQ PRIO:   %08x %08x %08x %08x\n",
+  irqinfo("  IRQ PRIO:   %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ0_3_PRIORITY),
           getreg32(NVIC_IRQ4_7_PRIORITY),
           getreg32(NVIC_IRQ8_11_PRIORITY),
           getreg32(NVIC_IRQ12_15_PRIORITY));
-  irqinfo("              %08x %08x %08x %08x\n",
+  irqinfo("              %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ16_19_PRIORITY),
           getreg32(NVIC_IRQ20_23_PRIORITY),
           getreg32(NVIC_IRQ24_27_PRIORITY),
           getreg32(NVIC_IRQ28_31_PRIORITY));
-  irqinfo("              %08x %08x %08x %08x\n",
+  irqinfo("              %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ32_35_PRIORITY),
           getreg32(NVIC_IRQ36_39_PRIORITY),
           getreg32(NVIC_IRQ40_43_PRIORITY),
           getreg32(NVIC_IRQ44_47_PRIORITY));
-  irqinfo("              %08x %08x %08x %08x\n",
+  irqinfo("              %08" PRIx32 " %08" PRIx32
+          " %08" PRIx32 " %08" PRIx32 "\n",
           getreg32(NVIC_IRQ48_51_PRIORITY),
           getreg32(NVIC_IRQ52_55_PRIORITY),
           getreg32(NVIC_IRQ56_59_PRIORITY),
           getreg32(NVIC_IRQ60_63_PRIORITY));
-  irqinfo("              %08x\n",
+  irqinfo("              %08" PRIx32 "\n",
           getreg32(NVIC_IRQ64_67_PRIORITY));
 
   leave_critical_section(flags);

--- a/drivers/usbhost/usbhost_storage.c
+++ b/drivers/usbhost/usbhost_storage.c
@@ -479,9 +479,9 @@ static void usbhost_dumpcbw(FAR struct usbmsc_cbw_s *cbw)
   int i;
 
   uinfo("CBW:\n");
-  uinfo("  signature: %08x\n", usbhost_getle32(cbw->signature));
-  uinfo("  tag:       %08x\n", usbhost_getle32(cbw->tag));
-  uinfo("  datlen:    %08x\n", usbhost_getle32(cbw->datlen));
+  uinfo("  signature: %08" PRIx32 "\n", usbhost_getle32(cbw->signature));
+  uinfo("  tag:       %08" PRIx32 "\n", usbhost_getle32(cbw->tag));
+  uinfo("  datlen:    %08" PRIx32 "\n", usbhost_getle32(cbw->datlen));
   uinfo("  flags:     %02x\n", cbw->flags);
   uinfo("  lun:       %02x\n", cbw->lun);
   uinfo("  cdblen:    %02x\n", cbw->cdblen);
@@ -499,9 +499,9 @@ static void usbhost_dumpcbw(FAR struct usbmsc_cbw_s *cbw)
 static void usbhost_dumpcsw(FAR struct usbmsc_csw_s *csw)
 {
   uinfo("CSW:\n");
-  uinfo("  signature: %08x\n", usbhost_getle32(csw->signature));
-  uinfo("  tag:       %08x\n", usbhost_getle32(csw->tag));
-  uinfo("  residue:   %08x\n", usbhost_getle32(csw->residue));
+  uinfo("  signature: %08" PRIx32 "\n", usbhost_getle32(csw->signature));
+  uinfo("  tag:       %08" PRIx32 "\n", usbhost_getle32(csw->tag));
+  uinfo("  residue:   %08" PRIx32 "\n", usbhost_getle32(csw->residue));
   uinfo("  status:    %02x\n", csw->status);
 }
 #endif


### PR DESCRIPTION

## Summary

Replace '%x' printf format specifier in code under arch/arm/stm32* directories with more portable PRIx32 where corresponding value is uint32_t type.
This PR  fixes potential format warnings due to arm GCC declaring uint32_t as a long unsigned int which requires '%lx' instead of the '%x' format specifier currently used.

## Impact

User experience: No adaptation required.
Build: No impact.
Hardware: Should not affect STM32-based boards.
Documentation: No impact.
Security: No impact.
Compatibility: No impact.

## Testing

Build Host:

+ OS: Ubuntu 24.04.4 LTS
+ Compiler: arm-none-eabi-gcc 13.2.1

Target:

```
Architecture: ARM (STM32H7x3ZIx)
Board: Nucleo-h743zi2
Configuration: Default nucleo-h743zi2:nsh 

Architecture: ARM (STM32F767ZITx)
Board: Nucleo-f767zi
Configuration: Default nucleo-h767zi:nsh

Architecture: ARM (STM32F446RETx)
Board: Nucleo-f446re
Configuration: Default nucleo-f446re:nsh 

```

Note, for each board configuration, following tweaks were performed after configuration/before build to enable ramlog and compile as much debug accessible via Kconfig:

```
kconfig-tweak --file .config --enable DEBUG_FEATURES
kconfig-tweak --file .config --enable DEBUG_IRQ --enable DEBUG_IRQ_INFO
kconfig-tweak --file .config --enable ARCH_IRQPRIO
kconfig-tweak --file .config --set-val TASK_NAME_SIZE 16
kconfig-tweak --file .config --disable SYSLOG_DEFAULT
kconfig-tweak --file .config --enable RAMLOG
kconfig-tweak --file .config --disable SYSLOG_INTBUFFER
kconfig-tweak --file .config --enable SYSLOG_TIMESTAMP
kconfig-tweak --file .config --enable SYSLOG_PROCESS_NAME
kconfig-tweak --file .config --enable RAMLOG_SYSLOG
kconfig-tweak --file .config --set-val SYSLOG_DEVPATH "/dev/kmsg"
kconfig-tweak --file .config --set-val RAMLOG_BUFSIZE 10240
# Enable debug
kconfig-tweak --file .config --enable DEBUG_BINFMT \
              --enable DEBUG_BINFMT_ERROR \
              --enable DEBUG_BINFMT_WARN \
              --enable DEBUG_BINFMT_INFO
kconfig-tweak --file .config --enable DEBUG_FS
              --enable DEBUG_FS_ERROR \
              --enable DEBUG_FS_WARN \
              --enable DEBUG_FS_INFO
kconfig-tweak --file .config --enable DEBUG_GRAPHICS
              --enable DEBUG_GRAPHICS_ERROR \
              --enable DEBUG_GRAPHICS_WARN \
              --enable DEBUG_GRAPHICS_INFO
kconfig-tweak --file .config --enable DEBUG_LIB \
              --enable DEBUG_LIB_ERROR \
              --enable DEBUG_LIB_WARN \
              --enable DEBUG_LIB_INFO
kconfig-tweak --file .config --enable DEBUG_MM \
              --enable DEBUG_MM_ERROR \
              --enable DEBUG_MM_WARN \
              --enable DEBUG_MM_INFO
kconfig-tweak --file .config --enable DEBUG_NET \
              --enable DEBUG_NET_ERROR \
              --enable DEBUG_NET_WARN \
              --enable DEBUG_NET_INFO
kconfig-tweak --file .config --enable DEBUG_POWER \
              --enable DEBUG_POWER_ERROR \
              --enable DEBUG_POWER_WARN \
              --enable DEBUG_POWER_INFO
kconfig-tweak --file .config --enable DEBUG_BATTERY \
              --enable DEBUG_BATTERY_ERROR \
              --enable DEBUG_BATTERY_WARN \
              --enable DEBUG_BATTERY_INFO
kconfig-tweak --file .config --enable DEBUG_IRQ \
              --enable DEBUG_IRQ_ERROR \
              --enable DEBUG_IRQ_WARN \
              --enable DEBUG_IRQ_INFO
kconfig-tweak --file .config --enable DEBUG_LEDS \
              --enable DEBUG_LEDS_ERROR \
              --enable DEBUG_LEDS_WARN \
              --enable DEBUG_LEDS_INFO
kconfig-tweak --file .config --enable DEBUG_INPUT \
              --enable DEBUG_INPUT_ERROR \
              --enable DEBUG_INPUT_WARN \
              --enable DEBUG_INPUT_INFO
kconfig-tweak --file .config --enable DEBUG_GPIO \
              --enable DEBUG_GPIO_ERROR \
              --enable DEBUG_GPIO_WARN \
              --enable DEBUG_GPIO_INFO
kconfig-tweak --file .config --enable DEBUG_THERMAL \
              --enable DEBUG_THERMAL_ERROR \
              --enable DEBUG_THERMAL_WARN \
              --enable DEBUG_THERMAL_INFO
kconfig-tweak --file .config --enable DEBUG_TIMER \
              --enable DEBUG_TIMER_ERROR \
              --enable DEBUG_TIMER_WARN \
              --enable DEBUG_TIMER_INFO
kconfig-tweak --file .config --enable DEBUG_USB \
              --enable DEBUG_USB_ERROR \
              --enable DEBUG_USB_WARN \
              --enable DEBUG_USB_INFO
kconfig-tweak --file .config --enable DEBUG_IPC
              --enable DEBUG_IPC_ERROR \
              --enable DEBUG_IPC_WARN \
              --enable DEBUG_IPC_INFO

make olddefconfig
```
nucleo-h743zi2:
```

NuttShell (NSH) NuttX-12.13.0-RC0
nsh> uname -a
NuttX 12.13.0-RC0 c9ff03d8a6-dirty Mar 31 2026 15:23:25 arm nucleo-h743zi2
nsh> dmesg
[    0.000000] Idle_Task: up_allocate_heap: 494Kb of SRAM at 0x240045e8
[    0.000000] Idle_Task: mm_initialize_heap: Heap: name=Umem, start=0x240045e8 size=506392
[    0.000000] Idle_Task: mm_addregion: Region 1: base=0x24004760 size=506016
[    0.000000] Idle_Task: mm_malloc: Allocated 0x24004770, size 72
[    0.000000] Idle_Task: mm_malloc: Allocated 0x240047b8, size 48
[    0.000000] Idle_Task: stm32_dumpnvic: NVIC (initial, irq=179):
[    0.000000] Idle_Task: stm32_dumpnvic:   INTCTRL:    00000000 VECTAB:  08000000
[    0.000000] Idle_Task: stm32_dumpnvic:   IRQ ENAB 0: 00000000 00000000 00000000 00000000
[    0.000000] Idle_Task: stm32_dumpnvic:          128: 00000000 00000000
[    0.000000] Idle_Task: stm32_dumpnvic:   SYSH_PRIO:  00808080 70000000 80800080
[    0.000000] Idle_Task: stm32_dumpnvic:   IRQ PRIO 0: 80808080 80808080 80808080 80808080
[    0.000000] Idle_Task: stm32_dumpnvic:           16: 80808080 80808080 80808080 80808080
[    0.000000] Idle_Task: stm32_dumpnvic:           32: 80808080 80808080 80808080 80808080
[    0.000000] Idle_Task: stm32_dumpnvic:           48: 80808080 80808080 80808080 80808080
[    0.000000] Idle_Task: stm32_dumpnvic:           64: 80808080 80808080 80808080 80808080
[    0.000000] Idle_Task: stm32_dumpnvic:           80: 80808080 80808080 80808080 80808080
[    0.000000] Idle_Task: stm32_dumpnvic:           96: 80808080 80808080 80808080 80808080
[    0.000000] Idle_Task: stm32_dumpnvic:          112: 80808080 80808080 80808080 80808080
[    0.000000] Idle_Task: stm32_dumpnvic:          128: 80808080 80808080 80808080 80808080
[    0.000000] Idle_Task: stm32_dumpnvic:          144: 80808080 00008080 00000000 00000000
[    0.000000] Idle_Task: stm32_dumpnvic:          160: 00000000
[    0.000000] Idle_Task: builtin_initialize: Registering Builtin Loader
[    0.000000] Idle_Task: addregion: 288Kb of SRAM1,2,3 at 0x30000000
[    0.000000] Idle_Task: mm_addregion: Region 2: base=0x30000000 size=294912
[    0.000000] Idle_Task: addregion: 64Kb of SRAM4 at 0x38000000
[    0.000000] Idle_Task: mm_addregion: Region 3: base=0x38000000 size=65536
[    0.000000] Idle_Task: addregion: 128Kb of DTCM at 0x20000000
[    0.000000] Idle_Task: mm_addregion: Region 4: base=0x20000000 size=131072
[    0.000000] Idle_Task: mm_malloc: Allocated 0x38000010, size 48
[    0.000000] Idle_Task: mm_malloc: Allocated 0x38000040, size 56
[    0.000000] Idle_Task: mm_malloc: Allocated 0x38000078, size 56
[    0.000000] Idle_Task: mm_malloc: Allocated 0x380000b0, size 48
[    0.000000] Idle_Task: mm_malloc: Allocated 0x380000e0, size 48
[    0.000000] Idle_Task: mm_malloc: Allocated 0x38000110, size 48
[    0.000000] Idle_Task: mm_malloc: Allocated 0x38000140, size 24
[    0.000000] Idle_Task: mm_malloc: Allocated 0x38000158, size 16
[    0.000000] Idle_Task: mm_malloc: Allocated 0x38000168, size 32
[    0.000000] Idle_Task: mm_malloc: Allocated 0x38000188, size 192
[    0.000000] Idle_Task: mm_malloc: Allocated 0x38000248, size 696
[    0.000000] Idle_Task: mm_malloc: Allocated 0x38000500, size 32
[    0.000000] Idle_Task: mm_malloc: Allocated 0x38000520, size 16
[    0.000000] Idle_Task: mm_malloc: Allocated 0x38000530, size 2056
[    0.000000] nsh_main: mm_malloc: Allocated 0x38000d38, size 768
[   10.300000] nsh_main: mm_malloc: Allocated 0x38001038, size 24
[   10.300000] nsh_main: mm_malloc: Allocated 0x38001050, size 24
[   10.300000] nsh_main: mm_malloc: Allocated 0x38001068, size 520
nsh>

```
nucle0-f767zi:
```
NuttShell (NSH) NuttX-12.13.0-RC0
nsh> uname -a
NuttX 12.13.0-RC0 c9ff03d8a6-dirty Mar 31 2026 16:27:29 arm nucleo-f767zi
nsh> dmesg
[    0.000000] Idle_Task: mm_initialize_heap: Heap: name=Umem, start=0x200243c8 size=359480
[    0.000000] Idle_Task: mm_addregion: Region 1: base=0x20024538 size=359112
[    0.000000] Idle_Task: mm_malloc: Allocated 0x20024548, size 72
[    0.000000] Idle_Task: mm_malloc: Allocated 0x20024590, size 48
[    0.000000] Idle_Task: stm32_dumpnvic: NVIC (initial, irq=126):
[    0.000000] Idle_Task: stm32_dumpnvic:   INTCTRL:    00000000 VECTAB:  08000000
[    0.000000] Idle_Task: stm32_dumpnvic:   IRQ ENAB 0: 00000000 00000000 00000000 00000000
[    0.000000] Idle_Task: stm32_dumpnvic:   SYSH_PRIO:  00808080 70000000 80800080
[    0.000000] Idle_Task: stm32_dumpnvic:   IRQ PRIO 0: 80808080 80808080 80808080 80808080
[    0.000000] Idle_Task: stm32_dumpnvic:           16: 80808080 80808080 80808080 80808080
[    0.000000] Idle_Task: stm32_dumpnvic:           32: 80808080 80808080 80808080 80808080
[    0.000000] Idle_Task: stm32_dumpnvic:           48: 80808080 80808080 80808080 80808080
[    0.000000] Idle_Task: stm32_dumpnvic:           64: 80808080 80808080 80808080 80808080
[    0.000000] Idle_Task: stm32_dumpnvic:           80: 80808080 80808080 80808080 80808080
[    0.000000] Idle_Task: stm32_dumpnvic:           96: 80808080 80808080 80808080 00008080
[    0.000000] Idle_Task: builtin_initialize: Registering Builtin Loader
[    0.000000] Idle_Task: mm_addregion: Region 2: base=0x2007c000 size=16384
[    0.000000] Idle_Task: mm_addregion: Region 3: base=0x20000000 size=131072
[    0.000000] Idle_Task: mm_malloc: Allocated 0x2007c010, size 48
[    0.000000] Idle_Task: mm_malloc: Allocated 0x2007c040, size 56
[    0.000000] Idle_Task: mm_malloc: Allocated 0x2007c078, size 56
[    0.000000] Idle_Task: mm_malloc: Allocated 0x2007c0b0, size 48
[    0.000000] Idle_Task: mm_malloc: Allocated 0x2007c0e0, size 48
[    0.000000] Idle_Task: mm_malloc: Allocated 0x2007c110, size 48
[    0.000000] Idle_Task: mm_malloc: Allocated 0x2007c140, size 24
[    0.000000] Idle_Task: mm_malloc: Allocated 0x2007c158, size 16
[    0.000000] Idle_Task: mm_malloc: Allocated 0x2007c168, size 32
[    0.000000] Idle_Task: mm_malloc: Allocated 0x2007c188, size 192
[    0.000000] Idle_Task: mm_malloc: Allocated 0x2007c248, size 696
[    0.000000] Idle_Task: mm_malloc: Allocated 0x2007c500, size 32
[    0.000000] Idle_Task: mm_malloc: Allocated 0x2007c520, size 16
[    0.000000] Idle_Task: mm_malloc: Allocated 0x2007c530, size 2056
[    0.000000] nsh_main: mm_malloc: Allocated 0x2007cd38, size 768
[    5.830000] nsh_main: mm_malloc: Allocated 0x2007d038, size 24
[    5.830000] nsh_main: mm_malloc: Allocated 0x2007d050, size 24
[    5.830000] nsh_main: mm_malloc: Allocated 0x2007d068, size 520
nsh>
```
nucleo-f446re:
```
NuttShell (NSH) NuttX-12.13.0-RC0
nsh> uname -a
NuttX 12.13.0-RC0 c9ff03d8a6-dirty Mar 31 2026 16:48:33 arm nucleo-f446re
nsh> dmesg
[    0.000000] Idle_Task: mm_initialize_heap: Heap: name=Umem, start=0x20005220 size=110048
[    0.000000] Idle_Task: mm_addregion: Region 1: base=0x2000537c size=109696
[    0.000000] Idle_Task: mm_malloc: Allocated 0x20005390, size 72
[    0.000000] Idle_Task: mm_malloc: Allocated 0x200053d8, size 48
[    0.000000] Idle_Task: stm32_dumpnvic: NVIC (initial, irq=113):
[    0.000000] Idle_Task: stm32_dumpnvic:   INTCTRL:    00000000 VECTAB:  08000000
[    0.000000] Idle_Task: stm32_dumpnvic:   IRQ ENAB 0: 00000000 00000000 00000000 00000000
[    0.000000] Idle_Task: stm32_dumpnvic:   SYSH_PRIO:  00808080 70000000 80800080
[    0.000000] Idle_Task: stm32_dumpnvic:   IRQ PRIO 0: 80808080 80808080 80808080 80808080
[    0.000000] Idle_Task: stm32_dumpnvic:           16: 80808080 80808080 80808080 80808080
[    0.000000] Idle_Task: stm32_dumpnvic:           32: 80808080 80808080 80808080 80808080
[    0.000000] Idle_Task: stm32_dumpnvic:           48: 80808080 80808080 80808080 80808080
[    0.000000] Idle_Task: stm32_dumpnvic:           64: 80808080 80808080 80808080 80808080
[    0.000000] Idle_Task: stm32_dumpnvic:           80: 80808080 80808080 80808080 80808080
[    0.000000] Idle_Task: stm32_dumpnvic:           96: 00000080
[    0.000000] Idle_Task: builtin_initialize: Registering Builtin Loader
[    0.000000] Idle_Task: mm_malloc: Allocated 0x20005408, size 48
[    0.000000] Idle_Task: mm_malloc: Allocated 0x20005438, size 56
[    0.000000] Idle_Task: mm_malloc: Allocated 0x20005470, size 56
[    0.000000] Idle_Task: mm_malloc: Allocated 0x200054a8, size 48
[    0.000000] Idle_Task: mm_malloc: Allocated 0x200054d8, size 48
[    0.000000] Idle_Task: mm_malloc: Allocated 0x20005508, size 48
[    0.000000] Idle_Task: mm_malloc: Allocated 0x20005538, size 24
[    0.000000] Idle_Task: mm_malloc: Allocated 0x20005550, size 16
[    0.000000] Idle_Task: mm_malloc: Allocated 0x20005560, size 32
[    0.000000] Idle_Task: mm_malloc: Allocated 0x20005580, size 192
[    0.000000] Idle_Task: mm_malloc: Allocated 0x20005640, size 696
[    0.000000] Idle_Task: mm_malloc: Allocated 0x200058f8, size 32
[    0.000000] Idle_Task: mm_malloc: Allocated 0x20005918, size 16
[    0.000000] Idle_Task: mm_malloc: Allocated 0x20005928, size 2056
[    0.000000] nsh_main: mm_malloc: Allocated 0x20006130, size 768
[    8.300000] nsh_main: mm_malloc: Allocated 0x20006430, size 24
[    8.300000] nsh_main: mm_malloc: Allocated 0x20006448, size 24
[    8.300000] nsh_main: mm_malloc: Allocated 0x20006460, size 520
nsh>
```
using modifid tools/testbuild.sh compile-tested across all stm32:nsh configurations
