### PR TITLE
fix macOS sim cmake build and compiler-rt

### DIFF
--- a/arch/sim/src/cmake/Toolchain.cmake
+++ b/arch/sim/src/cmake/Toolchain.cmake
@@ -21,8 +21,20 @@
 # ##############################################################################
 
 if(APPLE AND CONFIG_SIM_TOOLCHAIN_GCC)
-  find_program(CMAKE_C_ELF_COMPILER x86_64-elf-gcc)
-  find_program(CMAKE_CXX_ELF_COMPILER x86_64-elf-g++)
+  if(CONFIG_HOST_ARM64)
+    find_program(CMAKE_C_ELF_COMPILER aarch64-elf-gcc)
+    find_program(CMAKE_CXX_ELF_COMPILER aarch64-elf-g++)
+  else()
+    find_program(CMAKE_C_ELF_COMPILER x86_64-elf-gcc)
+    find_program(CMAKE_CXX_ELF_COMPILER x86_64-elf-g++)
+  endif()
+endif()
+
+# Ninja archives large object lists through response files. Use LLVM binutils
+# because macOS /usr/bin/ar does not understand the @rsp syntax.
+if(APPLE)
+  find_program(CMAKE_AR NAMES llvm-ar REQUIRED)
+  find_program(CMAKE_RANLIB NAMES llvm-ranlib REQUIRED)
 endif()
 
 if(WIN32)

--- a/arch/sim/src/sim/CMakeLists.txt
+++ b/arch/sim/src/sim/CMakeLists.txt
@@ -156,6 +156,7 @@ list(
 if(CONFIG_HOST_MACOS)
   if(CONFIG_HAVE_CXXINITIALIZE)
     list(APPEND HOSTSRCS sim_macho_init.c)
+    target_link_options(nuttx PRIVATE -Wl,-ld_classic,-no_fixup_chains)
   endif()
 endif()
 

--- a/libs/libbuiltin/compiler-rt/CMakeLists.txt
+++ b/libs/libbuiltin/compiler-rt/CMakeLists.txt
@@ -137,6 +137,10 @@ if(CONFIG_COVERAGE_COMPILER_RT)
   target_compile_options(rt.profile PRIVATE -DCOMPILER_RT_HAS_UNAME -Wno-undef
                                             -Wno-strict-prototypes -Wno-shadow)
 
+  if(APPLE)
+    target_compile_options(rt.profile PRIVATE -D__APPLE__)
+  endif()
+
   set(SRCSTMP)
   set(RT_PROFILE_SRCS InstrProfilingPlatform.c)
 

--- a/libs/libbuiltin/compiler-rt/InstrProfilingPlatform.c
+++ b/libs/libbuiltin/compiler-rt/InstrProfilingPlatform.c
@@ -32,12 +32,27 @@
  * Public Data
  ****************************************************************************/
 
+#ifdef __APPLE__
+extern char __start__llvm_prf_names[]
+  __asm("section$start$__DATA$__llvm_prf_names");
+extern char __end__llvm_prf_names[]
+  __asm("section$end$__DATA$__llvm_prf_names");
+extern char __start__llvm_prf_data[]
+  __asm("section$start$__DATA$__llvm_prf_data");
+extern char __end__llvm_prf_data[]
+  __asm("section$end$__DATA$__llvm_prf_data");
+extern char __start__llvm_prf_cnts[]
+  __asm("section$start$__DATA$__llvm_prf_cnts");
+extern char __end__llvm_prf_cnts[]
+  __asm("section$end$__DATA$__llvm_prf_cnts");
+#else
 extern char __start__llvm_prf_names[];
 extern char __end__llvm_prf_names[];
 extern char __start__llvm_prf_data[];
 extern char __end__llvm_prf_data[];
 extern char __start__llvm_prf_cnts[];
 extern char __end__llvm_prf_cnts[];
+#endif
 
 COMPILER_RT_VISIBILITY ValueProfNode *CurrentVNode = 0;
 COMPILER_RT_VISIBILITY ValueProfNode *EndVNode = 0;

--- a/libs/libbuiltin/compiler-rt/Make.defs
+++ b/libs/libbuiltin/compiler-rt/Make.defs
@@ -36,8 +36,11 @@ COMPILER_RT_OBJDIR = compiler-rt \
                      compiler-rt/compiler-rt \
                      compiler-rt/compiler-rt/lib \
                      compiler-rt/compiler-rt/lib/builtins \
-                     compiler-rt/compiler-rt/lib/builtins/$(ARCH) \
                      compiler-rt/compiler-rt/lib/profile
+
+ifneq ($(ARCH),)
+COMPILER_RT_OBJDIR += compiler-rt/compiler-rt/lib/builtins/$(ARCH)
+endif
 
 BIN_OBJDIR = $(addprefix $(BINDIR)$(DELIM),$(COMPILER_RT_OBJDIR))
 KBIN_OBJDIR = $(addprefix $(KBINDIR)$(DELIM),$(COMPILER_RT_OBJDIR))
@@ -80,13 +83,16 @@ endif
 ifeq ($(CONFIG_BUILTIN_COMPILER_RT),y)
 
 FLAGS += ${INCDIR_PREFIX}$(CURDIR)/compiler-rt/compiler-rt/lib/builtins
-FLAGS += ${INCDIR_PREFIX}$(CURDIR)/compiler-rt/compiler-rt/lib/builtins/${ARCH}
 
 FLAGS += -Wno-undef -Wno-macro-redefined
 
 CSRCS += $(wildcard compiler-rt/compiler-rt/lib/builtins/*.c)
+
+ifneq ($(ARCH),)
+FLAGS += ${INCDIR_PREFIX}$(CURDIR)/compiler-rt/compiler-rt/lib/builtins/${ARCH}
 ASRCS += $(wildcard compiler-rt/compiler-rt/lib/builtins/$(ARCH)/*.S)
 CSRCS += $(wildcard compiler-rt/compiler-rt/lib/builtins/$(ARCH)/*.c)
+endif
 
 ifeq ($(CONFIG_LIB_COMPILER_RT_HAS_BFLOAT16),)
   BFLOAT16_SRCS := compiler-rt/compiler-rt/lib/builtins/truncdfbf2.c

--- a/libs/libbuiltin/compiler-rt/Make.defs
+++ b/libs/libbuiltin/compiler-rt/Make.defs
@@ -114,6 +114,10 @@ FLAGS += -fno-profile-instr-generate -fno-coverage-mapping
 FLAGS += -Wno-undef -Wno-strict-prototypes  -Wno-shadow
 FLAGS += -DCOMPILER_RT_HAS_UNAME
 
+ifeq ($(CONFIG_HOST_MACOS),y)
+FLAGS += -D__APPLE__
+endif
+
 CSRCS += $(wildcard compiler-rt/compiler-rt/lib/profile/*.c)
 CPPSRCS += $(wildcard compiler-rt/compiler-rt/lib/profile/*.cpp)
 CSRCS += InstrProfilingPlatform.c


### PR DESCRIPTION
## Summary

This patch fixes macOS sim cmake build by using llvm binutils. Also fixes compiler-rt build on macOS sim by adding the missing `__APPLE__`.

## Impact

macOS simulator

## Testing

macOS sim:nsh can build and run successfully with both CMake and Makefile when enabling `COVERAGE_COMPILER_RT=y` instead of `COVERAGE_TOOLCHAIN=y`. Maybe we should remove this from nsh defconfig as the current configuration is not universal (at least for macOS)?