### PR TITLE
arch/risc-v: update MCUboot slot sizes on Espressif devices

### DIFF
--- a/Documentation/platforms/risc-v/esp32c3/index.rst
+++ b/Documentation/platforms/risc-v/esp32c3/index.rst
@@ -700,18 +700,18 @@ based on the default KConfig values:
      - 64KB
    * - Primary Application Slot (/dev/ota0)
      - 0x020000
-     - 1MB
+     - 1.4MB
    * - Secondary Application Slot (/dev/ota1)
-     - 0x120000
-     - 1MB
+     - 0x170000
+     - 1.4MB
    * - Scratch Partition (/dev/otascratch)
-     - 0x220000
+     - 0x2C0000
      - 256KB
    * - Storage MTD (optional)
-     - 0x260000
+     - 0x300000
      - 1MB
    * - Available Flash
-     - 0x360000+
+     - 0x400000+
      - Remaining
 
 .. raw:: html
@@ -740,27 +740,27 @@ virtual E-Fuses are later enabled.
     0x020000  ├─────────────────────────────┤
               │                             │
               │      Primary App Slot       │
-              │            (1MB)            │
+              │            (1.4MB)          │
               │          /dev/ota0          │
               │                             │
-    0x120000  ├─────────────────────────────┤
+    0x170000  ├─────────────────────────────┤
               │                             │
               │     Secondary App Slot      │
-              │            (1MB)            │
+              │            (1.4MB)          │
               │          /dev/ota1          │
               │                             │
-    0x220000  ├─────────────────────────────┤
+    0x2C0000  ├─────────────────────────────┤
               │                             │
               │      Scratch Partition      │
               │           (256KB)           │
               │       /dev/otascratch       │
               │                             │
-    0x260000  ├─────────────────────────────┤
+    0x300000  ├─────────────────────────────┤
               │                             │
               │   Storage MTD (optional)    │
               │            (1MB)            │
               │                             │
-    0x360000  ├─────────────────────────────┤
+    0x400000  ├─────────────────────────────┤
               │                             │
               │       Available Flash       │
               │         (Remaining)         │
@@ -770,11 +770,11 @@ virtual E-Fuses are later enabled.
 The key KConfig options that control this layout:
 
 - ``ESPRESSIF_OTA_PRIMARY_SLOT_OFFSET`` (default: 0x20000)
-- ``ESPRESSIF_OTA_SECONDARY_SLOT_OFFSET`` (default: 0x120000)
-- ``ESPRESSIF_OTA_SLOT_SIZE`` (default: 0x100000)
-- ``ESPRESSIF_OTA_SCRATCH_OFFSET`` (default: 0x220000)
+- ``ESPRESSIF_OTA_SECONDARY_SLOT_OFFSET`` (default: 0x170000)
+- ``ESPRESSIF_OTA_SLOT_SIZE`` (default: 0x150000)
+- ``ESPRESSIF_OTA_SCRATCH_OFFSET`` (default: 0x2C0000)
 - ``ESPRESSIF_OTA_SCRATCH_SIZE`` (default: 0x40000)
-- ``ESPRESSIF_STORAGE_MTD_OFFSET`` (default: 0x260000 when MCUBoot enabled)
+- ``ESPRESSIF_STORAGE_MTD_OFFSET`` (default: 0x300000 when MCUBoot enabled)
 - ``ESPRESSIF_STORAGE_MTD_SIZE`` (default: 0x100000)
 
 For MCUBoot operation:

--- a/Documentation/platforms/risc-v/esp32c6/index.rst
+++ b/Documentation/platforms/risc-v/esp32c6/index.rst
@@ -697,18 +697,18 @@ based on the default KConfig values:
      - 64KB
    * - Primary Application Slot (/dev/ota0)
      - 0x020000
-     - 1MB
+     - 1.4MB
    * - Secondary Application Slot (/dev/ota1)
-     - 0x120000
-     - 1MB
+     - 0x170000
+     - 1.4MB
    * - Scratch Partition (/dev/otascratch)
-     - 0x220000
+     - 0x2C0000
      - 256KB
    * - Storage MTD (optional)
-     - 0x260000
+     - 0x300000
      - 1MB
    * - Available Flash
-     - 0x360000+
+     - 0x400000+
      - Remaining
 
 .. raw:: html
@@ -737,27 +737,27 @@ virtual E-Fuses are later enabled.
     0x020000  ├─────────────────────────────┤
               │                             │
               │      Primary App Slot       │
-              │            (1MB)            │
+              │            (1.4MB)          │
               │          /dev/ota0          │
               │                             │
-    0x120000  ├─────────────────────────────┤
+    0x170000  ├─────────────────────────────┤
               │                             │
               │     Secondary App Slot      │
-              │            (1MB)            │
+              │            (1.4MB)          │
               │          /dev/ota1          │
               │                             │
-    0x220000  ├─────────────────────────────┤
+    0x2C0000  ├─────────────────────────────┤
               │                             │
               │      Scratch Partition      │
               │           (256KB)           │
               │       /dev/otascratch       │
               │                             │
-    0x260000  ├─────────────────────────────┤
+    0x300000  ├─────────────────────────────┤
               │                             │
-              │    Storage MTD (optional)   │
+              │   Storage MTD (optional)    │
               │            (1MB)            │
               │                             │
-    0x360000  ├─────────────────────────────┤
+    0x400000  ├─────────────────────────────┤
               │                             │
               │       Available Flash       │
               │         (Remaining)         │
@@ -767,11 +767,11 @@ virtual E-Fuses are later enabled.
 The key KConfig options that control this layout:
 
 - ``ESPRESSIF_OTA_PRIMARY_SLOT_OFFSET`` (default: 0x20000)
-- ``ESPRESSIF_OTA_SECONDARY_SLOT_OFFSET`` (default: 0x120000)
-- ``ESPRESSIF_OTA_SLOT_SIZE`` (default: 0x100000)
-- ``ESPRESSIF_OTA_SCRATCH_OFFSET`` (default: 0x220000)
+- ``ESPRESSIF_OTA_SECONDARY_SLOT_OFFSET`` (default: 0x170000)
+- ``ESPRESSIF_OTA_SLOT_SIZE`` (default: 0x150000)
+- ``ESPRESSIF_OTA_SCRATCH_OFFSET`` (default: 0x2C0000)
 - ``ESPRESSIF_OTA_SCRATCH_SIZE`` (default: 0x40000)
-- ``ESPRESSIF_STORAGE_MTD_OFFSET`` (default: 0x260000 when MCUBoot enabled)
+- ``ESPRESSIF_STORAGE_MTD_OFFSET`` (default: 0x300000 when MCUBoot enabled)
 - ``ESPRESSIF_STORAGE_MTD_SIZE`` (default: 0x100000)
 
 For MCUBoot operation:

--- a/Documentation/platforms/risc-v/esp32h2/index.rst
+++ b/Documentation/platforms/risc-v/esp32h2/index.rst
@@ -608,18 +608,18 @@ based on the default KConfig values:
      - 64KB
    * - Primary Application Slot (/dev/ota0)
      - 0x020000
-     - 1MB
+     - 1.4MB
    * - Secondary Application Slot (/dev/ota1)
-     - 0x120000
-     - 1MB
+     - 0x170000
+     - 1.4MB
    * - Scratch Partition (/dev/otascratch)
-     - 0x220000
+     - 0x2C0000
      - 256KB
    * - Storage MTD (optional)
-     - 0x260000
+     - 0x300000
      - 1MB
    * - Available Flash
-     - 0x360000+
+     - 0x400000+
      - Remaining
 
 .. raw:: html
@@ -648,27 +648,27 @@ virtual E-Fuses are later enabled.
     0x020000  ├─────────────────────────────┤
               │                             │
               │      Primary App Slot       │
-              │            (1MB)            │
+              │            (1.4MB)          │
               │          /dev/ota0          │
               │                             │
-    0x120000  ├─────────────────────────────┤
+    0x170000  ├─────────────────────────────┤
               │                             │
               │     Secondary App Slot      │
-              │            (1MB)            │
+              │            (1.4MB)          │
               │          /dev/ota1          │
               │                             │
-    0x220000  ├─────────────────────────────┤
+    0x2C0000  ├─────────────────────────────┤
               │                             │
               │      Scratch Partition      │
               │           (256KB)           │
               │       /dev/otascratch       │
               │                             │
-    0x260000  ├─────────────────────────────┤
+    0x300000  ├─────────────────────────────┤
               │                             │
-              │    Storage MTD (optional)   │
+              │   Storage MTD (optional)    │
               │            (1MB)            │
               │                             │
-    0x360000  ├─────────────────────────────┤
+    0x400000  ├─────────────────────────────┤
               │                             │
               │       Available Flash       │
               │         (Remaining)         │
@@ -678,11 +678,11 @@ virtual E-Fuses are later enabled.
 The key KConfig options that control this layout:
 
 - ``ESPRESSIF_OTA_PRIMARY_SLOT_OFFSET`` (default: 0x20000)
-- ``ESPRESSIF_OTA_SECONDARY_SLOT_OFFSET`` (default: 0x120000)
-- ``ESPRESSIF_OTA_SLOT_SIZE`` (default: 0x100000)
-- ``ESPRESSIF_OTA_SCRATCH_OFFSET`` (default: 0x220000)
+- ``ESPRESSIF_OTA_SECONDARY_SLOT_OFFSET`` (default: 0x170000)
+- ``ESPRESSIF_OTA_SLOT_SIZE`` (default: 0x150000)
+- ``ESPRESSIF_OTA_SCRATCH_OFFSET`` (default: 0x2C0000)
 - ``ESPRESSIF_OTA_SCRATCH_SIZE`` (default: 0x40000)
-- ``ESPRESSIF_STORAGE_MTD_OFFSET`` (default: 0x260000 when MCUBoot enabled)
+- ``ESPRESSIF_STORAGE_MTD_OFFSET`` (default: 0x300000 when MCUBoot enabled)
 - ``ESPRESSIF_STORAGE_MTD_SIZE`` (default: 0x100000)
 
 For MCUBoot operation:

--- a/arch/risc-v/src/common/espressif/Kconfig
+++ b/arch/risc-v/src/common/espressif/Kconfig
@@ -382,7 +382,7 @@ config ESPRESSIF_OTA_PRIMARY_SLOT_DEVPATH
 
 config ESPRESSIF_OTA_SECONDARY_SLOT_OFFSET
 	hex "Application image secondary slot offset"
-	default 0x120000
+	default 0x170000
 
 config ESPRESSIF_OTA_SECONDARY_SLOT_DEVPATH
 	string "Application image secondary slot device path"
@@ -390,11 +390,11 @@ config ESPRESSIF_OTA_SECONDARY_SLOT_DEVPATH
 
 config ESPRESSIF_OTA_SLOT_SIZE
 	hex "Application image slot size (in bytes)"
-	default 0x100000
+	default 0x150000
 
 config ESPRESSIF_OTA_SCRATCH_OFFSET
 	hex "Scratch partition offset"
-	default 0x220000
+	default 0x2C0000
 
 config ESPRESSIF_OTA_SCRATCH_SIZE
 	hex "Scratch partition size"
@@ -3056,7 +3056,7 @@ config ESPRESSIF_STORAGE_MTD_DEBUG
 config ESPRESSIF_STORAGE_MTD_OFFSET
 	hex "Storage MTD base address in SPI Flash"
 	default 0x180000 if !ESPRESSIF_BOOTLOADER_MCUBOOT
-	default 0x260000 if ESPRESSIF_BOOTLOADER_MCUBOOT
+	default 0x300000 if ESPRESSIF_BOOTLOADER_MCUBOOT
 	depends on ESPRESSIF_MTD
 	---help---
 		MTD base address in SPI Flash.


### PR DESCRIPTION
## Summary

RISC-V Espressif Kconfig defaults for MCUboot OTA layout are updated to use slot size `0x150000` (~1.4MB), with secondary slot offset `0x170000`, scratch at `0x2C0000`, storage MTD at `0x300000`, and matching documentation updates on the ESP32-C3, ESP32-C6, and ESP32-H2 platform pages.

* arch/risc-v: update MCUBoot slot size and offsets

Increase image slot size from ~1MB to ~1.4MB to allow more features by default.
Solves issues when enabling debug features would extrapolate the slot size.

* documentation: update ESP32-C3|C6|H2 flash allocation table

Update the user documentation for flash allocation when using MCUboot.


Reason for this change: image size is getting to close to 1MB and may not fit the slot when some features such as Wi-Fi are enabled.

## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: No.
<!-- Does it impact user's applications? How? -->

Impact on build: Yes, avoids bad image build when too many features are enabled along MCUboot.
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: ESP32-C3|C6|H2|P4.
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: Yes, updates the documentation for flash allocation when using MCUboot.
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: No.
<!-- Does it impact NuttX's security? -->

Impact on compatibility: No.
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

## Testing
<!-- Please provide all the testing procedure. Consider that upstream reviewers should be able to reproduce the same testing performed internally -->

### Building
<!-- Provide how to build the test for each SoC being tested -->
- `./tools/configure.sh esp32c6-devkitc:mcuboot_update_agent`
- Enable DEBUG_ASSERTIONS and DEBUG_FEATURES
- `make bootloader`
- `make ESPTOOL_BINDIR=./`

### Results

- Before change:
Build would failure when `imgtool` was invoked because the image size was bigger than the MCUboot slot.
```
Usage: imgtool sign [OPTIONS] INFILE OUTFILE
Try 'imgtool sign -h' for help.

Error: Image size (0x10a894) + trailer (0x630) exceeds requested size 0x100000
make: *** [tools/Unix.mk:575: nuttx] Error 2
```

- After changes:
Build succeeds.