### PR TITLE
sim: pass no-pie through gcc driver

### DIFF
--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -336,7 +336,7 @@ else ifeq ($(CONFIG_HOST_MACOS)$(CONFIG_HOST_ARM64),)
   # which works correctly on aarch64 hosts.
   ARCHCFLAGS += -no-pie
   ARCHPICFLAGS += -no-pie
-  LDFLAGS += -Wl,-no-pie
+  LDFLAGS += -no-pie
 endif
 
 ifeq ($(CONFIG_HOST_LINUX),y)


### PR DESCRIPTION
## Summary

Pass `-no-pie` through the gcc driver instead of forwarding it as `-Wl,-no-pie`.

## Problem

On Ubuntu 20 with GCC 9, `sim:nsh` failed during the final link step with `/usr/bin/ld: cannot find -lgcc_s`.

## Validation

```bash
./tools/configure.sh sim:nsh
make -j1 nuttx
```

This change fixes the link failure in that environment.