### PR TITLE
drivers/sensors: fix misplaced endif in bmi160_base.c

### DIFF
--- a/drivers/sensors/bmi160_base.c
+++ b/drivers/sensors/bmi160_base.c
@@ -49,7 +49,6 @@ static void bmi160_configspi(FAR struct spi_dev_s *spi)
   SPI_HWFEATURES(spi, 0);
   SPI_SETFREQUENCY(spi, BMI160_SPI_MAXFREQUENCY);
 }
-#endif
 
 /****************************************************************************
  * Name: bmi160_transferspi
@@ -122,6 +121,7 @@ static void bmi160_transferspi(FAR struct spi_dev_s *spi, bool write,
 
   SPI_LOCK(spi, false);
 }
+#endif
 
 /****************************************************************************
  * Private Data


### PR DESCRIPTION
## Summary
Compilation issues fixed.
An error occurred under BMI160 SPI.

## Impact

BMI160 sensor compilation and usage

## Testing

~~~
ap> uorb_listener -n 20 sensor_accel0
Mointor objects num:1
object_name:sensor_accel, object_instance:0
sensor_accel(now:72645141):timestamp:53011406,x:0.518492,y:-0.435391,z:9.832978,temperature:35.160156
sensor_accel(now:72685546):timestamp:53051872,x:0.494550,y:-0.495246,z:9.732422,temperature:35.160156
sensor_accel(now:72722595):timestamp:53090934,x:0.542434,y:-0.452151,z:9.682143,temperature:35.160156
sensor_accel(now:72766479):timestamp:53132865,x:0.590318,y:-0.495246,z:9.708480,temperature:35.160156
sensor_accel(now:72806945):timestamp:53173332,x:0.573559,y:-0.492852,z:9.583982,temperature:35.160156
sensor_accel(now:72847351):timestamp:53213798,x:0.568771,y:-0.559890,z:9.744392,temperature:35.160156
sensor_accel(now:72887817):timestamp:53254264,x:0.554405,y:-0.540736,z:9.698903,temperature:35.160156
sensor_accel(now:72928344):timestamp:53294792,x:0.626232,y:-0.466516,z:9.773123,temperature:35.160156
sensor_accel(now:72968811):timestamp:53335258,x:0.566376,y:-0.425814,z:9.773123,temperature:35.160156
sensor_accel(now:73008300):timestamp:53375724,x:0.563982,y:-0.495246,z:9.720450,temperature:35.160156
sensor_accel(now:73049804):timestamp:53416191,x:0.501733,y:-0.500035,z:9.732422,temperature:35.160156
sensor_accel(now:73090270):timestamp:53456657,x:0.532858,y:-0.488064,z:9.732422,temperature:35.160156
sensor_accel(now:73130859):timestamp:53497184,x:0.542434,y:-0.502429,z:9.758758,temperature:35.160156
sensor_accel(now:73171264):timestamp:53537651,x:0.556800,y:-0.452151,z:9.698903,temperature:35.160156
sensor_accel(now:73211669):timestamp:53578117,x:0.535252,y:-0.519188,z:9.770729,temperature:35.160156
sensor_accel(now:73252380):timestamp:53618583,x:0.513704,y:-0.478487,z:9.761152,temperature:35.160156
sensor_accel(now:73292846):timestamp:53659050,x:0.552011,y:-0.483275,z:9.756364,temperature:35.160156
sensor_accel(now:73333312):timestamp:53699516,x:0.566376,y:-0.497640,z:9.746787,temperature:35.160156
sensor_accel(now:73373840):timestamp:53740043,x:0.540040,y:-0.497640,z:9.794671,temperature:35.160156
sensor_accel(now:73411987):timestamp:53780448,x:0.530463,y:-0.437785,z:9.761152,temperature:35.246094
Object name:sensor_accel0, recieved:20
Total number of received Message:20/20
ap> 

~~~
