### PR TITLE
clock_settime: don't block when up_rtc_settime is called

### DIFF
--- a/sched/clock/clock_settime.c
+++ b/sched/clock/clock_settime.c
@@ -44,9 +44,21 @@
 #  include "clock/clock_timekeeping.h"
 #endif
 
+#if defined(CONFIG_RTC) && defined(CONFIG_SCHED_LPWORK)
+static struct work_s g_rtc_work;
+static struct timespec g_rtc_to_set;
+#endif
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
+#if defined(CONFIG_RTC) && defined(CONFIG_SCHED_LPWORK)
+static void rtc_worker(FAR void *arg)
+{
+  up_rtc_settime(arg);
+}
+#endif
 
 static void nxclock_set_realtime(FAR const struct timespec *tp)
 {
@@ -82,7 +94,24 @@ static void nxclock_set_realtime(FAR const struct timespec *tp)
 #  ifdef CONFIG_RTC
   if (g_rtc_enabled)
     {
+#    ifdef CONFIG_SCHED_LPWORK
+      /* Setting the current time in RTC may be a blocking operation (driver
+       * needs to wait for oscillator stabilization after reset and so on).
+       * This may cause the unwanted effect of clock_settime blocking the
+       * code execution for a considerable amount of time.
+       *
+       * The solution is to plan a low priority work that takes care
+       * of setting the time in RTC and let clock_settime continue. We don't
+       * have to check if the work is available, just cancel it if there
+       * is a new time set request.
+       */
+
+      g_rtc_to_set = *tp;
+      work_queue(LPWORK, &g_rtc_work, rtc_worker,
+                 (FAR void *)&g_rtc_to_set, 0);
+#    else
       up_rtc_settime(tp);
+#    endif
     }
 #  endif
 


### PR DESCRIPTION
## Summary
Setting the current time in RTC may be a blocking operation (driver needs to wait for oscillator stabilization after reset and so on). This may cause the unwanted effect of `clock_settime` blocking the code execution for a considerable amount of time.

The solution is to plan a low priority work that takes care of setting the time in RTC and let `clock_settime` continue. We don't have to check if the work is available, just cancel it if there is a new time set request.

This is used only if `CONFIG_SCHED_LPWORK` is enabled. I was thinking about putting this under a special separate config option, but it seems like something you always want if you have LPWORK - but feel free to suggest otherwise, I am not against creating an option solely for this.

## Impact

`clock_settime` now shouldn't block the code execution.

## Testing

We encountered this with `mcp794xx` RTC - the controller waits until the oscillator is started, which may take tens of milliseconds (we measured up to ~40 ms on oscilloscope delay). This caused issue in a customer's custom protocol implementation - we receive the current time, set it and response with status message - but there were timeouts in the communication if time was set.

The issue no longer occurs if RTC set time is done in a separate work thread as `clock_settime` doesn't block.
