### PR TITLE
arch/arm/src/Makefile: Avoid uncessary relinking of the nuttx binary.

### DIFF
--- a/arch/arm/src/Makefile
+++ b/arch/arm/src/Makefile
@@ -161,6 +161,8 @@ VPATH += chip
 VPATH += common
 VPATH += $(ARCH_SUBDIR)
 
+vpath nuttx$(EXEEXT) $(TOPDIR)
+
 ifeq ($(CONFIG_ARM_TOOLCHAIN_IAR),y)
   VPATH += common$(DELIM)iar
 else # ifeq ($(CONFIG_ARCH_TOOLCHAIN_GNU),y)
@@ -169,8 +171,6 @@ else # ifeq ($(CONFIG_ARCH_TOOLCHAIN_GNU),y)
 endif
 
 all: $(HEAD_OBJ) $(BIN)
-
-.PHONY: board$(DELIM)libboard$(LIBEXT)
 
 $(AOBJS) $(UAOBJS) $(HEAD_OBJ): %$(OBJEXT): %.S
 	$(call ASSEMBLE, $<, $@)
@@ -192,8 +192,12 @@ endif
 $(KBIN): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-board$(DELIM)libboard$(LIBEXT):
+board$(DELIM)libboard$(LIBEXT): FORCE
 	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+
+.PHONY: FORCE
+
+FORCE:
 
 # When multiple linking, these two additional linking objects will be included
 
@@ -218,10 +222,10 @@ define LINK_ALLSYMS_KASAN
 		$(LDSTARTGROUP) $(LDLIBS) $(EXTRA_LIBS) $(LDENDGROUP)
 endef
 
-$(addsuffix .tmp,$(ARCHSCRIPT)): $(ARCHSCRIPT)
+$(addsuffix .tmp,$(ARCHSCRIPT)): $(ARCHSCRIPT) $(TOPDIR)$(DELIM).config
 	$(call PREPROCESS, $(patsubst %.tmp,%,$@), $@)
 
-nuttx$(EXEEXT): $(HEAD_OBJ) board$(DELIM)libboard$(LIBEXT) $(addsuffix .tmp,$(ARCHSCRIPT))
+nuttx$(EXEEXT): $(HEAD_OBJ) board$(DELIM)libboard$(LIBEXT) $(addsuffix .tmp,$(ARCHSCRIPT)) $(addprefix $(TOPDIR)$(DELIM)staging$(DELIM),$(LINKLIBS))
 	$(Q) echo "LD: nuttx"
 ifeq ($(CONFIG_ALLSYMS)$(CONFIG_MM_KASAN_GLOBAL),)
 	$(Q) $(LD) $(LDFLAGS) $(LIBPATHS) $(EXTRA_LIBPATHS) \
@@ -242,7 +246,6 @@ ifneq ($(CONFIG_WINDOWS_NATIVE),y)
 	grep -v '\(compiled\)\|\(\$(OBJEXT)$$\)\|\( [aUw] \)\|\(\.\.ng$$\)\|\(LASH[RL]DI\)' | \
 	sort > $(TOPDIR)$(DELIM)System.map
 endif
-	$(Q) $(call DELFILE, $(addsuffix .tmp,$(ARCHSCRIPT)))
 
 # This is part of the top-level export target
 # Note that there may not be a head object if layout is handled


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

The goal is to only execute recipes when there is an actual change in the prerequisites.

There were several issues which cause the nuttx binary target to be re-made every time the top level make is run, which was hiding some missing prerequisites.

Changes:
  1. vpath nuttx$(EXEEXT) $(TOPDIR) — so Make can find the existing binary
  2. FORCE pattern replaces .PHONY on libboard — sub-make always runs but nuttx only relinks when library content changes
  3. .config added as prerequisite to .tmp linker script rule — config changes trigger re-preprocessing
  4. Staging libs added as prerequisite to nuttx rule — changed libs trigger relink
  5. Stop deleting .tmp after link — preserves timestamps for dependency tracking

## Impact

This change ensures that we only run the nuttx recipe (and others) if the prerequisites are meaningfully out of date. In other words, the make should be faster and have a more concise output when there were no changes made by the user.

## Testing

Methodology:

Scripts were made to reproduce build/test steps (e.g. make and touching files).

The change has the intended effects:
- That is, it doesn't run recipes where the intended prerequisites haven't meaningfully changed. To test, I ran make twice with no changes, the second make shouldn't execute the nuttx target recipe (and link).

The change doesn't have unintended effects:
- That is, when there *are* meaningful changes, we run the necessary recipes. To test, I made a trivial change in different prerequisites to ensure that the build works correctly.

Results:
  - PR branch off Nuttx main HEAD
  - Build host: Linux x86_64
  - Toolchain: arm-none-eabi-gcc
  - Target: qemu-armv7a:nsh (CONFIG_LIBC_UNAME_DISABLE_TIMESTAMP=y)

  Intended effects (script: test-results/test-intended.sh, output: test-results/test-intended.log):                                                                   
  
  Two consecutive make runs with no changes — neither triggers LD: nuttx:                                                                                             
  --- make (no changes, attempt 1) ---                                                                                    
  CP: nuttx.bin                          
  --- end ---

  --- make (no changes, attempt 2) ---
  CP: nuttx.bin
  --- end ---

  No unintended effects (script: test-results/test-unintended.sh, output: test-results/test-unintended.log):

  Touching a source file recompiles and relinks, then stabilizes:
  --- make (after touching arch/arm/src/chip/qemu_boot.c) ---
  CC: chip/qemu_boot.c  IN: libarch.a -> staging/libarch.a  LD: nuttx  CP: nuttx.bin
  --- make (no changes after source touch) ---
  CP: nuttx.bin

  Touching .config re-preprocesses linker script and relinks, then stabilizes:
  --- make (after touching .config) ---
  CPP: dramboot.ld -> dramboot.ld.tmp  LD: nuttx  CP: nuttx.bin
  --- make (no changes after .config touch) ---
  CP: nuttx.bin

[test-results.zip](https://github.com/user-attachments/files/26613022/test-results.zip)

Sanity Hardware Test:
 - Build host: Linux x86_64
 - Nuttx 12.1 (with this Makefile patch applied)
 - Target: custom board config, stm32h7xx

```
$ arm-none-eabi-nm (proprietary target) | grep nx_start
0801b484 T nx_start
0801b5f8 t nx_start_task
```

```
$ arm-none-eabi-gdb  (proprietary target)
GNU gdb (GNU Arm Embedded Toolchain 10-2020-q4-major) 10.1.90.20201028-git
...
Reading symbols from  (proprietary target)...
(gdb) tar ext :8082
Remote debugging using :8082
main (argc=1, argv=0x30009388) at ../main.c:1556
1556	{
(gdb) load
...
(gdb) b main
Breakpoint 1 at 0x80298c4: file ..main.c, line 1556.
Note: automatically using hardware breakpoints for read-only addresses.
(gdb) c
Continuing.

Breakpoint 1, main (argc=1, argv=0x30009388) at ..main.c:1556
1556	{
(gdb) 
```