### PR TITLE
libs/netdb: Fix dns_recv_response() to dns_answer_s size

### DIFF
--- a/libs/libc/netdb/lib_dnsquery.c
+++ b/libs/libc/netdb/lib_dnsquery.c
@@ -694,6 +694,19 @@ static int dns_recv_response(int sd, FAR union dns_addr_u *addr, int naddr,
           break;
         }
 
+      /* Verify that a complete answer header (10 bytes: type, class,
+       * ttl[2], len) is available before casting to dns_answer_s.
+       * Without this check, accessing ans->ttl and ans->type/class/len
+       * would be an OOB read if fewer than 10 bytes remain.
+       */
+
+      if (nameptr + sizeof(struct dns_answer_s) > endofbuffer)
+        {
+          ret = -EILSEQ;
+          nwarn("DNS answer header truncated\n");
+          break;
+        }
+
       ans = (FAR struct dns_answer_s *)nameptr;
 
       ninfo("Answer: type=%04x, class=%04x, ttl=%06x, length=%04x\n",


### PR DESCRIPTION
## Summary

This commit avoid that dns_recv_response() accepts fewer tha 10 bytes that could end up with an OOB read.

## Impact

Fix a BUG

## Testing

```
Initial NuttX sim default 10.0.1.2 IP:

NuttShell (NSH) NuttX-12.13.0
nsh> ifconfig
eth0	Link encap:Ethernet HWaddr 42:29:9f:00:77:89 at DOWN mtu 1500
	inet addr:10.0.1.2 DRaddr:10.0.1.1 Mask:255.255.255.0
	inet6 addr: fc00::2/112
	inet6 DRaddr: fc00::1

	RX: Received Fragment Errors   Bytes   
	    00000000 00000000 00000000 0               
	    IPv4     IPv6     ARP      Dropped 
	    00000000 00000000 00000000 00000000
	TX: Queued   Sent     Errors   Timeouts Bytes   
	    00000000 00000000 00000000 00000000 0                
	Total Errors: 00000000

lo	Link encap:Local Loopback at RUNNING mtu 1518
	inet addr:127.0.0.1 DRaddr:127.0.0.1 Mask:255.0.0.0
	inet6 addr: ::1/128
	inet6 DRaddr: ::1

	RX: Received Fragment Errors   Bytes   
	    00000000 00000000 00000000 0               
	    IPv4     IPv6     ARP      Dropped 
	    00000000 00000000 00000000 00000000
	TX: Queued   Sent     Errors   Timeouts Bytes   
	    00000000 00000000 00000000 00000000 0                
	Total Errors: 00000000

             IPv4  IPv6   TCP   UDP  ICMP ICMPv6
Received     0000  0000  0000  0000  0000  0000
Dropped      0000  0000  0000  0000  0000  0000
  IPv4        VHL: 0000   Frg: 0000
  IPv6        VHL: 0000
  Checksum   0000  ----  0000  0000  ----  ----
  TCP         ACK: 0000   SYN: 0000
              RST: 0000  0000
  Type       0000  0000  ----  ----  0000  0000
Sent         0000  0000  0000  0000  0000  0000
  Rexmit     ----  ----  0000  ----  ----  ----


Running dnsmasq to server IP to our SIM over tap0:


$ sudo systemctl stop dnsmasq

$ sudo systemctl disable dnsmasq

$ sudo ip addr add 10.0.1.1/24 dev tap0

$ sudo dnsmasq \
  --interface=tap0 \
  --bind-interfaces \
  --dhcp-range=10.0.1.23,10.0.1.45,255.255.255.0,12h \
  --dhcp-option=option:router,10.0.1.1 \
  --dhcp-option=option:dns-server,10.0.1.1 \
  --no-daemon \
  --log-dhcp \
  --log-queries

Try to get the new IP over DHCP on NuttX side:

nsh> renew eth0
[  138.020000] dhcp_obtain_statefuladdr: ERROR: dhcpc request failed: -1
ERROR: netlib_obtain_ipv4addr() failed
nsh> ifup eth0
ifup eth0...OK
nsh> renew eth0
nsh> ifconfig
eth0	Link encap:Ethernet HWaddr 42:29:9f:00:77:89 at RUNNING mtu 1500
	inet addr:10.0.1.41 DRaddr:10.0.1.1 Mask:255.255.255.0
	inet6 addr: fc00::2/112
	inet6 DRaddr: fc00::1

	RX: Received Fragment Errors   Bytes   
	    0000002c 00000000 00000000 19a4            
	    IPv4     IPv6     ARP      Dropped 
	    00000017 00000012 00000003 00000000
	TX: Queued   Sent     Errors   Timeouts Bytes   
	    00000003 00000003 00000000 00000000 3a0              
	Total Errors: 00000000

lo	Link encap:Local Loopback at RUNNING mtu 1518
	inet addr:127.0.0.1 DRaddr:127.0.0.1 Mask:255.0.0.0
	inet6 addr: ::1/128
	inet6 DRaddr: ::1

	RX: Received Fragment Errors   Bytes   
	    00000000 00000000 00000000 0               
	    IPv4     IPv6     ARP      Dropped 
	    00000000 00000000 00000000 00000000
	TX: Queued   Sent     Errors   Timeouts Bytes   
	    00000000 00000000 00000000 00000000 0                
	Total Errors: 00000000

             IPv4  IPv6   TCP   UDP  ICMP ICMPv6
Received     0017  0012  0000  000c  0000  0009
Dropped      0014  0000  0000  0000  0000  0009
  IPv4        VHL: 0000   Frg: 0000
  IPv6        VHL: 0000
  Checksum   0000  ----  0000  0000  ----  ----
  TCP         ACK: 0000   SYN: 0000
              RST: 0000  0000
  Type       0000  0000  ----  ----  0000  0008
Sent         0003  0000  0000  0003  0000  0000
  Rexmit     ----  ----  0000  ----  ----  ----
nsh>
```
