### PR TITLE
tools/ci: Added esptool for Windows Native and fix Filename too long

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -451,8 +451,6 @@ jobs:
         run: |
           pip install kconfiglib
 
-      - run: git config --global core.autocrlf false
-
       - name: Download Source Artifact
         uses: actions/download-artifact@v8
         with:
@@ -467,6 +465,8 @@ jobs:
       - name: Run Builds
         run: |
           "ARTIFACTDIR=${{github.workspace}}\sources\buildartifacts" >> $env:GITHUB_ENV
+          git config --global core.autocrlf false
+          git config --global core.longpaths true
           git config --global --add safe.directory ${{github.workspace}}\sources\nuttx
           git config --global --add safe.directory ${{github.workspace}}\sources\apps
           cd sources\nuttx\tools\ci

--- a/tools/ci/platforms/windows.ps1
+++ b/tools/ci/platforms/windows.ps1
@@ -139,7 +139,6 @@ function arm_gcc_toolchain() {
 
 function arm64_gcc_toolchain() {
   Write-Host "Check ARM64 GCC toolchain toolchain ..." -ForegroundColor Green
-
   try {
     if (run_command("aarch64-none-elf-gcc") -ne 0) {
       add_path "$NUTTXTOOLS\gcc-aarch64-none-elf\bin"
@@ -167,7 +166,7 @@ function cmake_tool {
   if (run_command("cmake") -ne 0) {
     add_path "$NUTTXTOOLS\cmake\bin"
     if ($null -eq (Get-Command cmake -ErrorAction SilentlyContinue)) {
-      Write-Host "Download: Ninja package" -ForegroundColor Green
+      Write-Host "Download: Cmake package" -ForegroundColor Green
       # Download the file
       $basefile = "cmake-3.31.6-windows-x86_64"
       Set-Location "$NUTTXTOOLS"
@@ -179,6 +178,25 @@ function cmake_tool {
     }
   }
   cmake --version
+}
+
+function esp_tool {
+  Write-Host "Check esptool ..." -ForegroundColor Green
+  if (run_command("esptool") -ne 0) {
+    add_path "$NUTTXTOOLS\esptool"
+    if ($null -eq (Get-Command esptool -ErrorAction SilentlyContinue)) {
+      Write-Host "Download: esptool package" -ForegroundColor Green
+      # Download the file
+      $basefile = "esptool-v5.2.0-windows-amd64"
+      Set-Location "$NUTTXTOOLS"
+      # Download tool esptool
+      Invoke-WebRequest -Uri "https://github.com/espressif/esptool/releases/download/v5.2.0/$basefile.zip" -OutFile "$NUTTXTOOLS\$basefile.zip" -ErrorAction Stop
+      Expand-Archive "$NUTTXTOOLS\$basefile.zip"
+      Move-Item -Path "$basefile\esptool-windows-amd64" -Destination "esptool"
+      Remove-Item "$basefile*" -Force
+    }
+  }
+  esptool version
 }
 
 function kconfig_frontends() {
@@ -337,7 +355,7 @@ function install_build_tools {
   if (-not (Test-Path -Path "$NUTTXTOOLS\env.ps1")) {
     add_envpath "$NUTTXTOOLS\env.ps1"
   }
-  $install = "arm_clang_toolchain arm_gcc_toolchain arm64_gcc_toolchain riscv_gcc_toolchain pico_sdk pico_tool cmake_tool kconfig_frontends ninja_tool"
+  $install = "arm_clang_toolchain arm_gcc_toolchain arm64_gcc_toolchain riscv_gcc_toolchain pico_sdk pico_tool cmake_tool esp_tool kconfig_frontends ninja_tool"
 
   $splitArray = $install.Split(" ")
   $oldpath = Get-Location

--- a/tools/ci/testlist/windows.dat
+++ b/tools/ci/testlist/windows.dat
@@ -16,6 +16,8 @@
 
 /risc-v/qemu-rv/rv-virt/configs/nsh
 
+/risc-v/esp32c3/esp32-c3-zero/configs/nsh
+
 # The simulator currently builds only with Visual Studio 2022
 
 /sim/sim/sim/configs/windows
@@ -26,4 +28,5 @@ CMake,nucleo-l152re:nsh
 CMake,nucleo-f411re:nsh
 CMake,raspberrypi-pico:nsh
 CMake,rv-virt:nsh
+CMake,esp32-c3-zero:nsh
 CMake,sim:windows

--- a/tools/testbuild.ps1
+++ b/tools/testbuild.ps1
@@ -423,6 +423,7 @@ function dotest {
   if ($NINJACMAKE -eq 1) {
     foreach ($l in $cmakelist) {
       if ("Cmake," + $config -replace '\\', ':' -eq "$l") {
+        Write-Host "Cmake in present: $config" -ForegroundColor Yellow
         $cmake = 1
       }
     }


### PR DESCRIPTION
## Summary

Windows Native

- Added esptool

- Added build for esp32-c3-zero

Git
  - Enabled long path support by setting the core.longpaths setting to true.

Fix

```
Cloning into 'esp-hal-3rdparty'...
HEAD is now at 5d8324708f5 Enable using `esp_timer` on RISC-V devices
error: unable to create file tf-psa-crypto/drivers/everest/include/tf-psa-crypto/private/everest/kremlib/FStar_UInt64_FStar_UInt32_FStar_UInt16_FStar_UInt8.h: Filename too long
fatal: Unable to checkout '582ff482038db6e4010dbf6f943d97b05ad06ea5' in submodule path 'components/mbedtls/mbedtls'
error: unable to create file tf-psa-crypto/drivers/everest/include/tf-psa-crypto/private/everest/kremlib/FStar_UInt64_FStar_UInt32_FStar_UInt16_FStar_UInt8.h: Filename too long
fatal: Could not reset index file to revision 'HEAD'.
```

## Impact

Impact on user: NO

Impact on build: Fix long path

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing
GitHub
```
====================================================================================
Cmake in present: esp32-c3-zero\nsh
Configuration/Tool: esp32-c3-zero\nsh
2026-04-13 09:38:53
------------------------------------------------------------------------------------
  Cleaning...
  Configuring...
  Select HOST_WINDOWS=y
  Select WINDOWS_NATIVE=y
   TOOLS_DIR path is "D:/a/manual-nuttx-ci/manual-nuttx-ci/sources/nuttx"
   HOST = WINDOWS NATIVE
Cloning into 'esp-hal-3rdparty'...
HEAD is now at b7e51db97a3 Fix PM build error
  CMake configuration completed successfully.
  Building NuttX...
  Build completed successfully.
  Refresh completed successfully.
====================================================================================

```

https://github.com/simbit18/manual-nuttx-ci/actions/runs/24336215216/job/71053700710#logs