### PR TITLE
arch/tricore: Improve up_backtrace implementation

### DIFF
--- a/arch/tricore/src/common/CMakeLists.txt
+++ b/arch/tricore/src/common/CMakeLists.txt
@@ -22,7 +22,6 @@
 
 set(SRCS
     tricore_allocateheap.c
-    tricore_backtrace.c
     tricore_cache.c
     tricore_checkstack.c
     tricore_createstack.c
@@ -44,6 +43,10 @@ set(SRCS
     tricore_trapcall.c
     tricore_systimer.c
     tricore_usestack.c)
+
+if(CONFIG_SCHED_BACKTRACE)
+  list(APPEND SRCS tricore_backtrace.c)
+endif()
 
 if(CONFIG_ENABLE_ALL_SIGNALS)
   list(APPEND SRCS tricore_schedulesigaction.c tricore_sigdeliver.c)

--- a/arch/tricore/src/common/Make.defs
+++ b/arch/tricore/src/common/Make.defs
@@ -23,7 +23,6 @@
 HEAD_CSRC += tricore_doirq.c
 
 CMN_CSRCS += tricore_allocateheap.c
-CMN_CSRCS += tricore_backtrace.c
 CMN_CSRCS += tricore_cache.c
 CMN_CSRCS += tricore_checkstack.c
 CMN_CSRCS += tricore_createstack.c
@@ -45,6 +44,10 @@ CMN_CSRCS += tricore_tcbinfo.c
 CMN_CSRCS += tricore_trapcall.c
 CMN_CSRCS += tricore_systimer.c
 CMN_CSRCS += tricore_usestack.c
+
+ifeq ($(CONFIG_SCHED_BACKTRACE),y)
+  CMN_CSRCS += tricore_backtrace.c
+endif
 
 ifeq ($(CONFIG_ENABLE_ALL_SIGNALS),y)
 CMN_CSRCS += tricore_schedulesigaction.c tricore_sigdeliver.c

--- a/arch/tricore/src/common/tricore_backtrace.c
+++ b/arch/tricore/src/common/tricore_backtrace.c
@@ -25,7 +25,9 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+
 #include <nuttx/arch.h>
+
 #include "sched/sched.h"
 #include "tricore_internal.h"
 
@@ -42,29 +44,34 @@
  ****************************************************************************/
 
 nosanitize_address
-static int backtrace(uintptr_t pcxi, void **buffer, int size, int *skip)
+static int backtrace(uintptr_t pcxi, void **buffer,
+                     int size, int *skip)
 {
+  uintptr_t *csa;
   int i = 0;
 
-  for (; ((pcxi & FCX_FREE) != 0U) && (i < size); )
+  for (; i < size && (pcxi & FCX_FREE) != 0; )
     {
-      uintptr_t *csa;
-
       csa = tricore_csa2addr(pcxi);
       if (csa == NULL)
         {
           break;
         }
 
-      if ((pcxi & PCXI_UL) != 0U)
+      if ((pcxi & PCXI_UL) != 0)
         {
+          if (csa[REG_UA11] == 0)
+            {
+              break;
+            }
+
           if ((*skip)-- <= 0)
             {
               buffer[i++] = (void *)csa[REG_UA11];
             }
         }
 
-      pcxi = csa[0];
+      pcxi = csa[REG_UPCXI];
     }
 
   return i;
@@ -107,10 +114,11 @@ static int backtrace(uintptr_t pcxi, void **buffer, int size, int *skip)
  *
  ****************************************************************************/
 
-int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
+int up_backtrace(struct tcb_s *tcb,
+                 void **buffer, int size, int skip)
 {
   struct tcb_s *rtcb = running_task();
-  int ret;
+  int ret = 0;
 
   if (size <= 0 || !buffer)
     {
@@ -119,13 +127,12 @@ int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
 
   if (tcb == NULL || tcb == rtcb)
     {
-      ret = backtrace((uintptr_t)__mfcr(CPU_PCXI),
-                      buffer, size, &skip);
+      ret = backtrace(__mfcr(CPU_PCXI), buffer, size, &skip);
     }
   else
     {
-      ret = backtrace(tricore_addr2csa(tcb->xcp.regs),
-                      buffer, size, &skip);
+      uintptr_t *regs = tcb->xcp.regs;
+      ret = backtrace(regs[REG_LPCXI], buffer, size, &skip);
     }
 
   return ret;


### PR DESCRIPTION
## Summary

Improve the existing TriCore `up_backtrace()` implementation (merged in #18899):

1. **Conditional compilation** — Make `tricore_backtrace.c` conditional on `CONFIG_SCHED_BACKTRACE`, consistent with RISC-V and ARM architectures.
2. **NULL return address check** — Terminate backtrace early when `csa[REG_UA11] == 0` to avoid invalid entries.
3. **Fix non-current task backtrace** — Use `regs[REG_LPCXI]` instead of `tricore_addr2csa(tcb->xcp.regs)` to preserve the UL bit needed for correct CSA type identification.

## Testing

Verified on TC4D9 EVB (triboard_tc4x9_com:nsh) with `CONFIG_SCHED_BACKTRACE=y`:

- ostest passes completely (`Exiting with status 0`)
- Triggered PANIC() in hello app, backtrace output:

```
sched_dumpstack: backtrace| 4: 0x80028be4 0x80024650 0x800141b0 0x800144aa 0x800115d0 0x80011570
```

addr2line verification:
```
0x80028be4 → sched_dumpstack (libs/libc/sched/sched_dumpstack.c:71)
0x80024650 → dump_assert_info (sched/misc/assert.c:727)
0x800141b0 → __assert (libs/libc/assert/lib_assert.c:39)
0x800144aa → nxtask_startup (libs/libc/sched/task_startup.c:72)
0x800115d0 → nxtask_start (sched/task/task_start.c:72)
0x80011570 → nxtask_start (sched/task/task_start.c:70)
```

Call chain is correct. User-space functions (`hello_main/func_a/func_b/func_c`) are not in backtrace because the compiler optimized them into tail-jumps (`j` instead of `call`), which is expected TriCore behavior — only `call` instructions save Upper CSA.