### PR TITLE
drivers/fb: Fix a symbol missing CONFIG_

### DIFF
--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -2046,7 +2046,7 @@ int fb_register_device(int display, int plane,
       nxsched_sleep(SPLASH_SLEEP);
     }
 
-#  ifdef VIDEO_FB_SPLASHSCREEN_CLR_ON_EXIT
+#  ifdef CONFIG_VIDEO_FB_SPLASHSCREEN_CLR_ON_EXIT
   ret = fb_splash_fill(&vinfo, &pinfo, 0); /* Fill with black to clear LCD  */
   if (ret < 0)
     {


### PR DESCRIPTION

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This was a mistake that was preventing the boot logo to be cleared after boot.

## Impact

Now NX Logo will disappear  after the expected time. 

## Testing

NuttShell (NSH) NuttX-12.13.0
nsh> fb
VideoInfo:
      fmt: 6
     xres: 320
     yres: 240
  nplanes: 1
PlaneInfo (plane 0):
    fbmem: 0x170368
    fblen: 76800
   stride: 320
  display: 0
      bpp: 8
Mapped FB: 0x170368
 0: (  0,  0) (320,240)
 1: ( 29, 21) (262,198)
 2: ( 58, 42) (204,156)
 3: ( 87, 63) (146,114)
 4: (116, 84) ( 88, 72)
 5: (145,105) ( 30, 30)
Test finished
nsh>