### PR TITLE
fs/vfs: allow NULL iov_base in KERNEL build with zero-based text

### DIFF
--- a/fs/vfs/fs_read.c
+++ b/fs/vfs/fs_read.c
@@ -178,6 +178,7 @@ ssize_t file_readv(FAR struct file *filep,
 
   /* Are all iov_base accessible? */
 
+#if !defined(CONFIG_BUILD_KERNEL) || CONFIG_ARCH_TEXT_VBASE != 0
   for (ret = 0; ret < iovcnt; ret++)
     {
       if (iov[ret].iov_base == NULL && iov[ret].iov_len != 0)
@@ -185,6 +186,7 @@ ssize_t file_readv(FAR struct file *filep,
           return -EFAULT;
         }
     }
+#endif
 
   ret = -EBADF;
 


### PR DESCRIPTION
## Summary

This commit fixes a regression introduced by
89df084b0e51593643ccc2f6427ac11c99243295. That commit added a check to ensure iov_base is not NULL, assuming NULL always represents an inaccessible address.

However, in CONFIG_BUILD_KERNEL mode where CONFIG_ARCH_TEXT_VBASE is set to 0, address zero is a valid virtual address for the user-space text segment. The previous check caused libelf to fail with -EFAULT when attempting to load ELF program headers into the base of the user address space.

This patch wraps the safety check in a conditional to ensure it is only executed when address zero is not considered a valid executable base.

## Impact

Make kernel builds work on armv7a again

## Testing

Successfully reached the NuttShell prompt

NuttShell (NSH) NuttX-12.13.0                                                                          
knsh>  /bin/hello                                                                                       
Hello, World!!                                                                                         
knsh> 

Without this change this change the machine does not run NuttShell.

[    0.000000] libelf_loadfile: Loading sections - text: 0.b530 data: 0x80101000.7a8                   
[    0.000000] libelf_read: ERROR: Read from offset 56 failed: 14                                      
[    0.010000] libelf_loadfile: ERROR: Failed to read section 1: -14                                   
[    0.020000] libelf_load_with_addrenv: ERROR: libelf_loadfile failed: -14                            
[    0.020000] elf_loadbinary: Failed to load ELF program binary: -14                                  
[    0.030000] exec_internal: ERROR: Failed to load program '/bin/init': -14   
