### PR TITLE
graphics/nxglib: use putarea for lcd copyrectangle when available

### DIFF
--- a/graphics/nxglib/lcd/nxglib_copyrectangle.c
+++ b/graphics/nxglib/lcd/nxglib_copyrectangle.c
@@ -75,8 +75,18 @@ void NXGL_FUNCNAME(nxgl_copyrectangle, NXGLIB_SUFFIX)
   xoffset = dest->pt1.x - origin->x;
   sline = (FAR const uint8_t *)src + NXGL_SCALEX(xoffset) +
            (dest->pt1.y - origin->y) * srcstride;
+
 #if NXGLIB_BITSPERPIXEL < 8
   remainder = NXGL_REMAINDERX(xoffset);
+#else
+  if (pinfo->putarea != NULL)
+    {
+      pinfo->putarea(pinfo->dev,
+                     dest->pt1.y, dest->pt2.y,
+                     dest->pt1.x, dest->pt2.x,
+                     sline, srcstride);
+      return;
+    }
 #endif
 
   /* Copy the image, one row at a time */


### PR DESCRIPTION
## Summary

When `nxgl_copyrectangle` draws a bitmap onto an LCD via the NX graphics subsystem, it currently iterates row by row, calling `putrun()` for each scanline. Each `putrun()` call on a typical SPI LCD (e.g. ST7789) must send CASET + RASET commands to set the display window before sending pixel data, adding significant per-row overhead.

LCD drivers that implement the `putarea()` callback can accept an entire rectangular region in a single call, setting the display window once for the whole rectangle.

This change adds a fast path in `nxgl_copyrectangle`: when `NXGLIB_BITSPERPIXEL >= 8` and `pinfo->putarea` is non-NULL, delegate the entire copy to `putarea()` and return immediately, bypassing the per-row loop. For sub-byte pixel formats (< 8 bpp), the existing `putrun()` path with bit-alignment handling is preserved unchanged.

## Impact

- **Performance**: On an ESP32-S3 + ST7789 SPI LCD (40 MHz, 320x240 RGB565), full-screen `nx_bitmap()` draw time dropped from ~2210 ms to ~50 ms (~44x improvement) by eliminating 240 redundant CASET/RASET SPI transactions.
- **Compatibility**: No behavior change for LCD drivers that do not implement `putarea()` (the pointer is NULL, fallback to existing `putrun()` loop). No change for sub-byte pixel formats (1/2/4 bpp).
- **Build**: No new Kconfig options. No additional memory usage.

## Testing

**Host**: Ubuntu x86_64  
**Board**: lckfb-szpi-esp32s3 (ESP32-S3-WROOM-1-N16R8)  
**Display**: ST7789 320x240 SPI LCD (40 MHz, RGB565)  
**Config**: `lckfb-szpi-esp32s3:camera`

Ran the `camera` example application in continuous preview mode (`camera 0`), which calls `nx_bitmap()` for every frame from a QVGA camera (320x240 RGB565):

```
nsh> camera 0
nximage_listener: Connected
nximage_initialize: Screen resolution (320,240)
Start video this mode is eternal. (Non stop, non save files.)
DQBUF 70ms draw 50ms QBUF 0ms
DQBUF 40ms draw 50ms QBUF 0ms
DQBUF 30ms draw 50ms QBUF 0ms
DQBUF 30ms draw 50ms QBUF 0ms
DQBUF 40ms draw 50ms QBUF 0ms
DQBUF 30ms draw 50ms QBUF 0ms
DQBUF 30ms draw 50ms QBUF 0ms
DQBUF 40ms draw 50ms QBUF 0ms
```

The `draw` column shows the time spent inside `nx_bitmap()` → `nxgl_copyrectangle` → `putarea`. Before this change, `draw` was ~2210 ms per frame; after, it is consistently ~50 ms.