### PR TITLE
arch/xtensa: Scope Wi-Fi disconnect case declarations.

### DIFF
--- a/arch/xtensa/src/common/espressif/esp_wifi_event_handler.c
+++ b/arch/xtensa/src/common/espressif/esp_wifi_event_handler.c
@@ -205,17 +205,19 @@ static void esp_evt_work_cb(void *arg)
             break;
 
           case WIFI_EVENT_STA_DISCONNECTED:
-            wifi_event_sta_disconnected_t *event =
-              (wifi_event_sta_disconnected_t *)evt_adpt->buf;
-            wifi_err_reason_t reason = event->reason;
+            {
+              wifi_event_sta_disconnected_t *event =
+                (wifi_event_sta_disconnected_t *)evt_adpt->buf;
+              wifi_err_reason_t reason = event->reason;
 
-            wlinfo("Wi-Fi station disconnected, reason: %u\n", reason);
-            esp_wlan_sta_disconnect_hook();
-            if (reason == WIFI_REASON_ASSOC_LEAVE)
-              {
-                work_queue(LPWORK, &g_wifi_evt_work, esp_reconnect_work_cb,
-                           NULL, 0);
-              }
+              wlinfo("Wi-Fi station disconnected, reason: %u\n", reason);
+              esp_wlan_sta_disconnect_hook();
+              if (reason == WIFI_REASON_ASSOC_LEAVE)
+                {
+                  work_queue(LPWORK, &g_wifi_evt_work, esp_reconnect_work_cb,
+                             NULL, 0);
+                }
+            }
 
             break;
 


### PR DESCRIPTION
- fix a "a label can only be part of a statement and a declaration is not a statement" compile error.
- toolchain `xtensa-esp32s3-elf-gcc (crosstool-NG esp-2021r2) 8.4.0`
## Summary

  I encountered the following compilation error while building ESP32 Wi-Fi related code
  ```
    Register: wapi
    CC:  pthread/pthread_setschedparam.c common/espressif/esp_wifi_event_handler.c: In function 'esp_evt_work_cb':
    common/espressif/esp_wifi_event_handler.c:208:13: error: a label can only be part of a statement and a declaration is not a statement
                 wifi_event_sta_disconnected_t *event =
                 ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    common/espressif/esp_wifi_event_handler.c:210:13: error: expected expression before 'wifi_err_reason_t'
                 wifi_err_reason_t reason = event->reason;
                 ^~~~~~~~~~~~~~~~~
    In file included from common/espressif/esp_wifi_event_handler.c:29:
    common/espressif/esp_wifi_event_handler.c:212:64: error: 'reason' undeclared (first use in this function); did you mean 'read'?
                 wlinfo("Wi-Fi station disconnected, reason: %u\n", reason);
                                                                    ^~~~~~
    common/espressif/esp_wifi_event_handler.c:212:64: note: each undeclared identifier is reported only once for each function it appears in
    make[1]: *** [Makefile:146: esp_wifi_event_handler.o] Error 1
    make[1]: *** Waiting for unfinished jobs....
    make: *** [tools/LibTargets.mk:170: arch/xtensa/src/libarch.a] Error 2
    CC:  vfs/fs_dir.c make: *** Waiting for unfinished jobs....
  ```
  
  My toolchain is
  ```
    xtensa-esp32s3-elf-gcc --version
    xtensa-esp32s3-elf-gcc (crosstool-NG esp-2021r2) 8.4.0
    Copyright (C) 2018 Free Software Foundation, Inc.
    This is free software; see the source for copying conditions.  There is NO
    warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
  ```

  Wrap WIFI_EVENT_STA_DISCONNECTED case declarations in braces to make the switch case
  compile correctly with standard C rules.

## Impact
  
  bugfix

## Testing

  Config : `CONFIG_BASE_DEFCONFIG="esp32s3-devkit:nsh-dirty"` + 

  Logs after patch:
  ```
    make -j(nproc)
    Create version.h
    CPP:  /home/ankohuu/Project/nuttx/boards/xtensa/esp32s3/esp32s3-devkit/../common/scripts/esp32s3_peripherals.ld-> /home/ankohuu/Project/nuttx/boards/xtensa/esp32s3/esp32s3CPP:  /home/ankohuu/Project/nuttx/boards/xtensa/esp32s3/esp32s3-devkit/../common/scripts/esp32s3_rom_aliases.ld-> /home/ankohuu/Project/nuttx/boards/xtensa/esp32s3/esp32s3
    CPP:  /home/ankohuu/Project/nuttx/boards/xtensa/esp32s3/esp32s3-devkit/../common/scripts/esp32s3_sections.ld-> /home/ankohuu/Project/nuttx/boards/xtensa/esp32s3/esp32s3-de
    CPP:  /home/ankohuu/Project/nuttx/boards/xtensa/esp32s3/esp32s3-devkit/../common/scripts/flat_memory.ld-> /home/ankohuu/Project/nuttx/boards/xtensa/esp32s3/esp32s3-devkit/CPP:  /home/ankohuu/Project/nuttx/arch/xtensa/src/chip/esp-hal-3rdparty/components/esp_rom/esp32s3/ld/esp32s3.rom.api.ld-> /home/ankohuu/Project/nuttx/arch/xtensa/src/chipCPP:  /home/ankohuu/Project/nuttx/arch/xtensa/src/chip/esp-hal-3rdparty/components/esp_rom/esp32s3/ld/esp32s3.rom.ld-> /home/ankohuu/Project/nuttx/arch/xtensa/src/chip/espCPP:  /home/ankohuu/Project/nuttx/arch/xtensa/src/chip/esp-hal-3rdparty/components/esp_rom/esp32s3/ld/esp32s3.rom.libc.ld-> /home/ankohuu/Project/nuttx/arch/xtensa/src/chi
    CPP:  /home/ankohuu/Project/nuttx/arch/xtensa/src/chip/esp-hal-3rdparty/components/esp_rom/esp32s3/ld/esp32s3.rom.libgcc.ld-> /home/ankohuu/Project/nuttx/arch/xtensa/src/cCPP:  /home/ankohuu/Project/nuttx/arch/xtensa/src/chip/esp-hal-3rdparty/components/esp_rom/esp32s3/ld/esp32s3.rom.newlib.ld-> /home/ankohuu/Project/nuttx/arch/xtensa/src/cCPP:  /home/ankohuu/Project/nuttx/arch/xtensa/src/chip/esp-hal-3rdparty/components/esp_hal_wdt/esp32s3/rom.wdt.ld-> /home/ankohuu/Project/nuttx/arch/xtensa/src/chip/esp-haCPP:  /home/ankohuu/Project/nuttx/arch/xtensa/src/chip/esp-hal-3rdparty/components/soc/esp32s3/ld/esp32s3.peripherals.ld-> /home/ankohuu/Project/nuttx/arch/xtensa/src/chipCPP:  /home/ankohuu/Project/nuttx/arch/xtensa/src/chip/esp-hal-3rdparty/components/esp_rom/esp32s3/ld/esp32s3.rom.version.ld-> /home/ankohuu/Project/nuttx/arch/xtensa/src/CPP:  /home/ankohuu/Project/nuttx/arch/xtensa/src/chip/esp-hal-3rdparty/components/esp_rom/esp32s3/ld/esp32s3.rom.bt_funcs.ld-> /home/ankohuu/Project/nuttx/arch/xtensa/srcLD: nuttx
    Memory region         Used Size  Region Size  %age Used
                 ROM:      804972 B   16777184 B      4.80%
         iram0_0_seg:       64000 B       304 KB     20.56%
         irom0_0_seg:      597337 B   16777184 B      3.56%
         dram0_0_seg:      136800 B       288 KB     46.39%
         drom0_0_seg:      804908 B   16777184 B      4.80%
        rtc_iram_seg:          0 GB       8168 B      0.00%
        rtc_data_seg:          0 GB       8168 B      0.00%
    rtc_reserved_seg:          24 B         24 B    100.00%
        rtc_slow_seg:          64 B         8 KB      0.78%
    CP: nuttx.hex
    MKIMAGE: ESP32-S3 binary
    esptool.py -c esp32s3 elf2image --ram-only-header -fs 16MB -fm dio -ff "40m" -o nuttx.bin nuttx
    Warning: DEPRECATED: 'esptool.py' is deprecated. Please use 'esptool' instead. The '.py' suffix will be removed in a future major release.
    esptool v5.2.0
    Creating ESP32-S3 image...
    Image has only RAM segments visible. ROM segments are hidden and SHA256 digest is not appended.
    Merged 1 ELF section.
    Successfully created ESP32-S3 image.
    Generated: nuttx.bin
  ```