### PR TITLE
nuttx/nx: compilation error occurs

### DIFF
--- a/include/nuttx/nx/nxmu.h
+++ b/include/nuttx/nx/nxmu.h
@@ -300,7 +300,7 @@ struct nxsvrmsg_curenable_s
 struct nxsvrmsg_curimage_s
 {
   uint32_t msgid;                    /* NX_SVRMSG_CURSOR_IMAGE */
-  struct nx_cursorimage_s image      /* Describes the cursor image */
+  struct nx_cursorimage_s image;     /* Describes the cursor image */
 };
 #endif
 


### PR DESCRIPTION
Enabling CONFIG_NX_HWCURSORIMAGE or CONFIG_NX_SWCURSOR causes a compile error due to a missing semicolon after a structure variable.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Enabling CONFIG_NX_HWCURSORIMAGE or CONFIG_NX_SWCURSOR leads to a compilation error due to a missing semicolon after the struct nx_cursorimage_s image member in the struct nxsvrmsg_curimage_s structure definition.

This change adds the missing semicolon to fix the syntax error and ensure successful compilation when the related cursor configuration options are enabled.

## Impact

1. Fixes a build failure when CONFIG_NX_HWCURSORIMAGE or CONFIG_NX_SWCURSOR is enabled.
2. No functional impact on system behavior, hardware operations, or user applications.
3. No effect on users who disable the cursor configuration options.
4. No impact on security, compatibility, or documentation.
5. No breakage to existing NX server and cursor-related functionality.

## Testing

1. Host Machine: Ubuntu 20.04 LTS
2. Test Configuration: Enabled CONFIG_NX_HWCURSORIMAGE or CONFIG_NX_SWCURSOR in the NuttX configuration
3. Test Procedure: Executed the standard build command make to verify compilation
4. Test Result:
Before the fix: Compilation failed with a "missing semicolon" error
After the fix: Build completes successfully without any errors
5. No regressions observed in existing NX server and cursor modules.
