### PR TITLE
git: Specify multiple build directories in .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,7 +84,7 @@ uImage
 .idea
 .DS_Store
 tools/gdb/__pycache__
-/build
+/build*
 .ccls-cache
 compile_commands.json
 imx9-sdimage.img


### PR DESCRIPTION
## Summary

When building with CMake, we may use multiple build directories, as in the following examples:

* build-debug
* build-release
* build-test

Change to allow ignoring multiple build directories.

* Related [NuttX Issue #18882](https://github.com/apache/nuttx/issues/18882)

## Impact

* Impact on build: This makes it convenient to switch between multiple build configurations.

## Testing

Testing logs before change:

```
❯ git status
On branch change_build_in_gitignore
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        build-debug/
        build-release/
```

Testing logs after change:

```
❯ git status
On branch change_build_in_gitignore
nothing to commit, working tree clean
```

## PR verification Self-Check

* [x] I have updated all required description fields above.
* [x] My PR adheres to Contributing [Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) and [Documentation](https://nuttx.apache.org/docs/latest/contributing/index.html) (git commit title and message, coding standard, etc).
* [x] My PR is ready for review and can be safely merged into a codebase.
