### PR TITLE
kinetis/pinirq: Drop assert for out pin interrupts

### DIFF
--- a/arch/arm/src/kinetis/kinetis_pinirq.c
+++ b/arch/arm/src/kinetis/kinetis_pinirq.c
@@ -282,12 +282,15 @@ int kinetis_pinirqattach(uint32_t pinset, xcpt_t pinisr, void *arg)
   unsigned int port;
   unsigned int pin;
 
-  /* It only makes sense to call this function for input pins that are
-   * configured as interrupts.
+  /* It makes sense to call this function for input pins that are configured
+   * as interrupts.
+   *
+   * In rare cases, for example when a GPIO pin is used in both directions, it
+   * also make sense to call this function for output pins.  However, the pins
+   * must be configured for interrupts in all cases.
    */
 
   DEBUGASSERT((pinset & _PIN_INTDMA_MASK) == _PIN_INTERRUPT);
-  DEBUGASSERT((pinset & _PIN_IO_MASK) == _PIN_INPUT);
 
   /* Get the port number and pin number */
 


### PR DESCRIPTION
When GPIO pin is used in both (input and output) directions, we need two pin definitions now:

	#define PIN_IN  (GPIO_INPUT | PIN_INT_BOTH | ...)
	#define PIN_OUT (GPIO_OUTPUT | GPIO_OUTPUT_ONE | ...)

attach the ISR to the PIN_IN:

	kinetis_pinirqattach(PIN_IN, isr, NULL);

and then when writing the pin:

	kinetis_pinconfig(PIN_OUT);
	kinetis_gpiowrite(PIN_OUT, ...);

and when reading the pin:

	kinetis_pinconfig(PIN_IN);
	kinetis_pinirqenable(PIN_IN);

We could use a single define for the pin:

	#define PIN (GPIO_OUTPUT | GPIO_OUTPUT_ONE | GPIO_OPENDRAIN | PIN_INT_BOTH | ...)

because the pin is the same, but then the

	kinetis_pinirqattach(PIN, isr, NULL);

fails with the

	DEBUGASSERT((pinset & _PIN_IO_MASK) == _PIN_INPUT);

This commit removes the failing debug assert.

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Necessary to enable attaching Interrupt Service Routine (ISR) for GPIO pins used in both directions.

## Impact

Drops the requirement for pins to be input for attaching ISR.

## Testing

For this PR, I compiled and run the code with

```
#define PIN (GPIO_OUTPUT | GPIO_OUTPUT_ONE | GPIO_OPENDRAIN | PIN_INT_BOTH | ...)
kinetis_pinirqattach(PIN, isr, NULL);
```