### PR TITLE
net/nat: Let ICMP echo id zero be a valid NAT id.

### DIFF
--- a/net/nat/ipv4_nat_entry.c
+++ b/net/nat/ipv4_nat_entry.c
@@ -411,6 +411,7 @@ ipv4_nat_outbound_entry_find(FAR struct net_driver_s *dev, uint8_t protocol,
   FAR hash_node_t *tmp;
   uint16_t external_port;
   int32_t current_time = TICK2SEC(clock_systime_ticks());
+  int ret;
 
   ipv4_nat_reclaim_entry(current_time);
 
@@ -454,9 +455,10 @@ ipv4_nat_outbound_entry_find(FAR struct net_driver_s *dev, uint8_t protocol,
         "proto=%" PRIu8 ", local=%" PRIx32 ":%" PRIu16 ", try create one.\n",
         protocol, local_ip, local_port);
 
-  external_port = nat_port_select(dev, PF_INET, protocol,
-                          (FAR union ip_addr_u *)&dev->d_ipaddr, local_port);
-  if (!external_port)
+  ret = nat_port_select(dev, PF_INET, protocol,
+                        (FAR union ip_addr_u *)&dev->d_ipaddr, local_port,
+                        &external_port);
+  if (ret < 0)
     {
       nwarn("WARNING: Failed to find an available port!\n");
       return NULL;

--- a/net/nat/ipv6_nat_entry.c
+++ b/net/nat/ipv6_nat_entry.c
@@ -411,6 +411,7 @@ ipv6_nat_outbound_entry_find(FAR struct net_driver_s *dev, uint8_t protocol,
   FAR union ip_addr_u *external_ip;
   uint16_t external_port;
   int32_t current_time = TICK2SEC(clock_systime_ticks());
+  int ret;
 
   ipv6_nat_reclaim_entry(current_time);
 
@@ -457,10 +458,10 @@ ipv6_nat_outbound_entry_find(FAR struct net_driver_s *dev, uint8_t protocol,
         local_ip[4], local_ip[5], local_ip[6], local_ip[7], local_port);
 
   external_ip = (FAR union ip_addr_u *)netdev_ipv6_srcaddr(dev, peer_ip);
-  external_port = nat_port_select(dev, PF_INET6, protocol,
-                                  external_ip, local_port);
+  ret = nat_port_select(dev, PF_INET6, protocol, external_ip, local_port,
+                        &external_port);
 
-  if (!external_port)
+  if (ret < 0)
     {
       nwarn("WARNING: Failed to find an available port!\n");
       return NULL;

--- a/net/nat/nat.c
+++ b/net/nat/nat.c
@@ -56,13 +56,14 @@ static rmutex_t g_nat_lock = NXRMUTEX_INITIALIZER;
  *   Used when corresponding stack is disabled.
  *
  * Input Parameters:
- *   domain     - The domain of the packet.
- *   protocol   - The L4 protocol of the packet.
- *   ip         - The IP bind with the port (in network byte order).
- *   local_port - The local port (in network byte order), as reference.
+ *   domain        - The domain of the packet.
+ *   protocol      - The L4 protocol of the packet.
+ *   ip            - The IP bind with the port (in network byte order).
+ *   local_port    - The local port (in network byte order), as reference.
+ *   external_port - The selected external port (in network byte order).
  *
  * Returned Value:
- *   port number on success; 0 on failure
+ *   0 on success; a negated errno on failure.
  *
  ****************************************************************************/
 
@@ -71,12 +72,15 @@ static rmutex_t g_nat_lock = NXRMUTEX_INITIALIZER;
     (defined(CONFIG_NET_ICMP) && !defined(CONFIG_NET_ICMP_SOCKET)) || \
     (defined(CONFIG_NET_ICMPv6) && !defined(CONFIG_NET_ICMPv6_SOCKET))
 
-static uint16_t nat_port_select_without_stack(
+static int nat_port_select_without_stack(
     uint8_t domain, uint8_t protocol, FAR const union ip_addr_u *ip,
-    uint16_t local_port)
+    uint16_t local_port, FAR uint16_t *external_port)
 {
   uint16_t portno = local_port;
   uint16_t hport = NTOHS(portno);
+
+  DEBUGASSERT(external_port != NULL);
+
   while (nat_port_inuse(domain, protocol, ip, portno))
     {
       NET_PORT_NEXT_NH(portno, hport);
@@ -84,11 +88,12 @@ static uint16_t nat_port_select_without_stack(
         {
           /* We have looped back, failed. */
 
-          return 0;
+          return -EADDRINUSE;
         }
     }
 
-  return portno;
+  *external_port = portno;
+  return OK;
 }
 
 #endif
@@ -216,22 +221,26 @@ bool nat_port_inuse(uint8_t domain, uint8_t protocol,
  *   Select an available port number for TCP/UDP protocol, or id for ICMP.
  *
  * Input Parameters:
- *   dev         - The device on which the packet will be sent.
- *   domain      - The domain of the packet.
- *   protocol    - The L4 protocol of the packet.
- *   external_ip - The external IP bind with the port.
- *   local_port  - The local port of the packet, as reference.
+ *   dev           - The device on which the packet will be sent.
+ *   domain        - The domain of the packet.
+ *   protocol      - The L4 protocol of the packet.
+ *   external_ip   - The external IP bind with the port.
+ *   local_port    - The local port of the packet, as reference.
+ *   external_port - The selected external port.
  *
  * Returned Value:
- *   External port number on success; 0 on failure
+ *   0 on success; a negated errno on failure.
  *
  ****************************************************************************/
 
-uint16_t nat_port_select(FAR struct net_driver_s *dev,
-                         uint8_t domain, uint8_t protocol,
-                         FAR const union ip_addr_u *external_ip,
-                         uint16_t local_port)
+int nat_port_select(FAR struct net_driver_s *dev,
+                    uint8_t domain, uint8_t protocol,
+                    FAR const union ip_addr_u *external_ip,
+                    uint16_t local_port,
+                    FAR uint16_t *external_port)
 {
+  DEBUGASSERT(external_port != NULL);
+
   switch (protocol)
     {
 #ifdef CONFIG_NET_TCP
@@ -249,10 +258,17 @@ uint16_t nat_port_select(FAR struct net_driver_s *dev,
               ret = tcp_selectport(domain, external_ip, 0);
             }
 
-          return ret > 0 ? ret : 0;
+          if (ret < 0)
+            {
+              return ret;
+            }
+
+          *external_port = ret;
+          return OK;
 #else
           return nat_port_select_without_stack(domain, IP_PROTO_TCP,
-                                               external_ip, local_port);
+                                               external_ip, local_port,
+                                               external_port);
 #endif
         }
 #endif
@@ -284,10 +300,12 @@ uint16_t nat_port_select(FAR struct net_driver_s *dev,
 
           /* TODO: Try keep origin port as possible. */
 
-          return HTONS(udp_select_port(domain, &u));
+          *external_port = HTONS(udp_select_port(domain, &u));
+          return *external_port == 0 ? -EADDRINUSE : OK;
 #else
           return nat_port_select_without_stack(domain, IP_PROTO_UDP,
-                                               external_ip, local_port);
+                                               external_ip, local_port,
+                                               external_port);
 #endif
         }
 #endif
@@ -306,14 +324,16 @@ uint16_t nat_port_select(FAR struct net_driver_s *dev,
                 {
                   /* We have looped back, failed. */
 
-                  return 0;
+                  return -EADDRINUSE;
                 }
             }
 
-          return id;
+          *external_port = id;
+          return OK;
 #else
           return nat_port_select_without_stack(domain, IP_PROTO_ICMP,
-                                               external_ip, local_port);
+                                               external_ip, local_port,
+                                               external_port);
 #endif
         }
 #endif
@@ -332,14 +352,16 @@ uint16_t nat_port_select(FAR struct net_driver_s *dev,
                 {
                   /* We have looped back, failed. */
 
-                  return 0;
+                  return -EADDRINUSE;
                 }
             }
 
-          return id;
+          *external_port = id;
+          return OK;
 #else
           return nat_port_select_without_stack(domain, IP_PROTO_ICMP6,
-                                               external_ip, local_port);
+                                               external_ip, local_port,
+                                               external_port);
 #endif
         }
 #endif
@@ -347,7 +369,8 @@ uint16_t nat_port_select(FAR struct net_driver_s *dev,
 
   /* Select original port for unsupported protocol. */
 
-  return local_port;
+  *external_port = local_port;
+  return OK;
 }
 
 /****************************************************************************

--- a/net/nat/nat.h
+++ b/net/nat/nat.h
@@ -256,21 +256,23 @@ bool nat_port_inuse(uint8_t domain, uint8_t protocol,
  *   Select an available port number for TCP/UDP protocol, or id for ICMP.
  *
  * Input Parameters:
- *   dev         - The device on which the packet will be sent.
- *   domain      - The domain of the packet.
- *   protocol    - The L4 protocol of the packet.
- *   external_ip - The external IP bind with the port.
- *   local_port  - The local port of the packet, as reference.
+ *   dev           - The device on which the packet will be sent.
+ *   domain        - The domain of the packet.
+ *   protocol      - The L4 protocol of the packet.
+ *   external_ip   - The external IP bind with the port.
+ *   local_port    - The local port of the packet, as reference.
+ *   external_port - The selected external port.
  *
  * Returned Value:
- *   External port number on success; 0 on failure
+ *   0 on success; a negated errno on failure.
  *
  ****************************************************************************/
 
-uint16_t nat_port_select(FAR struct net_driver_s *dev,
-                         uint8_t domain, uint8_t protocol,
-                         FAR const union ip_addr_u *external_ip,
-                         uint16_t local_port);
+int nat_port_select(FAR struct net_driver_s *dev,
+                    uint8_t domain, uint8_t protocol,
+                    FAR const union ip_addr_u *external_ip,
+                    uint16_t local_port,
+                    FAR uint16_t *external_port);
 
 /****************************************************************************
  * Name: nat_expire_time


### PR DESCRIPTION
## Summary

  ICMP echo identifiers are 16-bit values defined by `RFC 792`, and zero is
  a valid identifier value. NAT currently uses nat_port_select() return
  value zero to mean port selection failure, which makes ICMP echo id zero
  ambiguous with failure.

  [https://datatracker.ietf.org/doc/html/rfc792](792)
  
  ```
  Identifier

      If code = 0, an identifier to aid in matching echos and replies,
      may be zero.
  ```

  Change nat_port_select() to return a status code and pass the selected
  external port or ICMP identifier through an output parameter. This lets
  NAT preserve and create entries for ICMP echo id zero while keeping real
  selection failures separate.

## Impact

  bugfix

## Testing

  The issue was identified while I try to set up a NAT environment using the NuttX simulator. The test setup consists of a sim instance with two network interfaces, both backed by TAP devices.
  
  Nuttx SIMulator:
  ```
  NuttShell (NSH) NuttX-12.13.0
  nsh> ifconfig
  eth0    Link encap:Ethernet HWaddr 42:b3:0d:d6:82:81 at RUNNING mtu 1500
          inet addr:10.0.0.2 DRaddr:10.0.0.1 Mask:255.255.255.0
  
  eth1    Link encap:Ethernet HWaddr 42:8a:90:eb:ef:03 at RUNNING mtu 1500
          inet addr:10.0.1.2 DRaddr:10.0.1.1 Mask:255.255.255.0
  
  nsh> iptables -t nat -L
  Chain POSTROUTING (policy ACCEPT)
  target        prot  idev  odev  source              destination
  MASQUERADE    all   any   eth1  anywhere            anywhere           MASQUERADE
  ```
  
  Linux:
  ```
   ip addr show dev tap0
  130: tap0: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UNKNOWN group default qlen 1000
      link/ether c2:ad:53:d1:33:d4 brd ff:ff:ff:ff:ff:ff
      inet 10.0.0.1/24 scope global tap0
         valid_lft forever preferred_lft forever
      inet6 fe80::4492:20ff:fe0d:b2cf/64 scope link
         valid_lft forever preferred_lft forever

  sudo ip netns exec lan ip addr show dev tap1
  131: tap1: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 1500 qdisc fq_codel state UNKNOWN group default qlen 1000
      link/ether c2:dc:48:70:0c:7b brd ff:ff:ff:ff:ff:ff
      inet 10.0.1.1/24 scope global tap1
         valid_lft forever preferred_lft forever
      inet6 fe80::c0dc:48ff:fe70:c7b/64 scope link
         valid_lft forever preferred_lft forever
  ```

  With the current port selection algorithm, a local ID of 0 is the most likely to result in an external ID of 0.
  
  Testing logs before change:
  ```
  ping -e 1 -c 5 -W 2 10.0.1.1
  PING 10.0.1.1 (10.0.1.1) 56(84) bytes of data.
  64 bytes from 10.0.1.1: icmp_seq=1 ttl=63 time=7.36 ms
  64 bytes from 10.0.1.1: icmp_seq=2 ttl=63 time=5.73 ms
  64 bytes from 10.0.1.1: icmp_seq=3 ttl=63 time=3.75 ms
  64 bytes from 10.0.1.1: icmp_seq=4 ttl=63 time=1.93 ms
  64 bytes from 10.0.1.1: icmp_seq=5 ttl=63 time=0.708 ms
  
  --- 10.0.1.1 ping statistics ---
  5 packets transmitted, 5 received, 0% packet loss, time 4007ms
  rtt min/avg/max/mdev = 0.708/3.896/7.361/2.426 ms
  
  ping -e 0 -c 5 -W 2 10.0.1.1
  PING 10.0.1.1 (10.0.1.1) 56(84) bytes of data.

  --- 10.0.1.1 ping statistics ---
  5 packets transmitted, 0 received, 100% packet loss, time 4080ms

  captured:
  sudo ip netns exec lan tshark -i tap1 icmp
  Running as user "root" and group "root". This could be dangerous.
  Capturing on 'tap1'
    1 0.000000000     10.0.1.2 → 10.0.1.1     ICMP 98 Echo (ping) request  id=0x0001, seq=1/256, ttl=63
    2 0.000015900     10.0.1.1 → 10.0.1.2     ICMP 98 Echo (ping) reply    id=0x0001, seq=1/256, ttl=64 (request in 1)
    3 1.000082339     10.0.1.2 → 10.0.1.1     ICMP 98 Echo (ping) request  id=0x0001, seq=2/512, ttl=63
    4 1.000106110     10.0.1.1 → 10.0.1.2     ICMP 98 Echo (ping) reply    id=0x0001, seq=2/512, ttl=64 (request in 3)
    5 2.000042143     10.0.1.2 → 10.0.1.1     ICMP 98 Echo (ping) request  id=0x0001, seq=3/768, ttl=63
    6 2.000064222     10.0.1.1 → 10.0.1.2     ICMP 98 Echo (ping) reply    id=0x0001, seq=3/768, ttl=64 (request in 5)
    7 3.000125124     10.0.1.2 → 10.0.1.1     ICMP 98 Echo (ping) request  id=0x0001, seq=4/1024, ttl=63
    8 3.000149002     10.0.1.1 → 10.0.1.2     ICMP 98 Echo (ping) reply    id=0x0001, seq=4/1024, ttl=64 (request in 7)
    9 4.000075849     10.0.1.2 → 10.0.1.1     ICMP 98 Echo (ping) request  id=0x0001, seq=5/1280, ttl=63
   10 4.000099183     10.0.1.1 → 10.0.1.2     ICMP 98 Echo (ping) reply    id=0x0001, seq=5/1280, ttl=64 (request in 9)
  ```

  Testing logs after change:
  ```
  ping -e 0 -c 5 -W 2 10.0.1.1
  PING 10.0.1.1 (10.0.1.1) 56(84) bytes of data.
  64 bytes from 10.0.1.1: icmp_seq=1 ttl=63 time=9.04 ms
  64 bytes from 10.0.1.1: icmp_seq=2 ttl=63 time=7.94 ms
  64 bytes from 10.0.1.1: icmp_seq=3 ttl=63 time=6.85 ms
  64 bytes from 10.0.1.1: icmp_seq=4 ttl=63 time=4.95 ms
  64 bytes from 10.0.1.1: icmp_seq=5 ttl=63 time=3.95 ms
  ```