### PR TITLE
arch/risc-v/espressif: Fix CMake irq.h header ordering race

### DIFF
--- a/arch/risc-v/src/common/espressif/CMakeLists.txt
+++ b/arch/risc-v/src/common/espressif/CMakeLists.txt
@@ -345,6 +345,7 @@ add_custom_command(
 add_custom_target(copy_esp3rdparty_headers DEPENDS ${_gpio_sig_map} ${_irq})
 
 add_dependencies(arch copy_esp3rdparty_headers)
+add_dependencies(nuttx_context copy_esp3rdparty_headers)
 
 # ##############################################################################
 # Compiler and Linker Flags


### PR DESCRIPTION
## Summary

<!--This field should contain a summary of the changes. It will be pre-filled with the commit's message and descriptions. Adjust it accordingly-->

* arch/risc-v/espressif: Fix CMake irq.h header ordering race

Ensure esp-hal copied headers are generated during nuttx_context so parallel CMake builds cannot compile sources before arch/chip/irq.h exists.

## Impact

<!--Please fill the following sections with YES/NO and provide a brief explanation-->

Impact on user: No.

<!--Does it impact user's applications? How?-->

Impact on build: Helps avoiding a build issue caused by a race condition during build.

<!--Does it impact on building NuttX? How? (please describe the required changes on the build system)-->

Impact on hardware: No.

<!--Does it impact a specific hardware supported by NuttX?-->

Impact on documentation: No.

<!--Does it impact the existing documentation? Please provide additional documentation to reflect that-->

Impact on security: No.

<!--Does it impact NuttX's security?-->

Impact on compatibility: No.

<!--Does it impact compatibility between previous and current versions? Is this a breaking change?-->

## Testing

### Building

Build any RISC-V Espressif device:

```
cmake -B build -DBOARD_CONFIG=esp32c3-devkit:watchdog -GNinja
cmake --build build
```

### Results

Before the fix, the following would happen sometimes during CI builds:

```
[15/1388] Building C object binfmt/CMakeFiles/binfmt.dir/binfmt_initialize.c.o
FAILED: binfmt/CMakeFiles/binfmt.dir/binfmt_initialize.c.o 
/home/fdcavalcanti/work/toolchains/riscv-none-elf-gcc/bin/riscv-none-elf-gcc -D__KERNEL__ -D__NuttX__ -I/home/fdcavalcanti/nuttxspace5/nuttx/binfmt -I/home/fdcavalcanti/nuttxspace5/nuttx/sched -isystem /home/fdcavalcanti/nuttxspace5/nuttx/include -isystem /home/fdcavalcanti/nuttxspace5/nuttx/build/include -Os -fno-strict-aliasing -fomit-frame-pointer -fno-common -Wall -Wshadow -Wundef -Wno-attributes -Wno-unknown-pragmas -Wstrict-prototypes -ffunction-sections -fdata-sections -g -march=rv32imac_zicsr_zifencei -mabi=ilp32 -fdiagnostics-color=always -fmacro-prefix-map=/home/fdcavalcanti/nuttxspace5/nuttx= -fmacro-prefix-map=/home/fdcavalcanti/nuttxspace5/nuttx-apps= -fmacro-prefix-map=/home/fdcavalcanti/nuttxspace5/nuttx/boards/risc-v/esp32p4/esp32p4-function-ev-board= -fmacro-prefix-map=/home/fdcavalcanti/nuttxspace5/nuttx/arch/risc-v/src/esp32p4= @binfmt/CMakeFiles/binfmt.dir/binfmt_initialize.c.o.rsp -MD -MT binfmt/CMakeFiles/binfmt.dir/binfmt_initialize.c.o -MF binfmt/CMakeFiles/binfmt.dir/binfmt_initialize.c.o.d -o binfmt/CMakeFiles/binfmt.dir/binfmt_initialize.c.o -c /home/fdcavalcanti/nuttxspace5/nuttx/binfmt/binfmt_initialize.c

In file included from /home/fdcavalcanti/nuttxspace5/nuttx/include/nuttx/irq.h:39,
                 from /home/fdcavalcanti/nuttxspace5/nuttx/include/errno.h:33,
                 from /home/fdcavalcanti/nuttxspace5/nuttx/include/nuttx/semaphore.h:32,
                 from /home/fdcavalcanti/nuttxspace5/nuttx/include/nuttx/mutex.h:33,
                 from /home/fdcavalcanti/nuttxspace5/nuttx/include/pthread.h:32,
                 from /home/fdcavalcanti/nuttxspace5/nuttx/include/nuttx/sched.h:37,
                 from /home/fdcavalcanti/nuttxspace5/nuttx/include/nuttx/binfmt/binfmt.h:35,
                 from /home/fdcavalcanti/nuttxspace5/nuttx/binfmt/binfmt_initialize.c:29:
/home/fdcavalcanti/nuttxspace5/nuttx/build/include/arch/irq.h:41:10: fatal error: arch/chip/irq.h: No such file or directory

   41 | #include &lt;arch/chip/irq.h&gt;
      |          ^~~~~~~~~~~~~~~~~
compilation terminated.
```