### PR TITLE
espressif: Add CMake build paths for Xtensa ESP32 chips and esp32c3-legacy.

### DIFF
--- a/arch/risc-v/src/esp32c3-legacy/CMakeLists.txt
+++ b/arch/risc-v/src/esp32c3-legacy/CMakeLists.txt
@@ -1,0 +1,44 @@
+# ##############################################################################
+# arch/risc-v/src/esp32c3-legacy/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../common/espressif espressif)
+
+set(SRCS
+    esp32c3_head.S
+    esp32c3_vectors.S
+    esp32c3_allocateheap.c
+    esp32c3_start.c
+    esp32c3_wdt.c
+    esp32c3_idle.c
+    esp32c3_irq.c
+    esp32c3_libc_stubs.c
+    esp32c3_clockconfig.c
+    esp32c3_gpio.c
+    esp32c3_rtc_gpio.c
+    esp32c3_lowputc.c
+    esp32c3_serial.c
+    esp32c3_systemreset.c
+    esp32c3_resetcause.c
+    esp32c3_uid.c
+    esp32c3_perf.c
+    esp32c3_rtc.c)
+
+if(CONFIG_SCHED_TICKLESS)
+  list(APPEND SRCS esp32c3_tickless.c)
+else()
+  list(APPEND SRCS esp32c3_timerisr.c)
+endif()
+
+if(CONFIG_ESPRESSIF_WIFI)
+  list(APPEND SRCS esp32c3_wifi_adapter.c)
+endif()
+
+if(CONFIG_ESPRESSIF_BLE)
+  list(APPEND SRCS esp32c3_ble_adapter.c esp32c3_ble.c)
+endif()
+
+target_compile_definitions(arch PRIVATE _RETARGETABLE_LOCKING)
+target_sources(arch PRIVATE ${SRCS})

--- a/arch/risc-v/src/esp32c3-legacy/hal_esp32c3-legacy.cmake
+++ b/arch/risc-v/src/esp32c3-legacy/hal_esp32c3-legacy.cmake
@@ -1,0 +1,8 @@
+# ##############################################################################
+# arch/risc-v/src/esp32c3-legacy/hal_esp32c3-legacy.cmake
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+set(CHIP_SERIES esp32c3)
+include(${NUTTX_ARCH_ABS_DIR}/src/esp32c3/hal_esp32c3.cmake)

--- a/arch/xtensa/src/common/espressif/CMakeLists.txt
+++ b/arch/xtensa/src/common/espressif/CMakeLists.txt
@@ -1,0 +1,137 @@
+# ##############################################################################
+# arch/xtensa/src/common/espressif/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+set(SRCS)
+
+if(CONFIG_ESP_RMT)
+  list(APPEND SRCS esp_rmt.c)
+  if(CONFIG_DRIVERS_RC)
+    list(APPEND SRCS esp_lirc.c)
+  endif()
+  if(CONFIG_WS2812_NON_SPI_DRIVER)
+    list(APPEND SRCS esp_ws2812.c)
+  endif()
+endif()
+
+if(CONFIG_ESP_MCPWM)
+  list(APPEND SRCS esp_mcpwm.c)
+endif()
+
+if(CONFIG_ESPRESSIF_SIMPLE_BOOT
+   OR CONFIG_ESP32_APP_FORMAT_MCUBOOT
+   OR CONFIG_ESP32S2_APP_FORMAT_MCUBOOT
+   OR CONFIG_ESP32S3_APP_FORMAT_MCUBOOT)
+  list(APPEND SRCS esp_loader.c)
+endif()
+
+if(CONFIG_ESPRESSIF_TEMP)
+  list(APPEND SRCS esp_temperature_sensor.c)
+endif()
+
+if(CONFIG_ESP_SDM)
+  list(APPEND SRCS esp_sdm.c)
+endif()
+
+if(CONFIG_ESPRESSIF_I2S)
+  list(APPEND SRCS esp_i2s.c)
+endif()
+
+if(CONFIG_ESPRESSIF_I2C_BITBANG)
+  list(APPEND SRCS esp_i2c_bitbang.c)
+endif()
+
+if(CONFIG_ESPRESSIF_SPI_BITBANG)
+  list(APPEND SRCS esp_spi_bitbang.c)
+endif()
+
+if(CONFIG_ESP_PCNT)
+  list(APPEND SRCS esp_pcnt.c)
+  if(CONFIG_ESP_PCNT_AS_QE)
+    list(APPEND SRCS esp_qencoder.c)
+  endif()
+endif()
+
+if(CONFIG_ESPRESSIF_LEDC)
+  list(APPEND SRCS esp_ledc.c)
+endif()
+
+if(CONFIG_ESPRESSIF_SPIFLASH)
+  list(APPEND SRCS esp_spiflash.c)
+  if(CONFIG_ESPRESSIF_MTD)
+    list(APPEND SRCS esp_spiflash_mtd.c)
+  endif()
+endif()
+
+if(CONFIG_ESPRESSIF_I2C_PERIPH_SLAVE_MODE)
+  list(APPEND SRCS esp_i2c_slave.c)
+endif()
+
+if(CONFIG_ESPRESSIF_DEDICATED_GPIO)
+  list(APPEND SRCS esp_dedic_gpio.c)
+endif()
+
+if(CONFIG_ESPRESSIF_SHA_ACCELERATOR)
+  list(APPEND SRCS esp_sha.c)
+endif()
+
+if(CONFIG_ESPRESSIF_AES_ACCELERATOR)
+  list(APPEND SRCS esp_aes.c)
+endif()
+
+if(NOT CONFIG_ARCH_CHIP_ESP32 AND CONFIG_CRYPTO_CRYPTODEV_HARDWARE)
+  list(APPEND SRCS esp_crypto.c)
+endif()
+
+if(CONFIG_ESPRESSIF_USE_ULP_RISCV_CORE)
+  list(APPEND SRCS esp_ulp.c)
+endif()
+
+if(CONFIG_SYSTEM_NXDIAG_ESPRESSIF_CHIP_WO_TOOL)
+  list(APPEND SRCS esp_nxdiag.c)
+endif()
+
+if(CONFIG_ESPRESSIF_WIRELESS)
+  list(APPEND SRCS esp_wireless.c esp_wifi_utils.c)
+  if(CONFIG_ESPRESSIF_WIFI)
+    list(APPEND SRCS esp_wifi_event_handler.c esp_wlan_netdev.c esp_wifi_api.c)
+  endif()
+  if(CONFIG_ESPRESSIF_ESPNOW_PKTRADIO)
+    list(APPEND SRCS esp_espnow_pktradio.c)
+  endif()
+endif()
+
+if(CONFIG_ESPRESSIF_ADC)
+  list(APPEND SRCS esp_adc.c)
+endif()
+
+if(CONFIG_PM)
+  if(NOT CONFIG_ARCH_CUSTOM_PMINIT)
+    list(APPEND SRCS esp_pm_initialize.c)
+  endif()
+  list(APPEND SRCS esp_pm.c)
+endif()
+
+list(APPEND SRCS esp_efuse.c esp_irq.c esp_xtensa_intr.c esp_gpio.c)
+
+if(CONFIG_RTC_DRIVER)
+  list(APPEND SRCS esp_rtc.c)
+endif()
+
+if(CONFIG_ESPRESSIF_HR_TIMER)
+  list(APPEND SRCS esp_timer_adapter.c)
+endif()
+
+target_compile_options(arch PRIVATE -Wno-shadow -Wno-undef)
+target_link_options(nuttx PRIVATE "SHELL:-u esp_system_include_startup_funcs"
+                    "SHELL:-u esp_timer_init_include_func")
+
+if(CONFIG_ESPRESSIF_EFUSE)
+  target_link_options(nuttx PRIVATE "SHELL:-u esp_efuse_startup_include_func")
+endif()
+
+target_include_directories(arch
+                           PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/platform_include)
+target_sources(arch PRIVATE ${SRCS})

--- a/arch/xtensa/src/common/espressif/hal_xtensa_espressif.cmake
+++ b/arch/xtensa/src/common/espressif/hal_xtensa_espressif.cmake
@@ -1,0 +1,96 @@
+# ##############################################################################
+# arch/xtensa/src/common/espressif/hal_xtensa_espressif.cmake
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+if(NOT EXISTS ${ESP_HAL_3RDPARTY_REPO})
+  message(
+    FATAL_ERROR
+      "ESP_HAL_3RDPARTY_REPO does not exist: ${ESP_HAL_3RDPARTY_REPO}. Please ensure the HAL 3rd party repository is cloned correctly."
+  )
+endif()
+
+target_include_directories(
+  arch
+  PRIVATE
+    ${ESP_HAL_3RDPARTY_REPO}/nuttx/include
+    ${ESP_HAL_3RDPARTY_REPO}/nuttx/include/mbedtls
+    ${ESP_HAL_3RDPARTY_REPO}/nuttx/${CHIP_SERIES}/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/bootloader_support/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/bootloader_support/private_include
+    ${ESP_HAL_3RDPARTY_REPO}/components/bootloader_support/bootloader_flash/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/efuse/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/efuse/private_include
+    ${ESP_HAL_3RDPARTY_REPO}/components/efuse/${CHIP_SERIES}/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/esp_common/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/esp_event/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/esp_adc/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/esp_adc/interface
+    ${ESP_HAL_3RDPARTY_REPO}/components/esp_hw_support/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/esp_hw_support/include/esp_private
+    ${ESP_HAL_3RDPARTY_REPO}/components/esp_hw_support/include/soc
+    ${ESP_HAL_3RDPARTY_REPO}/components/esp_hw_support/include/soc/${CHIP_SERIES}
+    ${ESP_HAL_3RDPARTY_REPO}/components/esp_mm/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/esp_phy/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/esp_phy/${CHIP_SERIES}/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/esp_pm/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/esp_rom/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/esp_rom/${CHIP_SERIES}
+    ${ESP_HAL_3RDPARTY_REPO}/components/esp_rom/${CHIP_SERIES}/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/esp_system/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/esp_system/port/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/esp_timer/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/esp_timer/private_include
+    ${ESP_HAL_3RDPARTY_REPO}/components/hal/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/hal/${CHIP_SERIES}/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/log/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/mbedtls/port/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/mbedtls/mbedtls/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/soc/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/soc/${CHIP_SERIES}/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/soc/${CHIP_SERIES}/register
+    ${ESP_HAL_3RDPARTY_REPO}/components/spi_flash/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/spi_flash/include/esp_flash_chips
+    ${ESP_HAL_3RDPARTY_REPO}/components/xtensa/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/xtensa/${CHIP_SERIES}/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/upper_hal_gpio/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/upper_hal_rmt/include
+    ${ESP_HAL_3RDPARTY_REPO}/components/upper_hal_rmt/src
+    ${ESP_HAL_3RDPARTY_REPO}/nuttx/src/components/esp_libc/platform_include)
+
+set(ESP_ROM_LD_DIR
+    ${ESP_HAL_3RDPARTY_REPO}/components/esp_rom/${CHIP_SERIES}/ld)
+set(ESP_SOC_LD_DIR ${ESP_HAL_3RDPARTY_REPO}/components/soc/${CHIP_SERIES}/ld)
+set_property(
+  GLOBAL APPEND
+  PROPERTY LD_SCRIPT ${ESP_ROM_LD_DIR}/${CHIP_SERIES}.rom.api.ld
+           ${ESP_ROM_LD_DIR}/${CHIP_SERIES}.rom.ld
+           ${ESP_SOC_LD_DIR}/${CHIP_SERIES}.peripherals.ld)
+
+set(HAL_SRCS)
+list(
+  APPEND
+  HAL_SRCS
+  ${ESP_HAL_3RDPARTY_REPO}/components/esp_common/src/esp_err_to_name.c
+  ${ESP_HAL_3RDPARTY_REPO}/components/esp_system/esp_system.c
+  ${ESP_HAL_3RDPARTY_REPO}/components/esp_system/esp_err.c
+  ${ESP_HAL_3RDPARTY_REPO}/components/esp_system/startup.c
+  ${ESP_HAL_3RDPARTY_REPO}/components/esp_system/startup_funcs.c
+  ${ESP_HAL_3RDPARTY_REPO}/components/esp_timer/src/esp_timer.c
+  ${ESP_HAL_3RDPARTY_REPO}/components/esp_timer/src/esp_timer_impl_common.c
+  ${ESP_HAL_3RDPARTY_REPO}/components/efuse/src/esp_efuse_api.c
+  ${ESP_HAL_3RDPARTY_REPO}/components/efuse/src/esp_efuse_utility.c
+  ${ESP_HAL_3RDPARTY_REPO}/components/efuse/${CHIP_SERIES}/esp_efuse_fields.c
+  ${ESP_HAL_3RDPARTY_REPO}/components/bootloader_support/src/flash_encrypt.c
+  ${ESP_HAL_3RDPARTY_REPO}/components/bootloader_support/bootloader_flash/src/bootloader_flash.c
+  ${ESP_HAL_3RDPARTY_REPO}/components/esp_rom/patches/esp_rom_sys.c
+  ${ESP_HAL_3RDPARTY_REPO}/components/esp_rom/patches/esp_rom_print.c
+  ${ESP_HAL_3RDPARTY_REPO}/components/spi_flash/esp_flash_api.c
+  ${ESP_HAL_3RDPARTY_REPO}/components/spi_flash/spi_flash_wrap.c
+  ${ESP_HAL_3RDPARTY_REPO}/components/log/src/log.c
+  ${ESP_HAL_3RDPARTY_REPO}/components/upper_hal_gpio/src/gpio.c
+  ${ESP_HAL_3RDPARTY_REPO}/nuttx/src/platform/os.c
+  ${ESP_HAL_3RDPARTY_REPO}/nuttx/src/heap_caps.c)
+
+target_sources(arch PRIVATE ${HAL_SRCS})

--- a/arch/xtensa/src/esp32/CMakeLists.txt
+++ b/arch/xtensa/src/esp32/CMakeLists.txt
@@ -1,0 +1,44 @@
+# ##############################################################################
+# arch/xtensa/src/esp32/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../common/espressif espressif)
+
+set(SRCS
+    esp32_start.c
+    esp32_wdt.c
+    esp32_allocateheap.c
+    esp32_systemreset.c
+    esp32_resetcause.c
+    esp32_region.c
+    esp32_rtc_gpio.c
+    esp32_user.c
+    esp32_libc_stubs.c
+    esp32_dma.c)
+
+if(NOT CONFIG_ARCH_IDLE_CUSTOM)
+  list(APPEND SRCS esp32_idle.c)
+endif()
+
+if(CONFIG_SCHED_TICKLESS)
+  list(APPEND SRCS esp32_tickless.c)
+else()
+  list(APPEND SRCS esp32_timerisr.c)
+endif()
+
+if(CONFIG_ESPRESSIF_WIFI)
+  list(APPEND SRCS esp32_wifi_adapter.c)
+endif()
+
+if(CONFIG_ESPRESSIF_BLE)
+  list(APPEND SRCS esp32_ble_adapter.c esp32_ble.c)
+endif()
+
+if(CONFIG_XTENSA_HAVE_WINDOW_EXCEPTION_HOOKS)
+  list(APPEND SRCS esp32_window_hooks.S)
+endif()
+
+target_compile_definitions(arch PRIVATE ESP_PLATFORM=1)
+target_sources(arch PRIVATE ${SRCS})

--- a/arch/xtensa/src/esp32/hal_esp32.cmake
+++ b/arch/xtensa/src/esp32/hal_esp32.cmake
@@ -1,0 +1,8 @@
+# ##############################################################################
+# arch/xtensa/src/esp32/hal_esp32.cmake
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+set(CHIP_SERIES esp32)
+include(${NUTTX_ARCH_ABS_DIR}/src/common/espressif/hal_xtensa_espressif.cmake)

--- a/arch/xtensa/src/esp32s2/CMakeLists.txt
+++ b/arch/xtensa/src/esp32s2/CMakeLists.txt
@@ -1,0 +1,34 @@
+# ##############################################################################
+# arch/xtensa/src/esp32s2/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../common/espressif espressif)
+
+set(SRCS
+    esp32s2_start.c
+    esp32s2_wdt.c
+    esp32s2_allocateheap.c
+    esp32s2_rtc_gpio.c
+    esp32s2_region.c
+    esp32s2_user.c
+    esp32s2_lowputc.c
+    esp32s2_systemreset.c
+    esp32s2_dma.c
+    esp32s2_libc_stubs.c)
+
+if(NOT CONFIG_ARCH_IDLE_CUSTOM)
+  list(APPEND SRCS esp32s2_idle.c)
+endif()
+
+if(NOT CONFIG_SCHED_TICKLESS)
+  list(APPEND SRCS esp32s2_timerisr.c)
+endif()
+
+if(CONFIG_ESPRESSIF_WIFI)
+  list(APPEND SRCS esp32s2_wifi_adapter.c)
+endif()
+
+target_compile_definitions(arch PRIVATE ESP_PLATFORM=1)
+target_sources(arch PRIVATE ${SRCS})

--- a/arch/xtensa/src/esp32s2/hal_esp32s2.cmake
+++ b/arch/xtensa/src/esp32s2/hal_esp32s2.cmake
@@ -1,0 +1,8 @@
+# ##############################################################################
+# arch/xtensa/src/esp32s2/hal_esp32s2.cmake
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+set(CHIP_SERIES esp32s2)
+include(${NUTTX_ARCH_ABS_DIR}/src/common/espressif/hal_xtensa_espressif.cmake)

--- a/arch/xtensa/src/esp32s3/CMakeLists.txt
+++ b/arch/xtensa/src/esp32s3/CMakeLists.txt
@@ -1,0 +1,43 @@
+# ##############################################################################
+# arch/xtensa/src/esp32s3/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../common/espressif espressif)
+
+set(SRCS
+    esp32s3_start.c
+    esp32s3_cache.c
+    esp32s3_region.c
+    esp32s3_systemreset.c
+    esp32s3_user.c
+    esp32s3_allocateheap.c
+    esp32s3_reset_reasons.c
+    esp32s3_wdt.c
+    esp32s3_lowputc.c
+    esp32s3_serial.c
+    esp32s3_rtc_gpio.c
+    esp32s3_libc_stubs.c
+    esp32s3_spi_timing.c)
+
+if(NOT CONFIG_ARCH_IDLE_CUSTOM)
+  list(APPEND SRCS esp32s3_idle.c)
+endif()
+
+if(CONFIG_SCHED_TICKLESS)
+  list(APPEND SRCS esp32s3_tickless.c)
+else()
+  list(APPEND SRCS esp32s3_timerisr.c)
+endif()
+
+if(CONFIG_ESPRESSIF_WIFI)
+  list(APPEND SRCS esp32s3_wifi_adapter.c)
+endif()
+
+if(CONFIG_ESPRESSIF_BLE)
+  list(APPEND SRCS esp32s3_ble_adapter.c esp32s3_ble.c)
+endif()
+
+target_compile_definitions(arch PRIVATE _RETARGETABLE_LOCKING ESP_PLATFORM=1)
+target_sources(arch PRIVATE ${SRCS})

--- a/arch/xtensa/src/esp32s3/hal_esp32s3.cmake
+++ b/arch/xtensa/src/esp32s3/hal_esp32s3.cmake
@@ -1,0 +1,8 @@
+# ##############################################################################
+# arch/xtensa/src/esp32s3/hal_esp32s3.cmake
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+set(CHIP_SERIES esp32s3)
+include(${NUTTX_ARCH_ABS_DIR}/src/common/espressif/hal_xtensa_espressif.cmake)

--- a/boards/risc-v/esp32c3-legacy/common/CMakeLists.txt
+++ b/boards/risc-v/esp32c3-legacy/common/CMakeLists.txt
@@ -1,0 +1,8 @@
+# ##############################################################################
+# boards/risc-v/esp32c3-legacy/common/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+add_subdirectory(src)
+target_include_directories(board PRIVATE include)

--- a/boards/risc-v/esp32c3-legacy/common/src/CMakeLists.txt
+++ b/boards/risc-v/esp32c3-legacy/common/src/CMakeLists.txt
@@ -1,0 +1,24 @@
+# ##############################################################################
+# boards/risc-v/esp32c3-legacy/common/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+set(SRCS)
+
+if(CONFIG_ARCH_BOARD_COMMON)
+  if(CONFIG_ESP32C3_SPI)
+    list(APPEND SRCS esp32c3_board_spi.c)
+  endif()
+  if(CONFIG_SPI_DRIVER)
+    list(APPEND SRCS esp32c3_board_spidev.c)
+  endif()
+  if(CONFIG_SPI_SLAVE_DRIVER)
+    list(APPEND SRCS esp32c3_board_spislavedev.c)
+  endif()
+  if(CONFIG_WATCHDOG)
+    list(APPEND SRCS esp32c3_board_wdt.c)
+  endif()
+endif()
+
+target_sources(board PRIVATE ${SRCS})

--- a/boards/risc-v/esp32c3-legacy/esp32c3-legacy-devkit/CMakeLists.txt
+++ b/boards/risc-v/esp32c3-legacy/esp32c3-legacy-devkit/CMakeLists.txt
@@ -1,0 +1,11 @@
+# ##############################################################################
+# boards/risc-v/esp32c3-legacy/esp32c3-legacy-devkit/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../common/CMakeLists.txt")
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../common common)
+endif()
+
+add_subdirectory(src)

--- a/boards/risc-v/esp32c3-legacy/esp32c3-legacy-devkit/src/CMakeLists.txt
+++ b/boards/risc-v/esp32c3-legacy/esp32c3-legacy-devkit/src/CMakeLists.txt
@@ -1,0 +1,20 @@
+# ##############################################################################
+# boards/risc-v/esp32c3-legacy/esp32c3-legacy-devkit/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+set(SRCS esp32c3_boot.c esp32c3_bringup.c)
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS esp32c3_appinit.c)
+  if(CONFIG_BOARDCTL_RESET)
+    list(APPEND SRCS esp32c3_reset.c)
+  endif()
+endif()
+
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS esp32c3_gpio.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})

--- a/boards/xtensa/esp32/common/CMakeLists.txt
+++ b/boards/xtensa/esp32/common/CMakeLists.txt
@@ -1,0 +1,8 @@
+# ##############################################################################
+# boards/xtensa/esp32/common/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+add_subdirectory(src)
+target_include_directories(board PRIVATE include)

--- a/boards/xtensa/esp32/common/src/CMakeLists.txt
+++ b/boards/xtensa/esp32/common/src/CMakeLists.txt
@@ -1,0 +1,36 @@
+# ##############################################################################
+# boards/xtensa/esp32/common/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+set(SRCS)
+
+if(CONFIG_ARCH_BOARD_COMMON)
+  if(CONFIG_WATCHDOG)
+    list(APPEND SRCS esp32_board_wdt.c)
+  endif()
+  if(CONFIG_ESPRESSIF_ADC)
+    list(APPEND SRCS esp32_board_adc.c)
+  endif()
+  if(CONFIG_ESP32_I2C)
+    list(APPEND SRCS esp32_board_i2c.c)
+  endif()
+  if(CONFIG_ESP32_SPI)
+    list(APPEND SRCS esp32_board_spi.c)
+  endif()
+  if(CONFIG_SPI_DRIVER)
+    list(APPEND SRCS esp32_board_spidev.c)
+  endif()
+  if(CONFIG_SPI_SLAVE_DRIVER)
+    list(APPEND SRCS esp32_board_spislavedev.c)
+  endif()
+  if(CONFIG_ESP32_SPIFLASH)
+    list(APPEND SRCS esp32_board_spiflash.c)
+  endif()
+  if(CONFIG_ESPRESSIF_WIFI)
+    list(APPEND SRCS esp32_board_wlan.c)
+  endif()
+endif()
+
+target_sources(board PRIVATE ${SRCS})

--- a/boards/xtensa/esp32/esp32-devkitc/CMakeLists.txt
+++ b/boards/xtensa/esp32/esp32-devkitc/CMakeLists.txt
@@ -1,0 +1,11 @@
+# ##############################################################################
+# boards/xtensa/esp32/esp32-devkitc/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../common/CMakeLists.txt")
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../common common)
+endif()
+
+add_subdirectory(src)

--- a/boards/xtensa/esp32/esp32-devkitc/src/CMakeLists.txt
+++ b/boards/xtensa/esp32/esp32-devkitc/src/CMakeLists.txt
@@ -1,0 +1,24 @@
+# ##############################################################################
+# boards/xtensa/esp32/esp32-devkitc/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+set(SRCS esp32_boot.c esp32_bringup.c)
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS esp32_appinit.c)
+  if(CONFIG_BOARDCTL_RESET)
+    list(APPEND SRCS esp32_reset.c)
+  endif()
+endif()
+
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS esp32_gpio.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS esp32_buttons.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})

--- a/boards/xtensa/esp32s2/common/CMakeLists.txt
+++ b/boards/xtensa/esp32s2/common/CMakeLists.txt
@@ -1,0 +1,8 @@
+# ##############################################################################
+# boards/xtensa/esp32s2/common/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+add_subdirectory(src)
+target_include_directories(board PRIVATE include)

--- a/boards/xtensa/esp32s2/common/src/CMakeLists.txt
+++ b/boards/xtensa/esp32s2/common/src/CMakeLists.txt
@@ -1,0 +1,27 @@
+# ##############################################################################
+# boards/xtensa/esp32s2/common/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+set(SRCS)
+
+if(CONFIG_ARCH_BOARD_COMMON)
+  if(CONFIG_ESPRESSIF_ADC)
+    list(APPEND SRCS esp32s2_board_adc.c)
+  endif()
+  if(CONFIG_WATCHDOG)
+    list(APPEND SRCS esp32s2_board_wdt.c)
+  endif()
+  if(CONFIG_ESP32S2_SPI)
+    list(APPEND SRCS esp32s2_board_spi.c)
+  endif()
+  if(CONFIG_SPI_DRIVER)
+    list(APPEND SRCS esp32s2_board_spidev.c)
+  endif()
+  if(CONFIG_SPI_SLAVE_DRIVER)
+    list(APPEND SRCS esp32s2_board_spislavedev.c)
+  endif()
+endif()
+
+target_sources(board PRIVATE ${SRCS})

--- a/boards/xtensa/esp32s2/esp32s2-saola-1/CMakeLists.txt
+++ b/boards/xtensa/esp32s2/esp32s2-saola-1/CMakeLists.txt
@@ -1,0 +1,11 @@
+# ##############################################################################
+# boards/xtensa/esp32s2/esp32s2-saola-1/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../common/CMakeLists.txt")
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../common common)
+endif()
+
+add_subdirectory(src)

--- a/boards/xtensa/esp32s2/esp32s2-saola-1/src/CMakeLists.txt
+++ b/boards/xtensa/esp32s2/esp32s2-saola-1/src/CMakeLists.txt
@@ -1,0 +1,20 @@
+# ##############################################################################
+# boards/xtensa/esp32s2/esp32s2-saola-1/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+set(SRCS esp32s2_boot.c esp32s2_bringup.c)
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS esp32s2_appinit.c)
+  if(CONFIG_BOARDCTL_RESET)
+    list(APPEND SRCS esp32s2_reset.c)
+  endif()
+endif()
+
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS esp32s2_gpio.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})

--- a/boards/xtensa/esp32s3/common/CMakeLists.txt
+++ b/boards/xtensa/esp32s3/common/CMakeLists.txt
@@ -1,0 +1,8 @@
+# ##############################################################################
+# boards/xtensa/esp32s3/common/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+add_subdirectory(src)
+target_include_directories(board PRIVATE include)

--- a/boards/xtensa/esp32s3/common/src/CMakeLists.txt
+++ b/boards/xtensa/esp32s3/common/src/CMakeLists.txt
@@ -1,0 +1,24 @@
+# ##############################################################################
+# boards/xtensa/esp32s3/common/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+set(SRCS)
+
+if(CONFIG_ARCH_BOARD_COMMON)
+  if(CONFIG_ESP32S3_TIMER)
+    list(APPEND SRCS esp32s3_board_tim.c)
+  endif()
+  if(CONFIG_WATCHDOG)
+    list(APPEND SRCS esp32s3_board_wdt.c)
+  endif()
+  if(CONFIG_ESP32S3_SPIFLASH)
+    list(APPEND SRCS esp32s3_board_spiflash.c)
+  endif()
+  if(CONFIG_SPI_DRIVER)
+    list(APPEND SRCS esp32s3_board_spidev.c)
+  endif()
+endif()
+
+target_sources(board PRIVATE ${SRCS})

--- a/boards/xtensa/esp32s3/esp32s3-devkit/CMakeLists.txt
+++ b/boards/xtensa/esp32s3/esp32s3-devkit/CMakeLists.txt
@@ -1,0 +1,11 @@
+# ##############################################################################
+# boards/xtensa/esp32s3/esp32s3-devkit/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+if(EXISTS "${CMAKE_CURRENT_SOURCE_DIR}/../common/CMakeLists.txt")
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../common common)
+endif()
+
+add_subdirectory(src)

--- a/boards/xtensa/esp32s3/esp32s3-devkit/src/CMakeLists.txt
+++ b/boards/xtensa/esp32s3/esp32s3-devkit/src/CMakeLists.txt
@@ -1,0 +1,24 @@
+# ##############################################################################
+# boards/xtensa/esp32s3/esp32s3-devkit/src/CMakeLists.txt
+#
+# SPDX-License-Identifier: Apache-2.0
+# ##############################################################################
+
+set(SRCS esp32s3_boot.c esp32s3_bringup.c)
+
+if(CONFIG_BOARDCTL)
+  list(APPEND SRCS esp32s3_appinit.c)
+  if(CONFIG_BOARDCTL_RESET)
+    list(APPEND SRCS esp32s3_reset.c)
+  endif()
+endif()
+
+if(CONFIG_DEV_GPIO)
+  list(APPEND SRCS esp32s3_gpio.c)
+endif()
+
+if(CONFIG_ARCH_BUTTONS)
+  list(APPEND SRCS esp32s3_buttons.c)
+endif()
+
+target_sources(board PRIVATE ${SRCS})


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Extends the NuttX **CMake** flow for Espressif targets that were mainly covered by Make before.

- **Xtensa (`arch/xtensa`):** Shared Espressif Xtensa CMake under `arch/xtensa/src/common/espressif/`, plus chip `CMakeLists.txt` / `hal_*.cmake` for **ESP32**, **ESP32-S2**, and **ESP32-S3** (HAL includes via `ESP_HAL_3RDPARTY_REPO` / `CHIP_SERIES`).
- **Boards (`boards/xtensa`):** `CMakeLists.txt` for **common**, **common/src**, and **esp32-devkitc**, **esp32s2-saola-1**, **esp32s3-devkit**.
- **Legacy RISC-V:** CMake for **esp32c3-legacy** and **esp32c3-legacy-devkit** (`hal_esp32c3-legacy.cmake` and board/common CMake).

Additive build-system files only; no runtime OS logic changes in this PR.

## Impact

- **Users:** CMake builds for the listed Xtensa boards and `esp32c3-legacy-devkit` gain explicit wiring; Make builds are unaffected by these files.
- **Build / hardware:** As above; no Kconfig changes in this scope.
- **Docs / security / compatibility:** No doc changes; no new security surface; backward compatible for Make users.

## Testing

**Hardware:** I do **not** have Espressif boards available, so I could **not** flash images, exercise the serial console, or run on-target tests (e.g. NSH, drivers).

**Build / CI:** This change is CMake-only (new `CMakeLists.txt` / `.cmake` wiring). Please rely on **NuttX CI** and/or a maintainer/local build with the documented Espressif toolchains and `esp-hal-3rdparty` checkout for full configure + link verification, for example:

```text
cd nuttx
cmake -B build -DBOARD_CONFIG=esp32-devkitc:nsh -GNinja
cmake --build build