### PR TITLE
arch/xtensa: properly set carrier on/off on espnow driver

### DIFF
--- a/arch/xtensa/src/common/espressif/esp_espnow_pktradio.c
+++ b/arch/xtensa/src/common/espressif/esp_espnow_pktradio.c
@@ -42,6 +42,7 @@
 #include <nuttx/net/ip.h>
 #include <nuttx/spinlock.h>
 #include <nuttx/net/radiodev.h>
+#include <nuttx/net/netdev.h>
 #include <nuttx/net/sixlowpan.h>
 #include <nuttx/wireless/pktradio.h>
 #include <nuttx/wdog.h>
@@ -1098,6 +1099,11 @@ static int espnow_ifup(FAR struct net_driver_s *dev)
 
   priv->txblocked = false;
   priv->bifup = true;
+
+  /* Link is ready for 6LoWPAN; set IFF_RUNNING (ifconfig "RUNNING"). */
+
+  netdev_carrier_on(dev);
+
   return OK;
 }
 
@@ -1147,6 +1153,8 @@ static int espnow_ifdown(FAR struct net_driver_s *dev)
   /* Mark the device "down" */
 
   priv->bifup = false;
+
+  netdev_carrier_off(dev);
 
   return OK;
 }


### PR DESCRIPTION
## Summary

<!-- This field should contain a summary of the changes. It will be pre-filled with the commit's message and descriptions. Adjust it accordingly -->

* arch/xtensa: properly set carrier on/off on espnow driver

In esp_espnow_pktradio.c, after ESP-NOW is successfully initialized in espnow_ifup, call netdev_carrier_on(dev).
In espnow_ifdown, call netdev_carrier_off(dev).

NuttX only sets IFF_RUNNING (carrier) when the driver calls netdev_carrier_on(). The ESP-NOW 6LoWPAN interface came up with IFF_UP but without RUNNING, so the stack still treated wpan0 as “not running.” That broke UDP paths that require IFF_IS_RUNNING (e.g. DHCPC over the interface) and other behavior that keys off “RUNNING” in ifconfig. Other radio/6LoWPAN drivers (e.g. xbee) already use the same netdev_carrier_on / netdev_carrier_off pairing.

## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: Yes. Fixes `espnow` functionality.
<!-- Does it impact user's applications? How? -->

Impact on build: No.
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: Only affects ESP32.
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: No.
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: No.
<!-- Does it impact NuttX's security? -->

Impact on compatibility: No.
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

## Testing
<!-- Please provide all the testing procedure. Consider that upstream reviewers should be able to reproduce the same testing performed internally -->
espnow two-board serial tests passed after the change (previous failure showed wpan0 as UP but not RUNNING; UDP/DHCP then failed on “device is not running”).

### Building
- `./tools/configure.sh esp32-devkitc:espnow`
- Make and flash two boards

### Running
<!-- Provide how to run the test for each SoC being tested -->
Execute the example available on the [documentation](https://nuttx.apache.org/docs/latest/platforms/xtensa/esp32/boards/esp32-devkitc/index.html#espnow).

On the board running as server:
- `ifconfig wpan0 inet6 fe80::ff:fe00:a`
- `udpserver &`

On the client:
- `udpclient fe80::ff:fe00:a &`

### Results
<!-- Provide tests' results and runtime logs -->
- Before changes:
No data was received on server side and had errors related to network interface.

- After changes:
Data exchanged as expected.
```
nsh&gt; #x1B[Kserver: 1. Received 96 bytes from fe80:0000:0000:0000:0000:00ff:fe00:feff port 5472
server: 2. Receiving up 1024 bytes
server: 2. Received 96 bytes from fe80:0000:0000:0000:0000:00ff:fe00:feff port 5472
server: 3. Receiving up 1024 bytes
[dut-1] 
[dut-1] nsh&gt; #x1B[Kserver: 3. Received 96 bytes from fe80:0000:0000:0000:0000:00ff:fe00:feff port 5472
[dut-1] server: 4. Receiving up 1024 bytes
[dut-0] client: 3. Sending 96 bytes
[dut-0] client: 3. Sent 96 bytes
[dut-0] client: 4. Sending 96 bytes
[dut-0] client: 4. Sent 96 bytes
[dut-1] server: 4. Received 96 bytes from fe80:0000:0000:0000:0000:00ff:fe00:feff port 5472
[dut-1] server: 5. Receiving up 1024 bytes
[dut-0] client: 5. Sending 96 bytes
[dut-0] client: 5. Sent 96 bytes
[dut-1] server: 5. Received 96 bytes from fe80:0000:0000:0000:0000:00ff:fe00:feff port 5472
[dut-1] server: 6. Receiving up 1024 bytes
```