### PR TITLE
arch/arm: add STM32H755XI chip

### DIFF
--- a/Documentation/platforms/arm/stm32h7/index.rst
+++ b/Documentation/platforms/arm/stm32h7/index.rst
@@ -13,7 +13,7 @@ MCU          Support Note
 STM32H747    Partial Only STM32H747XI
 STM32H757    No
 STM32H745    Yes
-STM32H755    No
+STM32H755    Partial Only STM32H755II and STM32H755XI
 ===========  ======= ================
 
 Single-core lines:

--- a/arch/arm/include/stm32h7/chip.h
+++ b/arch/arm/include/stm32h7/chip.h
@@ -82,7 +82,8 @@
     defined (CONFIG_ARCH_CHIP_STM32H750ZB) || \
     defined (CONFIG_ARCH_CHIP_STM32H750IB) || \
     defined (CONFIG_ARCH_CHIP_STM32H750XB) || \
-    defined (CONFIG_ARCH_CHIP_STM32H755II)
+    defined (CONFIG_ARCH_CHIP_STM32H755II) || \
+    defined (CONFIG_ARCH_CHIP_STM32H755XI)
 #elif defined(CONFIG_ARCH_CHIP_STM32H747XI)
 #else
 #  error STM32 H7 chip not identified

--- a/arch/arm/src/stm32h7/Kconfig
+++ b/arch/arm/src/stm32h7/Kconfig
@@ -335,10 +335,20 @@ config ARCH_CHIP_STM32H755II
 	select STM32H7_IO_CONFIG_I
 	select STM32H7_HAVE_FDCAN1
 	select STM32H7_HAVE_FDCAN2
-	select STM32H7_HAVE_SMPS
 	---help---
 		STM32 H7 Cortex M7, 2048 Kb FLASH, 1024K Kb SRAM,
 		with cryptographic accelerator, LQFP176/UFBGA176
+
+config ARCH_CHIP_STM32H755XI
+	bool "STM32H755XI"
+	select STM32H7_STM32H7X5XX
+	select STM32H7_FLASH_CONFIG_I
+	select STM32H7_IO_CONFIG_X
+	select STM32H7_HAVE_FDCAN1
+	select STM32H7_HAVE_FDCAN2
+	---help---
+		STM32 H7 Cortex M7, 2048 Kb FLASH, 1024K Kb SRAM,
+		with cryptographic accelerator, TFBGA240
 
 endchoice # STM32 H7 Chip Selection
 


### PR DESCRIPTION
## Summary
Add STM32H755XI, based on the STM32H755II. For JAE flight controllers with PX4 NuttX.

## Impact
None.

## Testing
We have confirmed that the firmware correctly on PX4 Autopilot.