### PR TITLE
ci/platform: Fix the “Repository not found” error for kconfig-frontends

### DIFF
--- a/tools/ci/platforms/msys2.sh
+++ b/tools/ci/platforms/msys2.sh
@@ -123,7 +123,7 @@ kconfig_frontends() {
   add_path "${NUTTXTOOLS}"/kconfig-frontends/bin
 
   if [ ! -f "${NUTTXTOOLS}/kconfig-frontends/bin/kconfig-conf" ]; then
-    git clone --depth 1 https://bitbucket.org/nuttx/tools.git "${NUTTXTOOLS}"/nuttx-tools
+    git clone --depth 1 https://github.com/patacongo/tools "${NUTTXTOOLS}"/nuttx-tools
     cd "${NUTTXTOOLS}"/nuttx-tools/kconfig-frontends
     ./configure --prefix="${NUTTXTOOLS}"/kconfig-frontends \
       --disable-kconfig --disable-nconf --disable-qconf \


### PR DESCRIPTION

## Summary

MSYS2 Fix

```
 ‘[’ '!‘ -f /d/a/nuttx/nuttx/sources/tools/kconfig-frontends/bin/kconfig-conf ’]'
+ git clone --depth 1 https://bitbucket.org/nuttx/tools.git /d/a/nuttx/nuttx/sources/tools/nuttx-tools
Cloning into ‘/d/a/nuttx/nuttx/sources/tools/nuttx-tools’...
```

Repository not found
https://bitbucket.org/nuttx/tools.git

Now use URL https://github.com/patacongo/tools

https://github.com/apache/nuttx/pull/18883#issuecomment-4467204640

## Impact

Impact on user: NO

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

GitHub

https://github.com/simbit18/manual-nuttx-ci/actions/runs/25968905510/job/76337274375#logs
