### PR TITLE
build: clean previous compiled files after menuconfig updates

### DIFF
--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -746,22 +746,34 @@ olddefconfig:
 menuconfig:
 	$(Q) $(MAKE) clean_context
 	$(Q) $(MAKE) apps_preconfig
+	$(Q) cp .config .config.tmp 2>/dev/null || true
 	$(Q) ${KCONFIG_ENV} ${KCONFIG_MENUCONFIG}
+	$(Q) cmp -s .config .config.tmp || $(MAKE) clean
+	$(Q) rm -f .config.tmp
 
 nconfig: apps_preconfig
 	$(Q) $(MAKE) clean_context
 	$(Q) $(MAKE) apps_preconfig
+	$(Q) cp .config .config.tmp
 	$(Q) ${KCONFIG_ENV} ${KCONFIG_NCONFIG}
+	$(Q) cmp -s .config .config.tmp || $(MAKE) clean
+	$(Q) rm -f .config.tmp
 
 qconfig: apps_preconfig
 	$(Q) $(MAKE) clean_context
 	$(Q) $(MAKE) apps_preconfig
+	$(Q) cp .config .config.tmp
 	$(Q) ${KCONFIG_ENV} ${KCONFIG_QCONFIG}
+	$(Q) cmp -s .config .config.tmp || $(MAKE) clean
+	$(Q) rm -f .config.tmp
 
 gconfig: apps_preconfig
-	$(Q) $(MAKE) clean_context
+	$(Q) $(MAKE) clean_context1
 	$(Q) $(MAKE) apps_preconfig
+	$(Q) cp .config .config.tmp
 	$(Q) ${KCONFIG_ENV} ${KCONFIG_GCONFIG}
+	$(Q) cmp -s .config .config.tmp || $(MAKE) clean
+	$(Q) rm -f .config.tmp
 
 savedefconfig: apps_preconfig
 	$(Q) ${KCONFIG_ENV} ${KCONFIG_SAVEDEFCONFIG}


### PR DESCRIPTION
## Summary
This PR addresses a build system bug where orphaned object files are left behind after configuration changes. 
* Captures the state of the `.config` file before entering configuration interfaces (`menuconfig`, `nconfig`, `qconfig`, `gconfig`, `xconfig`).
* Compares the `.config` state upon exit.
* If the configuration was modified, it automatically triggers `make clean` to ensure a fresh environment for the next build.

Fixes #16151

## Impact
* **Users/Developers:** Eliminates the need to manually run `make clean` after tweaking configurations. Prevents hidden linking errors and build corruption.
* **Build System:** Improves reliability and automation across all Unix configuration targets.

## Testing
* **Simulator/Local:** Verified that changing settings inside `menuconfig` successfully triggers a clean build upon exit.
* Verified that opening and closing `menuconfig` *without* saving changes bypasses the clean step, preserving the existing build.