### PR TITLE
drivers/mtd/mx25rxx.c: add support for MX25L12873G

### DIFF
--- a/drivers/mtd/mx25rxx.c
+++ b/drivers/mtd/mx25rxx.c
@@ -108,6 +108,7 @@
 #else
 #  define MX25R_JEDEC_MEMORY_TYPE          0x28  /* MX25Rx memory type */
 #endif
+#define MX25R_JEDEC_MX25L12873G_CAPACITY 0x18  /* MX25L12873G memory capacity */
 #define MX25R_JEDEC_MX25L25673G_CAPACITY 0x19  /* MX25L25673G memory capacity */
 #define MX25R_JEDEC_MX25R6435F_CAPACITY  0x17  /* MX25R6435F memory capacity */
 #define MX25R_JEDEC_MX25R8035F_CAPACITY  0x14  /* MX25R8035F memory capacity */
@@ -127,6 +128,14 @@
 #define MX25R6435F_SECTOR_COUNT     (2048)
 #define MX25R6435F_PAGE_SIZE        (256)
 
+/* MX25L12873G (128 MB) memory capacity */
+
+#define MX25L12873G_SECTOR_SIZE     (4*1024)
+#define MX25L12873G_SECTOR_SHIFT    (12)
+#define MX25L12873G_ADDRESS_BYTES   MX25R_ADDRESSBYTES_3
+#define MX25L12873G_SECTOR_COUNT    (4096)
+#define MX25L12873G_PAGE_SIZE       (256)
+
 /* MX25L25673G (256 MB) memory capacity */
 
 #define MX25L25673G_SECTOR_SIZE     (4*1024)
@@ -137,9 +146,11 @@
 
 #ifdef CONFIG_MX25RXX_PAGE128
 #  define MX25R6435F_PAGE_SHIFT     (7)
+#  define MX25L12873G_PAGE_SHIFT    (7)
 #  define MX25L25673G_PAGE_SHIFT    (7)
 #else
 #  define MX25R6435F_PAGE_SHIFT     (8)
+#  define MX25L12873G_PAGE_SHIFT    (8)
 #  define MX25L25673G_PAGE_SHIFT    (8)
 #endif
 
@@ -879,6 +890,13 @@ int mx25rxx_readid(FAR struct mx25rxx_dev_s *dev)
         dev->pageshift    = MX25R6435F_PAGE_SHIFT;
         dev->addressbytes = MX25R6435F_ADDRESS_BYTES;
         dev->nsectors     = MX25R6435F_SECTOR_COUNT;
+        break;
+
+      case MX25R_JEDEC_MX25L12873G_CAPACITY:
+        dev->sectorshift  = MX25L12873G_SECTOR_SHIFT;
+        dev->pageshift    = MX25L12873G_PAGE_SHIFT;
+        dev->addressbytes = MX25L12873G_ADDRESS_BYTES;
+        dev->nsectors     = MX25L12873G_SECTOR_COUNT;
         break;
 
       case MX25R_JEDEC_MX25L25673G_CAPACITY:


### PR DESCRIPTION
## Summary

This PR adds support for 128Mbit  MX25L12873G.

MX25L12873G is a SPI memory very similar to MX25L25673G, but 128Mbit, which means it does not use 4-byte addresses.

## Testing

Tested on a customized NUCLEO-H563ZI board, with an MX25L12873G connected to OCTOSPI1.
Bring-up code includes (error checking removed):
```
	/* Configure OCTOSPI1 pins */
	stm32_ospi1_pins();

	/* Initialize QSPI interface 0 (OCTOSPI1) */
	qspi = stm32_qspi_initialize(0);

	/* Bind the MX25Rxx driver */
	mtd = mx25rxx_initialize(qspi, true /* unprotect */);

	ret = register_mtddriver("/dev/mtd0", mtd, 0755, NULL);
```
And then a custom filesystem is mounted on `/dev/mtd0`.

NSH was used for testing:
```
nsh> rm file_for_tests
nsh> hexdump file_for_tests
nsh: hexdump: read failed: 84
nsh> echo test > file_for_tests
nsh> hexdump file_for_tests
file_for_tests at 00000000:
0000: 74 65 73 74 0a ff ff ff ff ff ff ff ff ff ff ff test............
03e0: ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ff ................
[...]
nsh> rm file_for_tests_encrypted
nsh> hexdump file_for_tests_encrypted
nsh: hexdump: read failed: 84
nsh> echo test > file_for_tests_encrypted
nsh> hexdump file_for_tests_encrypted
file_for_tests_encrypted at 000:
0000: 74 65 73 74 0a ff ff ff ff ff ff ff ff ff ff ff test............
[...]
```
That is the expected behavior for our file-system: files do not have size information, they are store on pre-allocated flash pages. So rm-ing is not really possible, but when files are erased the flash contents are wiped, CRC does not match, so read fails.

I also checked the geometry information (which is what changes wrt 256Mbit version, already tested in https://github.com/apache/nuttx/pull/18685).

```
(gdb) p fs->geo
$1 = {nsectors = 4096, sectorsize = 4096}
```

Unfortunately I can no longer test on a vanilla NUCLEO-H563ZI board.