### PR TITLE
.github: use ntfc test cases from Apache repo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -206,7 +206,8 @@ jobs:
             cd /github/workspace/nuttx-ntfc
             # get NTFC test cases
             cd external
-            git clone -b release-0.0.1 https://github.com/szafonimateusz-mi/nuttx-testing
+            git clone -b release-0.0.1 https://github.com/apache/nuttx-ntfc-testing
+            mv nuttx-ntfc-testing nuttx-testing
             export NTFCDIR=/github/workspace/nuttx-ntfc
 
             echo "::add-matcher::sources/nuttx/.github/gcc.json"


### PR DESCRIPTION
## Summary

use ntfc test cases from Apache repo

## Impact

use official ntfc repo

## Testing

CI