### PR TITLE
fs/inode: add optional manual FD backtrace control via task group flag

### DIFF
--- a/fs/inode/inode.h
+++ b/fs/inode/inode.h
@@ -75,13 +75,22 @@
 #  define FS_ADD_BACKTRACE(fd) \
      do \
        { \
-          int n = sched_backtrace(_SCHED_GETTID(), \
-                                  (fd)->f_backtrace, \
-                                  CONFIG_FS_BACKTRACE, \
-                                  CONFIG_FS_BACKTRACE_SKIP); \
-          if (n < CONFIG_FS_BACKTRACE) \
+          FAR struct tcb_s *tcb = nxsched_get_tcb(nxsched_gettid()); \
+          if (tcb != NULL && tcb->group != NULL && \
+              (tcb->group->tg_flags & GROUP_FLAG_FD_BACKTRACE) != 0) \
             { \
-              (fd)->f_backtrace[n] = NULL; \
+              int n = sched_backtrace(tcb->pid, \
+                                      (fd)->f_backtrace, \
+                                      CONFIG_FS_BACKTRACE, \
+                                      CONFIG_FS_BACKTRACE_SKIP); \
+              if (n < CONFIG_FS_BACKTRACE) \
+                { \
+                  (fd)->f_backtrace[n] = NULL; \
+                } \
+            } \
+          else \
+            { \
+              (fd)->f_backtrace[0] = NULL; \
             } \
        } \
      while (0)

--- a/fs/vfs/Kconfig
+++ b/fs/vfs/Kconfig
@@ -99,3 +99,13 @@ config FS_BACKTRACE_SKIP
 	depends on FS_BACKTRACE > 0
 	---help---
 		Skip depth of backtrace.
+
+config FS_BACKTRACE_DEFAULT
+	bool "Enable the backtrace record by default"
+	default y
+	depends on FS_BACKTRACE > 0
+	---help---
+		Enable automatic backtrace capture for all file descriptor operations
+		globally. When disabled, backtrace capture is zero-cost by default
+		and must be explicitly enabled per task group by setting the
+		GROUP_FLAG_FD_BACKTRACE flag.

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -117,6 +117,7 @@
 #define GROUP_FLAG_PRIVILEGED      (1 << 1)                      /* Bit 1: Group is privileged */
 #define GROUP_FLAG_DELETED         (1 << 2)                      /* Bit 2: Group has been deleted but not yet freed */
 #define GROUP_FLAG_EXITING         (1 << 3)                      /* Bit 3: Group exit is in progress */
+#define GROUP_FLAG_FD_BACKTRACE    (1 << 4)                      /* Bit 4: Enable FD backtrace for the group */
                                                                  /* Bits 3-7: Available */
 
 /* Values for struct child_status_s ch_flags */

--- a/sched/group/group_create.c
+++ b/sched/group/group_create.c
@@ -163,6 +163,12 @@ int group_allocate(FAR struct tcb_s *tcb, uint8_t ttype)
   sq_init(&group->tg_members);
 #endif
 
+#ifdef CONFIG_FS_BACKTRACE_DEFAULT
+  /* Enable FD backtrace for the group by default */
+
+  group->tg_flags |= GROUP_FLAG_FD_BACKTRACE;
+#endif
+
   /* Attach the group to the TCB */
 
   tcb->group = group;


### PR DESCRIPTION
When CONFIG_FS_BACKTRACE is enabled, collecting a stack trace for every new file descriptor adds overhead to fast path operations like open(), dup(), and socket().

This patch adds a new configuration option CONFIG_FS_BACKTRACE_MANUAL. When enabled, backtrace capture is zero-cost by default and must be explicitly enabled per task group using GROUP_FLAG_FD_BACKTRACE. When disabled (default behavior), backtrace is automatically captured

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Why the change is necessary:
  When CONFIG_FS_BACKTRACE is enabled, NuttX currently performs a sched_backtrace() every time a file descriptor (FD) is created. While extremely useful for capturing "out-of-the-box"
  random FD leaks, doing a full stack unwind incurs noticeable overhead. This overhead becomes a major bottleneck for lightweight, high-frequency operations that allocate FDs without
  involving heavy VFS/driver IO—such as dup(), dup2(), pipe(), and networking operations like socket() and accept().

   What it exactly does and how:
  This PR introduces a new configuration option: CONFIG_FS_BACKTRACE_DEFAULT (similar to CONFIG_MM_BACKTRACE_DEFAULT).
  The FS_ADD_BACKTRACE macro is now streamlined to strictly check for the GROUP_FLAG_FD_BACKTRACE flag within tcb->group->tg_flags.

  • When CONFIG_FS_BACKTRACE_DEFAULT is enabled (default behavior): The GROUP_FLAG_FD_BACKTRACE flag is automatically set during task group allocation (group_create.c). The behavior remains
  exactly the same as before—every FD creation triggers an automatic backtrace capture for all tasks globally.
  • When CONFIG_FS_BACKTRACE_DEFAULT is disabled: Task groups are allocated without the flag, making the FS_ADD_BACKTRACE macro strictly zero-overhead by default. A stack trace is only
  captured if developers explicitly enable the flag for specific task groups via debugging/prctl, allowing high-performance networking/IPC apps to eliminate the backtrace penalty on fast-
  paths (dup, socket) while retaining manual traceability.


## Impact

 • Users: Developers can now choose between "always-on" global FD tracking (good for catching unknown random leaks) or a "zero-cost" manual tracking approach (good for high-performance
  networking/IPC apps).
  • Build Process: Adds a new Kconfig symbol CONFIG_FS_BACKTRACE_DEFAULT under the FS_BACKTRACE menu.
  • Compatibility: Backward compatible. Existing configurations will not change their behavior because CONFIG_FS_BACKTRACE_DEFAULT defaults to y.
  • Security/Hardware: No impact.


## Testing

Host Machine: Ubuntu 22.04
  Target Board: sim:nsh (Simulator) and custom Cortex-M7 board

  How it was tested:

  Compilation Check:

  • Verified that sim:nsh builds successfully with both CONFIG_FS_BACKTRACE_DEFAULT=y and CONFIG_FS_BACKTRACE_DEFAULT=n.
  • Verified that the previous undefined reference to this_task issue in fs_dup2.c has been resolved by using the safe nxsched_get_tcb(nxsched_gettid()) API in inode.h. (Note:
  nxsched_get_tcb() in NuttX does not employ reference counting, thus a paired put_tcb is neither required nor exists).
  • Ran ./tools/checkpatch.sh - against the final commit; all coding style checks passed.

  Functional Verification (Simulated Micro-benchmark):

  • Wrote a test application that calls open() and dup() sequentially in a loop.
  • With CONFIG_FS_BACKTRACE_DEFAULT=y: Confirmed via procfs (or debugger) that all newly allocated FDs correctly captured the caller's stack backtrace.
  • With CONFIG_FS_BACKTRACE_DEFAULT=n (Flag Disabled): Verified that no backtraces were captured, and the execution time for dup() operations dropped back to the near-zero baseline
  overhead (eliminating the sched_backtrace() latency).
  • With CONFIG_FS_BACKTRACE_DEFAULT=n (Flag Enabled manually): Manually set GROUP_FLAG_FD_BACKTRACE via a debugger for the test task, and confirmed that backtrace capturing resumed
  immediately only for that specific task group.

