### PR TITLE
arch/arm/src/Makefile: Avoid uncessary relinking of the nuttx binary.

### DIFF
--- a/arch/arm/src/Makefile
+++ b/arch/arm/src/Makefile
@@ -161,6 +161,8 @@ VPATH += chip
 VPATH += common
 VPATH += $(ARCH_SUBDIR)
 
+vpath nuttx$(EXEEXT) $(TOPDIR)
+
 ifeq ($(CONFIG_ARM_TOOLCHAIN_IAR),y)
   VPATH += common$(DELIM)iar
 else # ifeq ($(CONFIG_ARCH_TOOLCHAIN_GNU),y)
@@ -169,8 +171,6 @@ else # ifeq ($(CONFIG_ARCH_TOOLCHAIN_GNU),y)
 endif
 
 all: $(HEAD_OBJ) $(BIN)
-
-.PHONY: board$(DELIM)libboard$(LIBEXT)
 
 $(AOBJS) $(UAOBJS) $(HEAD_OBJ): %$(OBJEXT): %.S
 	$(call ASSEMBLE, $<, $@)
@@ -192,8 +192,12 @@ endif
 $(KBIN): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-board$(DELIM)libboard$(LIBEXT):
+board$(DELIM)libboard$(LIBEXT): FORCE
 	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+
+.PHONY: FORCE
+
+FORCE:
 
 # When multiple linking, these two additional linking objects will be included
 
@@ -218,10 +222,10 @@ define LINK_ALLSYMS_KASAN
 		$(LDSTARTGROUP) $(LDLIBS) $(EXTRA_LIBS) $(LDENDGROUP)
 endef
 
-$(addsuffix .tmp,$(ARCHSCRIPT)): $(ARCHSCRIPT)
+$(addsuffix .tmp,$(ARCHSCRIPT)): $(ARCHSCRIPT) $(TOPDIR)$(DELIM).config
 	$(call PREPROCESS, $(patsubst %.tmp,%,$@), $@)
 
-nuttx$(EXEEXT): $(HEAD_OBJ) board$(DELIM)libboard$(LIBEXT) $(addsuffix .tmp,$(ARCHSCRIPT))
+nuttx$(EXEEXT): $(HEAD_OBJ) board$(DELIM)libboard$(LIBEXT) $(addsuffix .tmp,$(ARCHSCRIPT)) $(addprefix $(TOPDIR)$(DELIM)staging$(DELIM),$(LINKLIBS))
 	$(Q) echo "LD: nuttx"
 ifeq ($(CONFIG_ALLSYMS)$(CONFIG_MM_KASAN_GLOBAL),)
 	$(Q) $(LD) $(LDFLAGS) $(LIBPATHS) $(EXTRA_LIBPATHS) \
@@ -242,7 +246,6 @@ ifneq ($(CONFIG_WINDOWS_NATIVE),y)
 	grep -v '\(compiled\)\|\(\$(OBJEXT)$$\)\|\( [aUw] \)\|\(\.\.ng$$\)\|\(LASH[RL]DI\)' | \
 	sort > $(TOPDIR)$(DELIM)System.map
 endif
-	$(Q) $(call DELFILE, $(addsuffix .tmp,$(ARCHSCRIPT)))
 
 # This is part of the top-level export target
 # Note that there may not be a head object if layout is handled

--- a/arch/arm64/src/Makefile
+++ b/arch/arm64/src/Makefile
@@ -132,9 +132,9 @@ VPATH += chip
 VPATH += common
 VPATH += $(ARCH_SUBDIR)
 
-all: $(HEAD_OBJ) $(BIN)
+vpath nuttx$(EXEEXT) $(TOPDIR)
 
-.PHONY: board$(DELIM)libboard$(LIBEXT)
+all: $(HEAD_OBJ) $(BIN)
 
 $(AOBJS) $(UAOBJS) $(HEAD_OBJ): %$(OBJEXT): %.S
 	$(call ASSEMBLE, $<, $@)
@@ -156,8 +156,12 @@ endif
 $(KBIN): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-board$(DELIM)libboard$(LIBEXT):
+board$(DELIM)libboard$(LIBEXT): FORCE
 	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+
+.PHONY: FORCE
+
+FORCE:
 
 # When multiple linking, these two additional linking objects will be included
 
@@ -182,10 +186,10 @@ define LINK_ALLSYMS_KASAN
 		$(LDSTARTGROUP) $(LDLIBS) $(EXTRA_LIBS) $(LDENDGROUP)
 endef
 
-$(addsuffix .tmp,$(ARCHSCRIPT)): $(ARCHSCRIPT)
+$(addsuffix .tmp,$(ARCHSCRIPT)): $(ARCHSCRIPT) $(TOPDIR)$(DELIM).config
 	$(call PREPROCESS, $(patsubst %.tmp,%,$@), $@)
 
-nuttx$(EXEEXT): $(HEAD_OBJ) board$(DELIM)libboard$(LIBEXT) $(addsuffix .tmp,$(ARCHSCRIPT))
+nuttx$(EXEEXT): $(HEAD_OBJ) board$(DELIM)libboard$(LIBEXT) $(addsuffix .tmp,$(ARCHSCRIPT)) $(addprefix $(TOPDIR)$(DELIM)staging$(DELIM),$(LINKLIBS))
 	$(Q) echo "LD: nuttx"
 ifeq ($(CONFIG_ALLSYMS)$(CONFIG_MM_KASAN_GLOBAL),)
 	$(Q) $(LD) --entry=__start $(LDFLAGS) $(LIBPATHS) $(EXTRA_LIBPATHS) \
@@ -206,7 +210,6 @@ ifneq ($(CONFIG_WINDOWS_NATIVE),y)
 	grep -v '\(compiled\)\|\(\$(OBJEXT)$$\)\|\( [aUw] \)\|\(\.\.ng$$\)\|\(LASH[RL]DI\)' | \
 	sort > $(TOPDIR)$(DELIM)System.map
 endif
-	$(Q) $(call DELFILE, $(addsuffix .tmp,$(ARCHSCRIPT)))
 
 # This is part of the top-level export target
 # Note that there may not be a head object if layout is handled

--- a/arch/risc-v/src/Makefile
+++ b/arch/risc-v/src/Makefile
@@ -133,9 +133,9 @@ VPATH += $(SBI_DIR)
 VPATH += $(ARCH_SUBDIR)
 VPATH += $(CHIP_DIR)
 
-all: $(HEAD_OBJ) $(BIN)
+vpath nuttx$(EXEEXT) $(TOPDIR)
 
-.PHONY: board/libboard$(LIBEXT)
+all: $(HEAD_OBJ) $(BIN)
 
 $(AOBJS) $(UAOBJS) $(HEAD_OBJ): %$(OBJEXT): %.S
 	$(call ASSEMBLE, $<, $@)
@@ -157,8 +157,12 @@ endif
 $(KBIN): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-board/libboard$(LIBEXT):
+board/libboard$(LIBEXT): FORCE
 	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+
+.PHONY: FORCE
+
+FORCE:
 
 # When multiple linking, these two additional linking objects will be included
 
@@ -183,10 +187,10 @@ define LINK_ALLSYMS_KASAN
 		$(LDSTARTGROUP) $(LDLIBS) $(EXTRA_LIBS) $(LDENDGROUP)
 endef
 
-$(addsuffix .tmp,$(ARCHSCRIPT)): $(ARCHSCRIPT)
+$(addsuffix .tmp,$(ARCHSCRIPT)): $(ARCHSCRIPT) $(TOPDIR)$(DELIM).config
 	$(call PREPROCESS, $(patsubst %.tmp,%,$@), $@)
 
-nuttx$(EXEEXT): $(HEAD_OBJ) board/libboard$(LIBEXT) $(addsuffix .tmp,$(ARCHSCRIPT))
+nuttx$(EXEEXT): $(HEAD_OBJ) board/libboard$(LIBEXT) $(addsuffix .tmp,$(ARCHSCRIPT)) $(addprefix $(TOPDIR)$(DELIM)staging$(DELIM),$(LINKLIBS))
 	$(Q) echo "LD: nuttx"
 ifeq ($(CONFIG_ALLSYMS)$(CONFIG_MM_KASAN_GLOBAL),)
 	$(Q) $(LD) $(LDENTRY) $(LDFLAGS) $(LIBPATHS) $(EXTRA_LIBPATHS) \
@@ -207,7 +211,6 @@ ifneq ($(CONFIG_WINDOWS_NATIVE),y)
 	grep -v '\(compiled\)\|\(\$(OBJEXT)$$\)\|\( [aUw] \)\|\(\.\.ng$$\)\|\(LASH[RL]DI\)' | \
 	sort > $(TOPDIR)/System.map
 endif
-	$(Q) $(call DELFILE, $(addsuffix .tmp,$(ARCHSCRIPT)))
 
 # This is part of the top-level export target
 # Note that there may not be a head object if layout is handled

--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -106,6 +106,8 @@ else
 endif
 DEPPATH = $(patsubst %,--dep-path %,$(subst :, ,$(VPATH)))
 
+vpath nuttx$(EXEEXT) $(TOPDIR)
+
 CFLAGS += -fvisibility=default
 HOSTCFLAGS = $(ARCHWARNINGS) $(ARCHOPTIMIZATION) \
    $(ARCHCFLAGS) $(HOSTINCLUDES) $(EXTRAFLAGS) -D__SIM__ \
@@ -372,7 +374,7 @@ RELLIBS += -lboard
 
 all: sim_head$(OBJEXT) libarch$(LIBEXT)
 
-.PHONY: export_startup clean distclean cleanrel depend board/libboard$(LIBEXT)
+.PHONY: export_startup clean distclean cleanrel depend FORCE
 
 $(AOBJS): %$(OBJEXT): %.S
 	$(call ASSEMBLE, $<, $@)
@@ -394,8 +396,10 @@ libarch$(LIBEXT): $(NUTTXOBJS)
 # the simulation.  However, this is a good place to keep parts of the simulation
 # that are not hardware-related.
 
-board/libboard$(LIBEXT):
+board/libboard$(LIBEXT): FORCE
 	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+
+FORCE:
 
 # A partially linked object containing only NuttX code (no interface to host OS)
 # Change the names of most symbols that conflict with libc symbols.

--- a/arch/x86_64/src/Makefile
+++ b/arch/x86_64/src/Makefile
@@ -105,9 +105,9 @@ endif
 
 VPATH = chip:common:$(ARCH_SUBDIR)
 
-all: libarch$(LIBEXT)
+vpath nuttx$(EXEEXT) $(TOPDIR)
 
-.PHONY: board/libboard$(LIBEXT)
+all: libarch$(LIBEXT)
 
 $(AOBJS): %$(OBJEXT): %.S
 	$(call ASSEMBLE, $<, $@)
@@ -129,8 +129,12 @@ endif
 $(KBIN): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-board/libboard$(LIBEXT):
+board/libboard$(LIBEXT): FORCE
 	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+
+.PHONY: FORCE
+
+FORCE:
 
 ifeq ($(CONFIG_ALLSYMS),y)
 EXTRA_LIBS += allsyms$(OBJEXT)
@@ -154,10 +158,10 @@ define LINK_ALLSYMS_KASAN
 		$(LDSTARTGROUP) $(EXTRA_LIBS) --no-relax $(LDLIBS) $(LDENDGROUP)
 endef
 
-$(addsuffix .tmp,$(ARCHSCRIPT)): $(ARCHSCRIPT)
+$(addsuffix .tmp,$(ARCHSCRIPT)): $(ARCHSCRIPT) $(TOPDIR)$(DELIM).config
 	$(call PREPROCESS, $(patsubst %.tmp,%,$@), $@)
 
-nuttx$(EXEEXT): $(HEAD_OBJ) board/libboard$(LIBEXT) $(addsuffix .tmp,$(ARCHSCRIPT))
+nuttx$(EXEEXT): $(HEAD_OBJ) board/libboard$(LIBEXT) $(addsuffix .tmp,$(ARCHSCRIPT)) $(addprefix $(TOPDIR)$(DELIM)staging$(DELIM),$(LINKLIBS))
 	@echo "LD: nuttx$(EXEEXT)"
 
 ifeq ($(CONFIG_ALLSYMS)$(CONFIG_MM_KASAN_GLOBAL),)
@@ -170,7 +174,6 @@ else
 	$(Q) $(call LINK_ALLSYMS_KASAN)
 	$(Q) $(call LINK_ALLSYMS_KASAN)
 endif
-	$(Q) $(call DELFILE, $(addsuffix .tmp,$(ARCHSCRIPT)))
 
 ifneq ($(CONFIG_WINDOWS_NATIVE),y)
 	$(Q) $(NM) $(NUTTX) | \
@@ -217,6 +220,7 @@ clean:
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board clean
 endif
+	$(call DELFILE, $(addsuffix .tmp,$(ARCHSCRIPT)))
 	$(call DELFILE, libarch$(LIBEXT))
 	$(call CLEAN)
 

--- a/arch/xtensa/src/Makefile
+++ b/arch/xtensa/src/Makefile
@@ -135,9 +135,9 @@ VPATH += common/espressif
 VPATH += $(ARCH_SUBDIR)
 VPATH += $(CHIP_DIR)
 
-all: $(STARTUP_OBJS) libarch$(LIBEXT)
+vpath nuttx$(EXEEXT) $(TOPDIR)
 
-.PHONY: board/libboard$(LIBEXT)
+all: $(STARTUP_OBJS) libarch$(LIBEXT)
 
 $(AOBJS) $(UAOBJS) $(HEAD_AOBJ): %$(OBJEXT): %.S
 	$(call ASSEMBLE, $<, $@)
@@ -159,8 +159,12 @@ endif
 $(KBIN): $(OBJS)
 	$(call ARCHIVE, $@, $(OBJS))
 
-board/libboard$(LIBEXT):
+board/libboard$(LIBEXT): FORCE
 	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
+
+.PHONY: FORCE
+
+FORCE:
 
 define LINK_ALLSYMS
 	$(Q) $(TOPDIR)/tools/mkallsyms.py $(NUTTX) allsyms.tmp --orderbyname $(CONFIG_SYMTAB_ORDEREDBYNAME)
@@ -171,10 +175,10 @@ define LINK_ALLSYMS
 	$(Q) $(call DELFILE, allsyms.tmp allsyms$(OBJEXT))
 endef
 
-$(addsuffix .tmp,$(ARCHSCRIPT)): $(ARCHSCRIPT)
+$(addsuffix .tmp,$(ARCHSCRIPT)): $(ARCHSCRIPT) $(TOPDIR)$(DELIM).config
 	$(call PREPROCESS, $(patsubst %.tmp,%,$@), $@)
 
-nuttx$(EXEEXT): $(STARTUP_OBJS) board/libboard$(LIBEXT) $(addsuffix .tmp,$(ARCHSCRIPT))
+nuttx$(EXEEXT): $(STARTUP_OBJS) board/libboard$(LIBEXT) $(addsuffix .tmp,$(ARCHSCRIPT)) $(addprefix $(TOPDIR)$(DELIM)staging$(DELIM),$(LINKLIBS))
 	$(Q) echo "LD: nuttx"
 ifneq ($(CONFIG_ALLSYMS),y)
 	$(Q) $(LD) --entry=__start $(LDFLAGS) $(LIBPATHS) $(EXTRA_LIBPATHS) \
@@ -193,7 +197,6 @@ ifneq ($(CONFIG_WINDOWS_NATIVE),y)
 	grep -v '\(compiled\)\|\(\$(OBJEXT)$$\)\|\( [aUw] \)\|\(\.\.ng$$\)\|\(LASH[RL]DI\)' | \
 	sort > $(TOPDIR)/System.map
 endif
-	$(Q) $(call DELFILE, $(addsuffix .tmp,$(ARCHSCRIPT)))
 
 # This is part of the top-level export target
 

--- a/libs/libc/misc/Make.defs
+++ b/libs/libc/misc/Make.defs
@@ -91,9 +91,9 @@ endif
 # To ensure uname information is newest,
 # add lib_utsname.o to phony target for force rebuild
 
-#if !defined(CONFIG_LIBC_UNAME_DISABLE_TIMESTAMP)
+ifeq ($(CONFIG_LIBC_UNAME_DISABLE_TIMESTAMP),)
 .PHONY: bin$(DELIM)lib_utsname$(OBJEXT) kbin$(DELIM)lib_utsname$(OBJEXT)
-#endif
+endif
 
 # Add the misc directory to the build
 

--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -266,11 +266,12 @@ tools/mkconfig$(HOSTEXEEXT): prebuild
 include/nuttx/config.h: $(TOPDIR)/.config tools/mkconfig$(HOSTEXEEXT)
 	$(Q) grep -v "CONFIG_BASE_DEFCONFIG" "$(TOPDIR)/.config" > "$(TOPDIR)/.config.tmp"
 	$(Q) if ! cmp -s "$(TOPDIR)/.config.tmp" "$(TOPDIR)/.config.orig" ; then \
-		sed -i.bak -e "/CONFIG_BASE_DEFCONFIG/ { /-dirty/! s/\"$$/-dirty\"/; }" "$(TOPDIR)/.config" ; \
+		sed -e "/CONFIG_BASE_DEFCONFIG/ { /-dirty/! s/\"$$/-dirty\"/; }" "$(TOPDIR)/.config" > "$(TOPDIR)/.config.dirty" ; \
 	else \
-		sed -i.bak "s/-dirty//g" "$(TOPDIR)/.config"; \
+		sed "s/-dirty//g" "$(TOPDIR)/.config" > "$(TOPDIR)/.config.dirty"; \
 	fi
-	$(Q) rm -f "$(TOPDIR)/.config.tmp" "$(TOPDIR)/.config.bak"
+	$(Q) rm -f "$(TOPDIR)/.config.tmp"
+	$(Q) $(call TESTANDREPLACEFILE, $(TOPDIR)/.config.dirty, $(TOPDIR)/.config)
 	$(Q) tools/mkconfig $(TOPDIR) > $@.tmp
 	$(Q) $(call TESTANDREPLACEFILE, $@.tmp, $@)
 


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

The goal is to only execute recipes when there is an actual change in the prerequisites.

There were several issues which cause the nuttx binary target to be re-made every time the top level make is run, which was hiding some missing prerequisites.

Changes:
  1. vpath nuttx$(EXEEXT) $(TOPDIR) — so Make can find the existing binary
  2. FORCE pattern replaces .PHONY on libboard — sub-make always runs but nuttx only relinks when library content changes
  3. .config added as prerequisite to .tmp linker script rule — config changes trigger re-preprocessing
  4. Staging libs added as prerequisite to nuttx rule — changed libs trigger relink
  5. Stop deleting .tmp after link — preserves timestamps for dependency tracking
  6. use ifeq instead of #if - mistakenly used for conditional in libs/libc/misc/Make.defs
  7. use existing TESTANDREPLACEFILE instead of inplace sed - avoid touching file if there's no changes

## Impact

This change ensures that we only run the nuttx recipe (and others) if the prerequisites are meaningfully out of date. In other words, the make should be faster and have a more concise output when there were no changes made by the user.

## Testing

Methodology:

Scripts were made to reproduce build/test steps (e.g. make and touching files).

The change has the intended effects:
- That is, it doesn't run recipes where the intended prerequisites haven't meaningfully changed. To test, I ran make twice with no changes, the second make shouldn't execute the nuttx target recipe (and link).

The change doesn't have unintended effects:
- That is, when there *are* meaningful changes, we run the necessary recipes. To test, I made a trivial change in different prerequisites to ensure that the build works correctly.

Results:
  - PR branch off Nuttx main HEAD
  - Build host: Linux x86_64
  - Toolchain: arm-none-eabi-gcc
  - Target: qemu-armv7a:nsh (CONFIG_LIBC_UNAME_DISABLE_TIMESTAMP=y)

  Intended effects (script: test-results/test-intended.sh, output: test-results/test-intended.log):                                                                   
  
  Two consecutive make runs with no changes — neither triggers LD: nuttx:                                                                                             
  --- make (no changes, attempt 1) ---                                                                                    
  CP: nuttx.bin                          
  --- end ---

  --- make (no changes, attempt 2) ---
  CP: nuttx.bin
  --- end ---

  No unintended effects (script: test-results/test-unintended.sh, output: test-results/test-unintended.log):

  Touching a source file recompiles and relinks, then stabilizes:
  --- make (after touching arch/arm/src/chip/qemu_boot.c) ---
  CC: chip/qemu_boot.c  IN: libarch.a -> staging/libarch.a  LD: nuttx  CP: nuttx.bin
  --- make (no changes after source touch) ---
  CP: nuttx.bin

  Touching .config re-preprocesses linker script and relinks, then stabilizes:
  --- make (after touching .config) ---
  CPP: dramboot.ld -> dramboot.ld.tmp  LD: nuttx  CP: nuttx.bin
  --- make (no changes after .config touch) ---
  CP: nuttx.bin

[test-results.zip](https://github.com/user-attachments/files/26613022/test-results.zip)

Sanity Hardware Test:

The changes are only in the build system, but this confirms that everything is still built/linked correctly.

 - Build host: Linux x86_64
 - Nuttx 12.1 (with this Makefile patch applied)
 - Target: custom board config, stm32h7xx

```
$ arm-none-eabi-nm (proprietary binary) | grep nx_start
0801b484 T nx_start
0801b5f8 t nx_start_task
```

```
$ arm-none-eabi-gdb  (proprietary binary)
GNU gdb (GNU Arm Embedded Toolchain 10-2020-q4-major) 10.1.90.20201028-git
...
Reading symbols from  (proprietary binary)...
(gdb) tar ext :8082
Remote debugging using :8082
main (argc=1, argv=0x30009388) at ../main.c:1556
1556	{
(gdb) load
...
(gdb) b main
Breakpoint 1 at 0x80298c4: file ..main.c, line 1556.
Note: automatically using hardware breakpoints for read-only addresses.
(gdb) c
Continuing.

Breakpoint 1, main (argc=1, argv=0x30009388) at ..main.c:1556
1556	{
(gdb) 
```