### PR TITLE
arch/tricore: Suspend stm when CPU stops.

### DIFF
--- a/arch/tricore/src/common/tricore_systimer.c
+++ b/arch/tricore/src/common/tricore_systimer.c
@@ -309,6 +309,8 @@ tricore_systimer_initialize(volatile void *tbase, int irq, uint64_t freq)
 
   oneshot_count_init(&priv->lower, (uint32_t)freq);
 
+  IfxStm_setSuspendMode(priv->tbase, IfxStm_SuspendMode_hard);
+
   IfxStm_setCompareControl(tbase,
       IfxStm_Comparator_0,
       IfxStm_ComparatorOffset_0,


### PR DESCRIPTION
## Summary

  * Why: When debugging with breakpoints, the STM (System Timer Module) continues running while CPU is halted, causing timer drift and incorrect timing behavior after resume.
  * What: arch/tricore systimer suspend mode configuration.
  * How: Set STM suspend mode to hard so the timer stops when CPU is halted by debugger, preventing timer drift during debug sessions.

## Impact

  * Is new feature added? NO - Bug fix for debug behavior.
  * Impact on user (will user need to adapt to change)? NO
  * Impact on build (will build process change)? NO
  * Impact on hardware (will arch(s) / board(s) / driver(s) change)? YES - tricore arch only, affects STM behavior during debug halt.
  * Impact on documentation (is update required / provided)? NO
  * Impact on security (any sort of implications)? NO
  * Impact on compatibility (backward/forward/interoperability)? NO

## Testing

  I confirm that changes are verified on local setup and works as intended:
  * Build Host(s): Linux x86_64, GCC 11.3.1 (tricore-elf-gcc)
  * Target(s): tricore, triboard_tc4x9_com:nsh

  Testing logs (build):

  ```
  LD: nuttx
  ```

  Testing logs (runtime, ostest on TC4D9 EVB):

  ```
  nsh> ostest
  ...
  user_main: Exiting
  ostest_main: Exiting with status 0
  nsh>
  ```