### PR TITLE
arch/tricore: Add up_perf function for tricore.

### DIFF
--- a/arch/tricore/src/common/CMakeLists.txt
+++ b/arch/tricore/src/common/CMakeLists.txt
@@ -34,6 +34,7 @@ set(SRCS
     tricore_irq.c
     tricore_main.c
     tricore_nputs.c
+    tricore_perf.c
     tricore_registerdump.c
     tricore_releasestack.c
     tricore_saveusercontext.c

--- a/arch/tricore/src/common/Make.defs
+++ b/arch/tricore/src/common/Make.defs
@@ -35,6 +35,7 @@ CMN_CSRCS += tricore_initialstate.c
 CMN_CSRCS += tricore_irq.c
 CMN_CSRCS += tricore_main.c
 CMN_CSRCS += tricore_nputs.c
+CMN_CSRCS += tricore_perf.c
 CMN_CSRCS += tricore_registerdump.c
 CMN_CSRCS += tricore_releasestack.c
 CMN_CSRCS += tricore_saveusercontext.c

--- a/arch/tricore/src/common/tricore_perf.c
+++ b/arch/tricore/src/common/tricore_perf.c
@@ -26,6 +26,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/clock.h>
+#include <nuttx/lib/math32.h>
 
 #include "tricore_internal.h"
 
@@ -36,6 +37,7 @@
  ****************************************************************************/
 
 static unsigned long g_cpu_freq = ULONG_MAX;
+static invdiv_param64_t g_invdiv_param;
 
 /****************************************************************************
  * Public Functions
@@ -45,6 +47,7 @@ void up_perf_init(void *arg)
 {
   g_cpu_freq = (unsigned long)(uintptr_t)arg;
 
+  invdiv_init_param64(g_cpu_freq, &g_invdiv_param);
   IfxCpu_resetAndStartCounters(IfxCpu_CounterMode_normal);
 }
 
@@ -62,8 +65,8 @@ void up_perf_convert(clock_t elapsed, struct timespec *ts)
 {
   clock_t left;
 
-  ts->tv_sec  = elapsed / g_cpu_freq;
+  ts->tv_sec  = invdiv_u64(elapsed, &g_invdiv_param);
   left        = elapsed - ts->tv_sec * g_cpu_freq;
-  ts->tv_nsec = NSEC_PER_SEC * (uint64_t)left / g_cpu_freq;
+  ts->tv_nsec = invdiv_u64(NSEC_PER_SEC * (uint64_t)left, &g_invdiv_param);
 }
 #endif

--- a/arch/tricore/src/common/tricore_perf.c
+++ b/arch/tricore/src/common/tricore_perf.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * arch/tricore/src/common/tricore_initialize.c
+ * arch/tricore/src/common/tricore_perf.c
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -25,60 +25,45 @@
  ****************************************************************************/
 
 #include <nuttx/arch.h>
-#include <nuttx/board.h>
-#include <nuttx/cache.h>
-#include <arch/board/board.h>
+#include <nuttx/clock.h>
 
 #include "tricore_internal.h"
 
+#ifdef CONFIG_ARCH_PERF_EVENTS
+
 /****************************************************************************
- * Public Data
+ * Private Data
  ****************************************************************************/
 
-/* g_interrupt_context store irq status */
-
-volatile bool g_interrupt_context[CONFIG_SMP_NCPUS];
+static unsigned long g_cpu_freq = ULONG_MAX;
 
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
 
-/****************************************************************************
- * Name: up_initialize
- *
- * Description:
- *   up_initialize will be called once during OS initialization after the
- *   basic OS services have been initialized.  The architecture specific
- *   details of initializing the OS will be handled here.  Such things as
- *   setting up interrupt service routines, starting the clock, and
- *   registering device drivers are some of the things that are different
- *   for each processor and hardware platform.
- *
- *   up_initialize is called after the OS initialized but before the user
- *   initialization logic has been started and before the libraries have
- *   been initialized.  OS services and driver services are available.
- *
- ****************************************************************************/
-
-void up_initialize(void)
+void up_perf_init(void *arg)
 {
-#ifdef CONFIG_ARCH_PERF_EVENTS
-  up_perf_init((void *)IFX_CFG_CPU_CLOCK_FREQUENCY);
-#endif
+  g_cpu_freq = (unsigned long)(uintptr_t)arg;
 
-  tricore_trapinit();
-
-#ifdef CONFIG_ARCH_ICACHE
-  up_enable_icache();
-#endif
-
-#ifdef CONFIG_ARCH_DCACHE
-  up_enable_dcache();
-#endif
-
-  /* Initialize the serial device driver */
-
-#ifdef USE_SERIALDRIVER
-  tricore_serialinit();
-#endif
+  IfxCpu_resetAndStartCounters(IfxCpu_CounterMode_normal);
 }
+
+unsigned long up_perf_getfreq(void)
+{
+  return g_cpu_freq;
+}
+
+clock_t up_perf_gettime(void)
+{
+  return (clock_t)IfxCpu_getClockCounter();
+}
+
+void up_perf_convert(clock_t elapsed, struct timespec *ts)
+{
+  clock_t left;
+
+  ts->tv_sec  = elapsed / g_cpu_freq;
+  left        = elapsed - ts->tv_sec * g_cpu_freq;
+  ts->tv_nsec = NSEC_PER_SEC * (uint64_t)left / g_cpu_freq;
+}
+#endif


### PR DESCRIPTION
## Summary

  * Why: TriCore architecture needs performance counter support for profiling and timing measurements.
  * What: arch/tricore perf counter implementation using CPU clock counter (CCNT).
  * How: Add tricore_perf.c implementing up_perf_init/getfreq/gettime/convert interfaces, with optimized fast integer division (invdiv_u64) for time conversion.

## Impact

  * Is new feature added? YES - Performance counter support for TriCore.
  * Impact on user (will user need to adapt to change)? NO
  * Impact on build (will build process change)? NO
  * Impact on hardware (will arch(s) / board(s) / driver(s) change)? YES - tricore arch only, enabled via CONFIG_ARCH_PERF_EVENTS.
  * Impact on documentation (is update required / provided)? NO
  * Impact on security (any sort of implications)? NO
  * Impact on compatibility (backward/forward/interoperability)? NO

## Testing

  I confirm that changes are verified on local setup and works as intended:
  * Build Host(s): Linux x86_64, GCC 11.3.1 (tricore-elf-gcc)
  * Target(s): tricore, triboard_tc4x9_com:nsh (CONFIG_ARCH_PERF_EVENTS=y)

  Testing logs (build):

  ```
  LD: nuttx
  ```

  Testing logs (runtime, ostest on TC4D9 EVB):

  ```
  nsh> ostest
  ...
  user_main: Exiting
  ostest_main: Exiting with status 0
  nsh>
  ```