### PR TITLE
CI: CMake Added a folder nxtmpdir for storing third-party packages

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -230,6 +230,16 @@ set(ENV{HOST_OTHER} n)
 
 include(nuttx_sethost)
 
+option(NXTMPDIR "Create the nxtmpdir folder for third-party packages." OFF)
+
+include(nuttx_3rdparty)
+
+if(NXTMPDIR)
+  nuttx_make_nxtmpdir()
+else()
+  nuttx_remove_nxtmpdir()
+endif()
+
 include(nuttx_parse_function_args)
 include(nuttx_add_subdirectory)
 include(nuttx_create_symlink)

--- a/arch/risc-v/src/common/espressif/CMakeLists.txt
+++ b/arch/risc-v/src/common/espressif/CMakeLists.txt
@@ -243,8 +243,6 @@ if(NOT IS_DIRECTORY "${ESP_HAL_3RDPARTY_REPO}")
   # NXTMPDIR contains a cached version of the esp-hal-3rdparty repository, which
   # is located on nuttx/../nxtmpdir/esp-hal-3rdparty if it exists.
   if(NXTMPDIR)
-    include(${NUTTX_DIR}/cmake/nuttx_3rdparty.cmake)
-    nuttx_make_nxtmpdir()
     set(ESP_HAL_NXTMPDIR_CACHE "${NXTMPDIR_PATH}/${ESP_HAL_3RDPARTY_REPO_NAME}")
     get_filename_component(ESP_HAL_NXTMPDIR_CACHE "${ESP_HAL_NXTMPDIR_CACHE}"
                            REALPATH)

--- a/cmake/nuttx_3rdparty.cmake
+++ b/cmake/nuttx_3rdparty.cmake
@@ -41,6 +41,21 @@ function(nuttx_make_nxtmpdir)
 endfunction()
 
 # ~~~
+# nuttx_remove_nxtmpdir
+#
+# Description:
+#   Remove the third-party cache directory under nuttx/../nxtmpdir
+#
+# ~~~
+
+function(nuttx_remove_nxtmpdir)
+  set(_nxtmpdir "${NUTTX_DIR}/../nxtmpdir")
+  if(EXISTS "${_nxtmpdir}")
+    file(REMOVE_RECURSE "${_nxtmpdir}")
+  endif()
+endfunction()
+
+# ~~~
 # nuttx_check_git_hash
 #
 # Description:

--- a/tools/ci/testlist/risc-v-02.dat
+++ b/tools/ci/testlist/risc-v-02.dat
@@ -1,1 +1,11 @@
 /risc-v/esp32c[0-5]*
+
+# Boards build by CMake
+CMake,esp32c3-xiao:nimble
+CMake,esp32c3-xiao:gpio
+CMake,esp32c3-xiao:wifi
+CMake,esp32c3-xiao:usbnsh
+CMake,esp32-c3-zero:wifi
+CMake,esp32-c3-zero:jumbo
+CMake,esp32-c3-zero:sta_softap
+CMake,esp32-c3-zero:usbnsh

--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -35,6 +35,7 @@ MAKE=make
 unset testfile
 unset HOPTION
 unset STORE
+unset NXTMPDIR
 unset JOPTION
 PRINTLISTONLY=0
 GITCLEAN=0
@@ -42,6 +43,7 @@ SAVEARTIFACTS=0
 CHECKCLEAN=1
 CODECHECKER=0
 NINJACMAKE=0
+STORECMAKE=0
 RUN=0
 
 case $(uname -s) in
@@ -150,6 +152,7 @@ while [ ! -z "$1" ]; do
     ;;
   -S )
     STORE+=" $1"
+    STORECMAKE=1
     ;;
   --codechecker )
     CODECHECKER=1
@@ -198,6 +201,14 @@ blacklist=`grep "^-" $testfile || true`
 
 if [ ${NINJACMAKE} -eq 1 ]; then
   cmakelist=`grep "^[C|c][M|m][A|a][K|k][E|e]" $testfile | cut -d',' -f2 || true`
+fi
+
+if [ ${STORECMAKE} -eq 1 ]; then
+  NXTMPDIR="ON"
+  echo "NXTMPDIR store is enabled"
+else
+  NXTMPDIR="OFF"
+  echo "NXTMPDIR store is disabled"
 fi
 
 cd $nuttx || { echo "ERROR: failed to CD to $nuttx"; exit 1; }
@@ -342,8 +353,8 @@ function configure_default {
 }
 
 function configure_cmake {
-  if ! cmake -B build -DBOARD_CONFIG=$config -GNinja 1>/dev/null; then
-    cmake -B build -DBOARD_CONFIG=$config -GNinja
+  if ! cmake -B build -DBOARD_CONFIG=$config -DNXTMPDIR="$NXTMPDIR" -GNinja 1>/dev/null; then
+    cmake -B build -DBOARD_CONFIG=$config -DNXTMPDIR="$NXTMPDIR" -GNinja
     fail=1
   fi
 


### PR DESCRIPTION
## Summary


testbuild.sh: 
  - CMake Added -DNXTMPDIR

CMakeLists.txt: 
- Moved the creation of the `nxtmpdir` folder for third-party packages to the root  `CMakeLists.txt` file.

cmake/nuttx_3rdparty.cmake:
- Add the nuttx_remove_nxtmpdir function to remove the third-party cache directory under nuttx/../nxtmpdir

ci/testlist/risc-v-02.dat:
 - Add Boards build by CMake
    CMake,esp32c3-xiao:nimble
    CMake,esp32c3-xiao:gpio
    CMake,esp32c3-xiao:wifi
    CMake,esp32c3-xiao:usbnsh
    CMake,esp32-c3-zero:wifi
    CMake,esp32-c3-zero:jumbo
    CMake,esp32-c3-zero:sta_softap
    CMake,esp32-c3-zero:usbnsh


## Impact

Impact on user: NO

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO


## Testing

GitHub

```
====================================================================================
Cmake in present: esp32c3-xiao/nimble
Configuration/Tool: esp32c3-xiao/nimble
2026-04-16 14:51:32
------------------------------------------------------------------------------------
  Cleaning...
  Configuring...
  Select HOST_LINUX=y
   TOOLS_DIR path is "/github/workspace/sources/nuttx"
   HOST = Linux
Cloning into 'esp-hal-3rdparty'...
HEAD is now at 2209449c986 Add DFS support for esp32[-c3|-c6|-h2|-p4]
  Building NuttX...
Build Attempt 1 of 4
====================================================================================
Cmake in present: esp32c3-xiao/gpio
Configuration/Tool: esp32c3-xiao/gpio
2026-04-16 14:53:32
------------------------------------------------------------------------------------
  Cleaning...
  Configuring...
  Select HOST_LINUX=y
   TOOLS_DIR path is "/github/workspace/sources/nuttx"
   HOST = Linux
  Building NuttX...
Build Attempt 1 of 4
====================================================================================
Configuration/Tool: esp32c3-xiao/nsh
2026-04-16 14:54:25
------------------------------------------------------------------------------------
  Cleaning...
  Configuring...
  Building NuttX...
  [1/1] Normalize esp32c3-xiao/nsh
Build Attempt 1 of 4
====================================================================================
```

https://github.com/simbit18/manual-nuttx-ci/actions/runs/24516760711/job/71663210962#logs