### PR TITLE
ci/platforms: Bump Espressif esptool

### DIFF
--- a/tools/ci/platforms/darwin.sh
+++ b/tools/ci/platforms/darwin.sh
@@ -278,7 +278,7 @@ python_tools() {
     construct \
     cvt2utf \
     cxxfilt \
-    esptool==4.8.dev4 \
+    esptool==5.2.0 \
     imgtool==1.9.0 \
     kconfiglib \
     pexpect==4.8.0 \

--- a/tools/ci/platforms/darwin_arm64.sh
+++ b/tools/ci/platforms/darwin_arm64.sh
@@ -254,7 +254,7 @@ python_tools() {
     construct \
     cvt2utf \
     cxxfilt \
-    esptool==4.8.dev4 \
+    esptool==5.2.0 \
     imgtool==1.9.0 \
     kconfiglib \
     pexpect==4.8.0 \

--- a/tools/ci/platforms/linux.sh
+++ b/tools/ci/platforms/linux.sh
@@ -146,7 +146,7 @@ python_tools() {
     construct \
     cvt2utf \
     cxxfilt \
-    esptool==4.8.dev4 \
+    esptool==5.2.0 \
     imgtool \
     kconfiglib \
     pexpect==4.8.0 \

--- a/tools/ci/platforms/ubuntu.sh
+++ b/tools/ci/platforms/ubuntu.sh
@@ -199,7 +199,7 @@ python_tools() {
     construct \
     cvt2utf \
     cxxfilt \
-    esptool==4.8.dev4 \
+    esptool==5.2.0 \
     imgtool \
     kconfiglib \
     pexpect==4.8.0 \


### PR DESCRIPTION
## Summary

- Bump Espressif esptool 5.2.0


   ci/platforms/darwin.sh
   ci/platforms/darwin_arm64.sh
   ci/platforms/linux.sh
   ci/platforms/ubuntu.sh

aligned with docker  [#18696](https://github.com/apache/nuttx/pull/18696)

## Impact

Impact on user: No changes to user-facing functionality
Impact on build: Build process remains the same

## Testing

GitHub

macOS (macos)

```
Collecting esptool==5.2.0
  Downloading esptool-5.2.0.tar.gz (463 kB)
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
```

https://github.com/simbit18/manual-nuttx-ci/actions/runs/24241006182/job/70775384364#logs