### PR TITLE
arch/risc-v/espressif: Fix Kconfig option for TWAI

### DIFF
--- a/arch/risc-v/src/common/espressif/Kconfig
+++ b/arch/risc-v/src/common/espressif/Kconfig
@@ -1156,10 +1156,8 @@ config ESPRESSIF_LP_UART0
 	select ARCH_HAVE_SERIAL_TERMIOS
 
 config ESPRESSIF_TWAI
-	bool "TWAI (CAN)"
+	bool
 	default n
-	select ARCH_HAVE_CAN_ERRORS
-	select CAN
 
 config ESPRESSIF_TWAI0
 	bool "TWAI0 (CAN)"


### PR DESCRIPTION
## Summary

Unnecessary select lines and free to choose `ESPRESSIF_TWAI` option (which should not be) handled to have clearer Kconfig option system

<!-- This field should contain a summary of the changes. It will be pre-filled with the commit's message and descriptions. Adjust it accordingly -->

* arch/risc-v/espressif: Fix Kconfig option for TWAI

Fix Kconfig option for about on risc-v based Espressif chips

## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: No
<!-- Does it impact user's applications? How? -->

Impact on build: No
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: No
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: No
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: No
<!-- Does it impact NuttX's security? -->

Impact on compatibility: No
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

## Testing
<!-- Please provide all the testing procedure. Consider that upstream reviewers should be able to reproduce the same testing performed internally -->

`esp32c6-devkitc:twai` config used with `CAN_LOOPBACK` option enabled

### Building
<!-- Provide how to build the test for each SoC being tested -->

Command to build:

```
make distclean && ./tools/configure.sh esp32c6-devkitc:twai && kconfig-tweak -e CAN_LOOPBACK && make olddefconfig && make -j && make download ESPTOOL_PORT=/dev/ttyUSB0
```

### Running
<!-- Provide how to run the test for each SoC being tested -->

`can -n 5` command used to test with connecting PIN 2-3 with a cable

### Results
<!-- Provide tests' results and runtime logs -->



```
nsh> can -n 5
nmsgs: 5
min ID: 1 max ID: 2047
Bit timing:
   Baud: 909090
  TSEG1: 16
  TSEG2: 5
    SJW: 4
  ID:    1 DLC: 1
  ID:    1 DLC: 1
  ID:    1 DLC: 1 -- OK
  ID:    2 DLC: 2
  ID:    2 DLC: 2
  ID:    2 DLC: 2 -- OK
  ID:    3 DLC: 3
  ID:    3 DLC: 3
  ID:    3 DLC: 3 -- OK
  ID:    4 DLC: 4
  ID:    4 DLC: 4
  ID:    4 DLC: 4 -- OK
  ID:    5 DLC: 5
  ID:    5 DLC: 5
  ID:    5 DLC: 5 -- OK
Terminating!
nsh> 
```