### PR TITLE
arch/arm/src/rp23xx: correct NVIC and PendSV priority initialisation

### DIFF
--- a/arch/arm/src/rp23xx/rp23xx_irq.c
+++ b/arch/arm/src/rp23xx/rp23xx_irq.c
@@ -280,9 +280,14 @@ void up_irqinitialize(void)
   arm_ramvec_initialize();
 #endif
 
-  /* Now set all of the interrupt lines to the default priority */
+  /* Set all of the interrupt lines to the default priority.
+   * NVIC_IRQ_PRIORITY(n) maps IRQ number n to its IPR register via
+   * (n >> 2); each 32-bit IPR covers four IRQs.  Step by four and bound
+   * the loop by RP23XX_IRQ_NEXTINT so that every IPR (covering IRQs
+   * 0..51) is written exactly once.
+   */
 
-  for (i = 0; i < 12; i++)
+  for (i = 0; i < RP23XX_IRQ_NEXTINT; i += 4)
     {
       regaddr = NVIC_IRQ_PRIORITY(i);
       putreg32(DEFPRIORITY32, regaddr);

--- a/arch/arm/src/rp23xx/rp23xx_irq.c
+++ b/arch/arm/src/rp23xx/rp23xx_irq.c
@@ -249,6 +249,7 @@ static inline void rp23xx_clrpend(int irq)
 void up_irqinitialize(void)
 {
   uint32_t regaddr;
+  uint32_t regval;
   int i;
 
   /* Disable all interrupts */
@@ -303,6 +304,23 @@ void up_irqinitialize(void)
   irq_attach(RP23XX_IRQ_HARDFAULT, arm_hardfault, NULL);
 
   rp23xx_prioritize_syscall(NVIC_SYSH_SVCALL_PRIORITY);
+
+  /* Place PendSV at the lowest NVIC priority. This is the deferred
+   * half of the Cortex-M context-switch path: a higher-priority ISR
+   * that wakes a task sets PendSV pending and returns; after that
+   * PendSV does the actual register save/restore. For this pattern to
+   * work safely PendSV must run only after all peripheral ISRs have
+   * finished, i.e. at the lowest priority.
+   *
+   * Read-modify-write SHPR3 to lower just the PendSV byte to MIN
+   * (0XF0) without disturbing the SysTick and DebugMon bytes that
+   * share the same register.
+   */
+
+  regval  = getreg32(NVIC_SYSH12_15_PRIORITY);
+  regval &= ~NVIC_SYSH_PRIORITY_PR14_MASK;
+  regval |= (NVIC_SYSH_PRIORITY_MIN << NVIC_SYSH_PRIORITY_PR14_SHIFT);
+  putreg32(regval, NVIC_SYSH12_15_PRIORITY);
 
   /* Attach all other processor exceptions (except reset and sys tick) */
 


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Two related fixes to rp23xx exception priority initialisation:                                                                                                         
                                            
1. **fix NVIC priority init missing IRQs 12-51** - `NVIC_IRQ_PRIORITY(n)` does `n >> 2` internally, so the existing loop `for (i = 0; i < 12; i++)` only writes IPR0..IPR2. RP2350 has 52 external IRQs; IRQs 12-51 stay at reset priority 0 and fire through BASEPRI critical sections.

2. **place PendSV at lowest NVIC priority** - defence-in-depth follow-up. PendSV otherwise shares NVIC_SYSH_PRIORITY_DEFAULT with peripheral IRQs.  Aligns rp23xx with the canonical ARM Cortex-M priority layout and hardens against future peripheral-IRQ prioritisation.

See commit messages for full analysis and observed failure modes.

## Impact

Should reduce TCB ready-to-run list and semaphore wait queue corruption that appear spontaneously whenever external SPI or I2C hardware is being used.

## Testing

Vanilla apache/nuttx master at the time of this PR; `raspberrypi-pico-2:nsh`, built in `nix develop` shell with `arm-none-eabi-gcc 15.2.1`, flashed to a Raspberry Pi Pico 2 W via openocd / CMSIS-DAP.

- Without the patches: ostest runs to completion with exit status 0.  This is consistent with the bug being latent under software-only load, since ostest does not drive peripheral IRQs and patch 1's failure path needs an IRQ in the 12..51 range firing through a critical section.

- With the patches: ostest behaviour unchanged (still exits 0). `top` runs concurrently in the background without faults.


The corruption class that patch 1 closes was originally encountered in a downstream port under SPI+I2C+context-switch load (PX4 with NuttX 12.10). I have thought for a long time that patch 2 was the fix to my woes, but I kept having crashes and poking with gdb showed i2c semaphores with orphan waiters; and then I stumbled onto the proper fix, patch 1. I am keeping patch 2 in the PR as it reflects the canonical ARM priority layout, but I'm relegating its status as just hardening.