### PR TITLE
ci: MemBrowse Integration

### DIFF
--- a/.github/membrowse-targets.json
+++ b/.github/membrowse-targets.json
@@ -1,0 +1,83 @@
+[
+  {
+    "target_name": "stm32-nucleo-f103rb",
+    "board_config": "nucleo-f103rb:nsh",
+    "elf": "nuttx",
+    "ld": "boards/arm/stm32/nucleo-f103rb/scripts/ld.script",
+    "map_file": "nuttx.map",
+    "linker_vars": "",
+    "config_overrides": ""
+  },
+  {
+    "target_name": "arduino-mega2560",
+    "board_config": "arduino-mega2560:nsh",
+    "elf": "nuttx.elf",
+    "ld": "boards/avr/atmega/arduino-mega2560/scripts/flash.ld",
+    "map_file": "nuttx.map",
+    "linker_vars": "",
+    "config_overrides": ""
+  },
+  {
+    "target_name": "qemu-armv8a",
+    "board_config": "qemu-armv8a:nsh",
+    "elf": "nuttx",
+    "ld": "",
+    "map_file": "nuttx.map",
+    "linker_vars": "",
+    "config_overrides": ""
+  },
+  {
+    "target_name": "mirtoo",
+    "board_config": "mirtoo:nsh",
+    "elf": "nuttx",
+    "ld": "boards/mips/pic32mx/mirtoo/scripts/pinguino-debug.ld",
+    "map_file": "nuttx.map",
+    "linker_vars": "",
+    "config_overrides": "-d MIPS32_TOOLCHAIN_GNU_ELF -e MIPS32_TOOLCHAIN_PINGUINOL"
+  },
+  {
+    "target_name": "hifive1-revb",
+    "board_config": "hifive1-revb:nsh",
+    "elf": "nuttx",
+    "ld": "boards/risc-v/fe310/hifive1-revb/scripts/ld.script",
+    "map_file": "nuttx.map",
+    "linker_vars": "",
+    "config_overrides": ""
+  },
+  {
+    "target_name": "rx65n-rsk2mb",
+    "board_config": "rx65n-rsk2mb:nsh",
+    "elf": "nuttx",
+    "ld": "boards/renesas/rx65n/rx65n-rsk2mb/scripts/linker_script.ld",
+    "map_file": "",
+    "linker_vars": "",
+    "config_overrides": ""
+  },
+  {
+    "target_name": "s698pm-dkit",
+    "board_config": "s698pm-dkit:nsh",
+    "elf": "nuttx",
+    "ld": "",
+    "map_file": "",
+    "linker_vars": "",
+    "config_overrides": ""
+  },
+  {
+    "target_name": "qemu-intel64",
+    "board_config": "qemu-intel64:nsh",
+    "elf": "nuttx",
+    "ld": "",
+    "map_file": "nuttx.map",
+    "linker_vars": "",
+    "config_overrides": ""
+  },
+  {
+    "target_name": "esp32-devkitc",
+    "board_config": "esp32-devkitc:nsh",
+    "elf": "nuttx",
+    "ld": "boards/xtensa/esp32/common/scripts/flat_memory.ld.tmp boards/xtensa/esp32/common/scripts/esp32_sections.ld.tmp",
+    "map_file": "nuttx.map",
+    "linker_vars": "",
+    "config_overrides": ""
+  }
+]

--- a/.github/workflows/membrowse-comment.yml
+++ b/.github/workflows/membrowse-comment.yml
@@ -1,0 +1,30 @@
+name: MemBrowse PR Comment
+
+on:
+  workflow_run:
+    workflows: [MemBrowse Memory Report]
+    types:
+      - completed
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Post combined PR comment
+        if: ${{ env.MEMBROWSE_API_KEY != '' }}
+        uses: membrowse/membrowse-action/comment-action@v1
+        with:
+          api_key: ${{ secrets.MEMBROWSE_API_KEY }}
+          commit: ${{ github.event.workflow_run.head_sha }}
+        env:
+          MEMBROWSE_API_KEY: ${{ secrets.MEMBROWSE_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/membrowse-onboard.yml
+++ b/.github/workflows/membrowse-onboard.yml
@@ -1,0 +1,67 @@
+name: Onboard to MemBrowse
+
+on:
+  workflow_dispatch:
+    inputs:
+      num_commits:
+        description: 'Number of commits to process'
+        required: true
+        default: '100'
+        type: string
+
+jobs:
+  load-targets:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: set-matrix
+        run: echo "matrix=$(jq -c '.' .github/membrowse-targets.json)" >> $GITHUB_OUTPUT
+
+  onboard:
+    needs: load-targets
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/apache/nuttx/apache-nuttx-ci-linux
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.load-targets.outputs.matrix) }}
+
+    steps:
+      - name: Checkout nuttx
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Clone nuttx-apps
+        run: |
+          git config --global --add safe.directory '*'
+          git clone --depth=1 https://github.com/apache/nuttx-apps.git ../apps
+
+      - name: Run MemBrowse Onboard Action
+        uses: membrowse/membrowse-action/onboard-action@v1
+        with:
+          target_name: ${{ matrix.target_name }}
+          num_commits: ${{ github.event.inputs.num_commits }}
+          build_script: |
+            make distclean 2>/dev/null || true
+            ./tools/configure.sh -l ${{ matrix.board_config }}
+            echo CONFIG_DEBUG_SYMBOLS=y >> .config
+            echo CONFIG_DEBUG_LINK_MAP=y >> .config
+            if [ -n "${{ matrix.config_overrides }}" ]; then
+              kconfig-tweak ${{ matrix.config_overrides }}
+            fi
+            make olddefconfig
+            make -j$(nproc)
+          elf: ${{ matrix.elf }}
+          ld: ${{ matrix.ld }}
+          map_file: ${{ matrix.map_file }}
+          linker_vars: ${{ matrix.linker_vars }}
+          binary_search: 'true'
+          api_key: ${{ secrets.MEMBROWSE_API_KEY }}
+          api_url: ${{ vars.MEMBROWSE_API_URL }}

--- a/.github/workflows/membrowse-report.yml
+++ b/.github/workflows/membrowse-report.yml
@@ -1,0 +1,162 @@
+name: MemBrowse Memory Report
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+      - "releases/*"
+    tags:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  # Detect whether any source files (i.e. non-doc/CODEOWNERS) changed.
+  # When only docs/CODEOWNERS change we skip the build and post an "identical"
+  # MemBrowse report instead.
+  changes-filter:
+    runs-on: ubuntu-latest
+    outputs:
+      source: ${{ steps.filter.outputs.source }}
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            source:
+              - '**'
+              - '!AUTHORS'
+              - '!CONTRIBUTING.md'
+              - '!**/CODEOWNERS'
+              - '!Documentation/**'
+              - '!tools/ci/docker/linux/**'
+              - '!tools/codeowners/*'
+
+  load-targets:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v6
+      - id: set-matrix
+        run: echo "matrix=$(jq -c '.' .github/membrowse-targets.json)" >> $GITHUB_OUTPUT
+
+  # Post an "identical" MemBrowse report when only docs/CODEOWNERS changed.
+  # Only runs on push events (master/releases/tags) to keep the baseline
+  # complete; PR events don't produce identical markers.
+  identical:
+    needs: [changes-filter, load-targets]
+    if: needs.changes-filter.outputs.source == 'false' && github.event_name == 'push'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.load-targets.outputs.matrix) }}
+    steps:
+      - name: Upload identical - ${{ matrix.target_name }}
+        uses: membrowse/membrowse-action@v1
+        with:
+          target_name: ${{ matrix.target_name }}
+          identical: true
+          api_key: ${{ secrets.MEMBROWSE_API_KEY }}
+          api_url: ${{ vars.MEMBROWSE_API_URL }}
+
+  # Build target with debug symbols + linker map, then upload MemBrowse report.
+  # Uses the NuttX CI Docker image so toolchains, kconfig-frontends, etc. are
+  # already installed.
+  analyze:
+    needs: [changes-filter, load-targets]
+    if: needs.changes-filter.outputs.source == 'true'
+    runs-on: ubuntu-latest
+    env:
+      DOCKER_BUILDKIT: 1
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.load-targets.outputs.matrix) }}
+    steps:
+      - name: Checkout nuttx repo
+        uses: actions/checkout@v6
+        with:
+          path: sources/nuttx
+          fetch-depth: 0
+
+      - name: Checkout nuttx-apps repo
+        uses: actions/checkout@v6
+        with:
+          repository: apache/nuttx-apps
+          path: sources/apps
+          fetch-depth: 1
+
+      - name: Docker Login
+        uses: docker/login-action@b45d80f862d83dbcd57f89517bcf500b2ab88fb2  # v4.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker Pull
+        run: docker pull ghcr.io/apache/nuttx/apache-nuttx-ci-linux
+
+      - name: Build ${{ matrix.target_name }}
+        uses: ./sources/nuttx/.github/actions/ci-container
+        with:
+          run: |
+            git config --global --add safe.directory /github/workspace/sources/nuttx
+            git config --global --add safe.directory /github/workspace/sources/apps
+            cd /github/workspace/sources/nuttx
+            ./tools/configure.sh -l ${{ matrix.board_config }}
+            echo CONFIG_DEBUG_SYMBOLS=y >> .config
+            echo CONFIG_DEBUG_LINK_MAP=y >> .config
+            if [ -n "${{ matrix.config_overrides }}" ]; then
+              kconfig-tweak ${{ matrix.config_overrides }}
+            fi
+            make olddefconfig
+            # Preserve preprocessed linker scripts (.ld.tmp) so MemBrowse can
+            # read them. Arch Makefiles delete these immediately after linking.
+            find arch -name Makefile -exec sed -i '/DELFILE, $(addsuffix .tmp,$(ARCHSCRIPT))/d' {} +
+            make -j$(nproc)
+
+      # MemBrowse action runs from $GITHUB_WORKSPACE and discovers git via CWD,
+      # but nuttx is checked out to sources/nuttx/ (so apps can sit beside it).
+      # Expose the repo's .git at the workspace root so git metadata resolves.
+      - name: Expose nuttx .git to workspace root
+        run: ln -sfn sources/nuttx/.git .git
+
+      - name: Prefix linker script paths
+        id: ld
+        run: |
+          prefixed=""
+          for p in ${{ matrix.ld }}; do
+            prefixed="$prefixed sources/nuttx/$p"
+          done
+          paths=$(echo $prefixed | xargs)
+          echo "paths=$paths" >> "$GITHUB_OUTPUT"
+          echo "Resolved ld paths: [$paths]"
+          for p in $paths; do
+            if [ -e "$p" ]; then
+              echo "  OK   $p ($(stat -c '%s bytes, owner=%U:%G' "$p" 2>/dev/null))"
+            else
+              echo "  MISS $p"
+              echo "  ls dir:"
+              ls -la "$(dirname "$p")" 2>&1 | head -30
+            fi
+          done
+
+      - name: MemBrowse analysis - ${{ matrix.target_name }}
+        uses: membrowse/membrowse-action@v1
+        with:
+          target_name: ${{ matrix.target_name }}
+          elf: sources/nuttx/${{ matrix.elf }}
+          ld: ${{ steps.ld.outputs.paths }}
+          map_file: ${{ matrix.map_file != '' && format('sources/nuttx/{0}', matrix.map_file) || '' }}
+          linker_vars: ${{ matrix.linker_vars }}
+          api_key: ${{ secrets.MEMBROWSE_API_KEY }}
+          api_url: ${{ vars.MEMBROWSE_API_URL }}
+          verbose: INFO

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Contributors](https://img.shields.io/github/contributors/apache/nuttx)](https://github.com/apache/nuttx/graphs/contributors)
 [![GitHub Build Badge](https://github.com/apache/nuttx/workflows/Build/badge.svg)](https://github.com/apache/nuttx/actions/workflows/build.yml)
 [![Documentation Badge](https://github.com/apache/nuttx/workflows/Build%20Documentation/badge.svg)](https://nuttx.apache.org/docs/latest/index.html)
+[![MemBrowse](https://membrowse.com/badge.svg)](https://membrowse.com/public/apache/nuttx)
 
 Apache NuttX is a real-time operating system (RTOS) with an emphasis on
 standards compliance and small footprint. Scalable from 8-bit to 64-bit


### PR DESCRIPTION
Summary

  Integrates MemBrowse memory footprint tracking into NuttX CI to automatically report firmware memory footprint across a representative set of boards on
  every PR and push to master.

  - Adds .github/membrowse-targets.json: tracks 9 boards spanning all supported architectures
    - ARM Cortex-M/A
    -  AVR
    - MIPS
    -  RISC-V
    -  RX
    -  SPARC
    -  x86_64
    - Xtensa
  - Adds membrowse-report.yml: builds Nuttx on the above targets and runs membrowse-action to generate and upload the reports
  - Adds membrowse-comment.yml: posts a memory-diff comment on PRs after the report workflow finishes.
  - Adds membrowse-onboard.yml: manual workflow to backfill the last N commits per target.
  - Adds a MemBrowse badge to README.md to easily access the MemBrowse Nuttx dashboard

  Setup

  To view the memory dashboard and receive PR comments:

  1. Create an account and a project at https://membrowse.com.
  2. Copy the project's API key.
  3. In the MemBrowse project settings set the dashboard as publicly available
  4. In the GitHub repo, add it as a secret named MEMBROWSE_API_KEY

  Testing

  The integration has been running on a fork. See the live dashboard here:
https://membrowse.com/public/michael-membrowse/nuttx