### PR TITLE
fs/vfs: validate chmod and chown callers in inode_chstat()

### DIFF
--- a/fs/vfs/fs_chstat.c
+++ b/fs/vfs/fs_chstat.c
@@ -32,6 +32,7 @@
 #include <errno.h>
 
 #include <nuttx/fs/fs.h>
+#include <nuttx/sched.h>
 
 #include "inode/inode.h"
 
@@ -410,6 +411,11 @@ int lutimens(FAR const char *path, const struct timespec times[2])
 int inode_chstat(FAR struct inode *inode,
                  FAR const struct stat *buf, int flags, int resolve)
 {
+#ifdef CONFIG_SCHED_USER_IDENTITY
+  FAR struct tcb_s *rtcb;
+  uid_t euid;
+#endif
+
   DEBUGASSERT(inode != NULL && buf != NULL);
 
 #ifdef CONFIG_PSEUDOFS_SOFTLINKS
@@ -440,6 +446,28 @@ int inode_chstat(FAR struct inode *inode,
 
           return chstat_recursive(inode->u.i_link, buf, flags, ++resolve);
         }
+    }
+#endif
+
+#ifdef CONFIG_SCHED_USER_IDENTITY
+  rtcb = nxsched_self();
+  if ((rtcb->flags & TCB_FLAG_TTYPE_MASK) != TCB_FLAG_TTYPE_KERNEL &&
+      rtcb->group != NULL)
+    {
+      euid = rtcb->group->tg_euid;
+
+      if ((flags & (CH_STAT_UID | CH_STAT_GID)) != 0 && euid != 0)
+        {
+          return -EPERM;
+        }
+
+#ifdef CONFIG_PSEUDOFS_ATTRIBUTES
+      if ((flags & CH_STAT_MODE) != 0 &&
+          euid != 0 && euid != inode->i_owner)
+        {
+          return -EPERM;
+        }
+#endif
     }
 #endif
 


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary
Add caller validation for pseudoFS chmod and chown operations in inode_chstat(). This change validates the caller using the task's effective uid and aligns pseudoFS permission behavior with POSIX-style semantics by allowing owner/root chmod operations while restricting chown to root-only.
Part of GSoC https://github.com/apache/nuttx/issues/18458
## Impact
Prevents unprivileged tasks from modifying pseudoFS inode ownership or mode bits for arbitrary files. The change affects only pseudoFS inode attribute updates through inode_chstat() and does not modify mountpoint filesystem behavior.

## Testing

Validated using a dedicated permission test application on NuttX sim and compared against equivalent Linux behavior . Tested scenarios include root chmod, owner chmod, non-owner chmod denial, root chown, non-root chown denial, ownership propagation, and verification of -EPERM for denied operations.

<img width="833" height="475" alt="image" src="https://github.com/user-attachments/assets/e62f8fc7-49b7-43e8-a09e-0add221cc52e" />
ostest and checkpatch tests all passed
