### PR TITLE
net/can,udp: fix conn unlock position in callback

### DIFF
--- a/net/can/can_callback.c
+++ b/net/can/can_callback.c
@@ -152,7 +152,6 @@ uint32_t can_callback(FAR struct net_driver_s *dev,
 
       conn_lock(&conn->sconn);
       flags = devif_conn_event(dev, flags, conn->sconn.list);
-      conn_unlock(&conn->sconn);
 
       /* Either we did not get the lock or there is no application listening
        * If we did not get a lock we store the frame in the read-ahead buffer
@@ -164,6 +163,8 @@ uint32_t can_callback(FAR struct net_driver_s *dev,
 
           flags = can_data_event(dev, conn, flags);
         }
+
+      conn_unlock(&conn->sconn);
     }
 
   return flags;

--- a/net/udp/udp_callback.c
+++ b/net/udp/udp_callback.c
@@ -319,7 +319,6 @@ uint32_t udp_callback(FAR struct net_driver_s *dev,
 
       conn_lock(&conn->sconn);
       flags = devif_conn_event(dev, flags, conn->sconn.list);
-      conn_unlock(&conn->sconn);
 
       if ((flags & UDP_NEWDATA) != 0)
         {
@@ -327,6 +326,8 @@ uint32_t udp_callback(FAR struct net_driver_s *dev,
 
           flags = net_dataevent(dev, conn, flags);
         }
+
+      conn_unlock(&conn->sconn);
     }
 
   return flags;


### PR DESCRIPTION
## Summary
Move conn_unlock() after the data event handling in can_callback() and udp_callback().

## Impact
Previously, the connection lock was released immediately after devif_conn_event(), leaving the subsequent can_data_event() / net_dataevent() and read-ahead buffer operations unprotected. This could lead to a race condition where another context modifies the connection state while data is being stored into the read-ahead buffer.

This PR moves conn_unlock() to after the entire callback processing is complete, ensuring the connection remains locked during both the event dispatch and the data buffering phases.

## Testing
Build and runtime test on CAN and UDP network configurations. Verified no deadlock or lock ordering issues introduced by extending the lock hold duration. And the issue that high-priority recv after poll fails to read data has also been resolved.
