### PR TITLE
tools: add build path support on host_info tool

### DIFF
--- a/tools/host_info_dump.py
+++ b/tools/host_info_dump.py
@@ -475,7 +475,9 @@ def generate_header(args):
             arch_chip_key
         )[-1]
         if "esp" in arch_chip:
-            vendor_specific_module_path = os.path.abspath("./tools/espressif")
+            vendor_specific_module_path = os.path.abspath(
+                args.nuttx_path + "/tools/espressif"
+            )
             sys.path.append(os.path.abspath(vendor_specific_module_path))
             vendor_specific_module = importlib.import_module("chip_info")
             get_vendor_info = getattr(vendor_specific_module, "get_vendor_info")
@@ -525,6 +527,16 @@ if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(add_help=False)
     parser.add_argument("nuttx_path", help="NuttX source directory path.")
+    parser.add_argument(
+        "-b",
+        "--build_path",
+        help=(
+            "Build path. Required if using CMake build system.\n"
+            "If not provided, the current working directory will be used."
+        ),
+        action="store",
+        default=None,
+    )
     parser.add_argument(
         "-h",
         "--help",
@@ -584,6 +596,10 @@ if __name__ == "__main__":
         sys.exit(1)
 
     args = parser.parse_args()
-    os.chdir(args.nuttx_path)
+
+    if args.build_path is None:
+        args.build_path = args.nuttx_path
+
+    os.chdir(args.build_path)
     header = generate_header(args)
     print(header)


### PR DESCRIPTION
## Summary

<!-- This field should contain a summary of the changes. It will be pre-filled with the commit's message and descriptions. Adjust it accordingly -->

* tools: add build path support on host_info tool

Adds a build_path argument for when CMake builds are used.
This solves a problem when building the nxdiag tool with CMake.

This is related to [this PR](https://github.com/apache/nuttx-apps/pull/3491) on nuttx-apps.

## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: No.
<!-- Does it impact user's applications? How? -->

Impact on build: If using CMake, especially with Espressif devices, this will fix a problem related to the script path. Does not affect Make builds.
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: No.
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: No.
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: No.
<!-- Does it impact NuttX's security? -->

Impact on compatibility: No.
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

## Testing
<!-- Please provide all the testing procedure. Consider that upstream reviewers should be able to reproduce the same testing performed internally -->
Build with Make works fine, with CMake it would fail since build and source directory differs.


### Building
<!-- Provide how to build the test for each SoC being tested -->
Make example:
- ./tools/configure.sh esp32h2-devkit:nsh
- Enable `CONFIG_SYSTEM_NXDIAG` and `CONFIG_SYSTEM_NXDIAG_ESPRESSIF`
- build

CMake example:
- cmake -B build -DBOARD_CONFIG=esp32h2-devkit:nsh -GNinja
- Enable `CONFIG_SYSTEM_NXDIAG` and `CONFIG_SYSTEM_NXDIAG_ESPRESSIF`
- build 

### Running
<!-- Provide how to run the test for each SoC being tested -->
Make:
- `python3 -B tools/host_info_dump.py /home/fdcavalcanti/nuttxspace5/nuttx --target_info`

CMake:
- Need to pass the build directory to '-b'
- `python3 -B tools/host_info_dump.py /home/fdcavalcanti/nuttxspace5/nuttx -b build --target_info`

On both cases output works fine.