### PR TITLE
arch/risc-v/cmake: fix linker option case in Toolchain.cmake.

### DIFF
--- a/arch/risc-v/src/cmake/Toolchain.cmake
+++ b/arch/risc-v/src/cmake/Toolchain.cmake
@@ -106,7 +106,7 @@ elseif(CONFIG_LTO_FULL)
   if(CONFIG_ARCH_TOOLCHAIN_GNU)
     add_compile_options(-fno-builtin)
     add_compile_options(-fuse-linker-plugin)
-    add_link_options(-wl,--print-memory-usage)
+    add_link_options(-Wl,--print-memory-usage)
   endif()
 endif()
 


### PR DESCRIPTION
## Summary

Fix lowercase `-wl` to correct `-Wl` in `arch/risc-v/src/cmake/Toolchain.cmake`.

GCC requires uppercase `-Wl` as the linker option pass-through prefix.
The lowercase `-wl,--print-memory-usage` is silently ignored, causing
no memory usage report printed during LTO full linking.

## Impact

Impact on user: No
Impact on build: Yes, memory usage report now correctly printed for RISC-V LTO full builds.
Impact on hardware: No
Impact on documentation: No
Impact on security: No
Impact on compatibility: No

## Testing

Build Host: Ubuntu 22.04, x86_64, GCC 13.2
Target: risc-v, qemu-rv:nsh

Testing logs before change:

```
(no memory usage output during linking)
```

Testing logs after change:

```
Memory region         Used Size  Region Size  %age Used
flash:                  xxx KB       xxx KB     xx.xx%
sram:                   xxx KB       xxx KB     xx.xx%
```

## PR verification Self-Check

- [x] This PR introduces only one functional change.
- [x] I have updated all required description fields above.
- [x] My PR adheres to Contributing Guidelines and Documentation.
- [ ] My PR is still work in progress (not ready for review).
- [x] My PR is ready for review and can be safely merged into a codebase.