### PR TITLE
net/icmpv6/icmpv6_input.c: Dont increase d_pktsize from router advertise

### DIFF
--- a/net/icmpv6/icmpv6_input.c
+++ b/net/icmpv6/icmpv6_input.c
@@ -481,7 +481,8 @@ void icmpv6_input(FAR struct net_driver_s *dev, unsigned int iplen)
                   {
                     FAR struct icmpv6_mtu_s *mtuopt =
                                         (FAR struct icmpv6_mtu_s *)opt;
-                    dev->d_pktsize = NTOHS(mtuopt->mtu[1]) + dev->d_llhdrlen;
+                    dev->d_pktsize = MIN(dev->d_pktsize,
+                        NTOHS(mtuopt->mtu[1]) + dev->d_llhdrlen);
                   }
                   break;
 


### PR DESCRIPTION

## Summary

An IPV6 Router advertisement can have an MTU option. This option should not increase the d_pktsize for a given interface since that max size might have been set based on CONFIG or buffer size.

Change the processing code to only allow decreasing MTU

## Impact

* Only those who use CONFIG_NET_ICMPv6_AUTOCONF

## Testing

* Tested using an IPV6 enabled modem

Here is an image of captured network data showing an MTU of 1428. This was overriding/increasing my Kconfig set MTU of 1400 for my tun interface set in CONFIG_NET_TUN_PKTSIZE

<img width="1734" height="850" alt="image" src="https://github.com/user-attachments/assets/57100a34-2579-43f0-bae7-ffec6455a312" />

