### PR TITLE
net/bluetooth: fix BTPROTO_HCI socket device lookup

### DIFF
--- a/net/bluetooth/bluetooth_sendmsg.c
+++ b/net/bluetooth/bluetooth_sendmsg.c
@@ -75,9 +75,53 @@ struct bluetooth_sendto_s
   ssize_t is_sent;                      /* The number of bytes sent (or error) */
 };
 
+/* Used by bluetooth_dev_byidx_callback to locate the bc_ldev-th BT device */
+
+struct bluetooth_findbyidx_s
+{
+  uint8_t                    bf_tgt;   /* Target index among BT devices (bc_ldev) */
+  uint8_t                    bf_cur;   /* Count of BT devices seen so far */
+  FAR struct radio_driver_s *bf_radio; /* Result */
+};
+
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
+/****************************************************************************
+ * Name: bluetooth_dev_byidx_callback
+ *
+ * Description:
+ *   netdev_foreach callback that finds the bf_tgt-th NET_LL_BLUETOOTH device
+ *   (0-based index among BT devices only).
+ *
+ *   bluetooth_sendto() uses bc_ldev to identify the bound BT device, but
+ *   bc_ldev is a 0-based count among Bluetooth devices only — it bears no
+ *   fixed relationship to the global netdev interface index.  Walking all
+ *   netdevs and counting only NET_LL_BLUETOOTH entries makes the lookup
+ *   independent of what other netdevs are registered and in what order.
+ *
+ ****************************************************************************/
+
+static int bluetooth_dev_byidx_callback(FAR struct net_driver_s *dev,
+                                        FAR void *arg)
+{
+  FAR struct bluetooth_findbyidx_s *match =
+    (FAR struct bluetooth_findbyidx_s *)arg;
+
+  if (dev->d_lltype == NET_LL_BLUETOOTH)
+    {
+      if (match->bf_cur == match->bf_tgt)
+        {
+          match->bf_radio = (FAR struct radio_driver_s *)dev;
+          return 1;
+        }
+
+      match->bf_cur++;
+    }
+
+  return 0;
+}
 
 /****************************************************************************
  * Name: bluetooth_sendto_eventhandler
@@ -279,10 +323,13 @@ static ssize_t bluetooth_sendto(FAR struct socket *psock,
     }
   else if (psock->s_proto == BTPROTO_HCI)
     {
-      /* TODO: should actually look among BT devices */
+      struct bluetooth_findbyidx_s match;
+      match.bf_tgt   = conn->bc_ldev;
+      match.bf_cur   = 0;
+      match.bf_radio = NULL;
 
-      radio =
-          (FAR struct radio_driver_s *)netdev_findbyindex(conn->bc_ldev + 1);
+      netdev_foreach(bluetooth_dev_byidx_callback, &match);
+      radio = match.bf_radio;
 
       if (radio == NULL)
         {


### PR DESCRIPTION
  Summary                                                                       
                                                                                
  bluetooth_sendto() uses netdev_findbyindex(conn->bc_ldev + 1) to locate the
  Bluetooth network device for a BTPROTO_HCI socket. netdev_findbyindex searches
   by global interface index, but bc_ldev is a 0-based count among Bluetooth
  devices only. The two are only coincidentally equal when a BT device happens
  to be registered at global index 1 (immediately after loopback). On any system
   where a non-BT netdev (e.g. Ethernet, loopback) is registered before the BT
  device, bc_ldev + 1 will not match the BT device's global index and the lookup
   will silently return NULL or the wrong device.

  This was noted in the original code with a /* TODO: should actually look among
   BT devices */ comment that was never resolved.

  The fix replaces netdev_findbyindex with a netdev_foreach walk using a small
  private callback (bluetooth_dev_byidx_callback) that counts only
  NET_LL_BLUETOOTH devices and returns the bc_ldev-th one, making the lookup
  independent of global registration order.

  Impact

  Users of BTPROTO_HCI sockets on systems with more than one netdev (e.g.
  loopback + BT, or Ethernet + BT) were silently getting a failed or incorrect
  device lookup. This fix corrects that without any API or ABI changes. No
  Kconfig changes, no build system impact, no documentation changes required.

  Testing

  Tested on a custom ARM Cortex-M7 board (STM32H7-based) with an STM32WB BLE
  co-processor connected over HCI UART. The board registers a loopback netdev
  before the BT netdev, which caused netdev_findbyindex(conn->bc_ldev + 1) to
  return NULL consistently. With this fix, netdev_foreach correctly locates the
  BT device by position among NET_LL_BLUETOOTH devices, and HCI socket send
  succeeds.

  Host: Linux x86_64, GCC ARM toolchain.