### PR TITLE
arch/arm/stm32h7: Fix SPI RX DMA returning stale DCACHE data

### DIFF
--- a/arch/arm/src/stm32h7/stm32_spi.c
+++ b/arch/arm/src/stm32h7/stm32_spi.c
@@ -2169,12 +2169,6 @@ static void spi_exchange(struct spi_dev_s *dev, const void *txbuffer,
           up_clean_dcache((uintptr_t)txbuffer, (uintptr_t)txbuffer + nbytes);
         }
 
-      if (rxbuffer)
-        {
-          up_invalidate_dcache((uintptr_t)rxbuffer,
-                               (uintptr_t)rxbuffer + nbytes);
-        }
-
       /* N.B. the H7 tri-states the clock output on SPI disable and
        * unfortunately the Chip Select (CS) is active.  So we keep
        * the device disabled for the minimum time, that meets the
@@ -2249,6 +2243,14 @@ static void spi_exchange(struct spi_dev_s *dev, const void *txbuffer,
       spi_modifyreg(priv, STM32_SPI_CFG1_OFFSET, SPI_CFG1_TXDMAEN |
                           SPI_CFG1_RXDMAEN, 0);
       spi_enable(priv, true);
+
+      /* Force RAM re-read */
+
+      if (rxbuffer)
+        {
+          up_invalidate_dcache((uintptr_t)rxbuffer,
+                               (uintptr_t)rxbuffer + nbytes);
+        }
 
       /* Second copy: Copy the DMA internal buffer to caller's buffer */
 


### PR DESCRIPTION
## Summary

In sporadic cases it is possible that a SPI exchange returns stale RX data from the DCACHE.

This occurs when:
- DCACHE is enabled
- DMA is used

The impact of this can be hard to debug and vanishes when the timing even changes minimally.

This is caused by the DCACHE being invalidated before the actual DMA transaction starts which does not conform to the recommendations from AN4839 and also does not match the implementation of any of the other STM32H7/STM32F7 peripheral drivers using DMA.

Fixed by invalidating the DCACHE right before the actual read, which matches the implementation of the STM32F7 SPI driver.


## Testing

Tested on a Pixhawk v6x (STM32H753IIK6). Validated by setting a breakpoint in a driver running on SPI3 that checks if the current RX data returned by a SPI transfer matches the RX data format of another driver running on SPI3. Without the fix it is visible that stale data is present. As soon as the cache is invalidated the correct data is visible.

```
$11 = {
  spidev = {
    ops = 0x81f05e0 <g_sp3iops>
  },
  spibase = 1073757184,
  spiclock = 96000000,
  spiirq = 67 'C',
  rxresult = 176 '\260',
  txresult = 128 '\200',
  rxch = 573,
  txch = 574,
  rxbuf = 0x24015240 <g_spi3_rxbuf> "",
  txbuf = 0x24015640 <g_spi3_txbuf> "\277",
  buflen = 1024,
  rxdma = 0x240007e0 <g_dmach+160>,
  txdma = 0x240007f0 <g_dmach+176>,
  rxsem = taken (0),
  txsem = taken (0),
  txccr = 1088,
  rxccr = 1024,
  initialized = true,
  exclsem = available (1i),
  frequency = 10000000,
  actual = 6000000,
  nbits = 8 '\b',
  mode = 3 '\003',
  config = FULL_DUPLEX
}
```

```
(gdb) x/8xw 0x24015240
0x24015240 <g_spi3_rxbuf>:	0x001c0000	0x04000a84	0x84055d00	0x00080012
0x24015250 <g_spi3_rxbuf+16>:	0x08840562	0x66000500	0x000e8405	0x055a0005

(gdb) call up_invalidate_dcache(0x24015240, 0x24015260)

(gdb) x/8xw 0x24015240
0x24015240 <g_spi3_rxbuf>:	0xdc002aff	0x9c0012ff	0x00000aff	0x2a009200
0x24015250 <g_spi3_rxbuf+16>:	0x9effee00	0xaa0008ff	0xd0fffeff	0x050064ff
```

After applying the fix the breakpoint is not hit anymore and the high-level problem (gyroscope reading accelerometer data) does not happen anymore.
