### PR TITLE
include/errno.h: skip set_errno in interrupt context

### DIFF
--- a/include/errno.h
+++ b/include/errno.h
@@ -29,6 +29,10 @@
 
 #include <nuttx/compiler.h>
 
+#if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
+#  include <nuttx/irq.h>
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -41,12 +45,24 @@
  */
 
 #define errno *__errno()
+#if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
+#define set_errno(e) \
+  do \
+    { \
+      if (!up_interrupt_context()) \
+        { \
+          errno = (int)(e); \
+        } \
+    } \
+  while (0)
+#else
 #define set_errno(e) \
   do \
     { \
       errno = (int)(e); \
     } \
   while (0)
+#endif
 #define get_errno() errno
 
 /* Definitions of error numbers and the string that would be


### PR DESCRIPTION
## Summary

* **Why:** `errno` is defined as a per-thread value. When `set_errno()` is called from an interrupt handler, it currently modifies the interrupted task's `errno`, which violates POSIX semantics because the interrupted task did not request the failing operation.
* **What:** Add an `up_interrupt_context()` guard inside the `set_errno()` macro so that the assignment is skipped when running in an interrupt handler.
* **How:** Include `<nuttx/irq.h>` and wrap the `errno = (int)(e)` assignment with `if (!up_interrupt_context())`.

## Impact

* Is new feature added? Is existing feature changed? NO
* Impact on user (will user need to adapt to change)? NO
* Impact on build (will build process change)? NO
* Impact on hardware (will arch(s) / board(s) / driver(s) change)? NO
* Impact on documentation (is update required / provided)? NO
* Impact on security (any sort of implications)? NO
* Impact on compatibility (backward/forward/interoperability)? NO
* Anything else to consider or add? This is a defensive fix that prevents silent corruption of a task's errno by ISR code.

## Testing

I confirm that changes are verified on local setup and works as intended:

* Build Host(s): Linux x86_64, GCC 13.4.0 (arm-none-eabi)
* Target(s): arm/qemu-armv7a:full

Testing logs after change:

there is no log when do it, I tested this under qemu-armv7a and BES chip.