### PR TITLE
espressif: fix Wi-Fi IRQ issue during SPI Flash operations

### DIFF
--- a/arch/risc-v/src/esp32c3/esp_wifi_adapter.c
+++ b/arch/risc-v/src/esp32c3/esp_wifi_adapter.c
@@ -40,6 +40,7 @@
 #include "esp_hr_timer.h"
 
 #include "esp_log.h"
+#include "esp_intr_alloc.h"
 #include "esp_mac.h"
 #include "esp_random.h"
 #include "esp_private/wifi_os_adapter.h"
@@ -84,6 +85,12 @@ struct vector_desc_t
   shared_vector_desc_t *shared_vec_info;
   vector_desc_t *next;
 };
+
+/* From esp_hw_support/intr_alloc.c: returns a pointer to a HAL-owned
+ * vector descriptor for some intno and cpu.
+ */
+
+extern vector_desc_t *get_desc_for_int(int intno, int cpu);
 
 /****************************************************************************
  * Private Function Prototypes
@@ -532,7 +539,9 @@ static void wifi_delete_queue_wrapper(void *queue)
  * Name: set_intr_wrapper
  *
  * Description:
- *   Do nothing
+ *   Route the Wi-Fi interrupt source and attach a handle that uses the HAL
+ *   global vector descriptor list. Mark the CPU line as non-IRAM so
+ *   esp_intr_noniram_disable() masks it while SPI flash holds the cache off.
  *
  * Input Parameters:
  *     cpu_no      - The CPU which the interrupt number belongs.
@@ -550,6 +559,7 @@ static void set_intr_wrapper(int32_t cpu_no, uint32_t intr_source,
 {
   intr_handle_t handle;
   int irq = ESP_SOURCE2IRQ(intr_source);
+  esp_err_t err;
 
   wlinfo("cpu_no=%" PRId32 ", intr_source=%" PRIu32
          ", intr_num=%" PRIu32 ", intr_prio=%" PRId32 "\n",
@@ -566,22 +576,24 @@ static void set_intr_wrapper(int32_t cpu_no, uint32_t intr_source,
       return;
     }
 
-  handle->vector_desc = kmm_calloc(1, sizeof(vector_desc_t));
+  handle->vector_desc = get_desc_for_int(intr_num, cpu_no);
   if (handle->vector_desc == NULL)
     {
-      wlerr("Failed to kmm_calloc\n");
+      wlerr("get_desc_for_int failed\n");
       kmm_free(handle);
       return;
     }
 
-  handle->vector_desc->intno = intr_num;
-  handle->vector_desc->cpu = cpu_no;
   handle->vector_desc->source = intr_source;
-  handle->vector_desc->shared_vec_info = NULL;
-  handle->vector_desc->next = NULL;
   handle->shared_vector_desc = NULL;
 
   esp_set_handle(cpu_no, irq, handle);
+
+  err = esp_intr_set_in_iram(handle, false);
+  if (err != ESP_OK)
+    {
+      wlerr("esp_intr_set_in_iram failed: %d\n", err);
+    }
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/esp32c6/esp_wifi_adapter.c
+++ b/arch/risc-v/src/esp32c6/esp_wifi_adapter.c
@@ -121,6 +121,12 @@ struct vector_desc_t
   vector_desc_t *next;
 };
 
+/* From esp_hw_support/intr_alloc.c: returns a pointer to a HAL-owned
+ * vector descriptor for some intno and cpu.
+ */
+
+extern vector_desc_t *get_desc_for_int(int intno, int cpu);
+
 /****************************************************************************
  * Private Function Prototypes
  ****************************************************************************/
@@ -566,7 +572,9 @@ static void wifi_delete_queue_wrapper(void *queue)
  * Name: set_intr_wrapper
  *
  * Description:
- *   Do nothing
+ *   Route the Wi-Fi interrupt source and attach a handle that uses the HAL
+ *   global vector descriptor list. Mark the CPU line as non-IRAM so
+ *   esp_intr_noniram_disable() masks it while SPI flash holds the cache off.
  *
  * Input Parameters:
  *     cpu_no      - The CPU which the interrupt number belongs.
@@ -584,6 +592,7 @@ static void set_intr_wrapper(int32_t cpu_no, uint32_t intr_source,
 {
   intr_handle_t handle;
   int irq = ESP_SOURCE2IRQ(intr_source);
+  esp_err_t err;
 
   wlinfo("cpu_no=%" PRId32 ", intr_source=%" PRIu32
          ", intr_num=%" PRIu32 ", intr_prio=%" PRId32 "\n",
@@ -600,22 +609,24 @@ static void set_intr_wrapper(int32_t cpu_no, uint32_t intr_source,
       return;
     }
 
-  handle->vector_desc = kmm_calloc(1, sizeof(vector_desc_t));
+  handle->vector_desc = get_desc_for_int(intr_num, cpu_no);
   if (handle->vector_desc == NULL)
     {
-      wlerr("Failed to kmm_calloc\n");
+      wlerr("get_desc_for_int failed\n");
       kmm_free(handle);
       return;
     }
 
-  handle->vector_desc->intno = intr_num;
-  handle->vector_desc->cpu = cpu_no;
   handle->vector_desc->source = intr_source;
-  handle->vector_desc->shared_vec_info = NULL;
-  handle->vector_desc->next = NULL;
   handle->shared_vector_desc = NULL;
 
   esp_set_handle(cpu_no, irq, handle);
+
+  err = esp_intr_set_in_iram(handle, false);
+  if (err != ESP_OK)
+    {
+      wlerr("esp_intr_set_in_iram failed: %d\n", err);
+    }
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32/esp32_wifi_adapter.c
+++ b/arch/xtensa/src/esp32/esp32_wifi_adapter.c
@@ -49,6 +49,7 @@
 #include "esp32_wifi_adapter.h"
 #include "esp_hr_timer.h"
 #include "esp_irq.h"
+#include "esp_intr_alloc.h"
 #include "esp_cpu.h"
 #include "espressif/esp_wireless.h"
 #include "espressif/esp_wifi_utils.h"
@@ -1752,7 +1753,9 @@ static bool wifi_env_is_chip(void)
  * Name: set_intr_wrapper
  *
  * Description:
- *   Do nothing
+ *   Route the Wi-Fi interrupt source and attach a handle that uses the HAL
+ *   global vector descriptor list. Mark the CPU line as non-IRAM so
+ *   esp_intr_noniram_disable() masks it while SPI flash holds the cache off.
  *
  * Input Parameters:
  *     cpu_no      - The CPU which the interrupt number belongs.
@@ -1770,6 +1773,7 @@ static void set_intr_wrapper(int32_t cpu_no, uint32_t intr_source,
 {
   intr_handle_t handle;
   int irq = ESP_SOURCE2IRQ(intr_source);
+  esp_err_t err;
 
   wlinfo("cpu_no=%" PRId32 ", intr_source=%" PRIu32
          ", intr_num=%" PRIu32 ", intr_prio=%" PRId32 "\n",
@@ -1785,11 +1789,25 @@ static void set_intr_wrapper(int32_t cpu_no, uint32_t intr_source,
     }
 
   handle->vector_desc = get_desc_for_int(intr_num, cpu_no);
+  if (handle->vector_desc == NULL)
+    {
+      wlerr("get_desc_for_int failed\n");
+      kmm_free(handle);
+      return;
+    }
+
   handle->vector_desc->source = intr_source;
+  handle->shared_vector_desc = NULL;
 
   /* Register the handle - it contains all needed information (cpuint, cpu) */
 
   esp_set_handle(cpu_no, irq, handle);
+
+  err = esp_intr_set_in_iram(handle, false);
+  if (err != OK)
+    {
+      wlerr("esp_intr_set_in_iram failed: %d\n", err);
+    }
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32s2/esp32s2_wifi_adapter.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_wifi_adapter.c
@@ -44,6 +44,7 @@
 #include "xtensa.h"
 #include "esp_attr.h"
 #include "esp_irq.h"
+#include "esp_intr_alloc.h"
 #include "esp_cpu.h"
 #include "hardware/esp32s2_system.h"
 #include "soc/rtc_cntl_reg.h"
@@ -94,6 +95,12 @@ struct vector_desc_t
   shared_vector_desc_t *shared_vec_info;
   vector_desc_t *next;
 };
+
+/* From esp_hw_support/intr_alloc.c: returns a pointer to a HAL-owned
+ * vector descriptor for some intno and cpu.
+ */
+
+extern vector_desc_t *get_desc_for_int(int intno, int cpu);
 
 /****************************************************************************
  * Private Function Prototypes
@@ -1604,7 +1611,9 @@ static bool wifi_env_is_chip(void)
  * Name: set_intr_wrapper
  *
  * Description:
- *   Do nothing
+ *   Route the Wi-Fi interrupt source and attach a handle that uses the HAL
+ *   global vector descriptor list. Mark the CPU line as non-IRAM so
+ *   esp_intr_noniram_disable() masks it while SPI flash holds the cache off.
  *
  * Input Parameters:
  *     cpu_no      - The CPU which the interrupt number belongs.
@@ -1622,6 +1631,7 @@ static void set_intr_wrapper(int32_t cpu_no, uint32_t intr_source,
 {
   intr_handle_t handle;
   int irq = ESP_SOURCE2IRQ(intr_source);
+  esp_err_t err;
 
   wlinfo("cpu_no=%" PRId32 ", intr_source=%" PRIu32
          ", intr_num=%" PRIu32 ", intr_prio=%" PRId32 "\n",
@@ -1636,24 +1646,26 @@ static void set_intr_wrapper(int32_t cpu_no, uint32_t intr_source,
       return;
     }
 
-  handle->vector_desc = kmm_calloc(1, sizeof(vector_desc_t));
+  handle->vector_desc = get_desc_for_int(intr_num, cpu_no);
   if (handle->vector_desc == NULL)
     {
-      wlerr("Failed to kmm_calloc\n");
+      wlerr("get_desc_for_int failed\n");
       kmm_free(handle);
       return;
     }
 
-  handle->vector_desc->intno = intr_num;
-  handle->vector_desc->cpu = cpu_no;
   handle->vector_desc->source = intr_source;
-  handle->vector_desc->shared_vec_info = NULL;
-  handle->vector_desc->next = NULL;
   handle->shared_vector_desc = NULL;
 
   /* Register the handle - it contains all needed information (cpuint, cpu) */
 
   esp_set_handle(cpu_no, irq, handle);
+
+  err = esp_intr_set_in_iram(handle, false);
+  if (err != OK)
+    {
+      wlerr("esp_intr_set_in_iram failed: %d\n", err);
+    }
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32s3/esp32s3_wifi_adapter.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_wifi_adapter.c
@@ -44,6 +44,7 @@
 #include "xtensa.h"
 #include "esp_attr.h"
 #include "esp_irq.h"
+#include "esp_intr_alloc.h"
 #include "esp_cpu.h"
 #include "hardware/esp32s3_system.h"
 #include "soc/rtc_cntl_reg.h"
@@ -266,6 +267,10 @@ static int coex_schm_register_cb_wrapper(int type, int(*cb)(int));
 static int coex_schm_flexible_period_set_wrapper(uint8_t period);
 static uint8_t coex_schm_flexible_period_get_wrapper(void);
 static void * coex_schm_get_phase_by_idx_wrapper(int phase_idx);
+
+/* From esp_hw_support/intr_alloc.c: returns a pointer to a HAL-owned
+ * vector descriptor for some intno and cpu.
+ */
 
 extern vector_desc_t *get_desc_for_int(int intno, int cpu);
 
@@ -1738,7 +1743,9 @@ static bool wifi_env_is_chip(void)
  * Name: set_intr_wrapper
  *
  * Description:
- *   Do nothing
+ *   Route the Wi-Fi interrupt source and attach a handle that uses the HAL
+ *   global vector descriptor list. Mark the CPU line as non-IRAM so
+ *   esp_intr_noniram_disable() masks it while SPI flash holds the cache off.
  *
  * Input Parameters:
  *     cpu_no      - The CPU which the interrupt number belongs.
@@ -1756,6 +1763,7 @@ static void set_intr_wrapper(int32_t cpu_no, uint32_t intr_source,
 {
   intr_handle_t handle;
   int irq = ESP_SOURCE2IRQ(intr_source);
+  esp_err_t err;
 
   wlinfo("cpu_no=%" PRId32 ", intr_source=%" PRIu32
          ", intr_num=%" PRIu32 ", intr_prio=%" PRId32 "\n",
@@ -1771,12 +1779,25 @@ static void set_intr_wrapper(int32_t cpu_no, uint32_t intr_source,
     }
 
   handle->vector_desc = get_desc_for_int(intr_num, cpu_no);
+  if (handle->vector_desc == NULL)
+    {
+      wlerr("get_desc_for_int failed\n");
+      kmm_free(handle);
+      return;
+    }
 
   handle->vector_desc->source = intr_source;
+  handle->shared_vector_desc = NULL;
 
   /* Register the handle - it contains all needed information (cpuint, cpu) */
 
   esp_set_handle(cpu_no, irq, handle);
+
+  err = esp_intr_set_in_iram(handle, false);
+  if (err != OK)
+    {
+      wlerr("esp_intr_set_in_iram failed: %d\n", err);
+    }
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Wi-Fi interrupt setup in the ESP32/ESP32-S2/ESP32-S3 (Xtensa) and ESP32-C3/C6 (RISC-V) Wi-Fi adapters now uses the HAL’s global vector descriptor (`get_desc_for_int`) instead of a separately allocated `vector_desc`, and registers each line as **not** in IRAM via `esp_intr_set_in_iram(handle, false)`. That aligns Wi-Fi IRQs with `esp_intr_noniram_disable()` so they are masked while SPI flash operations hold the cache disabled, reducing risk of Wi-Fi ISRs running from flash in that window.

- `3405a94f29` arch/risc-v: register Wi-Fi IRQs in non_iram mask for SPI flash
- `909177e5b7` arch/xtensa: register Wi-Fi IRQs in non_iram mask for SPI flash

This PR fixes an issue where SPI Flash and Wi-Fi would crash when used together. The reason was that Wi-Fi interrupts were accessing cached functions while it was disabled. The correct operation here is to disable Wi-Fi interrupts while cache is off.

## Impact

Impact on user: **YES** — Wi-Fi stability on Espressif boards when SPI flash holds the cache disabled; no public API change.

Impact on build: **NO**

Impact on hardware: **YES** — ESP32, ESP32-S2, ESP32-S3, ESP32-C3, ESP32-C6 (Wi-Fi + SPI flash coexistence).

Impact on documentation: **NO**

Impact on security: **NO**

Impact on compatibility: **NO**

## Testing

### Building

- `./tools/configure.sh esp32c6-devkitc`
- `make` (with usual parallelism)
- Flash the board with your usual method for this defconfig

### Running

- `wapi psk wlan0 <password> 3 2`
- `wapi essid wlan0 <ssid> 1`
- `renew wlan0`
- `wapi save_config wlan0`

### Results
Before the changes, `wapi save_config`  would simply crash with no warning or backtrace. Now it works properly.

```
nsh> wapi psk wlan0 espmint123 3 2
nsh> wapi essid wlan0 Nuttx-IOT 1
nsh> renew wlan0
nsh> wapi save_config wlan0
nsh> echo $?
0
nsh> cat /data/wapi.conf
{"wlan0":{"mode":2,"auth":4,"cmode":8,"alg":3,"ssid":"Nuttx-IOT","bssid":"e0:1c:fc:00:??:??","psk":"espmint123"}}nsh> 
```