### PR TITLE
arch/[risc-v|xtensa]: Re-add `RMT_LOOP_TEST_MODE` Kconfig entry

### DIFF
--- a/arch/risc-v/src/common/espressif/Kconfig
+++ b/arch/risc-v/src/common/espressif/Kconfig
@@ -1662,6 +1662,15 @@ config ESP_RMT
 		format, RMT can be extended to a versatile and general-purpose
 		transceiver, transmitting or receiving many other types of signals.
 
+config RMT_LOOP_TEST_MODE
+	bool "Enable RMT loop test pin mapping"
+	default n
+	depends on ESP_RMT
+	---help---
+		Use a loop test pin mapping for RMT RX/TX.
+		When enabled, board pin definitions can route RX/TX to the same
+		GPIO for loopback testing without external wiring.
+
 if ESP_RMT
 
 config RMT_DEFAULT_RX_BUFFER_SIZE

--- a/arch/xtensa/src/common/espressif/Kconfig
+++ b/arch/xtensa/src/common/espressif/Kconfig
@@ -77,6 +77,15 @@ config ESP_RMT
 		format, RMT can be extended to a versatile and general-purpose
 		transceiver, transmitting or receiving many other types of signals.
 
+config RMT_LOOP_TEST_MODE
+	bool "Enable RMT loop test pin mapping"
+	default n
+	depends on ESP_RMT
+	---help---
+		Use a loop test pin mapping for RMT RX/TX.
+		When enabled, board pin definitions can route RX/TX to the same
+		GPIO for loopback testing without external wiring.
+
 if ESP_RMT
 
 config RMT_DEFAULT_RX_BUFFER_SIZE


### PR DESCRIPTION
## Summary

* arch/[risc-v|xtensa]: Re-add `RMT_LOOP_TEST_MODE` Kconfig entry
  - The PR #18654 removed the Kconfig option `RMT_LOOP_TEST_MODE` used by Espressif's RMT peripheral. This PR reintroduces it as a lower-half driver interface used to enable internal loopback tests.

## Impact

Impact on user: No.

Impact on build: No.

Impact on hardware: Yes. Impacts Espressif's RMT peripheral testing.

Impact on documentation: No.

Impact on security: No.

Impact on compatibility: No.

## Testing

Testing procedure can be copied from https://github.com/apache/nuttx-apps/pull/3461. If `CONFIG_RMT_LOOP_TEST_MODE` is set there is no need to externally wire RMT's output and input pins.