### PR TITLE
arch/sim: add host_set_timeratio stub for Windows

### DIFF
--- a/arch/sim/src/sim/win/sim_hosttime.c
+++ b/arch/sim/src/sim/win/sim_hosttime.c
@@ -151,6 +151,22 @@ int host_settimer(uint64_t nsec)
 }
 
 /****************************************************************************
+ * Name: host_set_timeratio
+ *
+ * Description:
+ *   Set the ratio of simulated time to real time in percent.
+ *   Not implemented on Windows.
+ *
+ * Input Parameters:
+ *   ratio - The new time ratio in percent
+ *
+ ****************************************************************************/
+
+void host_set_timeratio(int ratio)
+{
+}
+
+/****************************************************************************
  * Name: host_timerirq
  *
  * Description:


### PR DESCRIPTION
The simulated time ratio feature introduced a host_set_timeratio() call in sim_head.c, but the Windows host time implementation was missing this symbol, causing a link error. Add a no-op stub since the time ratio feature is not implemented on Windows.
