### PR TITLE
net/icmpv6: Discard Neighbor Discovery packet if optlen is 0

### DIFF
--- a/net/icmpv6/icmpv6_input.c
+++ b/net/icmpv6/icmpv6_input.c
@@ -428,6 +428,15 @@ void icmpv6_input(FAR struct net_driver_s *dev, unsigned int iplen)
            FAR struct icmpv6_generic_s *opt =
                                 (FAR struct icmpv6_generic_s *)&options[ndx];
 
+            /* RFC 4861 4.6: "The value 0 is invalid. Nodes MUST silently
+             * discard a packet that contains an option with length zero."
+             */
+
+            if (opt->optlen == 0)
+              {
+                goto icmpv6_drop_packet;
+              }
+
             switch (opt->opttype)
               {
                 case ICMPv6_OPT_SRCLLADDR:


### PR DESCRIPTION
## Summary

This commit make ICMPv6 on NuttX compliant with RFC4861 ignoring a DN packet when its optlen is 0.

## Impact

Make NuttX compliant with RFC 4861.
 
## Testing

Using sim:nettest

```
$ sudo ./nuttx
...
nsh> ifup eth0
ifup eth0...OK
nsh> ifconfig
eth0	Link encap:Ethernet HWaddr 42:29:9f:00:77:89 at RUNNING mtu 1500
	inet addr:10.0.1.2 DRaddr:10.0.1.1 Mask:255.255.255.0
	inet6 addr: fc00::2/112
	inet6 DRaddr: fc00::1

	RX: Received Fragment Errors   Bytes   
	    0000001e 00000000 00000000 109d            
	    IPv4     IPv6     ARP      Dropped 
	    00000000 0000001e 00000000 00000000
	TX: Queued   Sent     Errors   Timeouts Bytes   
	    00000000 00000000 00000000 00000000 0                
	Total Errors: 00000000

lo	Link encap:Local Loopback at RUNNING mtu 1518
	inet addr:127.0.0.1 DRaddr:127.0.0.1 Mask:255.0.0.0
	inet6 addr: ::1/128
	inet6 DRaddr: ::1

	RX: Received Fragment Errors   Bytes   
	    00000000 00000000 00000000 0               
	    IPv4     IPv6     ARP      Dropped 
	    00000000 00000000 00000000 00000000
	TX: Queued   Sent     Errors   Timeouts Bytes   
	    00000000 00000000 00000000 00000000 0                
	Total Errors: 00000000

             IPv4  IPv6   TCP   UDP  ICMP ICMPv6
Received     0000  001e  0000  000f  0000  000f
Dropped      0000  0000  0000  0000  0000  000f
  IPv4        VHL: 0000   Frg: 0000
  IPv6        VHL: 0000
  Checksum   0000  ----  0000  0000  ----  ----
  TCP         ACK: 0000   SYN: 0000
              RST: 0000  0000
  Type       0000  0000  ----  ----  0000  000e
Sent         0000  0000  0000  0000  0000  0000
  Rexmit     ----  ----  0000  ----  ----  ----
nsh> 
```

In another Linux terminal:

```
$ sudo ip -6 addr add fc00::1/112 dev tap0
$ sudo ip link set tap0 up
$ ping6 -I tap0 -c3 fc00::2
``