### PR TITLE
boards/raspberrypi-pico-2-rv: fix formatting mistake on docs

### DIFF
--- a/Documentation/platforms/risc-v/rp23xx-rv/boards/raspberrypi-pico-2-rv/index.rst
+++ b/Documentation/platforms/risc-v/rp23xx-rv/boards/raspberrypi-pico-2-rv/index.rst
@@ -224,6 +224,6 @@ nsh
 Basic NuttShell configuration (console enabled in UART0, at 115200 bps).
 
 usbnsh
----
+------
 
 Basic NuttShell configuration (console enabled via USB CDC/ACM).


### PR DESCRIPTION
## Summary

This PR just fixes a minor formatting issue that was causing me to go nuts...

## Impact

The very little hair I have left will remain in my head :P
More seriously, the separation between configurations will be clearer

## Testing

This doesn't change code, but I've verified with the Preview tool from Github