### PR TITLE
arch/risc-v/espressif: Fix auto light sleep enable flag

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_pm.c
+++ b/arch/risc-v/src/common/espressif/esp_pm.c
@@ -895,7 +895,7 @@ int esp_pmconfigure(void)
       .min_freq_mhz = CONFIG_ESPRESSIF_CPU_FREQ_MHZ,
 #endif
 #ifdef CONFIG_ESPRESSIF_AUTO_SLEEP
-      .light_sleep_enable = false
+      .light_sleep_enable = true
 #endif
     };
 


### PR DESCRIPTION
## Summary

* arch/risc-v/espressif: Fix auto light sleep enable flag

Fix auto light sleep enable flag

## Impact

Impact on user: Yes, auto light sleep bug fixed

Impact on build: No

Impact on hardware: No

Impact on documentation: No

Impact on security: No

Impact on compatibility: No


## Testing

### Building
<!-- Provide how to build the test for each SoC being tested -->

Used configs:
```
esp32c6-devkitc:autopm
```

Command to build:

```
make -j distclean && ./tools/configure.sh esp32c6-devkitc:autopm && make -j && make download ESPTOOL_PORT=/dev/ttyUSB0 ESPTOOL_BAUD=921600 ESPTOOL_BINDIR=./
```

Sleep logs and power consumption checked

### Results
<!-- Provide tests' results and runtime logs -->

System logs (Power Related debug options enabled):

```
...
NuttShell (NSH) NuttX-10.4.0
esp_pm_skip_light_sleep: UART wakeup still within guard window
nsh> esp_pm_skip_light_sleep: UART wakeup still within guard window
esp_pm_skip_light_sleep: UART wakeup still within guard window
nsh> esp_pm_skip_light_sleep: UART wakeup still within guard window
...
```