### PR TITLE
build.yml: Fix No files were found with the provided path

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -190,6 +190,8 @@ jobs:
           BLOBDIR: /tools/blobs
         with:
           run: |
+            export ARTIFACTDIR=`pwd`/buildartifacts
+
             pip install ntfc==0.0.1
             mkdir /github/workspace/nuttx-ntfc
             mkdir /github/workspace/nuttx-ntfc/external
@@ -197,10 +199,9 @@ jobs:
             # get NTFC test cases
             cd external
             git clone -b release-0.0.1 https://github.com/szafonimateusz-mi/nuttx-testing
+            export NTFCDIR=/github/workspace/nuttx-ntfc
 
             echo "::add-matcher::sources/nuttx/.github/gcc.json"
-            export ARTIFACTDIR=`pwd`/buildartifacts
-            export NTFCDIR=/github/workspace/nuttx-ntfc
             git config --global --add safe.directory /github/workspace/sources/nuttx
             git config --global --add safe.directory /github/workspace/sources/apps
             cd /github/workspace/sources/nuttx/tools/ci


### PR DESCRIPTION
## Summary

Fix

**Warning: No files were found with the provided path: buildartifacts/.**


```
Run actions/upload-artifact@v7.0.0
  with:
    name: linux-other-builds
    path: buildartifacts/
    if-no-files-found: warn
    compression-level: 6
    overwrite: false
    include-hidden-files: false
    archive: true
  env:
    DOCKER_BUILDKIT: 1
    nuttx_sha: a3b5fe0eda44cb00e4ed096cdc2e03bfd5c3cc00
Warning: No files were found with the provided path: buildartifacts/. No artifacts will be uploaded.
```

https://github.com/apache/nuttx/actions/runs/23833337478

## Impact

- Impact on user: NO
- Impact on build: NO
- Impact on hardware: NO
- Impact on documentation: NO
- Impact on security: NO
- Impact on compatibility: NO

## Testing

GitHub

https://github.com/simbit18/nuttx_test_pr/actions/runs/23850147075