### PR TITLE
fs/vfs/fs_lock.c: Close stale locks unconditionally

### DIFF
--- a/fs/vfs/fs_lock.c
+++ b/fs/vfs/fs_lock.c
@@ -784,7 +784,11 @@ void file_closelk(FAR struct file *filep)
       return;
     }
 
-  ret = file_lock_get_path(filep, path);
+  /* No need for inode type and signal handler context (e.g. "kill") checking
+   * here, but just get path unconditionally.
+   */
+
+  ret = file_fcntl(filep, F_GETPATH, path);
   if (ret < 0)
     {
       /* It isn't an error if fs doesn't support F_GETPATH, so we just end


### PR DESCRIPTION
## Summary

Allow to close the lock even the dying task is in signal handler context (e.g. kill).

## Impact

This patch prevents file locks to stay locked/acquired by already killed task,
so the file can be locked by new task if the previous owner has been
killed.

## Testing

Build target: RISC-V mpfs based custom hardware.

Test sequence:

1. File lock acquired by task (e.g. task pid 2790)
2. Task that has the file lock is killed (call `kill 2790`)
3. Spawn new task which acquires the lock for the same file

Without this patch the file lock is still acquired by the task that 
is already killed and not visible in task list anymore. New task
can't acquire the file lock anymore:
```
Daemon lock owner pid: 2790 (lock file: /tmp/enroll_agent.d_lock)
Polling daemon ready failed: Connection timed out
```

With this patch the file lock is released when the owner task is killed
and new task can acquire the file lock properly.
