### PR TITLE
drivers/video/vnc: fix typo in Kconfig

### DIFF
--- a/drivers/video/vnc/Kconfig
+++ b/drivers/video/vnc/Kconfig
@@ -137,7 +137,7 @@ config VNCSERVER_KBDENCODE
 	depends on LIBC_KBDCODEC
 	---help---
 		Use a special encoding of keyboard characters as defined in
-		include/nuttx/input/kbd_coded.h.
+		include/nuttx/input/kbd_codec.h.
 
 config VNCSERVER_TOUCH
 	bool "Enable touch input"


### PR DESCRIPTION
Mentioned header name is "kbd_codec.h", not "kbd_coded.h".

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Fix help text in drivers/video/vnc/Kconfig

## Impact

Documentation

## Testing

~~~
$ tools/configure.sh` -l qemu-intel64:ostest
$ make menuconfig
~~~
Go to Device Drivers -> Video Device Support -> VNC server -> Encode keyboard input and press "?"
