### PR TITLE
tools/Unix.mk: fix Untracked files defconfig.tmp-e on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ etctmp/
 /_SAVED_APPS_config
 /cscope.*
 /defconfig
+/defconfig.tmp.bak
 /Make.defs
 /nuttx
 /nuttx32

--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -767,8 +767,8 @@ savedefconfig: apps_preconfig
 	$(Q) ${KCONFIG_ENV} ${KCONFIG_SAVEDEFCONFIG}
 	$(Q) $(call kconfig_tweak_disable,defconfig.tmp,CONFIG_APPS_DIR)
 	$(Q) $(call kconfig_tweak_disable,defconfig.tmp,CONFIG_BASE_DEFCONFIG)
-	$(Q) sed -i -e '/^CONFIG_FSUTILS_PASSWD_KEY[0-9]/d' defconfig.tmp
-	$(Q) sed -i -e '/^CONFIG_BOARD_ETC_ROMFS_PASSWD_PASSWORD=/d' defconfig.tmp
+	$(Q) sed -i.bak -e '/^CONFIG_FSUTILS_PASSWD_KEY[0-9]/d' defconfig.tmp
+	$(Q) sed -i.bak -e '/^CONFIG_BOARD_ETC_ROMFS_PASSWD_PASSWORD=/d' defconfig.tmp
 	$(Q) grep "CONFIG_ARCH=" .config >> defconfig.tmp
 	$(Q) grep "^CONFIG_ARCH_CHIP_" .config >> defconfig.tmp; true
 	$(Q) grep "CONFIG_ARCH_CHIP=" .config >> defconfig.tmp; true
@@ -851,6 +851,7 @@ endif
 	$(Q) $(MAKE) -C tools -f Makefile.host clean
 	$(call DELFILE, Make.defs)
 	$(call DELFILE, defconfig)
+	$(call DELFILE, defconfig.tmp.bak)
 	$(call DELFILE, .config)
 	$(call DELFILE, .config.old)
 	$(call DELFILE, .config.orig)


### PR DESCRIPTION
## Summary

fix

```
===============================================================================```
=====
Configuration/Tool: stm32f4discovery/nsh,CONFIG_ARM_TOOLCHAIN_GNU_EABI
2026-04-14 09:32:23
------------------------------------------------------------------------------------
  Cleaning...
  Configuring...
  Disabling CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Enabling CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Building NuttX...
chip/stm32_gpio.c:44:11: note: '#pragma message: CONFIG_STM32_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py'
   44 | #  pragma message "CONFIG_STM32_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
      |           ^~~~~~~
  [1/1] Normalize stm32f4discovery/nsh
On branch fix_sim_mac
Your branch is up to date with 'origin/fix_sim_mac'.

Untracked files:
	defconfig.tmp-e

nothing added to commit but untracked files present
===============================================================================
```=====
```

## Impact

Impact on user: NO

Impact on build: Fix Untracked files on macOS

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

GitHub 
Linux,MSYS2 and macOS  jobs

```
====================================================================================
Configuration/Tool: stm32f4discovery/nsh,CONFIG_ARM_TOOLCHAIN_GNU_EABI
2026-04-14 12:21:09
------------------------------------------------------------------------------------
  Cleaning...
  Configuring...
  Disabling CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Enabling CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Building NuttX...
chip/stm32_gpio.c:44:11: note: '#pragma message: CONFIG_STM32_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py'
   44 | #  pragma message "CONFIG_STM32_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
      |           ^~~~~~~
  [1/1] Normalize stm32f4discovery/nsh
====================================================================================
```

https://github.com/simbit18/manual-nuttx-ci/actions/runs/24398267437/job/71261706391

