### PR TITLE
github/build.yml: improve ntfc installation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,7 +192,15 @@ jobs:
           run: |
             export ARTIFACTDIR=`pwd`/buildartifacts
 
-            pip install ntfc==0.0.1
+            for i in 1 2 3; do
+              python -m pip install \
+                --default-timeout=100 \
+                --retries 10 \
+                ntfc==0.0.1 && break
+              echo "Retry $i failed..."
+              sleep 5
+            done
+
             mkdir /github/workspace/nuttx-ntfc
             mkdir /github/workspace/nuttx-ntfc/external
             cd /github/workspace/nuttx-ntfc


### PR DESCRIPTION
## Summary
- .github/build.yml: improve ntfc installation
increase retries and timeout for pip install and try again in case of failure

## Impact
an attempt to increase the reliability of ntfc installations

If it improve reliability of ntfc installations then we can port it to nuttx-apps

## Testing

not tested, this needs to be tested upstream as we need network issues on the github infra or pip infra side.

