### PR TITLE
arch/arm: fix infinite loop in test and clean cache operations

### DIFF
--- a/arch/arm/src/arm/arm_cache.S
+++ b/arch/arm/src/arm/arm_cache.S
@@ -199,7 +199,7 @@ up_clean_dcache:
 	.type	up_clean_dcache_all, function
 
 up_clean_dcache_all:
-	mrc		p15, 0, r0, c7, c10, 3
+	mrc		p15, 0, r15, c7, c10, 3
 	bne		up_clean_dcache_all
 	bx		lr
 	.size	up_clean_dcache_all, . - up_clean_dcache_all
@@ -227,7 +227,7 @@ up_flush_dcache:
 	.type	up_flush_dcache_all, function
 
 up_flush_dcache_all:
-	mrc		p15, 0, r0, c7, c14, 3
+	mrc		p15, 0, r15, c7, c14, 3
 	bne		up_flush_dcache_all
 	bx		lr
 	.size	up_flush_dcache_all, . - up_flush_dcache_all


### PR DESCRIPTION
## Summary
Reboot command on my board was hanging (in boardctl) without resetting.

      case BOARDIOC_RESET:
        {
          g_nx_initstate = OSINIT_RESET;
          sched_trace_mark("RESET");
          reboot_notifier_call_chain(SYS_RESTART, (FAR void *)arg);
          up_flush_dcache_all(); <------ This was not returning
          ret = board_reset((int)arg);
        }

FIX:
Update the destination register to r15 (PC) for test and clean operations, as specified by the ARM926EJ-S Technical Reference Manual (TRM). Using the wrong destination register prevented the loop condition from updating correctly, resulting in an infinite loop.

## Impact

## Testing
Reboot command now successfully reboots the target.
