### PR TITLE
i.MX95: ARM/CM7: LPI2C/Flexio backport and eDMA SG fix

### DIFF
--- a/arch/arm/src/imx9/CMakeLists.txt
+++ b/arch/arm/src/imx9/CMakeLists.txt
@@ -65,8 +65,8 @@ if(CONFIG_IMX9_GPIO_IRQ)
   list(APPEND SRCS imx9_gpioirq.c)
 endif()
 
-if(CONFIG_IMX9_FLEXIO_PWM)
-  list(APPEND SRCS imx9_flexio_pwm.c)
+if(CONFIG_IMX9_FLEXIO)
+  list(APPEND SRCS imx9_flexio.c)
 endif()
 
 if(CONFIG_IMX9_TPM_PWM)

--- a/arch/arm/src/imx9/Kconfig
+++ b/arch/arm/src/imx9/Kconfig
@@ -643,6 +643,11 @@ config IMX9_LPI2C5_BUSYIDLE
 	int "Bus idle timeout period in clock cycles"
 	default 0
 
+config IMX9_LPI2C5_DMA
+	bool "Enable DMA for I2C5"
+	default n
+	depends on IMX9_LPI2C_DMA
+
 config IMX9_LPI2C5_FILTSCL
 	int "I2C master digital glitch filters for SCL input in clock cycles"
 	default 0
@@ -663,6 +668,11 @@ if IMX9_LPI2C6
 config IMX9_LPI2C6_BUSYIDLE
 	int "Bus idle timeout period in clock cycles"
 	default 0
+
+config IMX9_LPI2C6_DMA
+	bool "Enable DMA for I2C6"
+	default n
+	depends on IMX9_LPI2C_DMA
 
 config IMX9_LPI2C6_FILTSCL
 	int "I2C master digital glitch filters for SCL input in clock cycles"
@@ -685,6 +695,11 @@ config IMX9_LPI2C7_BUSYIDLE
 	int "Bus idle timeout period in clock cycles"
 	default 0
 
+config IMX9_LPI2C7_DMA
+	bool "Enable DMA for I2C7"
+	default n
+	depends on IMX9_LPI2C_DMA
+
 config IMX9_LPI2C7_FILTSCL
 	int "I2C master digital glitch filters for SCL input in clock cycles"
 	default 0
@@ -705,6 +720,11 @@ if IMX9_LPI2C8
 config IMX9_LPI2C8_BUSYIDLE
 	int "Bus idle timeout period in clock cycles"
 	default 0
+
+config IMX9_LPI2C8_DMA
+	bool "Enable DMA for I2C8"
+	default n
+	depends on IMX9_LPI2C_DMA
 
 config IMX9_LPI2C8_FILTSCL
 	int "I2C master digital glitch filters for SCL input in clock cycles"

--- a/arch/arm/src/imx9/Kconfig
+++ b/arch/arm/src/imx9/Kconfig
@@ -526,6 +526,10 @@ config IMX9_LPSPI
 	bool "LPSPI support"
 	default n
 
+config IMXRT_FLEXIO
+	bool "FLEXIO support"
+	default n
+
 menu "LPI2C Peripherals"
 
 menuconfig IMX9_LPI2C1
@@ -781,6 +785,20 @@ menuconfig IMX9_LPSPI8
 	select IMX9_LPSPI
 
 endmenu # LPSPI Peripherals
+
+menu "FlexIO Peripherals"
+
+config IMX9_FLEXIO1
+	bool "FLEXIO1"
+	default n
+	select IMX9_FLEXIO
+
+config IMX9_FLEXIO2
+	bool "FLEXIO2"
+	default n
+	select IMX9_FLEXIO
+
+endmenu # FlexIO Peripherals
 
 menu "eDMA Configuration"
 	depends on IMX9_EDMA

--- a/arch/arm/src/imx9/Make.defs
+++ b/arch/arm/src/imx9/Make.defs
@@ -66,8 +66,8 @@ ifeq ($(CONFIG_IMX9_GPIO_IRQ),y)
   CHIP_CSRCS += imx9_gpioirq.c
 endif
 
-ifeq ($(CONFIG_IMX9_FLEXIO_PWM),y)
-  CHIP_CSRCS += imx9_flexio_pwm.c
+ifeq ($(CONFIG_IMX9_FLEXIO),y)
+  CHIP_CSRCS += imx9_flexio.c
 endif
 
 ifeq ($(CONFIG_IMX9_TPM_PWM),y)

--- a/arch/arm/src/imx9/hardware/imx9_flexio.h
+++ b/arch/arm/src/imx9/hardware/imx9_flexio.h
@@ -1,0 +1,825 @@
+/****************************************************************************
+ * arch/arm/src/imx9/hardware/imx9_flexio.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_IMX9_HARDWARE_IMX9_FLEXIO_H
+#define __ARCH_ARM_SRC_IMX9_HARDWARE_IMX9_FLEXIO_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include "hardware/imx9_memorymap.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define IMX9_FLEXIO_VERID_OFFSET         0x0000 /* Version ID Register, offset: 0x0 */
+#define IMX9_FLEXIO_PARAM_OFFSET         0x0004 /* Parameter Register, offset: 0x4 */
+#define IMX9_FLEXIO_CTRL_OFFSET          0x0008 /* FlexIO Control Register, offset: 0x8 */
+#define IMX9_FLEXIO_PIN_OFFSET           0x000c /* Pin State Register, offset: 0xC */
+#define IMX9_FLEXIO_SHIFTSTAT_OFFSET     0x0010 /* Shifter Status Register, offset: 0x10 */
+#define IMX9_FLEXIO_SHIFTERR_OFFSET      0x0014 /* Shifter Error Register, offset: 0x14 */
+#define IMX9_FLEXIO_TIMSTAT_OFFSET       0x0018 /* Timer Status Register, offset: 0x18 */
+#define IMX9_FLEXIO_SHIFTSIEN_OFFSET     0x0020 /* Shifter Status Interrupt Enable, offset: 0x20 */
+#define IMX9_FLEXIO_SHIFTEIEN_OFFSET     0x0024 /* Shifter Error Interrupt Enable, offset: 0x24 */
+#define IMX9_FLEXIO_TIMIEN_OFFSET        0x0028 /* Timer Interrupt Enable Register, offset: 0x28 */
+#define IMX9_FLEXIO_SHIFTSDEN_OFFSET     0x0030 /* Shifter Status DMA Enable, offset: 0x30 */
+#define IMX9_FLEXIO_SHIFTSTATE_OFFSET    0x0040 /* Shifter State Register, offset: 0x40 */
+#define IMX9_FLEXIO_TRGSTAT_OFFSET       0x0048 /* Trigger Status */
+#define IMX9_FLEXIO_TRIGIEN_OFFSET       0x004c /* External Trigger Interrupt Enable */
+#define IMX9_FLEXIO_PINSTAT_OFFSET       0x0050 /* Pin Status */
+#define IMX9_FLEXIO_PINIEN_OFFSET        0x0054 /* Pin Interrupt Enable */
+#define IMX9_FLEXIO_PINREN_OFFSET        0x0058 /* Pin Rising Edge Enable */
+#define IMX9_FLEXIO_PINFEN_OFFSET        0x005c /* Pin Falling Edge Enable */
+#define IMX9_FLEXIO_PINOUTD_OFFSET       0x0060 /* Pin Output Data */
+#define IMX9_FLEXIO_PINOUTE_OFFSET       0x0064 /* Pin Output Enable */
+#define IMX9_FLEXIO_PINOUTDIS_OFFSET     0x0068 /* Pin Output Disable */
+#define IMX9_FLEXIO_PINOUTCLR_OFFSET     0x006c /* Pin Output Clear */
+#define IMX9_FLEXIO_PINOUTSET_OFFSET     0x0070 /* Pin Output Set */
+#define IMX9_FLEXIO_PINOUTTOG_OFFSET     0x0074 /* Pin Output Toggle */
+#define IMX9_FLEXIO_SHIFTCTL0_OFFSET     0x0080 /* Shifter Control N Register, array offset: 0x80, array step: 0x4 */
+#define IMX9_FLEXIO_SHIFTCTL1_OFFSET     0x0084
+#define IMX9_FLEXIO_SHIFTCTL2_OFFSET     0x0088
+#define IMX9_FLEXIO_SHIFTCTL3_OFFSET     0x008c
+#define IMX9_FLEXIO_SHIFTCTL4_OFFSET     0x0090
+#define IMX9_FLEXIO_SHIFTCTL5_OFFSET     0x0094
+#define IMX9_FLEXIO_SHIFTCTL6_OFFSET     0x0098
+#define IMX9_FLEXIO_SHIFTCTL7_OFFSET     0x009c
+#define IMX9_FLEXIO_SHIFTCFG0_OFFSET     0x0100 /* Shifter Configuration N Register, array offset: 0x100, array step: 0x4 */
+#define IMX9_FLEXIO_SHIFTCFG1_OFFSET     0x0104
+#define IMX9_FLEXIO_SHIFTCFG2_OFFSET     0x0108
+#define IMX9_FLEXIO_SHIFTCFG3_OFFSET     0x010c
+#define IMX9_FLEXIO_SHIFTCFG4_OFFSET     0x0110
+#define IMX9_FLEXIO_SHIFTCFG5_OFFSET     0x0114
+#define IMX9_FLEXIO_SHIFTCFG6_OFFSET     0x0118
+#define IMX9_FLEXIO_SHIFTCFG7_OFFSET     0x011c
+#define IMX9_FLEXIO_SHIFTBUF0_OFFSET     0x0200 /* Shifter Buffer N Register, array offset: 0x200, array step: 0x4 */
+#define IMX9_FLEXIO_SHIFTBUF1_OFFSET     0x0204
+#define IMX9_FLEXIO_SHIFTBUF2_OFFSET     0x0208
+#define IMX9_FLEXIO_SHIFTBUF3_OFFSET     0x020c
+#define IMX9_FLEXIO_SHIFTBUF4_OFFSET     0x0210
+#define IMX9_FLEXIO_SHIFTBUF5_OFFSET     0x0214
+#define IMX9_FLEXIO_SHIFTBUF6_OFFSET     0x0218
+#define IMX9_FLEXIO_SHIFTBUF7_OFFSET     0x021c
+#define IMX9_FLEXIO_SHIFTBUFBIS0_OFFSET  0x0280 /* Shifter Buffer N Bit Swapped Register, array offset: 0x280, array step: 0x4 */
+#define IMX9_FLEXIO_SHIFTBUFBIS1_OFFSET  0x0284
+#define IMX9_FLEXIO_SHIFTBUFBIS2_OFFSET  0x0288
+#define IMX9_FLEXIO_SHIFTBUFBIS3_OFFSET  0x028c
+#define IMX9_FLEXIO_SHIFTBUFBIS4_OFFSET  0x0290
+#define IMX9_FLEXIO_SHIFTBUFBIS5_OFFSET  0x0294
+#define IMX9_FLEXIO_SHIFTBUFBIS6_OFFSET  0x0298
+#define IMX9_FLEXIO_SHIFTBUFBIS7_OFFSET  0x029c
+#define IMX9_FLEXIO_SHIFTBUFBYS0_OFFSET  0x0300 /* Shifter Buffer N Byte Swapped Register, array offset: 0x300, array step: 0x4 */
+#define IMX9_FLEXIO_SHIFTBUFBYS1_OFFSET  0x0304
+#define IMX9_FLEXIO_SHIFTBUFBYS2_OFFSET  0x0308
+#define IMX9_FLEXIO_SHIFTBUFBYS3_OFFSET  0x030c
+#define IMX9_FLEXIO_SHIFTBUFBYS4_OFFSET  0x0310
+#define IMX9_FLEXIO_SHIFTBUFBYS5_OFFSET  0x0314
+#define IMX9_FLEXIO_SHIFTBUFBYS6_OFFSET  0x0318
+#define IMX9_FLEXIO_SHIFTBUFBYS7_OFFSET  0x031c
+#define IMX9_FLEXIO_SHIFTBUFBBS0_OFFSET  0x0380 /* Shifter Buffer N Bit Byte Swapped Register, array offset: 0x380, array step: 0x4 */
+#define IMX9_FLEXIO_SHIFTBUFBBS1_OFFSET  0x0384
+#define IMX9_FLEXIO_SHIFTBUFBBS2_OFFSET  0x0388
+#define IMX9_FLEXIO_SHIFTBUFBBS3_OFFSET  0x038c
+#define IMX9_FLEXIO_SHIFTBUFBBS4_OFFSET  0x0390
+#define IMX9_FLEXIO_SHIFTBUFBBS5_OFFSET  0x0394
+#define IMX9_FLEXIO_SHIFTBUFBBS6_OFFSET  0x0398
+#define IMX9_FLEXIO_SHIFTBUFBBS7_OFFSET  0x039c
+#define IMX9_FLEXIO_TIMCTL0_OFFSET       0x0400 /* Timer Control N Register, array offset: 0x400, array step: 0x4 */
+#define IMX9_FLEXIO_TIMCTL1_OFFSET       0x0404
+#define IMX9_FLEXIO_TIMCTL2_OFFSET       0x0408
+#define IMX9_FLEXIO_TIMCTL3_OFFSET       0x040c
+#define IMX9_FLEXIO_TIMCTL4_OFFSET       0x0410
+#define IMX9_FLEXIO_TIMCTL5_OFFSET       0x0414
+#define IMX9_FLEXIO_TIMCTL6_OFFSET       0x0418
+#define IMX9_FLEXIO_TIMCTL7_OFFSET       0x041c
+#define IMX9_FLEXIO_TIMCTL_OFFSET(x)     (IMX9_FLEXIO_TIMCTL0_OFFSET + (x) * 4)
+#define IMX9_FLEXIO_TIMCFG0_OFFSET       0x0480 /* Timer Configuration N Register, array offset: 0x480, array step: 0x4 */
+#define IMX9_FLEXIO_TIMCFG1_OFFSET       0x0484
+#define IMX9_FLEXIO_TIMCFG2_OFFSET       0x0488
+#define IMX9_FLEXIO_TIMCFG3_OFFSET       0x048c
+#define IMX9_FLEXIO_TIMCFG4_OFFSET       0x0490
+#define IMX9_FLEXIO_TIMCFG5_OFFSET       0x0494
+#define IMX9_FLEXIO_TIMCFG6_OFFSET       0x0498
+#define IMX9_FLEXIO_TIMCFG7_OFFSET       0x049c
+#define IMX9_FLEXIO_TIMCFG_OFFSET(x)     (IMX9_FLEXIO_TIMCFG0_OFFSET + (x) * 4)
+#define IMX9_FLEXIO_TIMCMP0_OFFSET       0x0500 /* Timer Compare N Register, array offset: 0x500, array step: 0x4 */
+#define IMX9_FLEXIO_TIMCMP1_OFFSET       0x0504
+#define IMX9_FLEXIO_TIMCMP2_OFFSET       0x0508
+#define IMX9_FLEXIO_TIMCMP3_OFFSET       0x050c
+#define IMX9_FLEXIO_TIMCMP4_OFFSET       0x0510
+#define IMX9_FLEXIO_TIMCMP5_OFFSET       0x0514
+#define IMX9_FLEXIO_TIMCMP6_OFFSET       0x0518
+#define IMX9_FLEXIO_TIMCMP7_OFFSET       0x051c
+#define IMX9_FLEXIO_TIMCMP_OFFSET(x)     (IMX9_FLEXIO_TIMCMP0_OFFSET + (x) * 4)
+#define IMX9_FLEXIO_SHIFTBUFNBS0_OFFSET  0x0680 /* Shifter Buffer N Nibble Byte Swapped Register, array offset: 0x680, array step: 0x4 */
+#define IMX9_FLEXIO_SHIFTBUFNBS1_OFFSET  0x0684
+#define IMX9_FLEXIO_SHIFTBUFNBS2_OFFSET  0x0688
+#define IMX9_FLEXIO_SHIFTBUFNBS3_OFFSET  0x068c
+#define IMX9_FLEXIO_SHIFTBUFNBS4_OFFSET  0x0690
+#define IMX9_FLEXIO_SHIFTBUFNBS5_OFFSET  0x0694
+#define IMX9_FLEXIO_SHIFTBUFNBS6_OFFSET  0x0698
+#define IMX9_FLEXIO_SHIFTBUFNBS7_OFFSET  0x069c
+#define IMX9_FLEXIO_SHIFTBUFHWS0_OFFSET  0x0700 /* Shifter Buffer N Half Word Swapped Register, array offset: 0x700, array step: 0x4 */
+#define IMX9_FLEXIO_SHIFTBUFHWS1_OFFSET  0x0704
+#define IMX9_FLEXIO_SHIFTBUFHWS2_OFFSET  0x0708
+#define IMX9_FLEXIO_SHIFTBUFHWS3_OFFSET  0x070c
+#define IMX9_FLEXIO_SHIFTBUFHWS4_OFFSET  0x0710
+#define IMX9_FLEXIO_SHIFTBUFHWS5_OFFSET  0x0714
+#define IMX9_FLEXIO_SHIFTBUFHWS6_OFFSET  0x0718
+#define IMX9_FLEXIO_SHIFTBUFHWS7_OFFSET  0x071c
+#define IMX9_FLEXIO_SHIFTBUFNIS0_OFFSET  0x0780 /* Shifter Buffer N Nibble Swapped Register, array offset: 0x780, array step: 0x4 */
+#define IMX9_FLEXIO_SHIFTBUFNIS1_OFFSET  0x0784
+#define IMX9_FLEXIO_SHIFTBUFNIS2_OFFSET  0x0788
+#define IMX9_FLEXIO_SHIFTBUFNIS3_OFFSET  0x078c
+#define IMX9_FLEXIO_SHIFTBUFNIS4_OFFSET  0x0790
+#define IMX9_FLEXIO_SHIFTBUFNIS5_OFFSET  0x0794
+#define IMX9_FLEXIO_SHIFTBUFNIS6_OFFSET  0x0798
+#define IMX9_FLEXIO_SHIFTBUFNIS7_OFFSET  0x079c
+#define IMX9_FLEXIO_SHIFTBUFOES0_OFFSET  0x0800 /* Shifter Buffer N Odd Even Swapped, array offset: 0x800, array step: 0x4 */
+#define IMX9_FLEXIO_SHIFTBUFOES1_OFFSET  0x0804
+#define IMX9_FLEXIO_SHIFTBUFOES2_OFFSET  0x0808
+#define IMX9_FLEXIO_SHIFTBUFOES3_OFFSET  0x080c
+#define IMX9_FLEXIO_SHIFTBUFOES4_OFFSET  0x0810
+#define IMX9_FLEXIO_SHIFTBUFOES5_OFFSET  0x0814
+#define IMX9_FLEXIO_SHIFTBUFOES6_OFFSET  0x0818
+#define IMX9_FLEXIO_SHIFTBUFOES7_OFFSET  0x081c
+#define IMX9_FLEXIO_SHIFTBUFEOS0_OFFSET  0x0880 /* Shifter Buffer N Even Odd Swapped, array offset: 0x880, array step: 0x4 */
+#define IMX9_FLEXIO_SHIFTBUFEOS1_OFFSET  0x0884
+#define IMX9_FLEXIO_SHIFTBUFEOS2_OFFSET  0x0888
+#define IMX9_FLEXIO_SHIFTBUFEOS3_OFFSET  0x088c
+#define IMX9_FLEXIO_SHIFTBUFEOS4_OFFSET  0x0890
+#define IMX9_FLEXIO_SHIFTBUFEOS5_OFFSET  0x0894
+#define IMX9_FLEXIO_SHIFTBUFEOS6_OFFSET  0x0898
+#define IMX9_FLEXIO_SHIFTBUFEOS7_OFFSET  0x089c
+#define IMX9_FLEXIO_SHIFTBUFHBS0_OFFSET  0x0900 /* Shifter Buffer N Halfword Byte Swapped, array offset: 0x900, array step: 0x4 */
+#define IMX9_FLEXIO_SHIFTBUFHBS1_OFFSET  0x0904
+#define IMX9_FLEXIO_SHIFTBUFHBS2_OFFSET  0x0908
+#define IMX9_FLEXIO_SHIFTBUFHBS3_OFFSET  0x090c
+#define IMX9_FLEXIO_SHIFTBUFHBS4_OFFSET  0x0910
+#define IMX9_FLEXIO_SHIFTBUFHBS5_OFFSET  0x0914
+#define IMX9_FLEXIO_SHIFTBUFHBS6_OFFSET  0x0918
+#define IMX9_FLEXIO_SHIFTBUFHBS7_OFFSET  0x091c
+
+/* VERID - Version ID Register */
+
+#define FLEXIO_VERID_FEATURE_MASK                (0xffffu)
+#define FLEXIO_VERID_FEATURE_SHIFT               (0u)
+
+/* FEATURE - Feature Specification Number
+ *  0b0000000000000000..Standard features implemented.
+ *  0b0000000000000001..Supports state, logic and parallel modes.
+ */
+
+#define FLEXIO_VERID_FEATURE(x)                  ((((uint32_t)(x)) << FLEXIO_VERID_FEATURE_SHIFT) & FLEXIO_VERID_FEATURE_MASK)
+
+#define FLEXIO_VERID_MINOR_MASK                  (0xff0000u)
+#define FLEXIO_VERID_MINOR_SHIFT                 (16u)
+
+/* MINOR - Minor Version Number */
+
+#define FLEXIO_VERID_MINOR(x)                    ((((uint32_t)(x)) << FLEXIO_VERID_MINOR_SHIFT) & FLEXIO_VERID_MINOR_MASK)
+
+#define FLEXIO_VERID_MAJOR_MASK                  (0xff000000u)
+#define FLEXIO_VERID_MAJOR_SHIFT                 (24u)
+
+/* MAJOR - Major Version Number */
+#define FLEXIO_VERID_MAJOR(x)                    ((((uint32_t)(x)) << FLEXIO_VERID_MAJOR_SHIFT) & FLEXIO_VERID_MAJOR_MASK)
+
+/* PARAM - Parameter Register */
+
+#define FLEXIO_PARAM_SHIFTER_MASK                (0xffu)
+#define FLEXIO_PARAM_SHIFTER_SHIFT               (0u)
+
+/* SHIFTER - Shifter Number */
+#define FLEXIO_PARAM_SHIFTER(x)                  ((((uint32_t)(x)) << FLEXIO_PARAM_SHIFTER_SHIFT) & FLEXIO_PARAM_SHIFTER_MASK)
+
+#define FLEXIO_PARAM_TIMER_MASK                  (0xff00u)
+#define FLEXIO_PARAM_TIMER_SHIFT                 (8u)
+
+/* TIMER - Timer Number */
+
+#define FLEXIO_PARAM_TIMER(x)                    ((((uint32_t)(x)) << FLEXIO_PARAM_TIMER_SHIFT) & FLEXIO_PARAM_TIMER_MASK)
+
+#define FLEXIO_PARAM_PIN_MASK                    (0xff0000u)
+#define FLEXIO_PARAM_PIN_SHIFT                   (16u)
+
+/* PIN - Pin Number */
+#define FLEXIO_PARAM_PIN(x)                      ((((uint32_t)(x)) << FLEXIO_PARAM_PIN_SHIFT) & FLEXIO_PARAM_PIN_MASK)
+
+#define FLEXIO_PARAM_TRIGGER_MASK                (0xff000000u)
+#define FLEXIO_PARAM_TRIGGER_SHIFT               (24u)
+
+/* TRIGGER - Trigger Number */
+
+#define FLEXIO_PARAM_TRIGGER(x)                  ((((uint32_t)(x)) << FLEXIO_PARAM_TRIGGER_SHIFT) & FLEXIO_PARAM_TRIGGER_MASK)
+
+/* CTRL - FlexIO Control Register */
+
+#define FLEXIO_CTRL_FLEXEN_MASK                  (0x1u)
+#define FLEXIO_CTRL_FLEXEN_SHIFT                 (0u)
+
+/* FLEXEN - FlexIO Enable
+ *  0b0..FlexIO module is disabled.
+ *  0b1..FlexIO module is enabled.
+ */
+
+#define FLEXIO_CTRL_FLEXEN(x)                    ((((uint32_t)(x)) << FLEXIO_CTRL_FLEXEN_SHIFT) & FLEXIO_CTRL_FLEXEN_MASK)
+
+#define FLEXIO_CTRL_SWRST_MASK                   (0x2u)
+#define FLEXIO_CTRL_SWRST_SHIFT                  (1u)
+
+/* SWRST - Software Reset
+ *  0b0..Software reset is disabled
+ *  0b1..Software reset is enabled, all FlexIO registers except the Control
+ *       Register are reset.
+ */
+
+#define FLEXIO_CTRL_SWRST(x)                     ((((uint32_t)(x)) << FLEXIO_CTRL_SWRST_SHIFT) & FLEXIO_CTRL_SWRST_MASK)
+
+#define FLEXIO_CTRL_FASTACC_MASK                 (0x4u)
+#define FLEXIO_CTRL_FASTACC_SHIFT                (2u)
+
+/* FASTACC - Fast Access
+ *  0b0..Configures for normal register accesses to FlexIO
+ *  0b1..Configures for fast register accesses to FlexIO
+ */
+
+#define FLEXIO_CTRL_FASTACC(x)                   ((((uint32_t)(x)) << FLEXIO_CTRL_FASTACC_SHIFT) & FLEXIO_CTRL_FASTACC_MASK)
+
+#define FLEXIO_CTRL_DBGE_MASK                    (0x40000000u)
+#define FLEXIO_CTRL_DBGE_SHIFT                   (30u)
+
+/* DBGE - Debug Enable
+ *  0b0..FlexIO is disabled in debug modes.
+ *  0b1..FlexIO is enabled in debug modes
+ */
+
+#define FLEXIO_CTRL_DBGE(x)                      ((((uint32_t)(x)) << FLEXIO_CTRL_DBGE_SHIFT) & FLEXIO_CTRL_DBGE_MASK)
+
+#define FLEXIO_CTRL_DOZEN_MASK                   (0x80000000u)
+#define FLEXIO_CTRL_DOZEN_SHIFT                  (31u)
+
+/* DOZEN - Doze Enable
+ *  0b0..FlexIO enabled in Doze modes.
+ *  0b1..FlexIO disabled in Doze modes.
+ */
+
+#define FLEXIO_CTRL_DOZEN(x)                     ((((uint32_t)(x)) << FLEXIO_CTRL_DOZEN_SHIFT) & FLEXIO_CTRL_DOZEN_MASK)
+
+/* PIN - Pin State Register */
+
+#define FLEXIO_PIN_PDI_MASK                      (0xffffffffu)  /* Merged from fields with different position or width, of widths (16, 32), largest definition used */
+#define FLEXIO_PIN_PDI_SHIFT                     (0u)
+
+/* PDI - Pin Data Input */
+
+#define FLEXIO_PIN_PDI(x)                        ((((uint32_t)(x)) << FLEXIO_PIN_PDI_SHIFT) & FLEXIO_PIN_PDI_MASK)  /* Merged from fields with different position or width, of widths (16, 32), largest definition used */
+
+/* SHIFTSTAT - Shifter Status Register */
+
+#define FLEXIO_SHIFTSTAT_SSF_MASK                (0xffu)
+#define FLEXIO_SHIFTSTAT_SSF_SHIFT               (0u)
+
+/* SSF - Shifter Status Flag */
+
+#define FLEXIO_SHIFTSTAT_SSF(x)                  ((((uint32_t)(x)) << FLEXIO_SHIFTSTAT_SSF_SHIFT) & FLEXIO_SHIFTSTAT_SSF_MASK)
+
+/* SHIFTERR - Shifter Error Register */
+
+#define FLEXIO_SHIFTERR_SEF_MASK                 (0xffu)
+#define FLEXIO_SHIFTERR_SEF_SHIFT                (0u)
+
+/* SEF - Shifter Error Flags */
+
+#define FLEXIO_SHIFTERR_SEF(x)                   ((((uint32_t)(x)) << FLEXIO_SHIFTERR_SEF_SHIFT) & FLEXIO_SHIFTERR_SEF_MASK)
+
+/* TIMSTAT - Timer Status Register */
+
+#define FLEXIO_TIMSTAT_TSF_MASK                  (0xffu)
+#define FLEXIO_TIMSTAT_TSF_SHIFT                 (0u)
+
+/* TSF - Timer Status Flags */
+
+#define FLEXIO_TIMSTAT_TSF(x)                    ((((uint32_t)(x)) << FLEXIO_TIMSTAT_TSF_SHIFT) & FLEXIO_TIMSTAT_TSF_MASK)
+
+/* SHIFTSIEN - Shifter Status Interrupt Enable */
+
+#define FLEXIO_SHIFTSIEN_SSIE_MASK               (0xffu)
+#define FLEXIO_SHIFTSIEN_SSIE_SHIFT              (0u)
+
+/* SSIE - Shifter Status Interrupt Enable */
+
+#define FLEXIO_SHIFTSIEN_SSIE(x)                 ((((uint32_t)(x)) << FLEXIO_SHIFTSIEN_SSIE_SHIFT) & FLEXIO_SHIFTSIEN_SSIE_MASK)
+
+/* SHIFTEIEN - Shifter Error Interrupt Enable */
+
+#define FLEXIO_SHIFTEIEN_SEIE_MASK               (0xffu)
+#define FLEXIO_SHIFTEIEN_SEIE_SHIFT              (0u)
+
+/* SEIE - Shifter Error Interrupt Enable */
+
+#define FLEXIO_SHIFTEIEN_SEIE(x)                 ((((uint32_t)(x)) << FLEXIO_SHIFTEIEN_SEIE_SHIFT) & FLEXIO_SHIFTEIEN_SEIE_MASK)
+
+/* TIMIEN - Timer Interrupt Enable Register */
+
+#define FLEXIO_TIMIEN_TEIE_MASK                  (0xffu)
+#define FLEXIO_TIMIEN_TEIE_SHIFT                 (0u)
+
+/* TEIE - Timer Status Interrupt Enable */
+
+#define FLEXIO_TIMIEN_TEIE(x)                    ((((uint32_t)(x)) << FLEXIO_TIMIEN_TEIE_SHIFT) & FLEXIO_TIMIEN_TEIE_MASK)
+
+/* SHIFTSDEN - Shifter Status DMA Enable */
+
+#define FLEXIO_SHIFTSDEN_SSDE_MASK               (0xffu)
+#define FLEXIO_SHIFTSDEN_SSDE_SHIFT              (0u)
+
+/* SSDE - Shifter Status DMA Enable */
+
+#define FLEXIO_SHIFTSDEN_SSDE(x)                 ((((uint32_t)(x)) << FLEXIO_SHIFTSDEN_SSDE_SHIFT) & FLEXIO_SHIFTSDEN_SSDE_MASK)
+
+/* TIMERSDEN - Timer Status DMA Enable */
+
+#define FLEXIO_TIMERSDEN_TSDE_MASK               (0xffu)
+#define FLEXIO_TIMERSDEN_TSDE_SHIFT              (0u)
+
+/* TSDE - Timer Status DMA Enable */
+
+#define FLEXIO_TIMERSDEN_TSDE(x)                 ((((uint32_t)(x)) << FLEXIO_TIMERSDEN_TSDE_SHIFT) & FLEXIO_TIMERSDEN_TSDE_MASK)
+
+/* SHIFTSTATE - Shifter State Register */
+
+#define FLEXIO_SHIFTSTATE_STATE_MASK             (0x7u)
+#define FLEXIO_SHIFTSTATE_STATE_SHIFT            (0u)
+
+/* STATE - Current State Pointer */
+
+#define FLEXIO_SHIFTSTATE_STATE(x)               ((((uint32_t)(x)) << FLEXIO_SHIFTSTATE_STATE_SHIFT) & FLEXIO_SHIFTSTATE_STATE_MASK)
+
+/* TRGSTAT - Trigger Status */
+
+#define FLEXIO_TRGSTAT_ETSF_MASK                (0xfu)
+#define FLEXIO_TRGSTAT_ETSF_SHIFT               (0u)
+
+#define FLEXIO_TRGSTAT_ETSF(x)                   ((((uint32_t)(x)) << FLEXIO_TRGSTAT_ETSF_SHIFT) & FLEXIO_TRGSTAT_ETSF_MASK)
+
+/* TRIGIEN - External Trigger Interrupt Enable */
+
+#define FLEXIO_TRIGIEN_TRIE_MASK                (0xfu)
+#define FLEXIO_TRIGIEN_TRIE_SHIFT               (0u)
+
+#define FLEXIO_TRIGIEN_TRIE(x)                  ((((uint32_t)(x)) << FLEXIO_TRIGIEN_TRIE_SHIFT) & FLEXIO_TRIGIEN_TRIE_MASK)
+
+/* SHIFTCTL - Shifter Control N Register */
+
+#define FLEXIO_SHIFTCTL_SMOD_MASK                (0x7u)
+#define FLEXIO_SHIFTCTL_SMOD_SHIFT               (0u)
+
+/* SMOD - Shifter Mode
+ *  0b000..Disabled.
+ *  0b001..Receive mode. Captures the current Shifter content into the
+ *         SHIFTBUF on expiration of the Timer.
+ *  0b010..Transmit mode. Load SHIFTBUF contents into the Shifter on
+ *         expiration of the Timer.
+ *  0b011..Reserved.
+ *  0b100..Match Store mode. Shifter data is compared to SHIFTBUF content on
+ *         expiration of the Timer.
+ *  0b101..Match Continuous mode. Shifter data is continuously compared to
+ *         SHIFTBUF contents.
+ *  0b110..State mode. SHIFTBUF contents are used for storing programmable
+ *         state attributes.
+ *  0b111..Logic mode. SHIFTBUF contents are used for implementing
+ *         programmable logic look up table.
+ */
+
+#define FLEXIO_SHIFTCTL_SMOD(x)                  ((((uint32_t)(x)) << FLEXIO_SHIFTCTL_SMOD_SHIFT) & FLEXIO_SHIFTCTL_SMOD_MASK)
+
+#define FLEXIO_SHIFTCTL_PINPOL_MASK              (0x80u)
+#define FLEXIO_SHIFTCTL_PINPOL_SHIFT             (7u)
+
+/* PINPOL - Shifter Pin Polarity
+ *  0b0..Pin is active high
+ *  0b1..Pin is active low
+ */
+
+#define FLEXIO_SHIFTCTL_PINPOL(x)                ((((uint32_t)(x)) << FLEXIO_SHIFTCTL_PINPOL_SHIFT) & FLEXIO_SHIFTCTL_PINPOL_MASK)
+
+#define FLEXIO_SHIFTCTL_PINSEL_MASK              (0x1f00u)  /* Merged from fields with different position or width, of widths (4, 5), largest definition used */
+#define FLEXIO_SHIFTCTL_PINSEL_SHIFT             (8u)
+
+/* PINSEL - Shifter Pin Select */
+
+#define FLEXIO_SHIFTCTL_PINSEL(x)                ((((uint32_t)(x)) << FLEXIO_SHIFTCTL_PINSEL_SHIFT) & FLEXIO_SHIFTCTL_PINSEL_MASK)  /* Merged from fields with different position or width, of widths (4, 5), largest definition used */
+
+#define FLEXIO_SHIFTCTL_PINCFG_MASK              (0x30000u)
+#define FLEXIO_SHIFTCTL_PINCFG_SHIFT             (16u)
+
+/* PINCFG - Shifter Pin Configuration
+ *  0b00..Shifter pin output disabled
+ *  0b01..Shifter pin open drain or bidirectional output enable
+ *  0b10..Shifter pin bidirectional output data
+ *  0b11..Shifter pin output
+ */
+
+#define FLEXIO_SHIFTCTL_PINCFG(x)                ((((uint32_t)(x)) << FLEXIO_SHIFTCTL_PINCFG_SHIFT) & FLEXIO_SHIFTCTL_PINCFG_MASK)
+
+#define FLEXIO_SHIFTCTL_TIMPOL_MASK              (0x800000u)
+#define FLEXIO_SHIFTCTL_TIMPOL_SHIFT             (23u)
+
+/* TIMPOL - Timer Polarity
+ *  0b0..Shift on posedge of Shift clock
+ *  0b1..Shift on negedge of Shift clock
+ */
+
+#define FLEXIO_SHIFTCTL_TIMPOL(x)                ((((uint32_t)(x)) << FLEXIO_SHIFTCTL_TIMPOL_SHIFT) & FLEXIO_SHIFTCTL_TIMPOL_MASK)
+
+#define FLEXIO_SHIFTCTL_TIMSEL_MASK              (0x7000000u)
+#define FLEXIO_SHIFTCTL_TIMSEL_SHIFT             (24u)
+
+/* TIMSEL - Timer Select */
+
+#define FLEXIO_SHIFTCTL_TIMSEL(x)                ((((uint32_t)(x)) << FLEXIO_SHIFTCTL_TIMSEL_SHIFT) & FLEXIO_SHIFTCTL_TIMSEL_MASK)
+
+/* The count of FLEXIO_SHIFTCTL */
+
+#define FLEXIO_SHIFTCTL_COUNT                    (8u)
+
+/* SHIFTCFG - Shifter Configuration N Register */
+
+#define FLEXIO_SHIFTCFG_SSTART_MASK              (0x3u)
+#define FLEXIO_SHIFTCFG_SSTART_SHIFT             (0u)
+
+/* SSTART - Shifter Start bit
+ *  0b00..Start bit disabled for transmitter/receiver/match store,
+ *        transmitter loads data on enable
+ *  0b01..Start bit disabled for transmitter/receiver/match store,
+ *        transmitter loads data on first shift
+ *  0b10..Transmitter outputs start bit value 0 before loading data on first
+ *        shift, receiver/match store sets error flag if start bit is not 0
+ *  0b11..Transmitter outputs start bit value 1 before loading data on first
+ *        shift, receiver/match store sets error flag if start bit is not 1
+ */
+
+#define FLEXIO_SHIFTCFG_SSTART(x)                ((((uint32_t)(x)) << FLEXIO_SHIFTCFG_SSTART_SHIFT) & FLEXIO_SHIFTCFG_SSTART_MASK)
+
+#define FLEXIO_SHIFTCFG_SSTOP_MASK               (0x30u)
+#define FLEXIO_SHIFTCFG_SSTOP_SHIFT              (4u)
+
+/* SSTOP - Shifter Stop bit
+ *  0b00..Stop bit disabled for transmitter/receiver/match store
+ *  0b01..Reserved for transmitter/receiver/match store
+ *  0b10..Transmitter outputs stop bit value 0 on store, receiver/match store
+ *        sets error flag if stop bit is not 0
+ *  0b11..Transmitter outputs stop bit value 1 on store, receiver/match store
+ *        sets error flag if stop bit is not 1
+ */
+
+#define FLEXIO_SHIFTCFG_SSTOP(x)                 ((((uint32_t)(x)) << FLEXIO_SHIFTCFG_SSTOP_SHIFT) & FLEXIO_SHIFTCFG_SSTOP_MASK)
+
+#define FLEXIO_SHIFTCFG_INSRC_MASK               (0x100u)
+#define FLEXIO_SHIFTCFG_INSRC_SHIFT              (8u)
+
+/* INSRC - Input Source
+ *  0b0..Pin
+ *  0b1..Shifter N+1 Output
+ */
+
+#define FLEXIO_SHIFTCFG_INSRC(x)                 ((((uint32_t)(x)) << FLEXIO_SHIFTCFG_INSRC_SHIFT) & FLEXIO_SHIFTCFG_INSRC_MASK)
+
+/* LATST - Late Store */
+
+#define FLEXIO_SHIFTCFG_LATST_MASK               (0x200u)
+#define FLEXIO_SHIFTCFG_LATST_SHIFT              (9u)
+
+#define FLEXIO_SHIFTCFG_LATST(x)                 ((((uint32_t)(x)) << FLEXIO_SHIFTCFG_LATST_SHIFT) & FLEXIO_SHIFTCFG_LATST_MASK)
+
+/* SSIZE - Shifter Size */
+
+#define FLEXIO_SHIFTCFG_SSIZE_MASK               (0x1000u)
+#define FLEXIO_SHIFTCFG_SSIZE_SHIFT              (12u)
+
+#define FLEXIO_SHIFTCFG_SSIZE(x)                 ((((uint32_t)(x)) << FLEXIO_SHIFTCFG_SSIZE_SHIFT) & FLEXIO_SHIFTCFG_SSIZE_MASK)
+
+#define FLEXIO_SHIFTCFG_PWIDTH_MASK              (0x1f0000u)  /* Merged from fields with different position or width, of widths (4, 5), largest definition used */
+#define FLEXIO_SHIFTCFG_PWIDTH_SHIFT             (16u)
+
+/* PWIDTH - Parallel Width */
+
+#define FLEXIO_SHIFTCFG_PWIDTH(x)                ((((uint32_t)(x)) << FLEXIO_SHIFTCFG_PWIDTH_SHIFT) & FLEXIO_SHIFTCFG_PWIDTH_MASK)  /* Merged from fields with different position or width, of widths (4, 5), largest definition used */
+
+/* The count of FLEXIO_SHIFTCFG */
+
+#define FLEXIO_SHIFTCFG_COUNT                    (8u)
+
+/* SHIFTBUF - Shifter Buffer N Register */
+
+#define FLEXIO_SHIFTBUF_SHIFTBUF_MASK            (0xffffffffu)
+#define FLEXIO_SHIFTBUF_SHIFTBUF_SHIFT           (0u)
+
+/* SHIFTBUF - Shift Buffer */
+
+#define FLEXIO_SHIFTBUF_SHIFTBUF(x)              ((((uint32_t)(x)) << FLEXIO_SHIFTBUF_SHIFTBUF_SHIFT) & FLEXIO_SHIFTBUF_SHIFTBUF_MASK)
+
+/* The count of FLEXIO_SHIFTBUF */
+
+#define FLEXIO_SHIFTBUF_COUNT                    (8u)
+
+/* SHIFTBUFBIS - Shifter Buffer N Bit Swapped Register */
+
+#define FLEXIO_SHIFTBUFBIS_SHIFTBUFBIS_MASK      (0xffffffffu)
+#define FLEXIO_SHIFTBUFBIS_SHIFTBUFBIS_SHIFT     (0u)
+
+/* SHIFTBUFBIS - Shift Buffer */
+
+#define FLEXIO_SHIFTBUFBIS_SHIFTBUFBIS(x)        ((((uint32_t)(x)) << FLEXIO_SHIFTBUFBIS_SHIFTBUFBIS_SHIFT) & FLEXIO_SHIFTBUFBIS_SHIFTBUFBIS_MASK)
+
+/* The count of FLEXIO_SHIFTBUFBIS */
+
+#define FLEXIO_SHIFTBUFBIS_COUNT                 (8u)
+
+/* SHIFTBUFBYS - Shifter Buffer N Byte Swapped Register */
+
+#define FLEXIO_SHIFTBUFBYS_SHIFTBUFBYS_MASK      (0xffffffffu)
+#define FLEXIO_SHIFTBUFBYS_SHIFTBUFBYS_SHIFT     (0u)
+
+/* SHIFTBUFBYS - Shift Buffer */
+
+#define FLEXIO_SHIFTBUFBYS_SHIFTBUFBYS(x)        ((((uint32_t)(x)) << FLEXIO_SHIFTBUFBYS_SHIFTBUFBYS_SHIFT) & FLEXIO_SHIFTBUFBYS_SHIFTBUFBYS_MASK)
+
+/* The count of FLEXIO_SHIFTBUFBYS */
+
+#define FLEXIO_SHIFTBUFBYS_COUNT                 (8u)
+
+/* SHIFTBUFBBS - Shifter Buffer N Bit Byte Swapped Register */
+
+#define FLEXIO_SHIFTBUFBBS_SHIFTBUFBBS_MASK      (0xffffffffu)
+#define FLEXIO_SHIFTBUFBBS_SHIFTBUFBBS_SHIFT     (0u)
+
+/* SHIFTBUFBBS - Shift Buffer */
+
+#define FLEXIO_SHIFTBUFBBS_SHIFTBUFBBS(x)        ((((uint32_t)(x)) << FLEXIO_SHIFTBUFBBS_SHIFTBUFBBS_SHIFT) & FLEXIO_SHIFTBUFBBS_SHIFTBUFBBS_MASK)
+
+/* The count of FLEXIO_SHIFTBUFBBS */
+
+#define FLEXIO_SHIFTBUFBBS_COUNT                 (8u)
+
+/* TIMCTL - Timer Control N Register */
+
+#define FLEXIO_TIMCTL_TIMOD_MASK                 (0x3u)
+#define FLEXIO_TIMCTL_TIMOD_SHIFT                (0u)
+
+/* TIMOD - Timer Mode
+ *  0b000..Timer Disabled.
+ *  0b001..Dual 8-bit counters baud mode.
+ *  0b010..Dual 8-bit counters PWM high mode.
+ *  0b011..Single 16-bit counter mode.
+ *  0b100..Single 16-bit counter disable mode.
+ *  0b101..Dual 8-bit counters word mode.
+ *  0b110..Dual 8-bit counters PWM low mode.
+ *  0b111..Single 16-bit input capture mode.
+ */
+
+#define FLEXIO_TIMCTL_TIMOD(x)                   ((((uint32_t)(x)) << FLEXIO_TIMCTL_TIMOD_SHIFT) & FLEXIO_TIMCTL_TIMOD_MASK)
+
+#define FLEXIO_TIMCTL_PINPOL_MASK                (0x80u)
+#define FLEXIO_TIMCTL_PINPOL_SHIFT               (7u)
+
+/* PINPOL - Timer Pin Polarity
+ *  0b0..Pin is active high
+ *  0b1..Pin is active low
+ */
+
+#define FLEXIO_TIMCTL_PINPOL(x)                  ((((uint32_t)(x)) << FLEXIO_TIMCTL_PINPOL_SHIFT) & FLEXIO_TIMCTL_PINPOL_MASK)
+
+#define FLEXIO_TIMCTL_PINSEL_MASK                (0x1f00u)  /* Merged from fields with different position or width, of widths (4, 5), largest definition used */
+#define FLEXIO_TIMCTL_PINSEL_SHIFT               (8u)
+
+/* PINSEL - Timer Pin Select */
+
+#define FLEXIO_TIMCTL_PINSEL(x)                  ((((uint32_t)(x)) << FLEXIO_TIMCTL_PINSEL_SHIFT) & FLEXIO_TIMCTL_PINSEL_MASK)  /* Merged from fields with different position or width, of widths (4, 5), largest definition used */
+
+#define FLEXIO_TIMCTL_PINCFG_MASK                (0x30000u)
+#define FLEXIO_TIMCTL_PINCFG_SHIFT               (16u)
+
+/* PINCFG - Timer Pin Configuration
+ *  0b00..Timer pin output disabled
+ *  0b01..Timer pin open drain or bidirectional output enable
+ *  0b10..Timer pin bidirectional output data
+ *  0b11..Timer pin output
+ */
+
+#define FLEXIO_TIMCTL_PINCFG(x)                  ((((uint32_t)(x)) << FLEXIO_TIMCTL_PINCFG_SHIFT) & FLEXIO_TIMCTL_PINCFG_MASK)
+
+#define FLEXIO_TIMCTL_TRGSRC_MASK                (0x400000u)
+#define FLEXIO_TIMCTL_TRGSRC_SHIFT               (22u)
+
+/* TRGSRC - Trigger Source
+ *  0b0..External trigger selected
+ *  0b1..Internal trigger selected
+ */
+
+#define FLEXIO_TIMCTL_TRGSRC(x)                  ((((uint32_t)(x)) << FLEXIO_TIMCTL_TRGSRC_SHIFT) & FLEXIO_TIMCTL_TRGSRC_MASK)
+
+#define FLEXIO_TIMCTL_TRGPOL_MASK                (0x800000u)
+#define FLEXIO_TIMCTL_TRGPOL_SHIFT               (23u)
+
+/* TRGPOL - Trigger Polarity
+ *  0b0..Trigger active high
+ *  0b1..Trigger active low
+ */
+
+#define FLEXIO_TIMCTL_TRGPOL(x)                  ((((uint32_t)(x)) << FLEXIO_TIMCTL_TRGPOL_SHIFT) & FLEXIO_TIMCTL_TRGPOL_MASK)
+
+#define FLEXIO_TIMCTL_TRGSEL_MASK                (0x3f000000u)  /* Merged from fields with different position or width, of widths (5, 6), largest definition used */
+#define FLEXIO_TIMCTL_TRGSEL_SHIFT               (24u)
+
+/* TRGSEL - Trigger Select */
+
+#define FLEXIO_TIMCTL_TRGSEL(x)                  ((((uint32_t)(x)) << FLEXIO_TIMCTL_TRGSEL_SHIFT) & FLEXIO_TIMCTL_TRGSEL_MASK)  /* Merged from fields with different position or width, of widths (5, 6), largest definition used */
+
+/* The count of FLEXIO_TIMCTL */
+
+#define FLEXIO_TIMCTL_COUNT                      (8u)
+
+/* TIMCFG - Timer Configuration N Register */
+
+#define FLEXIO_TIMCFG_TSTART_MASK                (0x2u)
+#define FLEXIO_TIMCFG_TSTART_SHIFT               (1u)
+
+/* TSTART - Timer Start Bit
+ *  0b0..Start bit disabled
+ *  0b1..Start bit enabled
+ */
+
+#define FLEXIO_TIMCFG_TSTART(x)                  ((((uint32_t)(x)) << FLEXIO_TIMCFG_TSTART_SHIFT) & FLEXIO_TIMCFG_TSTART_MASK)
+
+#define FLEXIO_TIMCFG_TSTOP_MASK                 (0x30u)
+#define FLEXIO_TIMCFG_TSTOP_SHIFT                (4u)
+
+/* TSTOP - Timer Stop Bit
+ *  0b00..Stop bit disabled
+ *  0b01..Stop bit is enabled on timer compare
+ *  0b10..Stop bit is enabled on timer disable
+ *  0b11..Stop bit is enabled on timer compare and timer disable
+ */
+
+#define FLEXIO_TIMCFG_TSTOP(x)                   ((((uint32_t)(x)) << FLEXIO_TIMCFG_TSTOP_SHIFT) & FLEXIO_TIMCFG_TSTOP_MASK)
+
+#define FLEXIO_TIMCFG_TIMENA_MASK                (0x700u)
+#define FLEXIO_TIMCFG_TIMENA_SHIFT               (8u)
+
+/* TIMENA - Timer Enable
+ *  0b000..Timer always enabled
+ *  0b001..Timer enabled on Timer N-1 enable
+ *  0b010..Timer enabled on Trigger high
+ *  0b011..Timer enabled on Trigger high and Pin high
+ *  0b100..Timer enabled on Pin rising edge
+ *  0b101..Timer enabled on Pin rising edge and Trigger high
+ *  0b110..Timer enabled on Trigger rising edge
+ *  0b111..Timer enabled on Trigger rising or falling edge
+ */
+
+#define FLEXIO_TIMCFG_TIMENA(x)                  ((((uint32_t)(x)) << FLEXIO_TIMCFG_TIMENA_SHIFT) & FLEXIO_TIMCFG_TIMENA_MASK)
+
+#define FLEXIO_TIMCFG_TIMDIS_MASK                (0x7000u)
+#define FLEXIO_TIMCFG_TIMDIS_SHIFT               (12u)
+
+/* TIMDIS - Timer Disable
+ *  0b000..Timer never disabled
+ *  0b001..Timer disabled on Timer N-1 disable
+ *  0b010..Timer disabled on Timer compare (upper 8-bits match and decrement)
+ *  0b011..Timer disabled on Timer compare (upper 8-bits match and decrement)
+ *         and Trigger Low
+ *  0b100..Timer disabled on Pin rising or falling edge
+ *  0b101..Timer disabled on Pin rising or falling edge provided Trigger is
+ *         high
+ *  0b110..Timer disabled on Trigger falling edge
+ *  0b111..Reserved
+ */
+
+#define FLEXIO_TIMCFG_TIMDIS(x)                  ((((uint32_t)(x)) << FLEXIO_TIMCFG_TIMDIS_SHIFT) & FLEXIO_TIMCFG_TIMDIS_MASK)
+
+#define FLEXIO_TIMCFG_TIMRST_MASK                (0x70000u)
+#define FLEXIO_TIMCFG_TIMRST_SHIFT               (16u)
+
+/* TIMRST - Timer Reset
+ *  0b000..Timer never reset
+ *  0b001..Reserved
+ *  0b010..Timer reset on Timer Pin equal to Timer Output
+ *  0b011..Timer reset on Timer Trigger equal to Timer Output
+ *  0b100..Timer reset on Timer Pin rising edge
+ *  0b101..Reserved
+ *  0b110..Timer reset on Trigger rising edge
+ *  0b111..Timer reset on Trigger rising or falling edge
+ */
+
+#define FLEXIO_TIMCFG_TIMRST(x)                  ((((uint32_t)(x)) << FLEXIO_TIMCFG_TIMRST_SHIFT) & FLEXIO_TIMCFG_TIMRST_MASK)
+
+#define FLEXIO_TIMCFG_TIMDEC_MASK                (0x300000u)
+#define FLEXIO_TIMCFG_TIMDEC_SHIFT               (20U)
+
+/* TIMDEC - Timer Decrement
+ *  0b00..Decrement counter on FlexIO clock, Shift clock equals Timer output.
+ *  0b01..Decrement counter on Trigger input (both edges), Shift clock equals
+ *        Timer output.
+ *  0b10..Decrement counter on Pin input (both edges), Shift clock equals Pin
+ *        input.
+ *  0b11..Decrement counter on Trigger input (both edges), Shift clock equals
+ *        Trigger input.
+ */
+
+#define FLEXIO_TIMCFG_TIMDEC(x)                  ((((uint32_t)(x)) << FLEXIO_TIMCFG_TIMDEC_SHIFT) & FLEXIO_TIMCFG_TIMDEC_MASK)
+
+#define FLEXIO_TIMCFG_TIMOUT_MASK                (0x3000000u)
+#define FLEXIO_TIMCFG_TIMOUT_SHIFT               (24u)
+
+/* TIMOUT - Timer Output
+ *  0b00..Timer output is logic one when enabled and is not affected by timer
+ *        reset
+ *  0b01..Timer output is logic zero when enabled and is not affected by
+ *        timer reset
+ *  0b10..Timer output is logic one when enabled and on timer reset
+ *  0b11..Timer output is logic zero when enabled and on timer reset
+ */
+
+#define FLEXIO_TIMCFG_TIMOUT(x)                  ((((uint32_t)(x)) << FLEXIO_TIMCFG_TIMOUT_SHIFT) & FLEXIO_TIMCFG_TIMOUT_MASK)
+
+/* The count of FLEXIO_TIMCFG */
+
+#define FLEXIO_TIMCFG_COUNT                      (8u)
+
+/* TIMCMP - Timer Compare N Register */
+
+#define FLEXIO_TIMCMP_CMP_MASK                   (0xffffu)
+#define FLEXIO_TIMCMP_CMP_SHIFT                  (0u)
+
+/* CMP - Timer Compare Value */
+
+#define FLEXIO_TIMCMP_CMP(x)                     ((((uint32_t)(x)) << FLEXIO_TIMCMP_CMP_SHIFT) & FLEXIO_TIMCMP_CMP_MASK)
+
+/* The count of FLEXIO_TIMCMP */
+
+#define FLEXIO_TIMCMP_COUNT                      (8u)
+
+/* SHIFTBUFNBS - Shifter Buffer N Nibble Byte Swapped Register */
+
+#define FLEXIO_SHIFTBUFNBS_SHIFTBUFNBS_MASK      (0xffffffffu)
+#define FLEXIO_SHIFTBUFNBS_SHIFTBUFNBS_SHIFT     (0u)
+
+/* SHIFTBUFNBS - Shift Buffer */
+
+#define FLEXIO_SHIFTBUFNBS_SHIFTBUFNBS(x)        ((((uint32_t)(x)) << FLEXIO_SHIFTBUFNBS_SHIFTBUFNBS_SHIFT) & FLEXIO_SHIFTBUFNBS_SHIFTBUFNBS_MASK)
+
+/* The count of FLEXIO_SHIFTBUFNBS */
+
+#define FLEXIO_SHIFTBUFNBS_COUNT                 (8u)
+
+/* SHIFTBUFHWS - Shifter Buffer N Half Word Swapped Register */
+
+#define FLEXIO_SHIFTBUFHWS_SHIFTBUFHWS_MASK      (0xffffffffu)
+#define FLEXIO_SHIFTBUFHWS_SHIFTBUFHWS_SHIFT     (0u)
+
+/* SHIFTBUFHWS - Shift Buffer */
+
+#define FLEXIO_SHIFTBUFHWS_SHIFTBUFHWS(x)        ((((uint32_t)(x)) << FLEXIO_SHIFTBUFHWS_SHIFTBUFHWS_SHIFT) & FLEXIO_SHIFTBUFHWS_SHIFTBUFHWS_MASK)
+
+/* The count of FLEXIO_SHIFTBUFHWS */
+
+#define FLEXIO_SHIFTBUFHWS_COUNT                 (8u)
+
+/* SHIFTBUFNIS - Shifter Buffer N Nibble Swapped Register */
+
+#define FLEXIO_SHIFTBUFNIS_SHIFTBUFNIS_MASK      (0xffffffffu)
+#define FLEXIO_SHIFTBUFNIS_SHIFTBUFNIS_SHIFT     (0u)
+
+/* SHIFTBUFNIS - Shift Buffer */
+
+#define FLEXIO_SHIFTBUFNIS_SHIFTBUFNIS(x)        ((((uint32_t)(x)) << FLEXIO_SHIFTBUFNIS_SHIFTBUFNIS_SHIFT) & FLEXIO_SHIFTBUFNIS_SHIFTBUFNIS_MASK)
+
+/* The count of FLEXIO_SHIFTBUFNIS */
+
+#define FLEXIO_SHIFTBUFNIS_COUNT                 (8u)
+
+#endif /* __ARCH_ARM_SRC_IMX9_HARDWARE_IMX9_FLEXIO_H */

--- a/arch/arm/src/imx9/imx9_edma.c
+++ b/arch/arm/src/imx9/imx9_edma.c
@@ -355,6 +355,50 @@ static inline void imx9_tcd_chanlink(uint8_t flags,
 #endif
 
 /****************************************************************************
+ * Name: imx9_edma_addr_to_dmaaddr
+ *
+ * Description:
+ *  Remap addr to eDMA address space if needed.
+ *
+ ****************************************************************************/
+
+static inline uint32_t imx9_edma_addr_to_dmaaddr(uintptr_t addr)
+{
+#ifdef CONFIG_ARCH_CHIP_IMX95_M7
+  if (addr >= (uintptr_t)_ram_start &&
+      addr <  (uintptr_t)_ram_end)
+    {
+      addr += DTCM_BACKDOOR_OFFSET;
+    }
+#endif
+
+  return (uint32_t)addr;
+}
+
+/****************************************************************************
+ * Name: imx9_edma_dmaaddr_to_addr
+ *
+ * Description:
+ *  Convert eDMA address back to CPU-visible address space.
+ *
+ ****************************************************************************/
+
+static inline uintptr_t imx9_edma_dmaaddr_to_addr(uint32_t dmaaddr)
+{
+  uintptr_t addr = (uintptr_t)dmaaddr;
+
+#ifdef CONFIG_ARCH_CHIP_IMX95_M7
+  if (addr >= (uintptr_t)_ram_start + DTCM_BACKDOOR_OFFSET &&
+      addr <  (uintptr_t)_ram_end   + DTCM_BACKDOOR_OFFSET)
+    {
+      addr -= DTCM_BACKDOOR_OFFSET;
+    }
+#endif
+
+  return addr;
+}
+
+/****************************************************************************
  * Name: imx9_tcd_configure
  *
  * Description:
@@ -367,7 +411,7 @@ static inline void imx9_tcd_chanlink(uint8_t flags,
 static inline void imx9_tcd_configure(struct imx9_edmatcd_s *tcd,
                             const struct imx9_edma_xfrconfig_s *config)
 {
-  tcd->saddr    = config->saddr;
+  tcd->saddr    = imx9_edma_addr_to_dmaaddr(config->saddr);
   tcd->soff     = config->soff;
   tcd->attr     = EDMA_TCD_ATTR_SSIZE(config->ssize) |  /* Transfer Attributes */
                   EDMA_TCD_ATTR_DSIZE(config->dsize);
@@ -379,7 +423,7 @@ static inline void imx9_tcd_configure(struct imx9_edmatcd_s *tcd,
   tcd->slast    = config->flags & EDMA_CONFIG_LOOPSRC ?
                                   -(config->iter * config->nbytes) : 0;
 
-  tcd->daddr    = config->daddr;
+  tcd->daddr    = imx9_edma_addr_to_dmaaddr(config->daddr);
   tcd->doff     = config->doff;
   tcd->citer    = config->iter & EDMA_TCD_CITER_MASK;
   tcd->biter    = config->iter & EDMA_TCD_BITER_MASK;
@@ -389,22 +433,6 @@ static inline void imx9_tcd_configure(struct imx9_edmatcd_s *tcd,
                                   EDMA_TCD_CSR_INTHALF : 0;
   tcd->dlastsga = config->flags & EDMA_CONFIG_LOOPDEST ?
                                   -(config->iter * config->nbytes) : 0;
-
-#ifdef CONFIG_ARCH_CHIP_IMX95_M7
-  /* Remap address to backdoor address for eDMA */
-
-  if (tcd->saddr >= (uint32_t)_ram_start &&
-      tcd->saddr < (uint32_t)_ram_end)
-    {
-        tcd->saddr += DTCM_BACKDOOR_OFFSET;
-    }
-
-  if (tcd->daddr >= (uint32_t)_ram_start &&
-      tcd->daddr < (uint32_t)_ram_end)
-    {
-        tcd->daddr += DTCM_BACKDOOR_OFFSET;
-    }
-#endif
 
   /* And special case flags */
 
@@ -501,7 +529,8 @@ static void imx9_dmaterminate(struct imx9_dmach_s *dmach, int result)
        */
 
        next = dmach->flags & EDMA_CONFIG_LOOPDEST ?
-              NULL : (struct imx9_edmatcd_s *)((uintptr_t)tcd->dlastsga);
+              NULL : (struct imx9_edmatcd_s *)
+              imx9_edma_dmaaddr_to_addr(tcd->dlastsga);
 
        imx9_tcd_free_nolock(tcd);
     }
@@ -1256,7 +1285,7 @@ int imx9_dmach_xfrsetup(DMACH_HANDLE handle,
       regval16      |= EDMA_TCD_CSR_ESG;
       prev->csr      = regval16;
 
-      prev->dlastsga = (uint32_t)((uintptr_t)tcd);
+      prev->dlastsga = imx9_edma_addr_to_dmaaddr((uintptr_t)tcd);
       dmach->tail    = tcd;
 
       /* Clean cache associated with the previous TCD memory */
@@ -1278,7 +1307,7 @@ int imx9_dmach_xfrsetup(DMACH_HANDLE handle,
           regval16 |= EDMA_TCD_CSR_ESG;
           putreg16(regval16, base + IMX9_EDMA_TCD_CSR_OFFSET);
 
-          putreg32((uint32_t)((uintptr_t)tcd),
+          putreg32(imx9_edma_addr_to_dmaaddr((uintptr_t)tcd),
                    base + IMX9_EDMA_TCD_DLAST_SGA_OFFSET);
         }
     }

--- a/arch/arm/src/imx9/imx9_flexio.c
+++ b/arch/arm/src/imx9/imx9_flexio.c
@@ -1,0 +1,889 @@
+/****************************************************************************
+ * arch/arm/src/imx9/imx9_flexio.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
+#include <errno.h>
+#include <assert.h>
+#include <debug.h>
+
+#include <arch/barriers.h>
+#include <arch/board/board.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/wdog.h>
+#include <nuttx/clock.h>
+#include <nuttx/kmalloc.h>
+#include <nuttx/mutex.h>
+
+#include "arm_internal.h"
+
+#include "imx9_gpio.h"
+#include "imx9_periphclks.h"
+#include "imx9_flexio.h"
+#include "hardware/imx9_flexio.h"
+
+#ifdef CONFIG_IMX9_FLEXIO
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/* The state of the FlexIO controller. */
+
+struct imx9_flexiodev_s
+{
+  struct flexio_dev_s     flexio;       /* Externally visible part of the FlexIO interface */
+  uint32_t                base;         /* FlexIO controller register base address */
+  bool                    initialized;  /* TRUE: Controller has been initialized */
+};
+
+struct flexio_config_s
+{
+  bool enable_flexio;                   /* Enable/disable FlexIO module */
+  bool enable_indoze;                   /* Enable/disable FlexIO operation in doze mode */
+  bool enable_indebug;                  /* Enable/disable FlexIO operation in debug mode */
+  bool enable_fast_access;              /* Enable/disable fast access to FlexIO registers, fast access requires
+                                         * the FlexIO clock to be at least twice the frequency of the bus clock. */
+};
+
+static void imx9_flexio_reset(struct flexio_dev_s *dev);
+static void imx9_flexio_enable(struct flexio_dev_s *dev, bool enable);
+static uint32_t imx9_flexio_read_pin_input(struct flexio_dev_s *dev);
+static uint8_t imx9_flexio_get_shifter_state(struct flexio_dev_s *dev);
+static void imx9_flexio_set_shifter_config(struct flexio_dev_s *dev,
+              uint8_t index,
+              const struct flexio_shifter_config_s *shifter_config);
+static void imx9_flexio_set_timer_config(struct flexio_dev_s *dev,
+              uint8_t index,
+              const struct flexio_timer_config_s *timer_config);
+static void imx9_flexio_set_clock_mode(struct flexio_dev_s *dev,
+              uint8_t index,
+              enum flexio_timer_decrement_source_e clocksource);
+static void imx9_flexio_enable_shifter_status_interrupts(
+              struct flexio_dev_s *dev, uint32_t mask);
+static void imx9_flexio_disable_shifter_status_interrupts(
+              struct flexio_dev_s *dev, uint32_t mask);
+static void imx9_flexio_enable_shifter_error_interrupts(
+              struct flexio_dev_s *dev, uint32_t mask);
+static void imx9_flexio_disable_shifter_error_interrupts(
+              struct flexio_dev_s *dev, uint32_t mask);
+static void imx9_flexio_enable_timer_status_interrupts(
+              struct flexio_dev_s *dev, uint32_t mask);
+static void imx9_flexio_disable_timer_status_interrupts(
+              struct flexio_dev_s *dev, uint32_t mask);
+static uint32_t imx9_flexio_get_shifter_status_flags(
+              struct flexio_dev_s *dev);
+static void imx9_flexio_clear_shifter_status_flags(
+              struct flexio_dev_s *dev, uint32_t mask);
+static uint32_t imx9_flexio_get_shifter_error_flags(
+                  struct flexio_dev_s *dev);
+static void imx9_flexio_clear_shifter_error_flags(
+              struct flexio_dev_s *dev, uint32_t mask);
+static uint32_t imx9_flexio_get_timer_status_flags(
+                  struct flexio_dev_s *dev);
+static void imx9_flexio_clear_timer_status_flags(
+              struct flexio_dev_s *dev, uint32_t mask);
+static void imx9_flexio_enable_shifter_status_dma(
+              struct flexio_dev_s *dev, uint32_t mask, bool enable);
+static uint32_t imx9_flexio_get_shifter_buffer_address(
+                  struct flexio_dev_s *dev,
+                  enum flexio_shifter_buffer_type_e type, uint8_t index);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct flexio_ops_s g_flexio_ops =
+{
+  .reset = imx9_flexio_reset,
+  .enable = imx9_flexio_enable,
+  .read_pin_input = imx9_flexio_read_pin_input,
+  .get_shifter_state = imx9_flexio_get_shifter_state,
+  .set_clock_mode = imx9_flexio_set_clock_mode,
+  .enable_shifter_status_interrupts =
+  imx9_flexio_enable_shifter_status_interrupts,
+  .disable_shifter_status_interrupts =
+  imx9_flexio_disable_shifter_status_interrupts,
+  .enable_shifter_error_interrupts =
+  imx9_flexio_enable_shifter_error_interrupts,
+  .disable_shifter_error_interrupts =
+  imx9_flexio_disable_shifter_error_interrupts,
+  .enable_timer_status_interrupts =
+  imx9_flexio_enable_timer_status_interrupts,
+  .disable_timer_status_interrupts =
+  imx9_flexio_disable_timer_status_interrupts,
+  .get_shifter_status_flags = imx9_flexio_get_shifter_status_flags,
+  .clear_shifter_status_flags = imx9_flexio_clear_shifter_status_flags,
+  .get_shifter_error_flags = imx9_flexio_get_shifter_error_flags,
+  .clear_shifter_error_flags = imx9_flexio_clear_shifter_error_flags,
+  .get_timer_status_flags = imx9_flexio_get_timer_status_flags,
+  .clear_timer_status_flags = imx9_flexio_clear_timer_status_flags,
+  .enable_shifter_status_dma = imx9_flexio_enable_shifter_status_dma,
+  .get_shifter_buffer_address = imx9_flexio_get_shifter_buffer_address,
+  .set_shifter_config = imx9_flexio_set_shifter_config,
+  .set_timer_config = imx9_flexio_set_timer_config,
+};
+
+#ifdef CONFIG_IMX9_FLEXIO1
+static struct imx9_flexiodev_s g_flexio1_dev =
+{
+  .flexio =
+  {
+    .ops = &g_flexio_ops,
+  },
+  .base = IMX9_FLEXIO1_BASE,
+};
+#endif
+
+#ifdef CONFIG_IMX9_FLEXIO2
+static struct imx9_flexiodev_s g_flexio2_dev =
+{
+  .flexio =
+  {
+    .ops = &g_flexio_ops,
+  },
+  .base = IMX9_FLEXIO2_BASE,
+};
+#endif
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/* Utility functions */
+
+static inline uint32_t imx9_flexio_getreg32(struct flexio_dev_s *dev,
+                                             uint32_t offset);
+static inline void imx9_flexio_putreg32(struct flexio_dev_s *dev,
+                                         uint32_t value, uint32_t offset);
+
+static inline void imx9_flexio_modifyreg32(struct flexio_dev_s *dev,
+                                            unsigned int offset,
+                                            uint32_t clearbits,
+                                            uint32_t setbits);
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: imx9_flexio_getreg32
+ *
+ * Description:
+ *   Get the contents of the ENET register at offset
+ *
+ * Input Parameters:
+ *   dev    - private FlexIO device structure
+ *   offset - offset to the register of interest
+ *
+ * Returned Value:
+ *   The contents of the 32-bit register
+ *
+ ****************************************************************************/
+
+static inline uint32_t imx9_flexio_getreg32(struct flexio_dev_s *dev,
+                                             uint32_t offset)
+{
+  return getreg32(((struct imx9_flexiodev_s *)dev)->base + offset);
+}
+
+/****************************************************************************
+ * Name: imx9_flexio_putreg32
+ *
+ * Description:
+ *   Atomically modify the specified bits in a memory mapped register
+ *
+ * Input Parameters:
+ *   dev       - private FlexIO device structure
+ *   offset    - offset to the register of interest
+ *   clearbits - the 32-bit value to be written as 0s
+ *   setbits   - the 32-bit value to be written as 1s
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static inline void imx9_flexio_modifyreg32(struct flexio_dev_s *dev,
+                                            unsigned int offset,
+                                            uint32_t clearbits,
+                                            uint32_t setbits)
+{
+  modifyreg32(((struct imx9_flexiodev_s *)dev)->base + offset, clearbits,
+              setbits);
+}
+
+/****************************************************************************
+ * Name: imx9_flexio_putreg32
+ *
+ * Description:
+ *   Write a value to the FlexIO register at offset
+ *
+ * Input Parameters:
+ *   dev    - private FlexIO device structure
+ *   value  - the 32-bit value to be written
+ *   offset - offset to the register of interest
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+static inline void imx9_flexio_putreg32(struct flexio_dev_s *dev,
+                                         uint32_t value, uint32_t offset)
+{
+  putreg32(value, ((struct imx9_flexiodev_s *)dev)->base + offset);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/* Resets the FlexIO module.
+ *
+ * param dev FlexIO device
+ */
+
+static void imx9_flexio_reset(struct flexio_dev_s *dev)
+{
+  /* do software reset, software reset operation affect all other FLEXIO
+   * registers except CTRL
+   */
+
+  imx9_flexio_modifyreg32(dev, IMX9_FLEXIO_CTRL_OFFSET, 0,
+                           FLEXIO_CTRL_SWRST_MASK);
+  imx9_flexio_putreg32(dev, 0, IMX9_FLEXIO_CTRL_OFFSET);
+}
+
+/* Enables the FlexIO module operation.
+ *
+ * param dev FlexIO device
+ * param enable true to enable, false to disable.
+ */
+
+static void imx9_flexio_enable(struct flexio_dev_s *dev, bool enable)
+{
+  if (enable)
+    {
+      imx9_flexio_modifyreg32(dev, IMX9_FLEXIO_CTRL_OFFSET, 0,
+                               FLEXIO_CTRL_FLEXEN_MASK);
+    }
+  else
+    {
+      imx9_flexio_modifyreg32(dev, IMX9_FLEXIO_CTRL_OFFSET,
+                               FLEXIO_CTRL_FLEXEN_MASK, 0);
+    }
+}
+
+/* Reads the input data on each of the FlexIO pins.
+ *
+ * param dev FlexIO device
+ * return FlexIO pin input data
+ */
+
+static uint32_t imx9_flexio_read_pin_input(struct flexio_dev_s *dev)
+{
+  uint32_t regval;
+
+  regval = imx9_flexio_getreg32(dev, IMX9_FLEXIO_PIN_OFFSET);
+
+  return regval;
+}
+
+/* Gets the current state pointer for state mode use.
+ *
+ * param dev FlexIO device
+ * return current State pointer
+ */
+
+static uint8_t imx9_flexio_get_shifter_state(struct flexio_dev_s *dev)
+{
+  uint32_t regval;
+
+  regval = imx9_flexio_getreg32(dev, IMX9_FLEXIO_SHIFTSTATE_OFFSET);
+
+  return ((uint8_t)regval & FLEXIO_SHIFTSTATE_STATE_MASK);
+}
+
+/* Configures the shifter with the shifter configuration. The configuration
+ * structure covers both the SHIFTCTL and SHIFTCFG registers. To configure
+ * the shifter to the proper mode, select which timer controls the shifter
+ * to shift, whether to generate start bit/stop bit, and the polarity of
+ * start bit and stop bit.
+ *
+ * Example
+ * code
+ * struct flexio_shifter_config_s config = {
+ * .timer_select = 0,
+ * .timer_polarity = FLEXIO_SHIFTER_TIMER_POLARITY_ON_POSITIVE,
+ * .pin_config = FLEXIO_PIN_CONFIG_OPEN_DRAIN_OR_BIDIRECTION,
+ * .pin_polarity = FLEXIO_PIN_ACTIVE_LOW,
+ * .shifter_mode = FLEXIO_SHIFTER_MODE_TRANSMIT,
+ * .input_source = FLEXIO_SHIFTER_INPUT_FROM_PIN,
+ * .shifter_stop = FLEXIO_SHIFTER_STOP_BIT_HIGH,
+ * .shifter_start = FLEXIO_SHIFTER_START_BIT_LOW
+ * };
+ * imx9_flexio_set_shifter_config(dev, &config);
+ * endcode
+ *
+ * param dev FlexIO device address
+ * param index Shifter index
+ * param shifter_config Pointer to flexio_shifter_config_s structure
+ */
+
+static void imx9_flexio_set_shifter_config(struct flexio_dev_s *dev,
+                                            uint8_t index,
+              const struct flexio_shifter_config_s *shifter_config)
+{
+  uint32_t regval;
+
+  regval =
+    FLEXIO_SHIFTCFG_INSRC(shifter_config->input_source) |
+    FLEXIO_SHIFTCFG_PWIDTH(shifter_config->parallel_width) |
+    FLEXIO_SHIFTCFG_SSTOP(shifter_config->shifter_stop) |
+    FLEXIO_SHIFTCFG_SSTART(shifter_config->shifter_start);
+
+  imx9_flexio_putreg32(dev, regval,
+                        IMX9_FLEXIO_SHIFTCFG0_OFFSET + index * 0x4);
+
+  regval =
+    FLEXIO_SHIFTCTL_TIMSEL(shifter_config->timer_select) |
+    FLEXIO_SHIFTCTL_TIMPOL(shifter_config->timer_polarity) |
+    FLEXIO_SHIFTCTL_PINCFG(shifter_config->pin_config) |
+    FLEXIO_SHIFTCTL_PINSEL(shifter_config->pin_select) |
+    FLEXIO_SHIFTCTL_PINPOL(shifter_config->pin_polarity) |
+    FLEXIO_SHIFTCTL_SMOD(shifter_config->shifter_mode);
+
+  imx9_flexio_putreg32(dev, regval,
+                        IMX9_FLEXIO_SHIFTCTL0_OFFSET + index * 0x4);
+}
+
+/* Configures the timer with the timer configuration. The configuration
+ * structure covers both the TIMCTL and TIMCFG registers. To configure the
+ * timer to the proper mode, select trigger source for timer and the timer
+ * pin output and the timing for timer.
+ *
+ * Example
+ * code
+ * struct flexio_timer_config_s config = {
+ * .trigger_select = FLEXIO_TIMER_TRIGGER_SEL_SHIFTnSTAT(0),
+ * .trigger_polarity = FLEXIO_TIMER_TRIGGER_POLARITY_ACTIVE_LOW,
+ * .trigger_source = FLEXIO_TIMER_TRIGGER_SOURCE_INTERNAL,
+ * .pin_config = FLEXIO_PIN_CONFIG_OPEN_DRAIN_OR_BIDIRECTION,
+ * .pin_select = 0,
+ * .pin_polarity = FLEXIO_PIN_ACTIVE_HIGH,
+ * .timer_mode = FLEXIO_TIMER_MODE_DUAL8_BIT_BAUD_BIT,
+ * .timer_output = FLEXIO_TIMER_OUTPUT_ZERO_NOT_AFFECTED_BY_RESET,
+ * .timer_decrement =
+ *    FLEXIO_TIMER_DEC_SRC_ON_FLEX_IO_CLOCK_SHIFT_TIMER_OUTPUT,
+ * .timer_reset = FLEXIO_TIMER_RESET_ON_TIMER_PIN_EQUAL_TO_TIMER_OUTPUT,
+ * .timer_disable = FLEXIO_TIMER_DISABLE_ON_TIMER_COMPARE,
+ * .timer_enable = FLEXIO_TIMER_ENABLE_ON_TRIGGER_HIGH,
+ * .timer_stop = FLEXIO_TIMER_STOP_BIT_ENABLE_ON_TIMER_DISABLE,
+ * .timer_start = FLEXIO_TIMER_START_BIT_ENABLED
+ * };
+ * imx9_flexio_set_timer_config(dev, &config);
+ * endcode
+ *
+ * param dev FlexIO peripheral dev address
+ * param index Timer index
+ * param timer_config Pointer to the flexio_timer_config_s structure
+ */
+
+static void imx9_flexio_set_timer_config(struct flexio_dev_s *dev,
+                                          uint8_t index,
+              const struct flexio_timer_config_s *timer_config)
+{
+  uint32_t regval;
+
+  regval =
+    FLEXIO_TIMCFG_TIMOUT(timer_config->timer_output) |
+    FLEXIO_TIMCFG_TIMDEC(timer_config->timer_decrement) |
+    FLEXIO_TIMCFG_TIMRST(timer_config->timer_reset) |
+    FLEXIO_TIMCFG_TIMDIS(timer_config->timer_disable) |
+    FLEXIO_TIMCFG_TIMENA(timer_config->timer_enable) |
+    FLEXIO_TIMCFG_TSTOP(timer_config->timer_stop) |
+    FLEXIO_TIMCFG_TSTART(timer_config->timer_start);
+
+  imx9_flexio_putreg32(dev, regval,
+                        IMX9_FLEXIO_TIMCFG0_OFFSET + index * 0x4);
+
+  regval = FLEXIO_TIMCMP_CMP(timer_config->timer_compare);
+
+  imx9_flexio_putreg32(dev, regval,
+                        IMX9_FLEXIO_TIMCMP0_OFFSET + index * 0x4);
+
+  regval =
+    FLEXIO_TIMCTL_TRGSEL(timer_config->trigger_select) |
+    FLEXIO_TIMCTL_TRGPOL(timer_config->trigger_polarity) |
+    FLEXIO_TIMCTL_TRGSRC(timer_config->trigger_source) |
+    FLEXIO_TIMCTL_PINCFG(timer_config->pin_config) |
+    FLEXIO_TIMCTL_PINSEL(timer_config->pin_select) |
+    FLEXIO_TIMCTL_PINPOL(timer_config->pin_polarity) |
+    FLEXIO_TIMCTL_TIMOD(timer_config->timer_mode);
+
+  imx9_flexio_putreg32(dev, regval,
+                        IMX9_FLEXIO_TIMCTL0_OFFSET + index * 0x4);
+}
+
+/* This function set the value of the prescaler on flexio channels
+ *
+ * param base Pointer to the FlexIO simulated peripheral type.
+ * param clocksource Set clock value
+ */
+
+static void imx9_flexio_set_clock_mode(struct flexio_dev_s *dev,
+                                        uint8_t index,
+              enum flexio_timer_decrement_source_e clocksource)
+{
+  imx9_flexio_modifyreg32(dev, IMX9_FLEXIO_TIMCFG0_OFFSET + index * 0x4,
+                           FLEXIO_TIMCFG_TIMDEC_MASK,
+                           FLEXIO_TIMCFG_TIMDEC(clocksource));
+}
+
+/* Enables the shifter status interrupt. The interrupt generates when the
+ * corresponding SSF is set.
+ *
+ * param dev FlexIO device
+ * param mask The shifter status mask which can be calculated by
+ * (1 << shifter index)
+ * note For multiple shifter status interrupt enable, for example, two
+ * shifter status enable, can calculate the mask by using
+ * ((1 << shifter index0) | (1 << shifter index1))
+ */
+
+static void imx9_flexio_enable_shifter_status_interrupts(
+              struct flexio_dev_s *dev, uint32_t mask)
+{
+  imx9_flexio_modifyreg32(dev, IMX9_FLEXIO_SHIFTSIEN_OFFSET, 0, mask);
+}
+
+/* Disables the shifter status interrupt. The interrupt won't generate when
+ * the corresponding SSF is set.
+ *
+ * param dev FlexIO device
+ * param mask The shifter status mask which can be calculated by
+ *            (1 << shifter index)
+ * note For multiple shifter status interrupt enable, for example, two
+ *      shifter status enable, can calculate the mask by using
+ *      ((1 << shifter index0) | (1 << shifter index1))
+ */
+
+static void imx9_flexio_disable_shifter_status_interrupts(
+              struct flexio_dev_s *dev, uint32_t mask)
+{
+  imx9_flexio_modifyreg32(dev, IMX9_FLEXIO_SHIFTSIEN_OFFSET, mask, 0);
+}
+
+/* Enables the shifter error interrupt. The interrupt generates when the
+ * corresponding SEF is set.
+ *
+ * param dev FlexIO device
+ * param mask The shifter error mask which can be calculated by
+ *            (1 << shifter index)
+ * note For multiple shifter error interrupt enable, for example, two shifter
+ *      error enable, can calculate the mask by using ((1 << shifter index0)
+ *      | (1 << shifter index1))
+ */
+
+static void imx9_flexio_enable_shifter_error_interrupts(
+              struct flexio_dev_s *dev, uint32_t mask)
+{
+  imx9_flexio_modifyreg32(dev, IMX9_FLEXIO_SHIFTEIEN_OFFSET, 0, mask);
+}
+
+/* Disables the shifter error interrupt. The interrupt won't generate when
+ * the corresponding SEF is set.
+ *
+ * param dev FlexIO device
+ * param mask The shifter error mask which can be calculated by
+ *            (1 << shifter index)
+ * note For multiple shifter error interrupt enable, for example, two shifter
+ *      error enable, can calculate the mask by using ((1 << shifter index0)
+ *      | (1 << shifter index1))
+ */
+
+static void imx9_flexio_disable_shifter_error_interrupts(
+              struct flexio_dev_s *dev, uint32_t mask)
+{
+  imx9_flexio_modifyreg32(dev, IMX9_FLEXIO_SHIFTEIEN_OFFSET, mask, 0);
+}
+
+/* Enables the timer status interrupt. The interrupt generates when the
+ * corresponding SSF is set.
+ *
+ * param dev FlexIO device
+ * param mask The timer status mask which can be calculated by
+ *            (1 << timer index)
+ * note For multiple timer status interrupt enable, for example, two timer
+ *      status enable, can calculate the mask by using ((1 << timer index0) |
+ *      (1 << timer index1))
+ */
+
+static void imx9_flexio_enable_timer_status_interrupts(
+              struct flexio_dev_s *dev, uint32_t mask)
+{
+  imx9_flexio_modifyreg32(dev, IMX9_FLEXIO_TIMIEN_OFFSET, 0, mask);
+}
+
+/* Disables the timer status interrupt. The interrupt won't generate when the
+ * corresponding SSF is set.
+ *
+ * param dev FlexIO device
+ * param mask The timer status mask which can be calculated by
+ *            (1 << timer index)
+ * note For multiple timer status interrupt enable, for example, two timer
+ *      status enable, can calculate the mask by using ((1 << timer index0) |
+ *      (1 << timer index1))
+ */
+
+static void imx9_flexio_disable_timer_status_interrupts(
+              struct flexio_dev_s *dev, uint32_t mask)
+{
+  imx9_flexio_modifyreg32(dev, IMX9_FLEXIO_TIMIEN_OFFSET, mask, 0);
+}
+
+/* Gets the shifter status flags.
+ *
+ * param dev FlexIO device
+ * return Shifter status flags
+ */
+
+static uint32_t imx9_flexio_get_shifter_status_flags(
+                  struct flexio_dev_s *dev)
+{
+  uint32_t regval;
+
+  regval = imx9_flexio_getreg32(dev, IMX9_FLEXIO_SHIFTSTAT_OFFSET);
+
+  return (regval & FLEXIO_SHIFTSTAT_SSF_MASK);
+}
+
+/* Clears the shifter status flags.
+ *
+ * param dev FlexIO device
+ * param mask The shifter status mask which can be calculated by
+ *            (1 << shifter index)
+ * note For clearing multiple shifter status flags, for example, two shifter
+ *      status flags, can calculate the mask by using ((1 << shifter index0)
+ *      | (1 << shifter index1))
+ */
+
+static void imx9_flexio_clear_shifter_status_flags(
+              struct flexio_dev_s *dev, uint32_t mask)
+{
+  imx9_flexio_putreg32(dev, mask, IMX9_FLEXIO_SHIFTSTAT_OFFSET);
+}
+
+/* Gets the shifter error flags.
+ *
+ * param dev FlexIO device
+ * return Shifter error flags
+ */
+
+static uint32_t imx9_flexio_get_shifter_error_flags(
+                  struct flexio_dev_s *dev)
+{
+  uint32_t regval;
+
+  regval = imx9_flexio_getreg32(dev, IMX9_FLEXIO_SHIFTERR_OFFSET);
+
+  return (regval & FLEXIO_SHIFTERR_SEF_MASK);
+}
+
+/* Clears the shifter error flags.
+ *
+ * param dev FlexIO device
+ * param mask The shifter error mask which can be calculated by
+ *            (1 << shifter index)
+ *
+ * note For clearing multiple shifter error flags, for example, two shifter
+ * error flags, can calculate the mask by using ((1 << shifter index0) |
+ * (1 << shifter index1))
+ */
+
+static void imx9_flexio_clear_shifter_error_flags(struct flexio_dev_s *dev,
+                                                   uint32_t mask)
+{
+  imx9_flexio_putreg32(dev, mask, IMX9_FLEXIO_SHIFTERR_OFFSET);
+}
+
+/* Gets the timer status flags.
+ *
+ * param dev FlexIO device
+ * return Timer status flags
+ */
+
+static uint32_t imx9_flexio_get_timer_status_flags(struct flexio_dev_s *dev)
+{
+  uint32_t regval;
+
+  regval = imx9_flexio_getreg32(dev, IMX9_FLEXIO_TIMSTAT_OFFSET);
+
+  return (regval & FLEXIO_TIMSTAT_TSF_MASK);
+}
+
+/* Clears the timer status flags.
+ *
+ * param dev FlexIO device
+ * param mask The timer status mask which can be calculated by
+ *            (1 << timer index)
+ *
+ * note For clearing multiple timer status flags, for example, two timer
+ * status flags, can calculate the mask by using ((1 << timer index0) |
+ * (1 << timer index1))
+ */
+
+static void imx9_flexio_clear_timer_status_flags(struct flexio_dev_s *dev,
+                                                  uint32_t mask)
+{
+  imx9_flexio_putreg32(dev, mask, IMX9_FLEXIO_TIMSTAT_OFFSET);
+}
+
+/* Enables/disables the shifter status DMA. The DMA request generates when
+ * the corresponding SSF is set.
+ *
+ * For multiple shifter status DMA enables, for example, calculate
+ * the mask by using ((1 << shifter index0) | (1 << shifter index1))
+ *
+ * param dev FlexIO device
+ * param mask The shifter status mask which can be calculated by
+ *            (1 << shifter index)
+ * param enable True to enable, false to disable.
+ */
+
+static void imx9_flexio_enable_shifter_status_dma(struct flexio_dev_s *dev,
+                                                  uint32_t mask, bool enable)
+{
+  if (enable)
+    {
+      imx9_flexio_modifyreg32(dev, IMX9_FLEXIO_SHIFTSDEN_OFFSET, 0, mask);
+    }
+  else
+    {
+      imx9_flexio_modifyreg32(dev, IMX9_FLEXIO_SHIFTSDEN_OFFSET, mask, 0);
+    }
+}
+
+/* Configures the FlexIO with a FlexIO configuration. The configuration
+ * structure can be filled by the user or be set with default values by
+ * imx9_flexio_get_default_config().
+ *
+ * Example
+ * code
+ * struct flexio_config_s config = {
+ * .enable_flexio = true,
+ * .enable_indoze = false,
+ * .enable_indebug = true,
+ * .enable_fast_access = false
+ * };
+ * imx9_flexio_init(base, &config);
+ * endcode
+ *
+ * param dev FlexIO device
+ * param user_config pointer to flexio_config_s structure
+ */
+
+static void imx9_flexio_init(struct flexio_dev_s *dev,
+                              const struct flexio_config_s *user_config)
+{
+  imx9_flexio_reset(dev);
+
+  imx9_flexio_modifyreg32(dev, IMX9_FLEXIO_CTRL_OFFSET,
+                      (FLEXIO_CTRL_DOZEN_MASK |
+                       FLEXIO_CTRL_DBGE_MASK |
+                       FLEXIO_CTRL_FASTACC_MASK |
+                       FLEXIO_CTRL_FLEXEN_MASK),
+                      (FLEXIO_CTRL_DBGE(user_config->enable_indebug) |
+                       FLEXIO_CTRL_FASTACC(user_config->enable_fast_access) |
+                       FLEXIO_CTRL_FLEXEN(user_config->enable_flexio)));
+
+  if (!user_config->enable_indoze)
+    {
+      imx9_flexio_modifyreg32(dev, IMX9_FLEXIO_CTRL_OFFSET, 0,
+                               FLEXIO_CTRL_DOZEN_MASK);
+    }
+}
+
+/* Gets the default configuration to configure the FlexIO module.
+ *
+ * Example:
+ * code
+ * struct flexio_config_s config;
+ * imx9_flexio_get_default_config(&config);
+ * endcode
+ *
+ * param user_config pointer to flexio_config_s structure
+ */
+
+static void imx9_flexio_get_default_config(
+              struct flexio_config_s *user_config)
+{
+  DEBUGASSERT(user_config != NULL);
+
+  memset(user_config, 0, sizeof(*user_config));
+
+  user_config->enable_flexio      = true;
+  user_config->enable_indoze      = false;
+  user_config->enable_indebug     = true;
+  user_config->enable_fast_access = false;
+}
+
+/* Gets the shifter buffer address for the DMA transfer usage.
+ *
+ * param dev FlexIO peripheral dev address
+ * param type Shifter type of enum flexio_shifter_buffer_type_e
+ * param index Shifter index
+ * return Corresponding shifter buffer address
+ */
+
+static uint32_t imx9_flexio_get_shifter_buffer_address(
+                  struct flexio_dev_s *dev,
+                  enum flexio_shifter_buffer_type_e type, uint8_t index)
+{
+  uint32_t address = 0;
+
+  UNUSED(dev);
+
+  DEBUGASSERT(index < FLEXIO_SHIFTBUF_COUNT);
+
+  switch (type)
+    {
+    case FLEXIO_SHIFTER_BUFFER:
+      address = (uint32_t)(((struct imx9_flexiodev_s *)dev)->base +
+                           IMX9_FLEXIO_SHIFTBUF0_OFFSET + index * 0x4);
+      break;
+
+    case FLEXIO_SHIFTER_BUFFER_BIT_SWAPPED:
+      address = (uint32_t)(((struct imx9_flexiodev_s *)dev)->base +
+                           IMX9_FLEXIO_SHIFTBUFBIS0_OFFSET + index * 0x4);
+      break;
+
+    case FLEXIO_SHIFTER_BUFFER_BYTE_SWAPPED:
+      address = (uint32_t)(((struct imx9_flexiodev_s *)dev)->base +
+                           IMX9_FLEXIO_SHIFTBUFBYS0_OFFSET + index * 0x4);
+      break;
+
+    case FLEXIO_SHIFTER_BUFFER_BIT_BYTE_SWAPPED:
+      address = (uint32_t)(((struct imx9_flexiodev_s *)dev)->base +
+                           IMX9_FLEXIO_SHIFTBUFBBS0_OFFSET + index * 0x4);
+      break;
+
+    case FLEXIO_SHIFTER_BUFFER_NIBBLE_BYTE_SWAPPED:
+      address = (uint32_t)(((struct imx9_flexiodev_s *)dev)->base +
+                           IMX9_FLEXIO_SHIFTBUFNBS0_OFFSET + index * 0x4);
+      break;
+
+    case FLEXIO_SHIFTER_BUFFER_HALF_WORD_SWAPPED:
+      address = (uint32_t)(((struct imx9_flexiodev_s *)dev)->base +
+                           IMX9_FLEXIO_SHIFTBUFHWS0_OFFSET + index * 0x4);
+      break;
+
+    case FLEXIO_SHIFTER_BUFFER_NIBBLE_SWAPPED:
+      address = (uint32_t)(((struct imx9_flexiodev_s *)dev)->base +
+                           IMX9_FLEXIO_SHIFTBUFNIS0_OFFSET + index * 0x4);
+      break;
+
+    default:
+      address = (uint32_t)(((struct imx9_flexiodev_s *)dev)->base +
+                           IMX9_FLEXIO_SHIFTBUF0_OFFSET + index * 0x4);
+      break;
+    }
+
+  return address;
+}
+
+/****************************************************************************
+ * Name: imx9_flexio_initialize
+ *
+ * Description:
+ *   Initialize the selected FlexIO port in master mode
+ *
+ * Input Parameters:
+ *   intf - Interface number(must be zero)
+ *
+ * Returned Value:
+ *   Valid FlexIO device structure reference on success; a NULL on failure
+ *
+ ****************************************************************************/
+
+struct flexio_dev_s *imx9_flexio_initialize(int intf)
+{
+  struct imx9_flexiodev_s *priv;
+  struct flexio_config_s flexio_config;
+
+  switch (intf)
+    {
+#ifdef CONFIG_IMX9_FLEXIO1
+    case 1:
+      priv = &g_flexio1_dev;
+      imx9_clockall_flexio1();
+      break;
+#endif
+#ifdef CONFIG_IMX9_FLEXIO2
+    case 2:
+      priv = &g_flexio2_dev;
+      imx9_clockall_flexio2();
+      break;
+#endif
+#ifdef CONFIG_IMX9_FLEXIO3
+    case 3:
+      priv = &g_flexio3_dev;
+      imx9_clockall_flexio2();
+      break;
+#endif
+    default:
+      return NULL;
+    }
+
+  /* Has the FlexSPI hardware been initialized? */
+
+  if (!priv->initialized)
+    {
+      /* Now perform one time initialization */
+
+      /* Perform hardware initialization. Puts the FlexIO into an active
+       * state.
+       */
+
+      imx9_flexio_get_default_config(&flexio_config);
+      imx9_flexio_init((struct flexio_dev_s *)priv, &flexio_config);
+
+      /* Enable interrupts at the NVIC */
+
+      priv->initialized = true;
+    }
+
+  return &priv->flexio;
+}
+
+#endif /* CONFIG_IMX9_FLEXIO */

--- a/arch/arm/src/imx9/imx9_flexio.h
+++ b/arch/arm/src/imx9/imx9_flexio.h
@@ -1,0 +1,368 @@
+/****************************************************************************
+ * arch/arm/src/imx9/imx9_flexio.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_IMX9_IMX9_FLEXIO_H
+#define __ARCH_ARM_SRC_IMX9_IMX9_FLEXIO_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "chip.h"
+#include "hardware/imx9_flexio.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Calculate FlexIO timer trigger. */
+
+#define FLEXIO_TIMER_TRIGGER_SEL_PININPUT(x)   ((uint32_t)(x) << 1u)
+#define FLEXIO_TIMER_TRIGGER_SEL_SHIFTnSTAT(x) (((uint32_t)(x) << 2u) | 0x1u)
+#define FLEXIO_TIMER_TRIGGER_SEL_TIMn(x)       (((uint32_t)(x) << 2u) | 0x3u)
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* Define time of timer trigger polarity. */
+
+enum flexio_timer_trigger_polarity_e
+{
+  FLEXIO_TIMER_TRIGGER_POLARITY_ACTIVE_HIGH = 0x0u, /* Active high. */
+  FLEXIO_TIMER_TRIGGER_POLARITY_ACTIVE_LOW  = 0x1u, /* Active low. */
+};
+
+/* Define type of timer trigger source. */
+
+enum flexio_timer_trigger_source_e
+{
+  FLEXIO_TIMER_TRIGGER_SOURCE_EXTERNAL = 0x0u, /* External trigger selected. */
+  FLEXIO_TIMER_TRIGGER_SOURCE_INTERNAL = 0x1u, /* Internal trigger selected. */
+};
+
+/* Define type of timer/shifter pin configuration. */
+
+enum flexio_pin_config_e
+{
+  FLEXIO_PIN_CONFIG_OUTPUT_DISABLED           = 0x0u, /* Pin output disabled. */
+  FLEXIO_PIN_CONFIG_OPEN_DRAIN_OR_BIDIRECTION = 0x1u, /* Pin open drain or bidirectional output enable. */
+  FLEXIO_PIN_CONFIG_BIDIRECTION_OUTPUT_DATA   = 0x2u, /* Pin bidirectional output data. */
+  FLEXIO_PIN_CONFIG_OUTPUT                    = 0x3u, /* Pin output. */
+};
+
+/* Definition of pin polarity. */
+
+enum flexio_pin_polarity_e
+{
+  FLEXIO_PIN_ACTIVE_HIGH = 0x0u, /* Active high. */
+  FLEXIO_PIN_ACTIVE_LOW  = 0x1u, /* Active low. */
+};
+
+/* Define type of timer work mode. */
+
+enum flexio_timer_mode_e
+{
+  FLEXIO_TIMER_MODE_DISABLED            = 0x0u, /* Timer Disabled. */
+  FLEXIO_TIMER_MODE_DUAL8_BIT_BAUD_BIT  = 0x1u, /* Dual 8-bit counters baud/bit mode. */
+  FLEXIO_TIMER_MODE_DUAL8_BIT_PWM       = 0x2u, /* Dual 8-bit counters PWM mode. */
+  FLEXIO_TIMER_MODE_SINGLE16_BIT        = 0x3u, /* Single 16-bit counter mode. */
+};
+
+/* Define type of timer initial output or timer reset condition. */
+
+enum flexio_timer_output_e
+{
+  FLEXIO_TIMER_OUTPUT_ONE_NOT_AFFECTED_BY_RESET   = 0x0u, /* Logic one when enabled and is not affected by timer reset. */
+  FLEXIO_TIMER_OUTPUT_ZERO_NOT_AFFECTED_BY_RESET  = 0x1u, /* Logic zero when enabled and is not affected by timer reset. */
+  FLEXIO_TIMER_OUTPUT_ONE_AFFECTED_BY_RESET       = 0x2u, /* Logic one when enabled and on timer reset. */
+  FLEXIO_TIMER_OUTPUT_ZERO_AFFECTED_BY_RESET      = 0x3u, /* Logic zero when enabled and on timer reset. */
+};
+
+/* Define type of timer decrement. */
+
+enum flexio_timer_decrement_source_e
+{
+  FLEXIO_TIMER_DEC_SRC_ON_FLEX_IO_CLOCK_SHIFT_TIMER_OUTPUT = 0x0u, /* Decrement counter on FlexIO clock, Shift clock equals Timer output. */
+  FLEXIO_TIMER_DEC_SRC_ON_TRIGGER_INPUT_SHIFT_TIMER_OUTPUT,        /* Decrement counter on Trigger input (both edges), shift clock equals Timer output. */
+  FLEXIO_TIMER_DEC_SRC_ON_PIN_INPUT_SHIFT_PIN_INPUT,               /* Decrement counter on Pin input (both edges), Shift clock equals Pin input. */
+  FLEXIO_TIMER_DEC_SRC_ON_TRIGGER_INPUT_SHIFT_TRIGGER_INPUT        /* Decrement counter on Trigger input (both edges), Shift clock equals Trigger input. */
+};
+
+/* Define type of timer reset condition. */
+
+enum flexio_timer_reset_condition_e
+{
+  FLEXIO_TIMER_RESET_NEVER                                  = 0x0u, /* Timer never reset. */
+  FLEXIO_TIMER_RESET_ON_TIMER_PIN_EQUAL_TO_TIMER_OUTPUT     = 0x2u, /* Timer reset on Timer Pin equal to Timer Output. */
+  FLEXIO_TIMER_RESET_ON_TIMER_TRIGGER_EQUAL_TO_TIMER_OUTPUT = 0x3u, /* Timer reset on Timer Trigger equal to Timer Output. */
+  FLEXIO_TIMER_RESET_ON_TIMER_PIN_RISING_EDGE               = 0x4u, /* Timer reset on Timer Pin rising edge. */
+  FLEXIO_TIMER_RESET_ON_TIMER_TRIGGER_RISING_EDGE           = 0x6u, /* Timer reset on Trigger rising edge. */
+  FLEXIO_TIMER_RESET_ON_TIMER_TRIGGER_BOTH_EDGE             = 0x7u, /* Timer reset on Trigger rising or falling edge. */
+};
+
+/* Define type of timer disable condition. */
+
+enum flexio_timer_disable_condition_e
+{
+  FLEXIO_TIMER_DISABLE_NEVER                          = 0x0u, /* Timer never disabled. */
+  FLEXIO_TIMER_DISABLE_ON_PRE_TIMER_DISABLE           = 0x1u, /* Timer disabled on Timer N-1 disable. */
+  FLEXIO_TIMER_DISABLE_ON_TIMER_COMPARE               = 0x2u, /* Timer disabled on Timer compare. */
+  FLEXIO_TIMER_DISABLE_ON_TIMER_COMPARE_TRIGGER_LOW   = 0x3u, /* Timer disabled on Timer compare and Trigger Low. */
+  FLEXIO_TIMER_DISABLE_ON_PIN_BOTH_EDGE               = 0x4u, /* Timer disabled on Pin rising or falling edge. */
+  FLEXIO_TIMER_DISABLE_ON_PIN_BOTH_EDGE_TRIGGER_HIGH  = 0x5u, /* Timer disabled on Pin rising or falling edge provided Trigger is high. */
+  FLEXIO_TIMER_DISABLE_ON_TRIGGER_FALLING_EDGE        = 0x6u, /* Timer disabled on Trigger falling edge. */
+};
+
+/* Define type of timer enable condition. */
+
+enum flexio_timer_enable_condition_e
+{
+  FLEXIO_TIMER_ENABLED_ALWAYS                         = 0x0u, /* Timer always enabled. */
+  FLEXIO_TIMER_ENABLE_ON_PREV_TIMER_ENABLE            = 0x1u, /* Timer enabled on Timer N-1 enable. */
+  FLEXIO_TIMER_ENABLE_ON_TRIGGER_HIGH                 = 0x2u, /* Timer enabled on Trigger high. */
+  FLEXIO_TIMER_ENABLE_ON_TRIGGER_HIGH_PIN_HIGH        = 0x3u, /* Timer enabled on Trigger high and Pin high. */
+  FLEXIO_TIMER_ENABLE_ON_PIN_RISING_EDGE              = 0x4u, /* Timer enabled on Pin rising edge. */
+  FLEXIO_TIMER_ENABLE_ON_PIN_RISING_EDGE_TRIGGER_HIGH = 0x5u, /* Timer enabled on Pin rising edge and Trigger high. */
+  FLEXIO_TIMER_ENABLE_ON_TRIGGER_RISING_EDGE          = 0x6u, /* Timer enabled on Trigger rising edge. */
+  FLEXIO_TIMER_ENABLE_ON_TRIGGER_BOTH_EDGE            = 0x7u, /* Timer enabled on Trigger rising or falling edge. */
+};
+
+/* Define type of timer stop bit generate condition. */
+
+enum flexio_timer_stop_bit_condition_e
+{
+  FLEXIO_TIMER_STOP_BIT_DISABLED                        = 0x0u, /* Stop bit disabled. */
+  FLEXIO_TIMER_STOP_BIT_ENABLE_ON_TIMER_COMPARE         = 0x1u, /* Stop bit is enabled on timer compare. */
+  FLEXIO_TIMER_STOP_BIT_ENABLE_ON_TIMER_DISABLE         = 0x2u, /* Stop bit is enabled on timer disable. */
+  FLEXIO_TIMER_STOP_BIT_ENABLE_ON_TIMER_COMPARE_DISABLE = 0x3u, /* Stop bit is enabled on timer compare and timer disable. */
+};
+
+/* Define type of timer start bit generate condition. */
+
+enum flexio_timer_start_bit_condition_e
+{
+  FLEXIO_TIMER_START_BIT_DISABLED = 0x0u, /* Start bit disabled. */
+  FLEXIO_TIMER_START_BIT_ENABLED  = 0x1u, /* Start bit enabled. */
+};
+
+/* FlexIO as PWM channel output state */
+
+enum flexio_timer_output_state_e
+{
+  FLEXIO_PWM_LOW = 0u, /* The output state of PWM channel is low */
+  FLEXIO_PWM_HIGH,     /* The output state of PWM channel is high */
+};
+
+/* Define type of timer polarity for shifter control. */
+
+enum flexio_shifter_timer_polarity_e
+{
+  FLEXIO_SHIFTER_TIMER_POLARITY_ON_POSITIVE = 0x0u, /* Shift on positive edge of shift clock. */
+  FLEXIO_SHIFTER_TIMER_POLARITY_ON_NEGATIVE = 0x1u, /* Shift on negative edge of shift clock. */
+};
+
+/* Define type of shifter working mode. */
+
+enum flexio_shifter_mode_e
+{
+  FLEXIO_SHIFTER_DISABLED               = 0x0u, /* Shifter is disabled. */
+  FLEXIO_SHIFTER_MODE_RECEIVE           = 0x1u, /* Receive mode. */
+  FLEXIO_SHIFTER_MODE_TRANSMIT          = 0x2u, /* Transmit mode. */
+  FLEXIO_SHIFTER_MODE_MATCH_STORE       = 0x4u, /* Match store mode. */
+  FLEXIO_SHIFTER_MODE_MATCH_CONTINUOUS  = 0x5u, /* Match continuous mode. */
+  FLEXIO_SHIFTER_MODE_STATE             = 0x6u, /* SHIFTBUF contents are used for storing programmable state attributes. */
+  FLEXIO_SHIFTER_MODE_LOGIC = 0x7u,             /* SHIFTBUF contents are used for implementing programmable logic look up table. */
+};
+
+/* Define type of shifter input source. */
+
+enum flexio_shifter_input_source_e
+{
+  FLEXIO_SHIFTER_INPUT_FROM_PIN                 = 0x0u, /* Shifter input from pin. */
+  FLEXIO_SHIFTER_INPUT_FROM_NEXT_SHIFTER_OUTPUT = 0x1u, /* Shifter input from Shifter N+1. */
+};
+
+/* Define of STOP bit configuration. */
+
+enum flexio_shifter_stop_bit_e
+{
+  FLEXIO_SHIFTER_STOP_BIT_DISABLE = 0x0u, /* Disable shifter stop bit. */
+  FLEXIO_SHIFTER_STOP_BIT_LOW     = 0x2u, /* Set shifter stop bit to logic low level. */
+  FLEXIO_SHIFTER_STOP_BIT_HIGH    = 0x3u, /* Set shifter stop bit to logic high level. */
+};
+
+/* Define type of START bit configuration. */
+
+enum flexio_shifter_start_bit_e
+{
+  FLEXIO_SHIFTER_START_BIT_DISABLED_LOAD_DATA_ON_ENABLE = 0x0u, /* Disable shifter start bit, transmitter loads data on enable. */
+  FLEXIO_SHIFTER_START_BIT_DISABLED_LOAD_DATA_ON_SHIFT  = 0x1u, /* Disable shifter start bit, transmitter loads data on first shift. */
+  FLEXIO_SHIFTER_START_BIT_LOW                          = 0x2u, /* Set shifter start bit to logic low level. */
+  FLEXIO_SHIFTER_START_BIT_HIGH                         = 0x3u, /* Set shifter start bit to logic high level. */
+};
+
+/* Define FlexIO shifter buffer type */
+
+enum flexio_shifter_buffer_type_e
+{
+  FLEXIO_SHIFTER_BUFFER                     = 0x0u, /* Shifter Buffer N Register. */
+  FLEXIO_SHIFTER_BUFFER_BIT_SWAPPED         = 0x1u, /* Shifter Buffer N Bit Byte Swapped Register. */
+  FLEXIO_SHIFTER_BUFFER_BYTE_SWAPPED        = 0x2u, /* Shifter Buffer N Byte Swapped Register. */
+  FLEXIO_SHIFTER_BUFFER_BIT_BYTE_SWAPPED    = 0x3u, /* Shifter Buffer N Bit Swapped Register. */
+  FLEXIO_SHIFTER_BUFFER_NIBBLE_BYTE_SWAPPED = 0x4u, /* Shifter Buffer N Nibble Byte Swapped Register. */
+  FLEXIO_SHIFTER_BUFFER_HALF_WORD_SWAPPED   = 0x5u, /* Shifter Buffer N Half Word Swapped Register. */
+  FLEXIO_SHIFTER_BUFFER_NIBBLE_SWAPPED      = 0x6u, /* Shifter Buffer N Nibble Swapped Register. */
+};
+
+#ifdef CONFIG_IMX9_FLEXIO
+
+struct flexio_timer_config_s
+{
+  uint32_t trigger_select;
+  enum flexio_timer_trigger_polarity_e    trigger_polarity;
+  enum flexio_timer_trigger_source_e      trigger_source;
+  enum flexio_pin_config_e                pin_config;
+  uint32_t                                pin_select;
+  enum flexio_pin_polarity_e              pin_polarity;
+  enum flexio_timer_mode_e                timer_mode;
+  enum flexio_timer_output_e              timer_output;
+  enum flexio_timer_decrement_source_e    timer_decrement;
+  enum flexio_timer_reset_condition_e     timer_reset;
+  enum flexio_timer_disable_condition_e   timer_disable;
+  enum flexio_timer_enable_condition_e    timer_enable;
+  enum flexio_timer_stop_bit_condition_e  timer_stop;
+  enum flexio_timer_start_bit_condition_e timer_start;
+  uint32_t timer_compare;
+};
+
+struct flexio_shifter_config_s
+{
+  uint32_t timer_select;
+  enum flexio_shifter_timer_polarity_e    timer_polarity;
+  enum flexio_pin_config_e                pin_config;
+  uint32_t                                pin_select;
+  enum flexio_pin_polarity_e              pin_polarity;
+  enum flexio_shifter_mode_e              shifter_mode;
+  uint32_t                                parallel_width;
+  enum flexio_shifter_input_source_e      input_source;
+  enum flexio_shifter_stop_bit_e          shifter_stop;
+  enum flexio_shifter_start_bit_e         shifter_start;
+};
+
+/* The FlexIO vtable */
+
+struct flexio_dev_s;
+
+struct flexio_ops_s
+{
+  void (*reset)(struct flexio_dev_s *dev);
+  void (*enable)(struct flexio_dev_s *dev, bool enable);
+  uint32_t (*read_pin_input)(struct flexio_dev_s *dev);
+  uint8_t (*get_shifter_state)(struct flexio_dev_s *dev);
+  void (*set_shifter_config)(struct flexio_dev_s *dev, uint8_t index,
+          const struct flexio_shifter_config_s *shifter_config);
+  void (*set_timer_config)(struct flexio_dev_s *dev, uint8_t index,
+          const struct flexio_timer_config_s *timer_config);
+  void (*set_clock_mode)(struct flexio_dev_s *dev, uint8_t index,
+          enum flexio_timer_decrement_source_e clocksource);
+  void (*enable_shifter_status_interrupts)(struct flexio_dev_s *dev,
+          uint32_t mask);
+  void (*disable_shifter_status_interrupts)(struct flexio_dev_s *dev,
+          uint32_t mask);
+  void (*enable_shifter_error_interrupts)(struct flexio_dev_s *dev,
+          uint32_t mask);
+  void (*disable_shifter_error_interrupts)(struct flexio_dev_s *dev,
+          uint32_t mask);
+  void (*enable_timer_status_interrupts)(struct flexio_dev_s *dev,
+          uint32_t mask);
+  void (*disable_timer_status_interrupts)(struct flexio_dev_s *dev,
+          uint32_t mask);
+  uint32_t (*get_shifter_status_flags)(struct flexio_dev_s *dev);
+  void (*clear_shifter_status_flags)(struct flexio_dev_s *dev,
+          uint32_t mask);
+  uint32_t (*get_shifter_error_flags)(struct flexio_dev_s *dev);
+  void (*clear_shifter_error_flags)(struct flexio_dev_s *dev,
+          uint32_t mask);
+  uint32_t (*get_timer_status_flags)(struct flexio_dev_s *dev);
+  void (*clear_timer_status_flags)(struct flexio_dev_s *dev,
+          uint32_t mask);
+  void (*enable_shifter_status_dma)(struct flexio_dev_s *dev,
+          uint32_t mask, bool enable);
+  uint32_t (*get_shifter_buffer_address)(struct flexio_dev_s *dev,
+              enum flexio_shifter_buffer_type_e type, uint8_t index);
+};
+
+/* FlexIO private data. This structure only defines the initial fields of
+ * the structure visible to the FlexIO client. The specific implementation
+ * may add additional, device specific fields
+ */
+
+struct flexio_dev_s
+{
+  const struct flexio_ops_s *ops;
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Name: imx9_flexio_initialize
+ *
+ * Description:
+ *   Initialize the selected FlexIO port
+ *
+ * Input Parameters:
+ *   intf - Interface number
+ *
+ * Returned Value:
+ *   Valid FlexIO device structure reference on success; a NULL on failure
+ *
+ ****************************************************************************/
+
+struct flexio_dev_s *imx9_flexio_initialize(int intf);
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __ASSEMBLY__ */
+#endif /* CONFIG_IMX9_FLEXIO */
+#endif /* __ARCH_ARM_SRC_IMX9_IMX9_FLEXIO_H */

--- a/arch/arm/src/imx9/imx9_lpi2c.c
+++ b/arch/arm/src/imx9/imx9_lpi2c.c
@@ -176,10 +176,6 @@ struct imx9_lpi2c_config_s
   uint8_t filtsda;             /* Glitch Filter for SDA pin */
   iomux_cfg_t scl_pin;         /* Peripheral configuration for SCL as SCL */
   iomux_cfg_t sda_pin;         /* Peripheral configuration for SDA as SDA */
-#if defined(CONFIG_I2C_RESET)
-  gpio_pinset_t reset_scl_pin; /* GPIO configuration for SCL as GPIO */
-  gpio_pinset_t reset_sda_pin; /* GPIO configuration for SDA as GPIO */
-#endif
   uint8_t mode;                /* Master or Slave mode */
 #ifndef CONFIG_I2C_POLLED
   uint32_t irq;                /* Event IRQ */
@@ -337,10 +333,6 @@ static const struct imx9_lpi2c_config_s imx9_lpi2c1_config =
   .filtsda       = CONFIG_IMX9_LPI2C1_FILTSDA,
   .scl_pin       = MUX_LPI2C1_SCL,
   .sda_pin       = MUX_LPI2C1_SDA,
-#if defined(CONFIG_I2C_RESET)
-  .reset_scl_pin = GPIO_LPI2C1_SCL_RESET,
-  .reset_sda_pin = GPIO_LPI2C1_SDA_RESET,
-#endif
 #ifndef CONFIG_I2C_SLAVE
   .mode          = LPI2C_MASTER,
 #else
@@ -384,10 +376,6 @@ static const struct imx9_lpi2c_config_s imx9_lpi2c2_config =
   .filtsda       = CONFIG_IMX9_LPI2C2_FILTSDA,
   .scl_pin       = MUX_LPI2C2_SCL,
   .sda_pin       = MUX_LPI2C2_SDA,
-#if defined(CONFIG_I2C_RESET)
-  .reset_scl_pin = GPIO_LPI2C2_SCL_RESET,
-  .reset_sda_pin = GPIO_LPI2C2_SDA_RESET,
-#endif
 #ifndef CONFIG_I2C_SLAVE
   .mode          = LPI2C_MASTER,
 #else
@@ -431,10 +419,6 @@ static const struct imx9_lpi2c_config_s imx9_lpi2c3_config =
   .filtsda       = CONFIG_IMX9_LPI2C3_FILTSDA,
   .scl_pin       = MUX_LPI2C3_SCL,
   .sda_pin       = MUX_LPI2C3_SDA,
-#if defined(CONFIG_I2C_RESET)
-  .reset_scl_pin = GPIO_LPI2C3_SCL_RESET,
-  .reset_sda_pin = GPIO_LPI2C3_SDA_RESET,
-#endif
 #ifndef CONFIG_I2C_SLAVE
   .mode          = LPI2C_MASTER,
 #else
@@ -478,10 +462,6 @@ static const struct imx9_lpi2c_config_s imx9_lpi2c4_config =
   .filtsda       = CONFIG_IMX9_LPI2C4_FILTSDA,
   .scl_pin       = MUX_LPI2C4_SCL,
   .sda_pin       = MUX_LPI2C4_SDA,
-#if defined(CONFIG_I2C_RESET)
-  .reset_scl_pin = GPIO_LPI2C4_SCL_RESET,
-  .reset_sda_pin = GPIO_LPI2C4_SDA_RESET,
-#endif
 #ifndef CONFIG_I2C_SLAVE
   .mode          = LPI2C_MASTER,
 #else
@@ -525,10 +505,6 @@ static const struct imx9_lpi2c_config_s imx9_lpi2c5_config =
   .filtsda       = CONFIG_IMX9_LPI2C5_FILTSDA,
   .scl_pin       = MUX_LPI2C5_SCL,
   .sda_pin       = MUX_LPI2C5_SDA,
-#if defined(CONFIG_I2C_RESET)
-  .reset_scl_pin = GPIO_LPI2C5_SCL_RESET,
-  .reset_sda_pin = GPIO_LPI2C5_SDA_RESET,
-#endif
 #ifndef CONFIG_I2C_SLAVE
   .mode          = LPI2C_MASTER,
 #else
@@ -572,10 +548,6 @@ static const struct imx9_lpi2c_config_s imx9_lpi2c6_config =
   .filtsda       = CONFIG_IMX9_LPI2C6_FILTSDA,
   .scl_pin       = MUX_LPI2C6_SCL,
   .sda_pin       = MUX_LPI2C6_SDA,
-#if defined(CONFIG_I2C_RESET)
-  .reset_scl_pin = GPIO_LPI2C6_SCL_RESET,
-  .reset_sda_pin = GPIO_LPI2C6_SDA_RESET,
-#endif
 #ifndef CONFIG_I2C_SLAVE
   .mode          = LPI2C_MASTER,
 #else
@@ -619,10 +591,6 @@ static const struct imx9_lpi2c_config_s imx9_lpi2c7_config =
   .filtsda       = CONFIG_IMX9_LPI2C7_FILTSDA,
   .scl_pin       = MUX_LPI2C7_SCL,
   .sda_pin       = MUX_LPI2C7_SDA,
-#if defined(CONFIG_I2C_RESET)
-  .reset_scl_pin = GPIO_LPI2C7_SCL_RESET,
-  .reset_sda_pin = GPIO_LPI2C7_SDA_RESET,
-#endif
 #ifndef CONFIG_I2C_SLAVE
   .mode          = LPI2C_MASTER,
 #else
@@ -666,10 +634,6 @@ static const struct imx9_lpi2c_config_s imx9_lpi2c8_config =
   .filtsda       = CONFIG_IMX9_LPI2C8_FILTSDA,
   .scl_pin       = MUX_LPI2C8_SCL,
   .sda_pin       = MUX_LPI2C8_SDA,
-#if defined(CONFIG_I2C_RESET)
-  .reset_scl_pin = GPIO_LPI2C8_SCL_RESET,
-  .reset_sda_pin = GPIO_LPI2C8_SDA_RESET,
-#endif
 #ifndef CONFIG_I2C_SLAVE
   .mode          = LPI2C_MASTER,
 #else
@@ -2037,7 +2001,7 @@ static int imx9_lpi2c_transfer(struct i2c_master_s *dev,
   priv->msgc  = count;
   priv->flags = msgs->flags;
 
-  i2cinfo("Flags %x, len %d\n", msgs->flags, msgs->length);
+  i2cinfo("Flags %x, len %ld\n", msgs->flags, msgs->length);
 
   /* Reset I2C trace logic */
 
@@ -2180,11 +2144,8 @@ static int imx9_lpi2c_transfer(struct i2c_master_s *dev,
 static int imx9_lpi2c_reset(struct i2c_master_s *dev)
 {
   struct imx9_lpi2c_priv_s *priv = (struct imx9_lpi2c_priv_s *)dev;
-  unsigned int clock_count;
-  unsigned int stretch_count;
-  uint32_t scl_gpio;
-  uint32_t sda_gpio;
-  uint32_t frequency;
+  uint32_t status;
+  unsigned count;
   int ret;
 
   DEBUGASSERT(dev);
@@ -2201,95 +2162,42 @@ static int imx9_lpi2c_reset(struct i2c_master_s *dev)
       return ret;
     }
 
-  ret = -EIO;
-
-  /* Save the current frequency */
-
-  frequency = priv->frequency;
-
   /* De-init the port */
 
   imx9_lpi2c_deinit(priv);
-
-  /* Use GPIO configuration to un-wedge the bus */
-
-  imx9_iomux_gpio(priv->config->scl_pin, true);
-  imx9_iomux_gpio(priv->config->sda_pin, true);
-
-  scl_gpio = priv->config->reset_scl_pin;
-  sda_gpio = priv->config->reset_sda_pin;
-
-  imx9_config_gpio(scl_gpio);
-  imx9_config_gpio(sda_gpio);
-
-  /* Let SDA go high */
-
-  imx9_gpio_write(sda_gpio, 1);
-
-  /* Clock the bus until any slaves currently driving it let it go. */
-
-  clock_count = 0;
-  while (!imx9_gpio_read(sda_gpio))
-    {
-      /* Give up if we have tried too hard */
-
-      if (clock_count++ > 10)
-        {
-          goto out;
-        }
-
-      /* Sniff to make sure that clock stretching has finished.
-       *
-       * If the bus never relaxes, the reset has failed.
-       */
-
-      stretch_count = 0;
-      while (!imx9_gpio_read(scl_gpio))
-        {
-          /* Give up if we have tried too hard */
-
-          if (stretch_count++ > 10)
-            {
-              goto out;
-            }
-
-          up_udelay(10);
-        }
-
-      /* Drive SCL low */
-
-      imx9_gpio_write(scl_gpio, 0);
-      up_udelay(10);
-
-      /* Drive SCL high again */
-
-      imx9_gpio_write(scl_gpio, 1);
-      up_udelay(10);
-    }
-
-  /* Generate a start followed by a stop to reset slave
-   * state machines.
-   */
-
-  imx9_gpio_write(sda_gpio, 0);
-  up_udelay(10);
-  imx9_gpio_write(scl_gpio, 0);
-  up_udelay(10);
-  imx9_gpio_write(scl_gpio, 1);
-  up_udelay(10);
-  imx9_gpio_write(sda_gpio, 1);
-  up_udelay(10);
 
   /* Re-init the port */
 
   imx9_lpi2c_init(priv);
 
-  /* Restore the frequency */
+  /* Set bus to relaxed mode - this allows clocking the bus even when it
+   * is busy
+   */
 
-  imx9_lpi2c_setclock(priv, frequency);
-  ret = OK;
+  imx9_lpi2c_modifyreg(priv, IMX9_LPI2C_MCFGR0_OFFSET,
+                       0, LPI2C_MCFG0_RELAX);
 
-out:
+  /* Clock the bus until it gets freed  (max 10 times) */
+
+  count = 0;
+  status = imx9_lpi2c_getstatus(priv);
+  while ((status & LPI2C_MSR_BBF) != 0 && count++ < 10)
+    {
+      i2cerr("Bus %d busy!\n", priv->config->clk_root - CCM_CR_LPI2C1 + 1);
+      imx9_lpi2c_sendstart(priv, 0);
+      imx9_lpi2c_sendstop(priv);
+      usleep(1000);
+      status = imx9_lpi2c_getstatus(priv);
+    }
+
+  /* Check that the bus is now free */
+
+  ret = (status & LPI2C_MSR_BBF) == 0 ? OK : -EIO;
+
+  /* Exit relaxed mode */
+
+  imx9_lpi2c_modifyreg(priv, IMX9_LPI2C_MCFGR0_OFFSET,
+                       LPI2C_MCFG0_RELAX, 0);
 
   /* Release the port for reuse by other clients */
 


### PR DESCRIPTION
## Summary

- Backport ARM64 LPI2C changes to the imx95 arm target
- eDMA fix TCM address calcuation for scatter-gatter
- Add FlexIO driver for imx95 (backport from i.mxrt)

## Impact

NavQ95
