### PR TITLE
Prefer tmpfs for /tmp mount in SIM and update documentation

### DIFF
--- a/Documentation/applications/nsh/customizing.rst
+++ b/Documentation/applications/nsh/customizing.rst
@@ -57,10 +57,13 @@ The NSH initialization function, ``nsh_initialize()``, be found in
      read-only, ROMFS file system is mounted by ``nsh_romfsetc()``.
 
      The ROMFS image is, itself, just built into the firmware. By default,
-     this ``rc.sysinit`` system init script contains the following logic::
+     this ``rc.sysinit`` system init script contains logic to prefer
+     TMPFS for ``/tmp`` and to fall back to FAT RAMDISK::
 
-        # Create a RAMDISK and mount it at XXXRDMOUNTPOINTXXX
+        # Mount /tmp on TMPFS
+        mount -t tmpfs XXXRDMOUNTPOINTXXX
 
+        # Otherwise create a RAMDISK and mount it at XXXRDMOUNTPOINTXXX
         mkrd -m XXXMKRDMINORXXX -s XXMKRDSECTORSIZEXXX XXMKRDBLOCKSXXX
         mkfatfs /dev/ramXXXMKRDMINORXXX
         mount -t vfat /dev/ramXXXMKRDMINORXXX XXXRDMOUNTPOINTXXX
@@ -79,15 +82,20 @@ The NSH initialization function, ``nsh_initialize()``, be found in
      -  ``XXXRDMOUNTPOINTXXX`` will become the configured mount point.
         Default: ``/etc``
 
-     By default, the substituted values would yield an ``rc.sysinit`` file like::
+     By default, with FAT fallback values substituted, ``rc.sysinit``
+     can look like::
 
-        # Create a RAMDISK and mount it at /tmp
+        # Mount /tmp on TMPFS
+        mount -t tmpfs /tmp
 
+        # Otherwise create a RAMDISK and mount it at /tmp
         mkrd -m 1 -s 512 1024
         mkfatfs /dev/ram1
         mount -t vfat /dev/ram1 /tmp
 
-     This script will, then:
+     This script will:
+
+     -  Mount ``/tmp`` as TMPFS when available, or else:
 
      -  Create a RAMDISK of size 512*1024 bytes at ``/dev/ram1``,
 

--- a/Documentation/guides/etcromfs.rst
+++ b/Documentation/guides/etcromfs.rst
@@ -58,10 +58,13 @@ behave as follows at Nuttx start-up time:
               `-- rcS
               `-- rc.sysinit
 
-  -  By default, the contents of ``rc.sysinit`` script are::
+  -  By default, the contents of ``rc.sysinit`` script prefer TMPFS for
+     ``/tmp`` and fall back to FAT RAMDISK when TMPFS is not enabled::
 
-      # Create a RAMDISK and mount it at /tmp
+      # Mount /tmp on TMPFS
+      mount -t tmpfs /tmp
 
+      # Otherwise create a RAMDISK and mount it at /tmp
       mkrd -m 1 -s 512 1024
       mkfatfs /dev/ram1
       mount -t vfat /dev/ram1 /tmp
@@ -96,8 +99,8 @@ In most of these cases, the configuration sets up the *default*
 script is here: ``apps/nshlib/rc.sysinit.template`` and
 ``apps/nshlib/rcS.template``. (The funny values in the rc.sysinit.template
 like ``XXXMKRDMINORXXX`` get replaced via ``sed`` at build time). This
-default configuration creates a ramdisk and mounts it at ``/tmp`` as
-discussed above.
+default configuration mounts ``/tmp`` as TMPFS when enabled, otherwise
+it creates a RAMDISK and mounts FAT at ``/tmp`` as discussed above.
 
 Customizing Start up Scripts
 ============================

--- a/boards/sim/sim/sim/src/etc/init.d/rc.sysinit
+++ b/boards/sim/sim/sim/src/etc/init.d/rc.sysinit
@@ -26,13 +26,19 @@
 #define CONCAT(x, y)  CONCAT_(x, y)
 
 #ifdef CONFIG_ETC_ROMFS
-#ifdef CONFIG_FS_FAT
+#ifdef CONFIG_FS_TMPFS
 
-/* Create a RAMDISK and mount it at /tmp */
+/* Mount /tmp on TMPFS */
+
+mount -t tmpfs /tmp
+
+#elif defined(CONFIG_FS_FAT)
+
+/* Create a FAT RAMDISK and mount it at /tmp */
 
 mkrd -m CONFIG_ETC_FATDEVNO -s CONFIG_ETC_FATSECTSIZE CONFIG_ETC_FATNSECTORS
 mkfatfs CONCAT(/dev/ram, CONFIG_ETC_FATDEVNO)
 mount -t vfat CONCAT(/dev/ram, CONFIG_ETC_FATDEVNO) CONFIG_ETC_FATMOUNTPT
 
-#endif /* CONFIG_FS_FAT */
+#endif /* CONFIG_FS_TMPFS || CONFIG_FS_FAT */
 #endif /* CONFIG_ETC_ROMFS */

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -552,8 +552,9 @@ menuconfig ETC_ROMFS
 	---help---
 		Mount a ROMFS filesystem at /etc and provide a system init
 		script at /etc/init.d/rc.sysinit and a startup script
-		at /etc/init.d/rcS.  The default system init script will mount
-		a FAT FS RAMDISK at /tmp but the logic is easily extensible.
+		at /etc/init.d/rcS.  The default system init script mounts
+		/tmp as TMPFS when FS_TMPFS is enabled, otherwise it can
+		fall back to mounting a FAT FS RAMDISK at /tmp.
 
 if ETC_ROMFS
 
@@ -591,37 +592,40 @@ config ETC_FATDEVNO
 	default 1
 	depends on FS_FAT
 	---help---
-		When the default rcS file used when ETC_ROMFS is selected, it
-		will mount a FAT FS under /tmp. This is the minor number of the FAT
-		FS block device.  The default is '1' corresponding to /dev/ram1.
+		When ETC_ROMFS is selected and FS_TMPFS is disabled, the
+		default rc.sysinit script mounts a FAT FS under /tmp. This
+		is the minor number of the FAT FS block device.  The default
+		is '1' corresponding to /dev/ram1.
 
 config ETC_FATSECTSIZE
 	int "FAT sector size"
 	default 512
 	depends on FS_FAT
 	---help---
-		When the default rcS file used when ETC_ROMFS is selected, it
-		will mount a FAT FS under /tmp. This is the sector size use with the
-		FAT FS. Default is 512.
+		When ETC_ROMFS is selected and FS_TMPFS is disabled, the
+		default rc.sysinit script mounts a FAT FS under /tmp. This
+		is the sector size used with the FAT FS. Default is 512.
 
 config ETC_FATNSECTORS
 	int "FAT number of sectors"
 	default 1024
 	depends on FS_FAT
 	---help---
-		When the default rcS file used when ETC_ROMFS is selected, it
-		will mount a FAT FS under /tmp. This is the number of sectors to use
-		with the FAT FS.  Default is 1024.  The amount of memory used by the
-		FAT FS will be ETC_FATSECTSIZE * ETC_FATNSECTORS bytes.
+		When ETC_ROMFS is selected and FS_TMPFS is disabled, the
+		default rc.sysinit script mounts a FAT FS under /tmp. This
+		is the number of sectors to use with the FAT FS.  Default is
+		1024.  The amount of memory used by the FAT FS will be
+		ETC_FATSECTSIZE * ETC_FATNSECTORS bytes.
 
 config ETC_FATMOUNTPT
 	string "FAT mount point"
 	default "/tmp"
 	depends on FS_FAT
 	---help---
-		When the default rcS file used when ETC_ROMFS is selected, it
-		will mount a FAT FS under /tmp. This is the location where the FAT
-		FS will be mounted.  Default is "/tmp".
+		When ETC_ROMFS is selected and FS_TMPFS is disabled, the
+		default rc.sysinit script mounts a FAT FS under /tmp. This
+		is the location where the FAT FS will be mounted.  Default is
+		"/tmp".
 
 endif # ETC_ROMFS
 


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

### Fixes #12791

### Why this change is needed
- Current SIM `rc.sysinit` behavior always creates a FAT RAMDISK and mounts it on `/tmp`.
- NuttX already supports TMPFS, and expected behavior is to use TMPFS for `/tmp` when available.

### What this change does
- Updates `boards/sim/sim/sim/src/etc/init.d/rc.sysinit` to:
  - Mount `/tmp` as `tmpfs` when `CONFIG_FS_TMPFS=y`.
  - Fall back to existing FAT RAMDISK flow when TMPFS is not enabled and `CONFIG_FS_FAT=y`.
- Updates `sched/Kconfig` help text for `ETC_ROMFS` and FAT options so documentation matches implementation.
- Updates documentation to reflect TMPFS-first `/tmp` behavior with FAT fallback:
  - `Documentation/guides/etcromfs.rst`
  - `Documentation/applications/nsh/customizing.rst`


## Impact

- **Users**: SIM configurations with TMPFS enabled now get `/tmp` backed by TMPFS by default.
- **Compatibility**: FAT RAMDISK fallback is preserved for configurations without TMPFS.
- **Build process**: No build system changes.
- **Hardware**: Change is scoped to SIM startup script behavior.
- **Documentation**: Kconfig help and guides now align with runtime behavior.
- **Security**: No direct security impact identified.

### What was tested

1. File-level style checks on all touched files:
```bash
./tools/checkpatch.sh -f boards/sim/sim/sim/src/etc/init.d/rc.sysinit \
  sched/Kconfig \
  Documentation/guides/etcromfs.rst \
  Documentation/applications/nsh/customizing.rst