### PR TITLE
video/fb: fix compilation errors

### DIFF
--- a/include/nuttx/video/fb.h
+++ b/include/nuttx/video/fb.h
@@ -654,7 +654,7 @@ struct fb_cmap_s
 struct fb_cursorimage_s
 {
   fb_coord_t     width;    /* Width of the cursor image in pixels */
-  fb_coord_t     height    /* Height of the cursor image in pixels */
+  fb_coord_t     height;   /* Height of the cursor image in pixels */
   const uint8_t *image;    /* Pointer to image data */
 };
 #endif


### PR DESCRIPTION
enabling CONFIG_FB_HWCURSOR and CONFIG_FB_HWCURSORIMAGE causes a compile error: missing semicolon after a structure variable.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Enabling CONFIG_FB_HWCURSOR and CONFIG_FB_HWCURSORIMAGE causes a compilation error due to a missing semicolon after the height variable in the struct fb_cursorimage_s structure.
This change adds the missing semicolon to fix the syntax error and ensure successful compilation when the two configuration options are enabled.

## Impact

1. Fixes a build failure when both CONFIG_FB_HWCURSOR and CONFIG_FB_HWCURSORIMAGE are enabled.
2. No effect on users who disable these two configuration options.
3. No breakage to existing functionality, hardware compatibility, or system security.
4. No documentation updates required.

## Testing

1. Host Machine: Ubuntu 24.04 
2. Tested Board: Framebuffer-supported board (with CONFIG_FB_HWCURSOR and CONFIG_FB_HWCURSORIMAGE enabled)
3. Test Procedure:
Enabled CONFIG_FB_HWCURSOR and CONFIG_FB_HWCURSORIMAGE in the configuration
Ran the standard build command: make
4. Result:
Before the fix: Compilation failed with "missing semicolon" error
After the fix: Build completes successfully with no errors
5. No regressions detected in existing framebuffer and hardware cursor functionality.
