### PR TITLE
arch/risc-v/espressif: Add LP_ADC support

### DIFF
--- a/Documentation/platforms/risc-v/esp32p4/index.rst
+++ b/Documentation/platforms/risc-v/esp32p4/index.rst
@@ -366,7 +366,7 @@ LP I2S             No
 LP UART            Yes
 LP GPIO            No
 LP Timers          No
-LP ADC             No
+LP ADC             Yes
 Temperature        Yes     Internal temperature sensor
 Touch Sensor       No
 eFuse              Yes     Virtual eFuses supported

--- a/arch/risc-v/src/common/espressif/Kconfig
+++ b/arch/risc-v/src/common/espressif/Kconfig
@@ -1238,6 +1238,11 @@ config ESPRESSIF_ADC_1
 	default y
 	bool "Enable SAR ADC 1"
 
+config ESPRESSIF_ADC_1_USE_LP
+	depends on ESPRESSIF_ADC_1 && ARCH_CHIP_ESP32P4
+	default n
+	bool "Use ADC 1 as LP ADC"
+
 config ESPRESSIF_ADC_2
 	default n
 	depends on ARCH_CHIP_ESP32P4

--- a/arch/risc-v/src/common/espressif/esp_adc.c
+++ b/arch/risc-v/src/common/espressif/esp_adc.c
@@ -504,6 +504,7 @@ static int esp_adc_oneshot_new_unit(struct adc_dev_s *dev)
   adc_oneshot_hal_cfg_t config;
   irqstate_t flags;
   uint32_t clk_src_freq_hz = 0;
+  soc_module_clk_t clk_src = ADC_DIGI_CLK_SRC_DEFAULT;
 
   DEBUGASSERT(priv);
   DEBUGASSERT(priv->mode == ESP_ADC_MODE_ONE_SHOT);
@@ -516,20 +517,38 @@ static int esp_adc_oneshot_new_unit(struct adc_dev_s *dev)
 
   flags = spin_lock_irqsave(&g_adc_common.esp_adc_spinlock);
 
-  esp_clk_tree_src_get_freq_hz(ADC_DIGI_CLK_SRC_DEFAULT,
+#if SOC_LP_ADC_SUPPORTED && defined(CONFIG_ESPRESSIF_ADC_1_USE_LP)
+  if (priv->unit == ADC_UNIT_1)
+    {
+      clk_src = LP_ADC_CLK_SRC_LP_DYN_FAST;
+    }
+
+#endif
+  esp_clk_tree_src_get_freq_hz(clk_src,
                                ESP_CLK_TREE_SRC_FREQ_PRECISION_CACHED,
                                &clk_src_freq_hz);
-
   config.unit = priv->unit;
-  config.work_mode = ADC_HAL_SINGLE_READ_MODE;
-  config.clk_src = ADC_DIGI_CLK_SRC_DEFAULT;
+  config.clk_src = clk_src;
   config.clk_src_freq_hz = clk_src_freq_hz;
+#ifdef CONFIG_ESPRESSIF_ADC_1_USE_LP
+  if (priv->unit == ADC_UNIT_1)
+    {
+      config.work_mode = ADC_HAL_LP_MODE;
+    }
+  else
+#endif
+    {
+      config.work_mode = ADC_HAL_SINGLE_READ_MODE;
+    }
 
   adc_oneshot_hal_init(hal, &config);
 
   /* Enable peripheral and power ADC */
 
-  adc_apb_periph_claim();
+  if (ADC_LL_NEED_APB_PERIPH_CLAIM(priv->unit))
+    {
+      adc_apb_periph_claim();
+    }
 
   sar_periph_ctrl_adc_oneshot_power_acquire();
 
@@ -588,6 +607,13 @@ static int esp_adc_oneshot_config_channel(struct adc_dev_s *dev,
 
   flags = spin_lock_irqsave(&g_adc_common.esp_adc_spinlock);
   adc_oneshot_hal_channel_config(hal, &config, channel);
+#ifdef CONFIG_ESPRESSIF_ADC_1_USE_LP
+  if (priv->unit == ADC_UNIT_1)
+    {
+      adc_oneshot_hal_setup(hal, channel);
+    }
+
+#endif
   spin_unlock_irqrestore(&g_adc_common.esp_adc_spinlock, flags);
 
   ainfo("init adc unit %u, ch %u (gpio %d), atten %d, bitwidth %d",


### PR DESCRIPTION
## Summary

<!-- This field should contain a summary of the changes. It will be pre-filled with the commit's message and descriptions. Adjust it accordingly -->

* arch/risc-v/espressif: Add LP_ADC support

Add LP_ADC support

## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: Yes, ADC can be used with ULP on P4
<!-- Does it impact user's applications? How? -->

Impact on build: No
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: No
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: Related docs added
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: No
<!-- Does it impact NuttX's security? -->

Impact on compatibility: No
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

## Testing
<!-- Please provide all the testing procedure. Consider that upstream reviewers should be able to reproduce the same testing performed internally -->

`esp32p4-function-ev-board:ulp` config with these options enabled:

```
CONFIG_ESPRESSIF_ADC
CONFIG_ESPRESSIF_ADC_1_USE_LP
```

### Building
<!-- Provide how to build the test for each SoC being tested -->

Command to build:

```
make distclean && ./tools/configure.sh esp32p4-function-ev-board:ulp && kconfig-tweak -e CONFIG_ESPRESSIF_ADC && kconfig-tweak -e CONFIG_ESPRESSIF_ADC_1_USE_LP && make olddefconfig && make -j && make download ESPTOOL_PORT=/dev/ttyUSB0
```

### Running
<!-- Provide how to run the test for each SoC being tested -->

Custom app used to test

ULP app:

```
#include <stdint.h>
#include <stdio.h>
#include <stdbool.h>
#include <stdbool.h>
#include "ulp_lp_core_gpio.h"
#include "ulp_lp_core_lp_adc_shared.h"
#include "hal/adc_types.h"
#include "sdkconfig.h"

#define nop()   __asm__ __volatile__ ("nop")

int32_t adc_result = 0;

int main(void)
{
    while (1)
        {
#if defined(CONFIG_ARCH_CHIP_ESP32S3) || defined(CONFIG_ARCH_CHIP_ESP32S2)
            adc_result = ulp_riscv_adc_read_channel(ADC_CHANNEL_0, ADC_UNIT_1);
#else
            lp_core_lp_adc_read_channel_converted(ADC_UNIT_1, ADC_CHANNEL_0, (int *)&adc_result);
#endif
            /* Delay */

            for (int i = 0; i < 1000000; i++)
                {
                    nop();
                }
        }

    /* ulp_lp_core_halt() is called automatically when main exits */

    return 0;
}

```

HP App:

```
#include <nuttx/config.h>

#include <stdio.h>
#include <fcntl.h>
#include <unistd.h>
#include <sys/ioctl.h>
#include <inttypes.h>

#include <nuttx/analog/adc.h>
#include <nuttx/analog/ioctl.h>
#include "nuttx/symtab.h"
#include "soc/periph_defs.h"
#include "hal/adc_periph.h"

#include "ulp/ulp/ulp_main.h"
#include "ulp/ulp/ulp_code.h"
#include "espressif/esp_gpio.h"

#define DEFAULT_STATE        INPUT_FUNCTION_2
#define ADC_RESULT_THRESHOLD 2048

void load_ulp_adc_binary(void)
{
  int fd;
  fd = open("/dev/ulp", O_WRONLY);
  if (fd < 0)
    {
      printf("Failed to open ULP: %d\n", errno);
      return;
    }
  write(fd, ulp_adc_bin, ulp_adc_bin_len);
}

int main(int argc, char *argv[])
{
  int fd;
  int ulp_fd;
  uint8_t gpio = 16;
  uint32_t read_result;
  struct symtab_s sym =
  {
    .sym_name = "ulp_adc_adc_result",
    .sym_value = &read_result,
  };

  ulp_fd = open("/dev/ulp", O_WRONLY);
  if (ulp_fd < 0)
    {
      printf("Failed to open ULP: %d\n", errno);
      return ERROR;
    }

  fd = open("/dev/adc0", O_RDWR);
  if (fd < 0)
    {
      printf("Failed to open adc unit 1: %d\n", errno);
      return ERROR;
    }

  load_ulp_adc_binary();
  esp_configgpio(gpio, INPUT_PULLDOWN | DEFAULT_STATE);
  sleep(2);

  ioctl(ulp_fd, FIONREAD, &sym);
  printf("Read result: %ld\n", read_result);
  if (read_result >= ADC_RESULT_THRESHOLD)
    {
      printf("ULP RISCV ADC failed\n");
      return ERROR;
    }

  esp_configgpio(gpio, INPUT_PULLUP | DEFAULT_STATE);
  sleep(2);

  ioctl(ulp_fd, FIONREAD, &sym);
  printf("Read result: %ld\n", read_result);
  if (read_result < ADC_RESULT_THRESHOLD)
    {
      printf("ULP RISCV ADC failed\n");
      return ERROR;
    }

  printf("Cheking done. Exiting.\n");

  return OK;
}
```


### Results
<!-- Provide tests' results and runtime logs -->

```
nsh> lp_adc_test_app
Read result: 900
Read result: 2203
Cheking done. Exiting.
nsh> 
```