### PR TITLE
sched/group: skip group_release for kernel thread group

### DIFF
--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -118,7 +118,7 @@
 #define GROUP_FLAG_DELETED         (1 << 2)                      /* Bit 2: Group has been deleted but not yet freed */
 #define GROUP_FLAG_EXITING         (1 << 3)                      /* Bit 3: Group exit is in progress */
 #define GROUP_FLAG_FD_BACKTRACE    (1 << 4)                      /* Bit 4: Enable FD backtrace for the group */
-                                                                 /* Bits 3-7: Available */
+                                                                 /* Bits 5-7: Available */
 
 /* Values for struct child_status_s ch_flags */
 

--- a/sched/group/group_leave.c
+++ b/sched/group/group_leave.c
@@ -59,7 +59,7 @@
  *   Release group resources after the last member has left the group.
  *
  * Input Parameters:
- *   group - The group to be removed.
+ *   group - The group to be released.
  *
  * Returned Value:
  *   None.
@@ -173,17 +173,26 @@ void group_leave(FAR struct tcb_s *tcb)
   group = tcb->group;
   if (group)
     {
+      /* Kernel threads share a single statically allocated g_kthread_group.
+       * Never call group_release() for them: doing so would destroy shared
+       * resources (mutex, fdlist, task_info) while other kernel threads are
+       * still using them, causing use-after-free crashes.
+       */
+
+      bool release = !(tcb->flags & TCB_FLAG_TTYPE_KERNEL);
+
       /* Remove the member from group. */
 
 #ifdef HAVE_GROUP_MEMBERS
       flags = spin_lock_irqsave(&group->tg_lock);
       sq_rem(&tcb->member, &group->tg_members);
+      release = release && sq_empty(&group->tg_members);
       spin_unlock_irqrestore(&group->tg_lock, flags);
 
       /* Have all of the members left the group? */
-
-      if (sq_empty(&group->tg_members))
 #endif
+
+      if (release)
         {
           /* Yes.. Release all of the resource held by the task group */
 


### PR DESCRIPTION
## Summary

When CONFIG_DISABLE_PTHREAD=y, HAVE_GROUP_MEMBERS is undefined and group_leave() unconditionally calls group_release() for every exiting thread. This destroys the shared g_kthread_group resources (mutex, fdlist, task_info) while other kernel threads are still using them, causing use-after-free crashes.

PR #18517 added GROUP_FLAG_STATIC to guard group_drop() against freeing the static g_kthread_group struct. However, group_release() still runs and destroys internal resources (tg_mutex, tg_fdlist, tg_info) that are shared by all kernel threads.

Fix by checking TCB_FLAG_TTYPE_KERNEL in group_leave() before calling group_release(), so the entire release path is skipped for kernel threads. This is safe because g_kthread_group is statically allocated and its lifetime is the entire system.

Also fix the "Bits 3-7: Available" comment to "Bits 5-7" since bit 4 is now used by GROUP_FLAG_FD_BACKTRACE.

## Impact

All configurations with CONFIG_DISABLE_PTHREAD=y that dynamically create and destroy kernel threads have fixed use-after-free.

## Testing

Tested on Infineon TC4D9 EVB (TriCore, NuttX SMP BMP). Verified kernel thread exit does not corrupt shared g_kthread_group by stopping an rptun channel (destroys rpmsg kthread).

Before rptun stop (rpmsg-corecs-0 kthread PID 48 present):

```
  core0> ps
  PID GROUP PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK    USED FILLED    CPU COMMAND
    0     0   0 FIFO     Kthread   - Ready              0000000000000000 0003008 0001136  37.7%  95.2% CPU0 IDLE
    1     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0003968 0001076  27.1%   0.1% hpwork 0xd0000540 0xd0000590
    2     0 100 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0003968 0001992  50.2%   0.3% lpwork 0xd00004c0 0xd0000510
    3     3 253 FIFO     Task      - Waiting  Semaphore 0000000000000000 0003904 0002820  72.2%   0.0% init
   12     0 253 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0003968 0002108  53.1%   0.0% kautocore_init
   13     0 201 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0003968 0000700  17.6%   0.7% BSW_TASK_1MS_C0
   14    14 254 FIFO     Task      - Running            0000000000000000 0003904 0002620  67.1%   0.0% nsh
   23    23 100 FIFO     Task      - Waiting  Semaphore 0000000000000000 0003904 0002044  52.3%   0.0% dfxd -f /etc/dfxd_setup_cpu0.cfg
   37     0 251 FIFO     Kthread   - Waiting  Semaphore fffffffffff7fdff 0003968 0000564  14.2%   0.0% isrwork 0x70030f40 0x70030f90
   38     0 250 FIFO     Kthread   - Waiting  Semaphore fffffffffff7fdff 0003968 0000564  14.2%   0.0% isrwork 0x70031240 0x70031290
   39     0 189 FIFO     Kthread   - Waiting  Semaphore fffffffffff7fdff 0003904 0001372  35.1%   0.0% rpmsg-core1-0 0x70033020 0x70033070
   40     0 200 FIFO     Kthread   - Waiting  Semaphore fffffffffff7fdff 0003904 0001212  31.0%   0.0% rpmsg-core1_1-0 0x70034710 0x70034760
   41     0 189 FIFO     Kthread   - Waiting  Semaphore fffffffffff7fdff 0003904 0001372  35.1%   0.0% rpmsg-core2-0 0x70029c08 0x70029c58
   42     0 189 FIFO     Kthread   - Waiting  Semaphore fffffffffff7fdff 0003968 0001372  34.5%   0.0% rpmsg-core3-0 0x7002a2a0 0x7002a2f0
   43     0 189 FIFO     Kthread   - Waiting  Semaphore fffffffffff7fdff 0003904 0001372  35.1%   0.0% rpmsg-core4-0 0x7002a5a8 0x7002a5f8
   47     0 189 FIFO     Kthread   - Waiting  Semaphore fffffffffff7fdff 0003968 0001372  34.5%   0.0% rpmsg-core5-0 0x7002c280 0x7002c2d0
   48     0 189 FIFO     Kthread   - Waiting  Semaphore fffffffffff7fdff 0003968 0001372  34.5%   0.0% rpmsg-corecs-0 0x7002c828 0x7002c878
   49     0 199 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0003968 0001256  31.6%   0.7% BSW_TASK_5MS_C0
   50     0 197 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0003968 0001892  47.6%   2.4% BSW_TASK_10MS_C0
   51     0 195 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0003968 0001304  32.8%   0.1% BSW_TASK_20MS_C0
   52     0 193 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0003968 0001256  31.6%   0.0% BSW_TASK_50MS_C0
   53     0 191 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0003968 0001884  47.4%   0.2% BSW_TASK_100MS_C0
   54     0 101 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0003904 0001396  35.7%   0.0% autocore_macc 0xb0036094

  core0> rptun stop /dev/rptun/corecs
  [01/01/70 00:01:32.462760] [CPU0] rx_vq: freeing non-empty virtqueue
  [01/01/70 00:01:32.462779] [CPU0] tx_vq: freeing non-empty virtqueue
```

After rptun stop (rpmsg-corecs-0 gone, all other kthreads intact):

```
  core0> ps
  PID GROUP PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK    USED FILLED    CPU COMMAND
    0     0   0 FIFO     Kthread   - Ready              0000000000000000 0003008 0001136  37.7%  95.2% CPU0 IDLE
    1     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0003968 0001076  27.1%   0.1% hpwork 0xd0000540 0xd0000590
    2     0 100 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0003968 0001992  50.2%   0.3% lpwork 0xd00004c0 0xd0000510
    3     3 253 FIFO     Task      - Waiting  Semaphore 0000000000000000 0003904 0002820  72.2%   0.0% init
   12     0 253 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0003968 0002108  53.1%   0.0% kautocore_init
   13     0 201 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0003968 0000700  17.6%   0.7% BSW_TASK_1MS_C0
   14    14 254 FIFO     Task      - Running            0000000000000000 0003904 0003316  84.9%!  0.0% nsh
   23    23 100 FIFO     Task      - Waiting  Semaphore 0000000000000000 0003904 0002044  52.3%   0.0% dfxd -f /etc/dfxd_setup_cpu0.cfg
   37     0 251 FIFO     Kthread   - Waiting  Semaphore fffffffffff7fdff 0003968 0000564  14.2%   0.0% isrwork 0x70030f40 0x70030f90
   38     0 250 FIFO     Kthread   - Waiting  Semaphore fffffffffff7fdff 0003968 0000564  14.2%   0.0% isrwork 0x70031240 0x70031290
   39     0 189 FIFO     Kthread   - Waiting  Semaphore fffffffffff7fdff 0003904 0001372  35.1%   0.0% rpmsg-core1-0 0x70033020 0x70033070
   40     0 200 FIFO     Kthread   - Waiting  Semaphore fffffffffff7fdff 0003904 0001212  31.0%   0.0% rpmsg-core1_1-0 0x70034710 0x70034760
   41     0 189 FIFO     Kthread   - Waiting  Semaphore fffffffffff7fdff 0003904 0001372  35.1%   0.0% rpmsg-core2-0 0x70029c08 0x70029c58
   42     0 189 FIFO     Kthread   - Waiting  Semaphore fffffffffff7fdff 0003968 0001372  34.5%   0.0% rpmsg-core3-0 0x7002a2a0 0x7002a2f0
   43     0 189 FIFO     Kthread   - Waiting  Semaphore fffffffffff7fdff 0003904 0001372  35.1%   0.0% rpmsg-core4-0 0x7002a5a8 0x7002a5f8
   47     0 189 FIFO     Kthread   - Waiting  Semaphore fffffffffff7fdff 0003968 0001372  34.5%   0.0% rpmsg-core5-0 0x7002c280 0x7002c2d0
   49     0 199 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0003968 0001256  31.6%   0.7% BSW_TASK_5MS_C0
   50     0 197 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0003968 0001892  47.6%   2.3% BSW_TASK_10MS_C0
   51     0 195 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0003968 0001304  32.8%   0.1% BSW_TASK_20MS_C0
   52     0 193 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0003968 0001256  31.6%   0.0% BSW_TASK_50MS_C0
   53     0 191 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0003968 0001884  47.4%   0.1% BSW_TASK_100MS_C0
   54     0 101 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0003904 0001396  35.7%   0.0% autocore_macc 0xb0036094
```

System continues running normally after kthread exit. No crash, no assert, no corruption of g_kthread_group resources. PID 48 (rpmsg-corecs-0) successfully destroyed while 20+ other kernel threads sharing the same g_kthread_group remain healthy.
