### PR TITLE
sim: resolve host symbols eagerly on Linux

### DIFF
--- a/boards/sim/sim/sim/scripts/Make.defs
+++ b/boards/sim/sim/sim/scripts/Make.defs
@@ -340,6 +340,10 @@ else ifeq ($(CONFIG_HOST_MACOS)$(CONFIG_HOST_ARM64),)
 endif
 
 ifeq ($(CONFIG_HOST_LINUX),y)
+  # Resolve PLT entries at load time so early host calls made with
+  # simulated interrupts masked do not fault inside the lazy binder.
+  LDFLAGS += -Wl,-z,now
+
   define POSTBUILD
   	$(Q)echo "Pac SIM with dynamic libs..";
   	@ rm -rf sim-pac;


### PR DESCRIPTION
## Summary

Resolve PLT entries at load time on Linux hosts so early host calls do not enter the lazy binder with simulated interrupts masked.

## Problem

On Ubuntu 20 with GCC 9, the `sim:nsh` binary linked successfully after the `-no-pie` fix but crashed very early at runtime inside `_dl_fixup` / `_dl_runtime_resolve_xsavec` when `up_irq_save()` triggered a first-time PLT resolution.

Setting `LD_BIND_NOW=1` avoided the crash and allowed NSH to start, which showed lazy binding was the trigger.

## Validation

```bash
./tools/configure.sh sim:nsh
make -j1 nuttx
timeout 5 ./nuttx
```

`./nuttx` reached `NuttShell (NSH) NuttX-12.13.0` without needing `LD_BIND_NOW=1`.