### PR TITLE
arch/arm/include/arm*/irq.h: fix FPU context layout guard macro

### DIFF
--- a/arch/arm/include/armv7-a/irq.h
+++ b/arch/arm/include/armv7-a/irq.h
@@ -123,7 +123,7 @@
 #  define REG_D15           (30) /* D15 */
 #  define REG_S30           (30) /* S30 */
 #  define REG_S31           (31) /* S31 */
-#  ifdef CONFIG_ARM_HAVE_DPFPU32
+#  ifdef CONFIG_ARM_DPFPU32
 #    define REG_D16         (32) /* D16 */
 #    define REG_D17         (34) /* D17 */
 #    define REG_D18         (36) /* D18 */

--- a/arch/arm/include/armv7-r/irq.h
+++ b/arch/arm/include/armv7-r/irq.h
@@ -123,7 +123,7 @@
 #  define REG_D15           (30) /* D15 */
 #  define REG_S30           (30) /* S30 */
 #  define REG_S31           (31) /* S31 */
-#  ifdef CONFIG_ARM_HAVE_DPFPU32
+#  ifdef CONFIG_ARM_DPFPU32
 #    define REG_D16         (32) /* D16 */
 #    define REG_D17         (34) /* D17 */
 #    define REG_D18         (36) /* D18 */

--- a/arch/arm/include/armv8-r/irq.h
+++ b/arch/arm/include/armv8-r/irq.h
@@ -123,7 +123,7 @@
 #  define REG_D15           (30) /* D15 */
 #  define REG_S30           (30) /* S30 */
 #  define REG_S31           (31) /* S31 */
-#  ifdef CONFIG_ARM_HAVE_DPFPU32
+#  ifdef CONFIG_ARM_DPFPU32
 #    define REG_D16         (32) /* D16 */
 #    define REG_D17         (34) /* D17 */
 #    define REG_D18         (36) /* D18 */


### PR DESCRIPTION
## Summary

The register index layout for D16–D31 and `FPU_CONTEXT_REGS` was guarded by `CONFIG_ARM_HAVE_DPFPU32` (hardware capability) in three header files, but all save/restore code in the corresponding `.S` files gates on `CONFIG_ARM_DPFPU32` (software enable).

These two macros are distinct:

- `CONFIG_ARM_HAVE_DPFPU32` — set by the chip via `select`; indicates the
  hardware has D16–D31 registers.
- `CONFIG_ARM_DPFPU32` — user-selectable; means the software has chosen to
  use D16–D31 (requires hardware support).

When `ARM_HAVE_DPFPU32=y` and `ARM_DPFPU32=n`, the header defined
`REG_FPSCR` at offset 64 and `FPU_CONTEXT_REGS=65`, while the assembly only saved S0–S31 + FPSCR (33 words), placing FPSCR at offset 32. This mismatch causes incorrect register access and wrong `xcptcontext` sizing.

Fix all three affected headers to use `CONFIG_ARM_DPFPU32`, matching the actual save/restore behavior in the assembly code.

All save/restore sites (`arm_vectors.S`, `arm_saveusercontext.S`, `arm_tcbinfo.c`) consistently gate on `CONFIG_ARM_DPFPU32` across all three architectures (ARMv8-R, ARMv7-R, ARMv7-A). The three `irq.h` headers were the only outliers using `CONFIG_ARM_HAVE_DPFPU32`. The three irq.h headers were the only outliers using `CONFIG_ARM_HAVE_DPFPU32`, making this a clear consistency fix::

```
arch/arm/src/armv8-r/arm_vectors.S        CONFIG_ARM_DPFPU32  (4 sites)
arch/arm/src/armv8-r/arm_saveusercontext.S CONFIG_ARM_DPFPU32
arch/arm/src/armv8-r/arm_tcbinfo.c        CONFIG_ARM_DPFPU32
arch/arm/src/armv7-r/arm_vectors.S        CONFIG_ARM_DPFPU32  (2 sites)
arch/arm/src/armv7-r/arm_saveusercontext.S CONFIG_ARM_DPFPU32
arch/arm/src/armv7-r/arm_tcbinfo.c        CONFIG_ARM_DPFPU32
arch/arm/src/armv7-a/arm_vectors.S        CONFIG_ARM_DPFPU32  (2 sites)
arch/arm/src/armv7-a/arm_saveusercontext.S CONFIG_ARM_DPFPU32
arch/arm/src/armv7-a/arm_tcbinfo.c        CONFIG_ARM_DPFPU32
arch/arm/include/armv8-r/irq.h            CONFIG_ARM_HAVE_DPFPU32  ← fixed
arch/arm/include/armv7-r/irq.h            CONFIG_ARM_HAVE_DPFPU32  ← fixed
arch/arm/include/armv7-a/irq.h            CONFIG_ARM_HAVE_DPFPU32  ← fixed
```

## Impact

Any ARMv8-R, ARMv7-R, or ARMv7-A platform that has hardware support for 32 double-precision FPU registers (`ARM_HAVE_DPFPU32=y`) but has not enabled the software use of D16–D31 (`ARM_DPFPU32=n`) is affected. In this configuration the FPU context layout in the header disagrees with what the assembly actually saves, leading to corrupted register restores and incorrect stack sizing, which typically manifests as a boot failure or crash at the first context switch involving FPU state.

## Testing

**Target:** Private ARMv8-R Cortex-R52 platform with `CONFIG_ARM_HAVE_DPFPU32=y` and `CONFIG_ARM_DPFPU32=n`
(hardware has D16–D31 but software use of the upper bank is isabled).

**Before the fix:** the system fails to boot when `CONFIG_ARM_DPFPU32=n`.

**After the fix:** the system boots normally and the `ostest` application completes without errors.
