### PR TITLE
drivers/timers: avoid 32-bit overflow in arch_timer current_usec

### DIFF
--- a/drivers/timers/arch_timer.c
+++ b/drivers/timers/arch_timer.c
@@ -114,7 +114,8 @@ static uint64_t current_usec(void)
     }
   while (timebase != g_timer.timebase);
 
-  return TICK2USEC(timebase) + (status.timeout - status.timeleft);
+  return TICK2USEC((uint64_t)timebase) +
+         (status.timeout - status.timeleft);
 }
 
 static void udelay_accurate(useconds_t microseconds)


### PR DESCRIPTION
## Summary

`current_usec()` in `drivers/timers/arch_timer.c` computes elapsed
microseconds as:

    return TICK2USEC(timebase) + (status.timeout - status.timeleft);

`TICK2USEC(timebase)` expands to `(timebase) * USEC_PER_TICK`. When
`timebase` is `clock_t` (uint32_t on 32-bit targets) and
`USEC_PER_TICK` is 10000, the multiplication overflows uint32_t at
tick 429,497 (~71 minutes at 100 Hz). The result wraps to near-zero.

Because `clock_systime_ticks()` calls `up_timer_gettick()` →
`current_usec() / USEC_PER_TICK` when `CONFIG_TIMER_ARCH=1`, the
scheduler's tick counter suddenly reads ~0 instead of ~429,497. Any
watchdog armed just before the overflow (e.g. for `usleep` /
`nanosleep`) has an expiry tick that now appears to be far in the
future; `wd_expiration()` never fires it, and the sleeping task
blocks permanently.

Fix: cast `timebase` to `uint64_t` before the multiply so the
computation is done in 64-bit arithmetic.

## Impact

- New or modified features: No
- User-facing changes required: No
- Build process modifications: No
- Architecture/board/driver implications: Affects all targets using
  `CONFIG_TIMER_ARCH=1` with a 32-bit `clock_t`
- Documentation updates: No
- Security considerations: No
- Backward/forward compatibility: No

## Testing

I confirm that changes are verified on local setup and works as
intended.

**Build environment:**
- OS: Linux
- Target: ARM Cortex-M4 (nRF52840)
- Compiler: arm-none-eabi-gcc

**Target:**
- Architecture: arm
- Board: nrf52840-dk
- Config: sdc_nimble_bleprph

**Observed before fix:** With `CONFIG_TIMER_ARCH=1` and a 100 Hz
system tick, `usleep()` hangs permanently after approximately 71
minutes of uptime. The board remains alive (BLE connectable) but the
sleeping task never wakes. Replacing `usleep` with a busy-loop never
fails, confirming the watchdog firing path is the issue.

**After fix:** Board runs the `sdc_nimble_bleprph` example
continuously past the 71-minute mark without any hang.

## PR Verification Self-Check

- [x] Single functional change
- [x] All description fields completed
- [x] Follows NuttX coding standards
- [x] Not a work in progress
- [x] Ready for review and merge
