### PR TITLE
fs/Kconfig: Add CONFIG_FS_PERMISSION option

### DIFF
--- a/fs/Kconfig
+++ b/fs/Kconfig
@@ -94,6 +94,27 @@ config PSEUDOFS_ATTRIBUTES
 		Enable support for attributes(e.g. mode, uid, gid and time)
 		in the pseudo file system.
 
+config FS_PERMISSION
+	bool "Enable UNIX Filesystem Permission Support"
+	default n
+	depends on !DISABLE_PSEUDOFS_OPERATIONS
+	depends on SCHED_USER_IDENTITY
+	depends on PSEUDOFS_ATTRIBUTES
+
+	---help---
+		Enable filesystem ownership and permission metadata
+		support for pseudoFS inodes.
+
+		Requires SCHED_USER_IDENTITY and
+		PSEUDOFS_ATTRIBUTES for task credential tracking
+		and inode ownership/mode metadata support.
+
+		This option alone does not enforce runtime
+		permission checks.
+
+	comment "UNIX filesystem permission support requires SCHED_USER_IDENTITY=y, PSEUDOFS_ATTRIBUTES=y and DISABLE_PSEUDOFS_OPERATIONS=n"
+		depends on !SCHED_USER_IDENTITY || !PSEUDOFS_ATTRIBUTES || DISABLE_PSEUDOFS_OPERATIONS
+
 config PSEUDOFS_SOFTLINKS
 	bool "Pseudo-filesystem soft links"
 	default n


### PR DESCRIPTION
## Summary

This change introduces a new CONFIG_FS_PERMISSION Kconfig option intended to act as the configuration entry point for future VFS permission support in NuttX. The option depends on `CONFIG_SCHED_USER_IDENTITY` and `CONFIG_PSEUDOFS_ATTRIBUTES`, ensuring that task credential tracking and pseudo-filesystem inode ownership/mode metadata are available before the feature can be enabled. This commit only adds the configuration wiring and related help text; no runtime permission enforcement or access-control logic is introduced yet.

Part of GSoC https://github.com/apache/nuttx/issues/18458

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Impact

This change does not modify existing filesystem behavior, permission checks, or runtime access control semantics. Existing configurations remain unaffected because the new option defaults to n. The impact is limited to Kconfig integration and dependency management, allowing future filesystem permission work to build on a consistent configuration foundation without silently enabling prerequisite features.

## Testing

Build Succesful
<img width="944" height="467" alt="WhatsApp Image 2026-05-12 at 8 21 08 PM" src="https://github.com/user-attachments/assets/85dc1e5b-36dd-4889-9590-c1ef8317861e" />

ostest 
<img width="940" height="420" alt="WhatsApp Image 2026-05-12 at 9 26 43 PM" src="https://github.com/user-attachments/assets/5918ea31-d60e-4340-a44c-6a30ffa04450" />

ls -l (permission bits)
<img width="258" height="157" alt="WhatsApp Image 2026-05-12 at 10 42 59 PM" src="https://github.com/user-attachments/assets/5218261c-b7a0-4b03-a0da-5f1a9ba9611f" />

make menuconfig
<img width="1289" height="293" alt="image" src="https://github.com/user-attachments/assets/9b9869b5-52ff-475b-a680-18f5ac2f5421" />

