### PR TITLE
tools: Update note about first line of a block

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -1036,7 +1036,13 @@ static int block_comment_width(char *line)
   if (strncmp(&line[b], "/***", 4) == 0 &&
       strncmp(&line[e - 2], "***", 3) == 0)
     {
-      /* Return the length of the line up to the final '*' */
+      /* Return the length of the line up to the final '*'.
+       *
+       * Please note, that here we lie. We return the length of the line plus
+       * one--the leading '/' plus the number of '*' plus 1. The reason is to
+       * fit the length of the last line of a block--the leading space ' '
+       * plus the number of '*' plus closing '/'.
+       */
 
       return e + 1;
     }


### PR DESCRIPTION
From the comments in the code:

```
The first line of a block comment starts with "[slash]***" and ends
with "***"
```

and:

```
The last line of a block begins with whitespace then "***" and ends
with "***[slash]"
```

However, the second is not written in the program, because

	return e;

returns the length of the line without the leading space, which makes the first line of a block comment ends with a space `' '` instead of `'*'` to make the lengths the same.

Please, note that I am not sure if the missing `'*'` at the end of the first line of a block comment is intentional, so take this PR more like a question. Thanks.

## Summary

Everywhere in the code, the first line of a block comment ends at column 77 instead of a column 78.

## Impact

NuttX style.

## Testing

Tested on a block comment where the start and the end of the block comment have the same length.