### PR TITLE
fs/vfs: fix pseudoFS mode reporting

### DIFF
--- a/fs/vfs/fs_stat.c
+++ b/fs/vfs/fs_stat.c
@@ -454,7 +454,7 @@ int inode_stat(FAR struct inode *inode, FAR struct stat *buf, int resolve)
     }
 
 #ifdef CONFIG_PSEUDOFS_ATTRIBUTES
-  buf->st_mode |= inode->i_mode;
+  buf->st_mode = (buf->st_mode & S_IFMT) | inode->i_mode;
   buf->st_uid   = inode->i_owner;
   buf->st_gid   = inode->i_group;
   buf->st_atim  = inode->i_atime;


### PR DESCRIPTION
## Summary
This PR fixes pseudoFS mode reporting in stat()/ls output by preserving only the synthesized file type bits (S_IFMT) and replacing permission bits from inode->i_mode instead of merging them with |= semantics. Previously, restrictive permission updates such as chmod 0600 could not override the default pseudoFS permission bits, causing stat() and ls -l to continue reporting modes like 0666.
Part of GSoC https://github.com/apache/nuttx/issues/18458
## Impact

This fixes incorrect permission reporting for pseudoFS inodes after chmod() updates and ensures that stat()/ls reflect the actual inode permission state.

## Testing

Tested on sim:nsh
Pre-requisite is https://github.com/apache/nuttx-apps/pull/3480 in chmod and chown is added in nsh
Before fix:
<img width="485" height="411" alt="image" src="https://github.com/user-attachments/assets/f8910651-7c99-49b2-b2ec-2b0cea6d8959" />


After fix:
<img width="425" height="362" alt="image" src="https://github.com/user-attachments/assets/f993cc89-3fdd-4dd5-bfb2-4fbb2a27d976" />

