### PR TITLE
fs/vfs/fs_fstat.c: fix write capability check in proxy_fstat()

### DIFF
--- a/fs/vfs/fs_fstat.c
+++ b/fs/vfs/fs_fstat.c
@@ -117,7 +117,7 @@ static int proxy_fstat(FAR struct file *filep, FAR struct inode *inode,
               buf->st_mode |= S_IROTH | S_IRGRP | S_IRUSR;
             }
 
-          if (inode->u.i_ops->writev || inode->u.i_ops->read)
+          if (inode->u.i_ops->writev || inode->u.i_ops->write)
             {
               buf->st_mode |= S_IWOTH | S_IWGRP | S_IWUSR;
             }


### PR DESCRIPTION
In `proxy_fstat()`, when detecting a block driver proxy , the condition that sets the write permission bits `(S_IWOTH | S_IWGRP | S_IWUSR)` in the `fstat(`) result incorrectly checked `i_ops->read` instead of `i_ops->write`. As a result, any block driver proxy that implements read but not write would be incorrectly reported as writable by `fstat()`

This is a one-line fix with no behavioural change for any driver that implements both `read `and `write `(the common case). Only drivers that implement `read `but not `write `are affected, and for them the fix corrects a wrong permission report.