### PR TITLE
net/netdev/netdev_txnotify.c: add debug log with interface name

### DIFF
--- a/net/netdev/netdev_txnotify.c
+++ b/net/netdev/netdev_txnotify.c
@@ -113,6 +113,8 @@ void netdev_txnotify_dev(FAR struct net_driver_s *dev, uint32_t polltype)
 {
   if (dev != NULL && dev->d_txavail != NULL)
     {
+      ninfo("txnotify dev: %s\n", dev->d_ifname);
+
       /* Set the poll type flags */
 
       dev->d_polltype |= polltype;


### PR DESCRIPTION
## Summary
- Add `ninfo()` in `netdev_txnotify_dev()` to log the network interface name when TX notification is triggered, aiding network debugging.

## Impact
- No functional change. Debug output only visible when `CONFIG_DEBUG_NET_INFO` is enabled.
- This is quite useful when debug on a system with multi-net interfaces.  It can tell which net device is chosen.

## Testing
- Build tested with `CONFIG_DEBUG_NET_INFO` enabled. and can see logs like:

netdev_txnotify_dev txnotify dev: cell-net.

Tested on BES chips.