### PR TITLE
sensors/Make.defs: Aligned Make with Cmake file

### DIFF
--- a/drivers/sensors/Make.defs
+++ b/drivers/sensors/Make.defs
@@ -78,12 +78,32 @@ ifeq ($(CONFIG_SENSORS_DHTXX),y)
   CSRCS += dhtxx.c
 endif
 
+# These drivers can be used with sensor connected over SPI or I2C bus
+
+ifeq ($(CONFIG_SENSORS_BMI160),y)
+  CSRCS += bmi160_base.c
+ifeq ($(CONFIG_SENSORS_BMI160_UORB),y)
+  CSRCS += bmi160_uorb.c
+else
+  CSRCS += bmi160.c
+endif
+endif
+
 ifeq ($(CONFIG_SENSORS_BMI270),y)
   CSRCS += bmi270_base.c
 ifeq ($(CONFIG_SENSORS_BMI270_UORB),y)
   CSRCS += bmi270_uorb.c
 else
   CSRCS += bmi270.c
+endif
+endif
+
+ifeq ($(CONFIG_SENSORS_BMI088),y)
+  CSRCS += bmi088_base.c
+ifeq ($(CONFIG_SENSORS_BMI088_UORB),y)
+  CSRCS += bmi088_uorb.c
+else
+  CSRCS += bmi088.c
 endif
 endif
 
@@ -179,24 +199,6 @@ endif
 
 ifeq ($(CONFIG_SENSORS_BMG160),y)
   CSRCS += bmg160.c
-endif
-
-ifeq ($(CONFIG_SENSORS_BMI160),y)
-  CSRCS += bmi160_base.c
-ifeq ($(CONFIG_SENSORS_BMI160_UORB),y)
-  CSRCS += bmi160_uorb.c
-else
-  CSRCS += bmi160.c
-endif
-endif
-
-ifeq ($(CONFIG_SENSORS_BMI088),y)
-  CSRCS += bmi088_base.c
-ifeq ($(CONFIG_SENSORS_BMI088_UORB),y)
-  CSRCS += bmi088_uorb.c
-else
-  CSRCS += bmi088.c
-endif
 endif
 
 ifeq ($(CONFIG_SENSORS_BMP180),y)
@@ -334,6 +336,10 @@ endif
 
 ifeq ($(CONFIG_SENSORS_BMM150),y)
   CSRCS += bmm150_uorb.c
+endif
+
+ifeq ($(CONFIG_SENSORS_AMG88XX),y)
+  CSRCS += amg88xx.c
 endif
 
 ifeq ($(CONFIG_SENSORS_TMP112),y)


### PR DESCRIPTION
## Summary

This sensor was not present in the Make.defs file 
AMG88xx Infrared Array Sensor #12829


Moved:
    These drivers can be used with sensor connected over SPI or I2C bus
         Bosch Sensortec BMI160
         Bosch Sensortec BMI088

## Impact

Impact on user: NO

Impact on build: This PR aligns Make with CMake file

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

local build test

```
LN: platform/board to /home/ubuntu20/nuttxspace/apps/platform/dummy
Register: hello
Register: dd
Register: nsh
Register: sh
CC:  sensors/amg88xx.c sensors/amg88xx.c:34:2: warning: #warning "This is a deprecated legacy sensor driver." [-Wcpp]
   34 | #warning "This is a deprecated legacy sensor driver."
      |  ^~~~~~~
CC:  chip/stm32_gpio.c chip/stm32_gpio.c:44:11: note: #pragma message: CONFIG_STM32_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py
   44 | #  pragma message "CONFIG_STM32_USE_LEGACY_PINMAP will be deprecated migrate board.h see tools/stm32_pinmap_tool.py"
      |           ^~~~~~~
LD: nuttx
CP: nuttx.hex
CP: nuttx.bin
```