### PR TITLE
cmake: add -D__NuttX__ to preprocessor

### DIFF
--- a/cmake/nuttx_toolchain.cmake
+++ b/cmake/nuttx_toolchain.cmake
@@ -74,6 +74,7 @@ endif()
 if(NOT NUTTX_TOOLCHAIN_PREPROCESS_DEFINED)
   function(nuttx_generate_preprocess_target)
 
+    set(DEFINES -D__NuttX__)
     # parse arguments into variables
 
     nuttx_parse_function_args(
@@ -92,8 +93,10 @@ if(NOT NUTTX_TOOLCHAIN_PREPROCESS_DEFINED)
 
     add_custom_command(
       OUTPUT ${TARGET_FILE}
-      COMMAND ${PREPROCESS} -I${CMAKE_BINARY_DIR}/include -I${NUTTX_DIR}/include
-              -I${NUTTX_CHIP_ABS_DIR} ${SOURCE_FILE} > ${TARGET_FILE}
+      COMMAND
+        ${PREPROCESS} ${DEFINES} -I${CMAKE_BINARY_DIR}/include
+        -I${NUTTX_DIR}/include -I${NUTTX_CHIP_ABS_DIR} ${SOURCE_FILE} >
+        ${TARGET_FILE}
       DEPENDS ${SOURCE_FILE} ${DEPENDS})
 
   endfunction()


### PR DESCRIPTION
## Summary

<!-- This field should contain a summary of the changes. It will be pre-filled with the commit's message and descriptions. Adjust it accordingly -->

* cmake: add -D__NuttX__ to preprocessor

This change allows for linker script files to be properly processed when
`#ifdef __NuttX__` is used.


On Make builds, the `.ld` files added to `ARCHSCRIPT` are preprocessed to keep or remove lines that contain `#ifdef __NuttX__`.
This same behavior is not present on CMake builds, which causes many linker scripts (on RISC-V Espressif builds at least) to be used improperly.

This changes simply adds `-D__NuttX__` to the `nuttx_generate_preprocess_target` function, solving this problem.

## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: No.
<!-- Does it impact user's applications? How? -->

Impact on build: Yes, CMake only. Preprocess linker script files with the __NuttX__ option.
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: No.
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: No.
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: No
<!-- Does it impact NuttX's security? -->

Impact on compatibility: No.
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

## Testing
<!-- Please provide all the testing procedure. Consider that upstream reviewers should be able to reproduce the same testing performed internally -->
Generate a ESP32-C6 build with and compare linker files used before and after this change.

### Building
<!-- Provide how to build the test for each SoC being tested -->
- `cmake -B build -DBOARD_CONFIG=esp32c6-devkitc:nsh -GNinja -DNXTMPDIR=on`
- `cmake --build build --verbose > out`

### Results
<!-- Provide tests' results and runtime logs -->
Original content of `esp32c6.rom.newlib.ld`:
```
...
_isatty_r = 0x400004d4;
strdup = 0x40000530;
strndup = 0x40000554;
#ifndef  __NuttX__
rand_r = 0x4000058c;
rand = 0x40000590;
srand = 0x40000594;
#endif
atoi = 0x400005a0;
atol = 0x400005a4;
...
```

Now we look into the generated `esp32c6.rom.newlib.ld.tmp` under `build` directory. 

Before the changes:
```
[4/1379] cd /home/fdcavalcanti/nuttxspace5/nuttx/build && /home/fdcavalcanti/work/toolchains/riscv-none-elf-gcc/bin/riscv-none-elf-gcc -E -P -x c -I/home/fdcavalcanti/nuttxspace5/nuttx/build/include -I/home/fdcavalcanti/nuttxspace5/nuttx/include -I/home/fdcavalcanti/nuttxspace5/nuttx/arch/risc-v/src/esp32c6 /home/fdcavalcanti/nuttxspace5/nuttx/build/arch/risc-v/src/common/espressif/esp-hal-3rdparty/components/esp_rom/esp32c6/ld/esp32c6.rom.newlib.ld > /home/fdcavalcanti/nuttxspace5/nuttx/build/esp32c6.rom.newlib.ld.tmp
```

```
...
_isatty_r = 0x400004d4;
strdup = 0x40000530;
strndup = 0x40000554;
rand_r = 0x4000058c;
rand = 0x40000590;
srand = 0x40000594;
atoi = 0x400005a0;
atol = 0x400005a4;
...
```


After the changes:
```
...
[8/1379] cd /home/fdcavalcanti/nuttxspace5/nuttx/build && /home/fdcavalcanti/work/toolchains/riscv-none-elf-gcc/bin/riscv-none-elf-gcc -E -P -x c -D__NuttX__ -I/home/fdcavalcanti/nuttxspace5/nuttx/build/include -I/home/fdcavalcanti/nuttxspace5/nuttx/include -I/home/fdcavalcanti/nuttxspace5/nuttx/arch/risc-v/src/esp32c6 /home/fdcavalcanti/nuttxspace5/nuttx/build/arch/risc-v/src/common/espressif/esp-hal-3rdparty/components/esp_rom/esp32c6/ld/esp32c6.rom.newlib.ld > /home/fdcavalcanti/nuttxspace5/nuttx/build/esp32c6.rom.newlib.ld.tmp
...
```

```
...
_isatty_r = 0x400004d4;
strdup = 0x40000530;
strndup = 0x40000554;
atoi = 0x400005a0;
atol = 0x400005a4;
strtol = 0x400005a8;
strtoul = 0x400005ac;
...
```

You can see that `rand_r`, `rand` and `srand` are gone, as expected.