### PR TITLE
Documentation/nsh: add chmod and chown command docs

### DIFF
--- a/Documentation/applications/nsh/commands.rst
+++ b/Documentation/applications/nsh/commands.rst
@@ -198,6 +198,51 @@ Also sets the previous working directory environment variable
 ``cd ..`` 	        sets the current working directory to the parent directory.
 ==================  =====================================
 
+.. _cmdchmod:
+
+``chmod`` Change File Permissions
+==================================
+
+**Command Syntax**::
+
+  chmod <octal-mode> <path>
+
+**Synopsis**. Change the permission bits of ``<path>``. Only numeric
+(octal) modes are supported.
+
+**Example**::
+
+  nsh> chmod 600 /tmp/secret
+  nsh> chmod 755 /usr/bin/app
+
+.. _cmdchown:
+
+``chown`` Change File Owner and Group
+======================================
+
+**Command Syntax**::
+
+  chown <uid>[:gid] <path>
+
+**Synopsis**. Change the owner and/or group of ``<path>``. Only
+numeric uid and gid values are accepted. Omitted uid or gid fields
+are left unchanged.
+
+**Forms:**
+
+===================  ===============================================================
+``chown uid:gid``    Sets owner to uid and group to gid.
+``chown uid``        Sets owner to uid; group is unchanged.
+``chown uid:``       Sets owner to uid; group is unchanged.
+``chown :gid``       Sets group to gid; owner is unchanged.
+===================  ===============================================================
+
+**Example**::
+
+  nsh> chown 1000:1000 /tmp/file
+  nsh> chown 0: /tmp/file
+  nsh> chown :100 /tmp/file
+
 .. _cmdcmp:
 
 ``cmp`` Compare Files


### PR DESCRIPTION
## Summary
This PR adds NSH documentation for the new chmod and chown builtins in Documentation/applications/nsh/commands.rst. The documentation covers the supported command syntax, numeric permission and ownership forms, and includes basic usage examples aligned with existing NSH command documentation style.
For PR: https://github.com/apache/nuttx-apps/pull/3480
Part of GSoC https://github.com/apache/nuttx/issues/18458
## Impact

This improves discoverability and usability of the new NSH filesystem permission and ownership commands by documenting their supported syntax and behavior directly in the NSH command reference.

## Testing
Sphinx local
<img width="1455" height="728" alt="image" src="https://github.com/user-attachments/assets/2926c1f5-2bec-4372-b3ee-1dd4c3526ba9" />
