### PR TITLE
arch/arm/imx9: eDMA5 don't enable all interrupts

### DIFF
--- a/arch/arm/src/imx9/imx9_edma.c
+++ b/arch/arm/src/imx9/imx9_edma.c
@@ -1001,7 +1001,8 @@ void weak_function arm_dma_initialize(void)
    * controller).
    */
 
-  for (i = 0; i < DMA4_IRQ_COUNT; i++)
+  for (i = CONFIG_IMX9_EDMA5_CHAN_OFFSET;
+       i < CONFIG_IMX9_EDMA5_CHAN_COUNT; i++)
     {
       up_enable_irq(IMX9_IRQ_DMA5_2_0_1 + i);
     }


### PR DESCRIPTION

## Summary
Fixes irq_unexpected_isr when receiving interrupts not used by the M7 core.
```
irq_unexpected_isr: ERROR irq: 146
dump_assert_info: Current Version: NuttX  12.12.0 11d5046019 Apr 13 2026 15:20:19 arm
dump_assert_info: Assertion failed panic: at file: irq/irq_unexpectedisr.c:56 task: Idle_Task process: Kernel 0x2ab05
```

## Impact

Minimal, small bug fix

## Testing

NavQ95 board with i.MX95 
