### PR TITLE
arch/xtensa: remove _info from startup of ESP32

### DIFF
--- a/arch/xtensa/src/esp32/esp32_start.c
+++ b/arch/xtensa/src/esp32/esp32_start.c
@@ -388,8 +388,8 @@ static noreturn_function void __esp32_start(void)
 
   chip_rev = esp_efuse_hal_chip_revision();
 
-  _info("ESP32 chip revision is v%" PRId32 ".%01ld\n",
-        chip_rev / 100, chip_rev % 100);
+  ets_printf("ESP32 chip revision is v%" PRId32 ".%01ld\n",
+             chip_rev / 100, chip_rev % 100);
 
   if (chip_rev < 300)
     {


### PR DESCRIPTION
## Summary

<!-- This field should contain a summary of the changes. It will be pre-filled with the commit's message and descriptions. Adjust it accordingly -->

* arch/xtensa: remove _info from startup of ESP32

During startup we should avoid using _info since the system is not
fully initialized. Default to use ets_printf which is safe for
this scenario.

This PR fixes an issue where `_info` gets stuck trying to print to serial. At this point, we should be using the `ets_printf` function instead, which is at ROM level.

## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: Fixes issue where `espnow` defconfig failed to boot properly.
<!-- Does it impact user's applications? How? -->

Impact on build: No.
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: ESP32 only.
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: No.
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: No.
<!-- Does it impact NuttX's security? -->

Impact on compatibility: No.
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

## Testing
<!-- Please provide all the testing procedure. Consider that upstream reviewers should be able to reproduce the same testing performed internally -->
- `./tools/configure.sh esp32-devkitc:espnow`
- Enabled DEBUG_ASSERTIONS and other debug features
- Make and flash

### Results
- Before the change:
Device would get stuck during startup while `_info` was called for the efuse revision info.
```
 esp32 defconfig would fail to boot (could be seen with espnow + debug features enabled).
Log:
*** Booting NuttX ***
I (65) boot: chip revision: v3.1
I (65) boot.esp32: SPI Speed      : 40MHz
I (65) boot.esp32: SPI Mode       : DIO
I (67) boot.esp32: SPI Flash Size : 4MB
I (70) boot: Enabling RNG early entropy source...
dram: lma 0x00001020 vma 0x3ffbaa70 len 0x43e0   (17376)
iram: lma 0x00005408 vma 0x40080000 len 0x18070  (98416)
padd: lma 0x0001d488 vma 0x00000000 len 0x2b90   (11152)
imap: lma 0x00020020 vma 0x400d0020 len 0x8178c  (530316)
padd: lma 0x000a17b4 vma 0x00000000 len 0xe864   (59492)
dmap: lma 0x000b0020 vma 0x3f400020 len 0x1a26c  (107116)
total segments stored 6
AB
```

- After the change:
Device boots properly.

```
...
ABESP32 chip revision is v3.0
I (120) cpu_start: Pro cpu start user code
I (120) cpu_start: cpu freq: 240000000 Hz
I (144) wifi_init: rx ba win: 6
I (144) wifi_init: LWIP disabled
I (149) phy_init: phy_version 4863,a3a4459,Oct 28 2025,14:30:06
telnetd [6:100]

NuttShell (NSH) NuttX-10.4.0
nsh> 
```