### PR TITLE
drivers/mtd/mx25rxx.c: use 4 byte address for large flash memories.

### DIFF
--- a/drivers/mtd/mx25rxx.c
+++ b/drivers/mtd/mx25rxx.c
@@ -91,6 +91,8 @@
 #define MX25R_SBL_ALT     0x77  /* Set Burst Length         */
 #define MX25R_NOP         0x00  /* No Operation             */
 
+#define MX25R_EN4B        0xb7  /* Enter 4-byte mode        */
+
 /* MX25Rxx Registers */
 
 /* Read ID (RDID) register values */
@@ -110,28 +112,35 @@
 #define MX25R_JEDEC_MX25R6435F_CAPACITY  0x17  /* MX25R6435F memory capacity */
 #define MX25R_JEDEC_MX25R8035F_CAPACITY  0x14  /* MX25R8035F memory capacity */
 
+/* Parts larger than 128Mbit require 4-byte addressing */
+
+#define MX25R_ADDRESSBYTES_3        (3)
+#define MX25R_ADDRESSBYTES_4        (4)
+
 /* Supported chips parameters */
 
 /* MX25R6435F (64 MB) memory capacity */
 
 #define MX25R6435F_SECTOR_SIZE      (4*1024)
 #define MX25R6435F_SECTOR_SHIFT     (12)
+#define MX25R6435F_ADDRESS_BYTES    MX25R_ADDRESSBYTES_3
 #define MX25R6435F_SECTOR_COUNT     (2048)
 #define MX25R6435F_PAGE_SIZE        (256)
 
 /* MX25L25673G (256 MB) memory capacity */
 
-#define MX25L25673G_SECTOR_SIZE      (4*1024)
-#define MX25L25673G_SECTOR_SHIFT     (12)
-#define MX25L25673G_SECTOR_COUNT     (8192)
-#define MX25L25673G_PAGE_SIZE        (256)
+#define MX25L25673G_SECTOR_SIZE     (4*1024)
+#define MX25L25673G_SECTOR_SHIFT    (12)
+#define MX25L25673G_ADDRESS_BYTES   MX25R_ADDRESSBYTES_4
+#define MX25L25673G_SECTOR_COUNT    (8192)
+#define MX25L25673G_PAGE_SIZE       (256)
 
 #ifdef CONFIG_MX25RXX_PAGE128
-#  define MX25R6435F_PAGE_SHIFT      (7)
-#  define MX25L25673G_PAGE_SHIFT     (7)
+#  define MX25R6435F_PAGE_SHIFT     (7)
+#  define MX25L25673G_PAGE_SHIFT    (7)
 #else
-#  define MX25R6435F_PAGE_SHIFT      (8)
-#  define MX25L25673G_PAGE_SHIFT     (8)
+#  define MX25R6435F_PAGE_SHIFT     (8)
+#  define MX25L25673G_PAGE_SHIFT    (8)
 #endif
 
 /* Status register bit definitions */
@@ -181,19 +190,20 @@
 
 struct mx25rxx_dev_s
 {
-  struct mtd_dev_s       mtd;         /* MTD interface */
-  FAR struct qspi_dev_s *qspi;        /* QuadSPI interface */
+  struct mtd_dev_s       mtd;          /* MTD interface */
+  FAR struct qspi_dev_s *qspi;         /* QuadSPI interface */
 
-  FAR uint8_t           *cmdbuf;      /* Allocated command buffer */
+  FAR uint8_t           *cmdbuf;       /* Allocated command buffer */
 
-  uint8_t                sectorshift; /* Log2 of sector size */
-  uint8_t                pageshift;   /* Log2 of page size */
-  uint16_t               nsectors;    /* Number of erase sectors */
+  uint8_t                sectorshift;  /* Log2 of sector size */
+  uint8_t                pageshift;    /* Log2 of page size */
+  uint8_t                addressbytes; /* Number of address bytes required */
+  uint16_t               nsectors;     /* Number of erase sectors */
 
 #ifdef CONFIG_MX25RXX_SECTOR512
-  uint8_t                flags;       /* Buffered sector flags */
-  uint16_t               esectno;     /* Erase sector number in the cache */
-  FAR uint8_t           *sector;      /* Allocated sector data */
+  uint8_t                flags;        /* Buffered sector flags */
+  uint16_t               esectno;      /* Erase sector number in the cache */
+  FAR uint8_t           *sector;       /* Allocated sector data */
 #endif
 };
 
@@ -370,7 +380,7 @@ int mx25rxx_read_byte(FAR struct mx25rxx_dev_s *dev, FAR uint8_t *buffer,
   finfo("address: %08lx nbytes: %d\n", (long)address, (int)buflen);
 
   meminfo.flags   = QSPIMEM_READ | QSPIMEM_QUADIO;
-  meminfo.addrlen = 3;
+  meminfo.addrlen = dev->addressbytes;
 
   /* Ignore performance enhanced mode => 2+4 dummies */
 
@@ -403,7 +413,7 @@ int mx25rxx_write_page(FAR struct mx25rxx_dev_s *priv,
 
   meminfo.flags   = QSPIMEM_WRITE | QSPIMEM_QUADIO;
   meminfo.cmd     = MX25R_4PP;
-  meminfo.addrlen = 3;
+  meminfo.addrlen = priv->addressbytes;
   meminfo.buflen  = pagesize;
   meminfo.dummies = 0;
 
@@ -461,7 +471,7 @@ int mx25rxx_erase_sector(FAR struct mx25rxx_dev_s *priv, off_t sector)
   /* Send the sector erase command */
 
   mx25rxx_write_enable(priv, true);
-  mx25rxx_command_address(priv->qspi, MX25R_SE, address, 3);
+  mx25rxx_command_address(priv->qspi, MX25R_SE, address, priv->addressbytes);
 
   /* Wait for erasure to finish */
 
@@ -865,15 +875,17 @@ int mx25rxx_readid(FAR struct mx25rxx_dev_s *dev)
   switch (dev->cmdbuf[2])
     {
       case MX25R_JEDEC_MX25R6435F_CAPACITY:
-        dev->sectorshift = MX25R6435F_SECTOR_SHIFT;
-        dev->pageshift   = MX25R6435F_PAGE_SHIFT;
-        dev->nsectors    = MX25R6435F_SECTOR_COUNT;
+        dev->sectorshift  = MX25R6435F_SECTOR_SHIFT;
+        dev->pageshift    = MX25R6435F_PAGE_SHIFT;
+        dev->addressbytes = MX25R6435F_ADDRESS_BYTES;
+        dev->nsectors     = MX25R6435F_SECTOR_COUNT;
         break;
 
       case MX25R_JEDEC_MX25L25673G_CAPACITY:
-        dev->sectorshift = MX25L25673G_SECTOR_SHIFT;
-        dev->pageshift   = MX25L25673G_PAGE_SHIFT;
-        dev->nsectors    = MX25L25673G_SECTOR_COUNT;
+        dev->sectorshift  = MX25L25673G_SECTOR_SHIFT;
+        dev->pageshift    = MX25L25673G_PAGE_SHIFT;
+        dev->addressbytes = MX25L25673G_ADDRESS_BYTES;
+        dev->nsectors     = MX25L25673G_SECTOR_COUNT;
         break;
 
       default:
@@ -1186,6 +1198,13 @@ FAR struct mtd_dev_s *mx25rxx_initialize(FAR struct qspi_dev_s *qspi,
 #endif
 
   mx25rxx_lock(dev->qspi, false);
+
+  /* Set MTD device in 4 byte address mode if required. */
+
+  if (dev->addressbytes == MX25R_ADDRESSBYTES_4)
+    {
+      mx25rxx_command(dev->qspi, MX25R_EN4B);
+    }
 
   /* Set MTD device in low power mode, with minimum dummy cycles */
 


### PR DESCRIPTION
## Summary

On power-up, MX25L25673G uses 3-byte addresses, so only the lower 128Mb (half the memory) can be accessed. This change ensures 4-byte addresses are used so the whole memory can be used.

## Impact

Without this patch, using  MX25L25673G is dangerous: the file-system might try to use/remove blocks higher than 4095, but
as only 3 bytes are used for the address, this folds onto the lower half of the memory, which will get overwritten. This can produce
data loss and/or corruption.

## Testing

On a nucleo-h563zi, with a MX25L25673G attached soldered to the connectors:
```
#define GPIO_QSPI_CS    (GPIO_OCTOSPI1_NCS_1)                  /* PE11 */
#define GPIO_QSPI_SCK   (GPIO_OCTOSPI1_CLK_5|GPIO_SPEED_50MHZ) /* PF10 */
#define GPIO_QSPI_IO0   (GPIO_OCTOSPI1_IO0_2|GPIO_SPEED_50MHZ) /* PC3 */
#define GPIO_QSPI_IO1   (GPIO_OCTOSPI1_IO1_1|GPIO_SPEED_50MHZ) /* PB0 */
#define GPIO_QSPI_IO2   (GPIO_OCTOSPI1_IO2_2|GPIO_SPEED_50MHZ) /* PC2 */
#define GPIO_QSPI_IO3   (GPIO_OCTOSPI1_IO3_3|GPIO_SPEED_50MHZ) /* PD13 */

#define STM32_RCC_CCIPR4_OCTOSPI1SEL RCC_CCIPR4_OCTOSPI1SEL_PLL1QCK
#define STM32_QSPI_FREQUENCY STM32_PLL1Q_FREQUENCY
```
And littlefs initialized:
```
  qspi = stm32_qspi_initialize(0);
  [...]
  mtd = mx25rxx_initialize(qspi, true /* unprotect */);
  [...]
  mkdir("/data", 0777);
  ret = mount("/dev/mtd0", "/data", "littlefs",
             0, "forceformat");
```

After boot, I set a breakpoint in `mx25rxx_bread` and access the littlefs filesystem (`ls data`) in the nsh prompt, causing the breakpoint to trigger:
```
Breakpoint 1, mx25rxx_bread (dev=0x20004650, startblock=0, nblocks=4, buf=0x20004800 "") at mtd/mx25rxx.c:651
651	  FAR struct mx25rxx_dev_s *priv = (FAR struct mx25rxx_dev_s *)dev;
(gdb) dis
(gdb) call mx25rxx_bread(0x20004650,0,1,0x20004800)
$1 = 1
(gdb) x/32 0x20004800
0x20004800:	0x00000aff	0xf7ff0ff0	0x7474696c	0x7366656c
0x20004810:	0x1000e02f	0x00020000	0x00001000	0x00002000
0x20004820:	0x00000020	0x7fffffff	0x000003fe	0xc8ff1f70
0x20004830:	0x9307be06	0xffffffff	0xffffffff	0xffffffff
0x20004840:	0xffffffff	0xffffffff	0xffffffff	0xffffffff
0x20004850:	0xffffffff	0xffffffff	0xffffffff	0xffffffff
0x20004860:	0xffffffff	0xffffffff	0xffffffff	0xffffffff
0x20004870:	0xffffffff	0xffffffff	0xffffffff	0xffffffff
(gdb) call mx25rxx_erase_sector(0x20004650, 4096)
$2 = 0
(gdb) call mx25rxx_bread(0x20004650,0,1,0x20004800)
$3 = 1
(gdb) x/32 0x20004800
0x20004800:	0xffffffff	0xffffffff	0xffffffff	0xffffffff
0x20004810:	0xffffffff	0xffffffff	0xffffffff	0xffffffff
0x20004820:	0xffffffff	0xffffffff	0xffffffff	0xffffffff
0x20004830:	0xffffffff	0xffffffff	0xffffffff	0xffffffff
0x20004840:	0xffffffff	0xffffffff	0xffffffff	0xffffffff
0x20004850:	0xffffffff	0xffffffff	0xffffffff	0xffffffff
0x20004860:	0xffffffff	0xffffffff	0xffffffff	0xffffffff
0x20004870:	0xffffffff	0xffffffff	0xffffffff	0xffffffff
(gdb) 
```
Erasing sector 4096 has folded and erased sector 0 instead.

After the patch:
```
Breakpoint 1, mx25rxx_bread (dev=0x20004650, startblock=0, nblocks=1, buf=0x20004808 "\355\016") at mtd/mx25rxx.c:661
661	  FAR struct mx25rxx_dev_s *priv = (FAR struct mx25rxx_dev_s *)dev;
(gdb) dis
(gdb) call mx25rxx_bread(0x20004650,0,1,0x20004808)
$1 = 1
(gdb) x/32 0x20004808
0x20004808:	0x00000eec	0xf7ff0ff0	0x7474696c	0x7366656c
0x20004818:	0x1000e02f	0x00020000	0x00001000	0x00002000
0x20004828:	0x00000020	0x7fffffff	0x000003fe	0xc8ff1f70
0x20004838:	0xc6bc61f5	0xffffffff	0xffffffff	0xffffffff
0x20004848:	0xffffffff	0xffffffff	0xffffffff	0xffffffff
0x20004858:	0xffffffff	0xffffffff	0xffffffff	0xffffffff
0x20004868:	0xffffffff	0xffffffff	0xffffffff	0xffffffff
0x20004878:	0xffffffff	0xffffffff	0xffffffff	0xffffffff
(gdb) call mx25rxx_erase_sector(0x20004650, 4096)
$2 = 0
(gdb) call mx25rxx_bread(0x20004650,0,1,0x20004808)
$3 = 1
(gdb) x/32 0x20004808
0x20004808:	0x00000eec	0xf7ff0ff0	0x7474696c	0x7366656c
0x20004818:	0x1000e02f	0x00020000	0x00001000	0x00002000
0x20004828:	0x00000020	0x7fffffff	0x000003fe	0xc8ff1f70
0x20004838:	0xc6bc61f5	0xffffffff	0xffffffff	0xffffffff
0x20004848:	0xffffffff	0xffffffff	0xffffffff	0xffffffff
0x20004858:	0xffffffff	0xffffffff	0xffffffff	0xffffffff
0x20004868:	0xffffffff	0xffffffff	0xffffffff	0xffffffff
0x20004878:	0xffffffff	0xffffffff	0xffffffff	0xffffffff
```

Now erasing sector 4096 works as expected, and sector 0 is untouched.

