### PR TITLE
arch/stm32f0l0g0/stm32_serial_v2.c: fix compilation error

### DIFF
--- a/arch/arm/src/stm32f0l0g0/stm32_serial_v2.c
+++ b/arch/arm/src/stm32f0l0g0/stm32_serial_v2.c
@@ -118,6 +118,7 @@ struct up_dev_s
    */
 
 #ifdef CONFIG_SERIAL_TERMIOS
+  uint8_t           rxftcfg;   /* Rx FIFO threshold level */
   uint8_t           parity;    /* 0=none, 1=odd, 2=even */
   uint8_t           bits;      /* Number of bits (7 or 8) */
   bool              stopbits2; /* True: Configure with 2 stop bits instead of 1 */


### PR DESCRIPTION
## Summary

fix compilation error for CONFIG_SERIAL_TERMIOS=y

chip/stm32_serial_v2.c:923:35: error: 'struct up_dev_s' has no member named 'rxftcfg'
  923 |   regval |= USART_CR3_RXFTCFG(priv->rxftcfg);

## Impact
fix compilation error

## Testing

nucleo-c071rb with termios enabled