### PR TITLE
boards/risc-v: CMake added esp32c6-xiao and esp32p4-pico-wifi-wareshare boards

### DIFF
--- a/boards/risc-v/esp32c6/esp32c6-xiao/CMakeLists.txt
+++ b/boards/risc-v/esp32c6/esp32c6-xiao/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# boards/risc-v/esp32c6/esp32c6-xiao/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/risc-v/esp32c6/esp32c6-xiao/src/CMakeLists.txt
+++ b/boards/risc-v/esp32c6/esp32c6-xiao/src/CMakeLists.txt
@@ -1,0 +1,62 @@
+# ##############################################################################
+# boards/risc-v/esp32c6/esp32c6-xiao/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS esp32c6_boot.c esp32c6_bringup.c)
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS esp32c6_appinit.c)
+
+  if(CONFIG_BOARDCTL_RESET)
+    list(APPEND SRCS esp32c6_reset.c)
+  endif()
+endif()
+
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS esp32c6_gpio.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS esp32c6_buttons.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+# ##############################################################################
+# Linker scripts
+# ##############################################################################
+
+string(REPLACE "\"" "" CHIP_SERIES "${CONFIG_ESPRESSIF_CHIP_SERIES}")
+
+set(BOARD_COMMON_DIR "${NUTTX_BOARD_DIR}/../common")
+
+set(LDSCRIPTS "${BOARD_COMMON_DIR}/scripts/${CHIP_SERIES}_aliases.ld"
+              "${BOARD_COMMON_DIR}/scripts/${CHIP_SERIES}_flat_memory.ld")
+
+if(CONFIG_ESPRESSIF_BOOTLOADER_MCUBOOT OR CONFIG_ESPRESSIF_SIMPLE_BOOT)
+  list(APPEND LDSCRIPTS
+       "${BOARD_COMMON_DIR}/scripts/${CHIP_SERIES}_sections.ld")
+else()
+  list(APPEND LDSCRIPTS
+       "${BOARD_COMMON_DIR}/scripts/${CHIP_SERIES}_legacy_sections.ld")
+endif()
+
+set_property(GLOBAL PROPERTY LD_SCRIPT ${LDSCRIPTS})

--- a/boards/risc-v/esp32p4/esp32p4-pico-wifi-wareshare/CMakeLists.txt
+++ b/boards/risc-v/esp32p4/esp32p4-pico-wifi-wareshare/CMakeLists.txt
@@ -1,0 +1,23 @@
+# ##############################################################################
+# boards/risc-v/esp32p4/esp32p4-pico-wifi-wareshare/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+add_subdirectory(src)

--- a/boards/risc-v/esp32p4/esp32p4-pico-wifi-wareshare/src/CMakeLists.txt
+++ b/boards/risc-v/esp32p4/esp32p4-pico-wifi-wareshare/src/CMakeLists.txt
@@ -1,0 +1,64 @@
+# ##############################################################################
+# boards/risc-v/esp32p4/esp32p4-pico-wifi-wareshare/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(SRCS esp32p4_boot.c esp32p4_bringup.c)
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS esp32p4_appinit.c)
+
+  if(CONFIG_BOARDCTL_RESET)
+    list(APPEND SRCS esp32p4_reset.c)
+  endif()
+endif()
+
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS esp32p4_gpio.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS esp32p4_buttons.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})
+
+# ##############################################################################
+# Linker scripts (P4: sections or sections.rev3 when REV_MIN_300)
+# ##############################################################################
+
+string(REPLACE "\"" "" CHIP_SERIES "${CONFIG_ESPRESSIF_CHIP_SERIES}")
+
+set(BOARD_COMMON_DIR "${NUTTX_BOARD_DIR}/../common")
+
+set(LDSCRIPTS "${BOARD_COMMON_DIR}/scripts/${CHIP_SERIES}_aliases.ld"
+              "${BOARD_COMMON_DIR}/scripts/${CHIP_SERIES}_flat_memory.ld")
+
+if(CONFIG_ESPRESSIF_BOOTLOADER_MCUBOOT OR CONFIG_ESPRESSIF_SIMPLE_BOOT)
+  if(CONFIG_ESP32P4_REV_MIN_300)
+    list(APPEND LDSCRIPTS
+         "${BOARD_COMMON_DIR}/scripts/${CHIP_SERIES}_sections.rev3.ld")
+  else()
+    list(APPEND LDSCRIPTS
+         "${BOARD_COMMON_DIR}/scripts/${CHIP_SERIES}_sections.ld")
+  endif()
+endif()
+
+set_property(GLOBAL PROPERTY LD_SCRIPT ${LDSCRIPTS})


### PR DESCRIPTION
## Summary

**esp32c6**
- CMake added esp32c6-xiao board


**esp32p4**
- CMake added esp32p4-pico-wifi-wareshare board

## Impact

Impact on user: This PR adds esp32c6-xiao and esp32p4-pico-wifi-wareshare boards with CMake build

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

<details>
<summary>esp32c6-xiao:nsh</summary>


```
D:\nuttxtmp\nuttx>cmake -B build -DBOARD_CONFIG=esp32c6-xiao:nsh -DNXTMPDIR=on -GNinja
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Initializing NuttX
Loaded configuration 'D:/nuttxtmp/nuttx/build/.config.compressed'
Minimal configuration saved to 'D:/nuttxtmp/nuttx/build/defconfig.tmp'
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  esp32c6-xiao
--   Config: nsh
--   Appdir: D:/nuttxtmp/apps
-- Building for: Ninja
-- The C compiler identification is GNU 14.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/mingw/mingw64/bin/gcc.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- NuttX Host Tools
-- CMake C compiler: GNU
   TOOLS_DIR path is "D:/nuttxtmp/nuttx"-- CMake system name: Windows
-- CMake host system processor: AMD64

   HOST = WINDOWS NATIVE
-- Configuring done (0.8s)
-- Generating done (0.0s)
-- Build files have been written to: D:/nuttxtmp/nuttx/build/bin_host
-- The C compiler identification is GNU 14.2.0
-- The CXX compiler identification is GNU 14.2.0
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/riscv-none-elf-gcc/bin/riscv-none-elf-gcc.exe
-- COMMIT SHA-1: b7e51db97a3f9dc82d3b3524d2bad298ba1e2647
HEAD is now at 582ff4820 feat(drivers): ESP-HMAC opaque driver
-- Copying from D:/nuttxtmp/nxtmpdir/esp-hal-3rdparty to D:/nuttxtmp/nuttx/build/arch/risc-v/src/common/espressif/esp-hal-3rdparty
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (26.1s)
-- Generating done (2.5s)
-- Build files have been written to: D:/nuttxtmp/nuttx/build

D:\nuttxtmp\nuttx>cmake --build build
[1365/1365] Running utility command for nuttx_post_build
-- Generate NuttX image (esptool elf2image)
esptool v5.2.0
Creating ESP32-C6 image...
Image has only RAM segments visible. ROM segments are hidden and SHA256 digest is not appended.
Note: Inserting 63628 bytes padding between .flash.text and .flash.rodata
Note: Inserting 4 bytes padding between .iram0.text and .dram0.data
Merged 2 ELF sections.
Successfully created ESP32-C6 image.
-- Generated: nuttx.bin

```
</details>


<details>
<summary>esp32p4-pico-wifi-wareshare:nsh</summary>

```
D:\nuttxtmp\nuttx>cmake -B build -DBOARD_CONFIG=esp32p4-pico-wifi-wareshare:nsh -DNXTMPDIR=on -GNinja
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Initializing NuttX
Loaded configuration 'D:/nuttxtmp/nuttx/build/.config.compressed'
Minimal configuration saved to 'D:/nuttxtmp/nuttx/build/defconfig.tmp'
--   ENV{PROCESSOR_ARCHITECTURE} = AMD64
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
--   CMake:  3.31.5
--   Ninja:  1.12.1
--   Board:  esp32p4-pico-wifi-wareshare
--   Config: nsh
--   Appdir: D:/nuttxtmp/apps
-- Building for: Ninja
-- The C compiler identification is GNU 14.2.0
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: C:/mingw/mingw64/bin/gcc.exe - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- NuttX Host Tools
-- CMake C compiler: GNU
-- CMake system name: Windows
-- CMake host system processor: AMD64
   TOOLS_DIR path is "D:/nuttxtmp/nuttx"
   HOST = WINDOWS NATIVE
-- Configuring done (0.9s)
-- Generating done (0.0s)
-- Build files have been written to: D:/nuttxtmp/nuttx/build/bin_host
-- The C compiler identification is GNU 14.2.0
-- The CXX compiler identification is GNU 14.2.0
-- The ASM compiler identification is GNU
-- Found assembler: D:/nx20250410/tools/riscv-none-elf-gcc/bin/riscv-none-elf-gcc.exe
-- COMMIT SHA-1: b7e51db97a3f9dc82d3b3524d2bad298ba1e2647
HEAD is now at 582ff4820 feat(drivers): ESP-HMAC opaque driver
-- Copying from D:/nuttxtmp/nxtmpdir/esp-hal-3rdparty to D:/nuttxtmp/nuttx/build/arch/risc-v/src/common/espressif/esp-hal-3rdparty
-- nuttx_add_subdirectory: Skipping cxx-oot-build
-- Configuring done (27.7s)
-- Generating done (2.6s)
-- Build files have been written to: D:/nuttxtmp/nuttx/build

D:\nuttxtmp\nuttx>cmake --build build
[1348/1348] Running utility command for nuttx_post_build
-- Generate NuttX image (esptool elf2image)
esptool v5.2.0
Creating ESP32-P4 image...
Image has only RAM segments visible. ROM segments are hidden and SHA256 digest is not appended.
Merged 2 ELF sections.
Successfully created ESP32-P4 image.
-- Generated: nuttx.bin


```
</details>