### PR TITLE
nuttx: Suppress UNUSED potential warnings

### DIFF
--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -625,7 +625,7 @@
 /* Indicate that a local variable is not used */
 
 #  ifndef UNUSED
-#    define UNUSED(a) ((void)(1 || &(a)))
+#    define UNUSED(a) ((void)(a))
 #  endif
 
 #  if defined(__clang__)


### PR DESCRIPTION
## Summary

Update UNUSED(a) for GCC to cast 'a' to void to suppress potential "address of 'xxx' will always evaluate to true" warning when enabling warnings in system headers.

## Impact

User experience: No adaptation required.
Build: No impact.
Hardware: Should not affect GCC builds.
Documentation: No impact.
Security: No impact.
Compatibility: No impact.

## Testing

Build Host:

- OS: Ubuntu 24.04.4 LTS
- Compiler: arm-none-eabi-gcc 13.2.1

Target: None
Built all ARM builds using modified tools/testbuild.sh script with increased warnings (-Wall -Wextra -Wsystem-headers), verified no warnings from invocations of UNUSED() macro.
