### PR TITLE
fs/fat: fix incorrect representation of SFN files created on Linux

### DIFF
--- a/fs/fat/fs_fat32dirent.c
+++ b/fs/fat/fs_fat32dirent.c
@@ -369,8 +369,19 @@ static inline int fat_parsesfname(FAR const char **path,
               node++;
             }
 
-          *terminator = ch;
-          *path       = node;
+          if (terminator != NULL)
+            {
+              /* Don't update the variables if terminator is NULL
+               *
+               * Call with terminator == NULL is used to obtain short
+               * file name from already given long file name that fits
+               * into 8.3 format
+               */
+
+              *terminator = ch;
+              *path       = node;
+            }
+
           return OK;
         }
 
@@ -1109,6 +1120,12 @@ static inline int fat_uniquealias(FAR struct fat_mountpt_s *fs,
  * Description:  Convert a user filename into a properly formatted FAT
  *   (short 8.3) filename as it would appear in a directory entry.
  *
+ *   Long file name is returned if CONFIG_FAT_LFN is defined. This applies
+ *   even for entries that would fit standard short 8.3 format. These have
+ *   both long file name and short file name filled. This is done mainly
+ *   because of compatibility with Linux that creates long file name entries
+ *   even if the file name fits into 8.3 format.
+ *
  ****************************************************************************/
 
 static int fat_path2dirname(FAR const char **path,
@@ -1121,17 +1138,35 @@ static int fat_path2dirname(FAR const char **path,
   /* Assume no long file name */
 
   dirinfo->fd_lfname[0] = '\0';
+  dirinfo->fd_name[0] = '\0';
 
-  /* Then parse the (assumed) 8+3 short file name */
+  /* Parse long file name */
 
-  ret = fat_parsesfname(path, dirinfo, terminator);
+  ret = fat_parselfname(path, dirinfo, terminator);
   if (ret < 0)
     {
-      /* No, the name is not a valid short 8+3 file name. Try parsing
-       * the long file name.
+      return ret;
+    }
+  else
+    {
+      /* Does the long file name fit into short file name? This means
+       * this is actually a short file name.
+       *
+       * There are following possibilities:
+       *   - file was created on Linux and is written as long file name
+       *   - file was created on Windows and is written as short file name
+       *   - we are creating file on NuttX -> write it as short file name
        */
 
-      ret = fat_parselfname(path, dirinfo, terminator);
+      if (strlen((FAR const char *)dirinfo->fd_lfname) <= DIR_MAXFNAME)
+        {
+          /* Get short file name for given path */
+
+          char name[DIR_MAXFNAME];
+          memcpy(name, dirinfo->fd_lfname, DIR_MAXFNAME);
+          FAR const char *tmp = (FAR const char *)name;
+          fat_parsesfname(&tmp, dirinfo, NULL);
+        }
     }
 
   return ret;
@@ -2609,20 +2644,25 @@ int fat_finddirentry(FAR struct fat_mountpt_s *fs,
           return ret;
         }
 
-      /* Is this a path segment a long or a short file.  Was a long file
-       * name parsed?
-       */
-
 #ifdef CONFIG_FAT_LFN
       if (dirinfo->fd_lfname[0] != '\0')
         {
-          /* Yes.. Search for the sequence of long file name directory
-           * entries. NOTE: As a side effect, this function returns with
-           * the sector containing the short file name directory entry
-           * in the cache.
+          /* We have to check for both LFN and SFN entry because of
+           * Linux/Windows differences
+           *
+           *  - file created on Linux is written as LFN even if it fits 8.3
+           *  - file created on Windows is written as SFN if it fits 8.3
            */
 
+          struct fat_dirinfo_s d = *dirinfo;
           ret = fat_findlfnentry(fs, dirinfo);
+          if (ret < 0)
+            {
+              /* There is no LFN entry for given file -> check SFN */
+
+              *dirinfo = d;
+              ret = fat_findsfnentry(fs, dirinfo);
+            }
         }
       else
 #endif
@@ -2752,7 +2792,7 @@ int fat_allocatedirentry(FAR struct fat_mountpt_s *fs,
        */
 
 #ifdef CONFIG_FAT_LFN
-      if (dirinfo->fd_lfname[0] != '\0')
+      if (dirinfo->fd_lfname[0] != '\0' && dirinfo->fd_name[0] == '\0')
         {
           /* Yes.. Allocate for the sequence of long file name directory
            * entries plus a short file name directory entry.
@@ -3008,7 +3048,7 @@ int fat_dirnamewrite(FAR struct fat_mountpt_s *fs,
 
   /* Is this a long file name? */
 
-  if (dirinfo->fd_lfname[0] != '\0')
+  if (dirinfo->fd_lfname[0] != '\0' && dirinfo->fd_name[0] == '\0')
     {
       /* Write the sequence of long file name directory entries (this
        * function also creates the short file name alias).
@@ -3054,7 +3094,7 @@ int fat_dirwrite(FAR struct fat_mountpt_s *fs,
 
   /* Does this directory entry have a long file name? */
 
-  if (dirinfo->fd_lfname[0] != '\0')
+  if (dirinfo->fd_lfname[0] != '\0' && dirinfo->fd_name[0] == '\0')
     {
       /* Write the sequence of long file name directory entries (this
        * function also creates the short file name alias).


### PR DESCRIPTION
## Summary
Linux creates all files as long file name entries even if they fit short 8.3 format. This caused issues when deleting or renaming files as the long file name entry was not recognized and only deleted it's short file name entry. This basically kept breaking the file system as subsequent long file name files were not correctly stored. The typical representation of this issue was long file name being represented as it's short name alias.

This commit adjusts the LFN/SFN logic a bit - the code now always fills in long file name and then checks if this could possibly be a short file entry (we still have to do that because Windows stores 8.3 files as short file entry). This ensures compatibility with files created both on Linux and Windows.

The following log is a FAT entry on Linux. You can see short file name `config.ini` is still written as a long file entry.

```
touch config.ini on Linux
00042000: 4163 006f 006e 0066 0069 000f 00e6 6700 2e00 6900 6e00 6900 0000 0000 ffff ffff  Ac.o.n.f.i....g...i.n.i.........
00042020: 434f 4e46 4947 2020 494e 4920 004a 8041 885c 885c 0000 8041 885c 0000 0000 0000  CONFIG  INI .J.A.\.\...A.\......

first rename on Linux
00042000: e563 006f 006e 0066 0069 000f 00e6 6700 2e00 6900 6e00 6900 0000 0000 ffff ffff  .c.o.n.f.i....g...i.n.i.........
00042020: e54f 4e46 4947 2020 494e 4920 004a 8041 885c 885c 0000 8041 885c 0000 0000 0000  .ONFIG  INI .J.A.\.\...A.\......
00042040: 4237 0038 002e 0069 006e 000f 00ee 6900 0000 ffff ffff ffff ffff 0000 ffff ffff  B7.8...i.n....i.................
00042060: 0163 006f 006e 0066 0069 000f 00ee 6700 5f00 3100 3200 3300 3400 0000 3500 3600  .c.o.n.f.i....g._.1.2.3.4...5.6.
00042080: 434f 4e46 4947 7e31 494e 4920 0080 8d41 885c 885c 0000 8d41 885c 0000 0000 0000  CONFIG~1INI ...A.\.\...A.\......

rename back on Linux
00042000: 4163 006f 006e 0066 0069 000f 00e6 6700 2e00 6900 6e00 6900 0000 0000 ffff ffff  Ac.o.n.f.i....g...i.n.i.........
00042020: 434f 4e46 4947 2020 494e 4920 003c 9741 885c 885c 0000 9741 885c 0000 0000 0000  CONFIG  INI .<.A.\.\...A.\......
00042040: e537 0038 002e 0069 006e 000f 00ee 6900 0000 ffff ffff ffff ffff 0000 ffff ffff  .7.8...i.n....i.................
00042060: e563 006f 006e 0066 0069 000f 00ee 6700 5f00 3100 3200 3300 3400 0000 3500 3600  .c.o.n.f.i....g._.1.2.3.4...5.6.
00042080: e54f 4e46 4947 7e31 494e 4920 0080 8d41 885c 885c 0000 8d41 885c 0000 0000 0000  .ONFIG~1INI ...A.\.\...A.\......

second rename on Linux
00042000: e563 006f 006e 0066 0069 000f 00e6 6700 2e00 6900 6e00 6900 0000 0000 ffff ffff  .c.o.n.f.i....g...i.n.i.........
00042020: e54f 4e46 4947 2020 494e 4920 004a 8041 885c 885c 0000 8041 885c 0000 0000 0000  .ONFIG  INI .J.A.\.\...A.\......
00042040: 4237 0038 002e 0069 006e 000f 00ee 6900 0000 ffff ffff ffff ffff 0000 ffff ffff  B7.8...i.n....i.................
00042060: 0163 006f 006e 0066 0069 000f 00ee 6700 5f00 3100 3200 3300 3400 0000 3500 3600  .c.o.n.f.i....g._.1.2.3.4...5.6.
00042080: 434f 4e46 4947 7e31 494e 4920 0049 a541 885c 885c 0000 a541 885c 0000 0000 0000  CONFIG~1INI .I.A.\.\...A.\......
```

The issue on NuttX is easily reproducible by renaming `config.ini` file to long name `config_12345678.ini`. The first rename is ok (though the erase of the old entry already not correct), but subsequent rename back to `config.ini` on Linux and another rename to long name breaks the system - `ls` command now doesn't show `config_12345678.ini` as it should, but it's short file alias `CONFIG~1.INI` - and it's not just `ls`, calling `open` on `config_12345678.ini` doesn't work either.

```
touch config.ini on Linux
00042000: 4163 006f 006e 0066 0069 000f 00e6 6700 2e00 6900 6e00 6900 0000 0000 ffff ffff  Ac.o.n.f.i....g...i.n.i.........
00042020: 434f 4e46 4947 2020 494e 4920 00c1 6f3e 885c 885c 0000 6f3e 885c 0000 0000 0000  CONFIG  INI ..o>.\.\..o>.\......

first rename from config.ini to config_12345678.ini on NuttX - you can see the first line is not erased (first byte should be e5)
00042000: 4163 006f 006e 0066 0069 000f 00e6 6700 2e00 6900 6e00 6900 0000 0000 ffff ffff  Ac.o.n.f.i....g...i.n.i.........
00042020: e54f 4e46 4947 2020 494e 4920 00c1 6f3e 885c 885c 0000 6f3e 885c 0000 0000 0000  .ONFIG  INI ..o>.\.\..o>.\......
00042040: 4237 0038 002e 0069 006e 000f 00ee 6900 0000 ffff ffff ffff ffff 0000 ffff ffff  B7.8...i.n....i.................
00042060: 0163 006f 006e 0066 0069 000f 00ee 6700 5f00 3100 3200 3300 3400 0000 3500 3600  .c.o.n.f.i....g._.1.2.3.4...5.6.
00042080: 434f 4e46 4947 7e31 494e 4920 00c1 6f3e 885c 885c 0000 6f3e 885c 0000 0000 0000  CONFIG~1INI ..o>.\.\..o>.\......

rename back to config.ini on Linux
00042000: 4163 006f 006e 0066 0069 000f 00e6 6700 2e00 6900 6e00 6900 0000 0000 ffff ffff  Ac.o.n.f.i....g...i.n.i.........
00042020: e54f 4e46 4947 2020 494e 4920 00c1 6f3e 885c 885c 0000 6f3e 885c 0000 0000 0000  .ONFIG  INI ..o>.\.\..o>.\......
00042040: e537 0038 002e 0069 006e 000f 00ee 6900 0000 ffff ffff ffff ffff 0000 ffff ffff  .7.8...i.n....i.................
00042060: e563 006f 006e 0066 0069 000f 00ee 6700 5f00 3100 3200 3300 3400 0000 3500 3600  .c.o.n.f.i....g._.1.2.3.4...5.6.
00042080: e54f 4e46 4947 7e31 494e 4920 00c1 6f3e 885c 885c 0000 6f3e 885c 0000 0000 0000  .ONFIG~1INI ..o>.\.\..o>.\......
000420a0: 4163 006f 006e 0066 0069 000f 00e6 6700 2e00 6900 6e00 6900 0000 0000 ffff ffff  Ac.o.n.f.i....g...i.n.i.........
000420c0: 434f 4e46 4947 2020 494e 4920 0020 ac3e 885c 885c 0000 ac3e 885c 0000 0000 0000  CONFIG  INI . .>.\.\...>.\......

second rename on NuttX -> ls shows CONFIG~1.INI
00042000: 4163 006f 006e 0066 0069 000f 00e6 6700 2e00 6900 6e00 6900 0000 0000 ffff ffff  Ac.o.n.f.i....g...i.n.i.........
00042020: 4237 0038 002e 0069 006e 000f 00ee 6900 0000 ffff ffff ffff ffff 0000 ffff ffff  B7.8...i.n....i.................
00042040: 0163 006f 006e 0066 0069 000f 00ee 6700 5f00 3100 3200 3300 3400 0000 3500 3600  .c.o.n.f.i....g._.1.2.3.4...5.6.
00042060: 434f 4e46 4947 7e31 494e 4920 00c1 6f3e 885c 885c 0000 6f3e 885c 0000 0000 0000  CONFIG~1INI ..o>.\.\..o>.\......
00042080: e54f 4e46 4947 7e31 494e 4920 00c1 6f3e 885c 885c 0000 6f3e 885c 0000 0000 0000  .ONFIG~1INI ..o>.\.\..o>.\......
000420a0: 4163 006f 006e 0066 0069 000f 00e6 6700 2e00 6900 6e00 6900 0000 0000 ffff ffff  Ac.o.n.f.i....g...i.n.i.........
000420c0: e54f 4e46 4947 2020 494e 4920 00c1 6f3e 885c 885c 0000 6f3e 885c 0000 0000 0000  .ONFIG  INI ..o>.\.\..o>.\......
```

## Impact

fs/fat: Fix long/short file (re)name issues caused by incorrect representation of SFN files created on Linux.

## Testing

Here are the logs after the fix - both Linux and Windows created files are correctly renamed now.

### Linux

```
touch config.ini
00042000: 4163 006f 006e 0066 0069 000f 00e6 6700 2e00 6900 6e00 6900 0000 0000 ffff ffff  Ac.o.n.f.i....g...i.n.i.........
00042020: 434f 4e46 4947 2020 494e 4920 00a2 d67d 895c 895c 0000 d67d 895c 0000 0000 0000  CONFIG  INI ...}.\.\...}.\......

first rename from config.ini to config_12345678.ini on NuttX - first entry is correctly erased
00042000: e563 006f 006e 0066 0069 000f 00e6 6700 2e00 6900 6e00 6900 0000 0000 ffff ffff  .c.o.n.f.i....g...i.n.i.........
00042020: e54f 4e46 4947 2020 494e 4920 00a2 d67d 895c 895c 0000 d67d 895c 0000 0000 0000  .ONFIG  INI ...}.\.\...}.\......
00042040: 4237 0038 002e 0069 006e 000f 00ee 6900 0000 ffff ffff ffff ffff 0000 ffff ffff  B7.8...i.n....i.................
00042060: 0163 006f 006e 0066 0069 000f 00ee 6700 5f00 3100 3200 3300 3400 0000 3500 3600  .c.o.n.f.i....g._.1.2.3.4...5.6.
00042080: 434f 4e46 4947 7e31 494e 4920 00a2 d67d 895c 895c 0000 d67d 895c 0000 0000 0000  CONFIG~1INI ...}.\.\...}.\......

rename back to config.ini on Linux
00042000: 4163 006f 006e 0066 0069 000f 00e6 6700 2e00 6900 6e00 6900 0000 0000 ffff ffff  Ac.o.n.f.i....g...i.n.i.........
00042020: 434f 4e46 4947 2020 494e 4920 00b3 f87d 895c 895c 0000 f87d 895c 0000 0000 0000  CONFIG  INI ...}.\.\...}.\......
00042040: e537 0038 002e 0069 006e 000f 00ee 6900 0000 ffff ffff ffff ffff 0000 ffff ffff  .7.8...i.n....i.................
00042060: e563 006f 006e 0066 0069 000f 00ee 6700 5f00 3100 3200 3300 3400 0000 3500 3600  .c.o.n.f.i....g._.1.2.3.4...5.6.
00042080: e54f 4e46 4947 7e31 494e 4920 00a2 d67d 895c 895c 0000 d67d 895c 0000 0000 0000  .ONFIG~1INI ...}.\.\...}.\......

second rename on NuttX -> ls shows correctly config_12345678.ini
00042000: e563 006f 006e 0066 0069 000f 00e6 6700 2e00 6900 6e00 6900 0000 0000 ffff ffff  .c.o.n.f.i....g...i.n.i.........
00042020: e54f 4e46 4947 2020 494e 4920 00a2 d67d 895c 895c 0000 d67d 895c 0000 0000 0000  .ONFIG  INI ...}.\.\...}.\......
00042040: 4237 0038 002e 0069 006e 000f 00ee 6900 0000 ffff ffff ffff ffff 0000 ffff ffff  B7.8...i.n....i.................
00042060: 0163 006f 006e 0066 0069 000f 00ee 6700 5f00 3100 3200 3300 3400 0000 3500 3600  .c.o.n.f.i....g._.1.2.3.4...5.6.
00042080: 434f 4e46 4947 7e31 494e 4920 00a2 d67d 895c 895c 0000 d67d 895c 0000 0000 0000  CONFIG~1INI ...}.\.\...}.\......

echo "Hello" > /sdcard/test.txt - file with short name still takes only one entry
00042000: 5445 5354 2020 2020 5458 5420 1800 0000 0000 0000 0000 0000 0000 0200 0600 0000  TEST    TXT ....................
00042020: e54f 4e46 4947 2020 494e 4920 00a2 d67d 895c 895c 0000 d67d 895c 0000 0000 0000  .ONFIG  INI ...}.\.\...}.\......
00042040: 4237 0038 002e 0069 006e 000f 00ee 6900 0000 ffff ffff ffff ffff 0000 ffff ffff  B7.8...i.n....i.................
00042060: 0163 006f 006e 0066 0069 000f 00ee 6700 5f00 3100 3200 3300 3400 0000 3500 3600  .c.o.n.f.i....g._.1.2.3.4...5.6.
00042080: 434f 4e46 4947 7e31 494e 4920 00a2 d67d 895c 895c 0000 d67d 895c 0000 0000 0000  CONFIG~1INI ...}.\.\...}.\......
```

### Windows

```
created config.ini -> short file name on Windows 10
00042000: 4220 0049 006e 0066 006f 000f 0072 7200 6d00 6100 7400 6900 6f00 0000 6e00 0000  B .I.n.f.o...rr.m.a.t.i.o...n...
00042020: 0153 0079 0073 0074 0065 000f 0072 6d00 2000 5600 6f00 6c00 7500 0000 6d00 6500  .S.y.s.t.e...rm. .V.o.l.u...m.e.
00042040: 5359 5354 454d 7e31 2020 2016 0088 ec8d 895c 895c 0000 ed8d 895c 0200 0000 0000  SYSTEM~1   ......\.\.....\......
00042060: 434f 4e46 4947 2020 494e 4920 1807 f58d 895c 895c 0000 3582 885c 0000 0000 0000  CONFIG  INI .....\.\..5..\......

first rename from config.ini to config_12345678.ini on NuttX
00042000: 4220 0049 006e 0066 006f 000f 0072 7200 6d00 6100 7400 6900 6f00 0000 6e00 0000  B .I.n.f.o...rr.m.a.t.i.o...n...
00042020: 0153 0079 0073 0074 0065 000f 0072 6d00 2000 5600 6f00 6c00 7500 0000 6d00 6500  .S.y.s.t.e...rm. .V.o.l.u...m.e.
00042040: 5359 5354 454d 7e31 2020 2016 0088 ec8d 895c 895c 0000 ed8d 895c 0200 0000 0000  SYSTEM~1   ......\.\.....\......
00042060: e54f 4e46 4947 2020 494e 4920 1807 f58d 895c 895c 0000 3582 885c 0000 0000 0000  .ONFIG  INI .....\.\..5..\......
00042080: 4237 0038 002e 0069 006e 000f 00ee 6900 0000 ffff ffff ffff ffff 0000 ffff ffff  B7.8...i.n....i.................
000420a0: 0163 006f 006e 0066 0069 000f 00ee 6700 5f00 3100 3200 3300 3400 0000 3500 3600  .c.o.n.f.i....g._.1.2.3.4...5.6.
000420c0: 434f 4e46 4947 7e31 494e 4920 1807 f58d 895c 895c 0000 3582 885c 0000 0000 0000  CONFIG~1INI .....\.\..5..\......

rename back to config.ini on Windows
00042000: 4220 0049 006e 0066 006f 000f 0072 7200 6d00 6100 7400 6900 6f00 0000 6e00 0000  B .I.n.f.o...rr.m.a.t.i.o...n...
00042020: 0153 0079 0073 0074 0065 000f 0072 6d00 2000 5600 6f00 6c00 7500 0000 6d00 6500  .S.y.s.t.e...rm. .V.o.l.u...m.e.
00042040: 5359 5354 454d 7e31 2020 2016 0088 ec8d 895c 895c 0000 ed8d 895c 0200 0000 0000  SYSTEM~1   ......\.\.....\......
00042060: e54f 4e46 4947 2020 494e 4920 1807 f58d 895c 895c 0000 3582 885c 0000 0000 0000  .ONFIG  INI .....\.\..5..\......
00042080: e537 0038 002e 0069 006e 000f 00ee 6900 0000 ffff ffff ffff ffff 0000 ffff ffff  .7.8...i.n....i.................
000420a0: e563 006f 006e 0066 0069 000f 00ee 6700 5f00 3100 3200 3300 3400 0000 3500 3600  .c.o.n.f.i....g._.1.2.3.4...5.6.
000420c0: e54f 4e46 4947 7e31 494e 4920 1807 f58d 895c 895c 0000 3582 885c 0000 0000 0000  .ONFIG~1INI .....\.\..5..\......
000420e0: 434f 4e46 4947 2020 494e 4920 1807 f58d 895c 895c 0000 3582 885c 0000 0000 0000  CONFIG  INI .....\.\..5..\......

second rename on NuttX -> ls shows correctly config_12345678.ini
00042000: 4220 0049 006e 0066 006f 000f 0072 7200 6d00 6100 7400 6900 6f00 0000 6e00 0000  B .I.n.f.o...rr.m.a.t.i.o...n...
00042020: 0153 0079 0073 0074 0065 000f 0072 6d00 2000 5600 6f00 6c00 7500 0000 6d00 6500  .S.y.s.t.e...rm. .V.o.l.u...m.e.
00042040: 5359 5354 454d 7e31 2020 2016 0088 ec8d 895c 895c 0000 ed8d 895c 0200 0000 0000  SYSTEM~1   ......\.\.....\......
00042060: 4237 0038 002e 0069 006e 000f 00ee 6900 0000 ffff ffff ffff ffff 0000 ffff ffff  B7.8...i.n....i.................
00042080: 0163 006f 006e 0066 0069 000f 00ee 6700 5f00 3100 3200 3300 3400 0000 3500 3600  .c.o.n.f.i....g._.1.2.3.4...5.6.
000420a0: 434f 4e46 4947 7e31 494e 4920 1807 f58d 895c 895c 0000 3582 885c 0000 0000 0000  CONFIG~1INI .....\.\..5..\......
000420c0: e54f 4e46 4947 7e31 494e 4920 1807 f58d 895c 895c 0000 3582 885c 0000 0000 0000  .ONFIG~1INI .....\.\..5..\......
000420e0: e54f 4e46 4947 2020 494e 4920 1807 f58d 895c 895c 0000 3582 885c 0000 0000 0000  .ONFIG  INI .....\.\..5..\......
```

I kept the original design that NuttX creates a file with short name as a short file entry - it seems like a better strategy for us since we are embedded and one would expect we wouldn't waste memory unless really have to.