### PR TITLE
tools: mksyscall fix compilation warning

### DIFF
--- a/tools/mksyscall.c
+++ b/tools/mksyscall.c
@@ -142,8 +142,8 @@ static void get_actualparmtype(const char *arg, char *actual)
 
 static void get_fieldname(const char *arg, char *fieldname)
 {
-  char *pactual = strchr(arg, '|');
-  char *pstart;
+  const char *pactual = strchr(arg, '|');
+  const char *pstart;
 
   if (pactual)
     {


### PR DESCRIPTION
## Summary

```
mksyscall.c:145:19: warning: initialization discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  145 |   char *pactual = strchr(arg, '|');
      |                   ^~~~~~
```
Change to use `const char*` on pointers

## Impact

none

## Testing

```
 make
Create version.h
CPP:  /home/shtirlic/nuttx-space/nuttx/../picocalc-nx/scripts/memmap_default.ld-> /home/shtirlic/nuttx-space/nuttx/../picocalc-nx/scripts/memmapLD: nuttx
riscv-none-elf-ld: warning: /home/shtirlic/nuttx-space/nuttx/nuttx has a LOAD segment with RWX permissions
Memory region         Used Size  Region Size  %age Used
           FLASH:      822308 B         4 MB     19.61%
             RAM:       93100 B       512 KB     17.76%
       SCRATCH_X:           0 B         4 KB      0.00%
       SCRATCH_Y:           0 B         4 KB      0.00%
Generating: nuttx.uf2
Done.
```