### PR TITLE
CI: Remove corrupted downloads for build retry

### DIFF
--- a/tools/testbuild.sh
+++ b/tools/testbuild.sh
@@ -599,15 +599,15 @@ function retrytest {
       break
     else
       # Build Failed: Clean up any corrupted downloads, don't reuse
-      git -C $nuttx clean -fd
-      git -C $APPSDIR clean -fd
+      git -C $nuttx clean -xfdq
+      git -C $APPSDIR clean -xfdq
       pushd $nuttx ; git status ; popd
       pushd $APPSDIR ; git status ; popd
     fi
 
     # If this is Final Retry: Don't retry subsequent builds
     if [ $i -eq $maxbuilds ]; then
-			maxbuilds=1
+      maxbuilds=1
       break
     fi
 


### PR DESCRIPTION
## Summary

We have implemented CI Build Retry for mitigating Download Failures. But right now it will reuse any Corrupted Downloads (instead of deleting them), which will cause CI Build Retry to fail repeatedly: https://github.com/apache/nuttx/actions/runs/24611381081/job/71966407518#step:10:627

```
Ignored files: system/argtable3/v3.2.0.7402e6e.tar.gz
gzip: stdin: not in gzip format
make[3]: *** [Makefile:76: argtable3] Error 2
```

This PR proposes to change `git clean -fd` to `git clean -xfdq`. This will remove any Corrupted Downloads, preventing their reuse for CI Build Retry:

```bash
## Simulate a corrupted download for argtable3
$ tools/configure.sh qemu-armv8a/netnsh
$ Downloading v3.2.0.7402e6e.tar.gz--argtable3
## Press Ctrl-C to stop the build

## `git clean -fd` won't remove the corrupted download 
$ cd ../apps
$ git clean -fd
$ find . -name "v3.2.0.7402e6e.tar.gz" 
./system/argtable3/v3.2.0.7402e6e.tar.gz

## `git clean -xfdq` removes the corrupted download
$ git clean -xfdq 
$ find . -name "v3.2.0.7402e6e.tar.gz" 
## Corrupted download is deleted correctly
```

`git clean -xfdq` is also found in the same testbuild script, so we are using it consistently:

https://github.com/apache/nuttx/blob/12e8f92a282fac58e0dfff587ea3d9502e4804c0/tools/testbuild.sh#L286-L291

## Impact

CI Build Retry will now work correctly, retrying any Failed Downloads, instead of reusing them.

## Testing

We tested a Normal Build (without errors), since Download Failures are unpredictable and hard to simulate:
- https://github.com/lupyuen18/nuttx/actions/runs/24617084017

We hope to eliminate these Download Errors that we see in NuttX Build Monitor: https://lupyuen.github.io/nuttx-github-jobs/build-monitor

<img width="2253" height="1849" alt="Screenshot 2026-04-19 at 9 09 17 AM" src="https://github.com/user-attachments/assets/01e5a24b-1ede-49c8-b283-942afd4e9488" />