### PR TITLE
arch/tricore: Support setjmp and longjmp.

### DIFF
--- a/arch/tricore/Kconfig
+++ b/arch/tricore/Kconfig
@@ -32,6 +32,7 @@ config ARCH_TC1V6
 	select ARCH_HAVE_SETJMP
 	select ARCH_HAVE_RESET
 	select ARCH_HAVE_TESTSET
+	select ARCH_SETJMP_H
 	default n
 
 config ARCH_TC1V8
@@ -46,6 +47,7 @@ config ARCH_TC1V8
 	select ARCH_HAVE_SETJMP
 	select ARCH_HAVE_RESET
 	select ARCH_HAVE_TESTSET
+	select ARCH_SETJMP_H
 	default n
 
 config ARCH_FAMILY

--- a/arch/tricore/include/setjmp.h
+++ b/arch/tricore/include/setjmp.h
@@ -31,35 +31,27 @@
 #include <stdint.h>
 
 /****************************************************************************
- * Pre-processor Prototypes
- ****************************************************************************/
-
-#define JB_LPCXI    0
-#define JB_LA11     1
-#define JB_A2       2
-#define JB_A3       3
-#define JB_D0       4
-#define JB_D1       5
-#define JB_D2       6
-#define JB_D3       7
-#define JB_A4       8
-#define JB_A5       9
-#define JB_A6       10
-#define JB_A7       11
-#define JB_D4       12
-#define JB_D5       13
-#define JB_D6       14
-#define JB_D7       15
-#define JB_UA11     16
-#define JB_REG_NUM  17
-
-/****************************************************************************
  * Public Types
  ****************************************************************************/
 
 struct setjmp_buf_s
 {
-  uintptr_t regs[JB_REG_NUM];
+  uintptr_t pcxi;
+  uintptr_t psw;
+  uintptr_t sp;
+  uintptr_t a11;
+  uintptr_t d8;
+  uintptr_t d9;
+  uintptr_t d10;
+  uintptr_t d11;
+  uintptr_t a12;
+  uintptr_t a13;
+  uintptr_t a14;
+  uintptr_t a15;
+  uintptr_t d12;
+  uintptr_t d13;
+  uintptr_t d14;
+  uintptr_t d15;
 };
 
 /* Traditional typedef for setjmp_buf */
@@ -79,7 +71,7 @@ extern "C"
 #endif
 
 int setjmp(jmp_buf env);
-void longjmp(jmp_buf env, int val);
+void longjmp(jmp_buf env, int val) noreturn_function;
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/arch/tricore/include/setjmp.h
+++ b/arch/tricore/include/setjmp.h
@@ -1,0 +1,89 @@
+/****************************************************************************
+ * arch/tricore/include/setjmp.h
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_TRICORE_INCLUDE_SETJUMP_H
+#define __ARCH_TRICORE_INCLUDE_SETJUMP_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/compiler.h>
+
+#include <stdint.h>
+
+/****************************************************************************
+ * Pre-processor Prototypes
+ ****************************************************************************/
+
+#define JB_LPCXI    0
+#define JB_LA11     1
+#define JB_A2       2
+#define JB_A3       3
+#define JB_D0       4
+#define JB_D1       5
+#define JB_D2       6
+#define JB_D3       7
+#define JB_A4       8
+#define JB_A5       9
+#define JB_A6       10
+#define JB_A7       11
+#define JB_D4       12
+#define JB_D5       13
+#define JB_D6       14
+#define JB_D7       15
+#define JB_UA11     16
+#define JB_REG_NUM  17
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+struct setjmp_buf_s
+{
+  uintptr_t regs[JB_REG_NUM];
+};
+
+/* Traditional typedef for setjmp_buf */
+
+typedef struct setjmp_buf_s jmp_buf[1];
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+int setjmp(jmp_buf env);
+void longjmp(jmp_buf env, int val);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ARCH_TRICORE_INCLUDE_SETJUMP_H */

--- a/libs/libc/machine/Make.defs
+++ b/libs/libc/machine/Make.defs
@@ -53,6 +53,9 @@ endif
 ifeq ($(CONFIG_ARCH_SPARC),y)
 include $(TOPDIR)/libs/libc/machine/sparc/Make.defs
 endif
+ifeq ($(CONFIG_ARCH_TRICORE),y)
+include $(TOPDIR)/libs/libc/machine/tricore/Make.defs
+endif
 DEPPATH += --dep-path machine
 VPATH += :machine
 

--- a/libs/libc/machine/tricore/CMakeLists.txt
+++ b/libs/libc/machine/tricore/CMakeLists.txt
@@ -19,3 +19,11 @@
 # the License.
 #
 # ##############################################################################
+
+set(SRCS)
+
+if(CONFIG_ARCH_SETJMP_H)
+  list(APPEND SRCS arch_setjmp.c)
+endif()
+
+target_sources(c PRIVATE ${SRCS})

--- a/libs/libc/machine/tricore/Kconfig
+++ b/libs/libc/machine/tricore/Kconfig
@@ -1,0 +1,4 @@
+#
+# For a description of the syntax of this configuration file,
+# see the file kconfig-language.txt in the NuttX tools repository.
+#

--- a/libs/libc/machine/tricore/Make.defs
+++ b/libs/libc/machine/tricore/Make.defs
@@ -1,0 +1,28 @@
+############################################################################
+# libs/libc/machine/tricore/Make.defs
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.  The
+# ASF licenses this file to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance with the
+# License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations
+# under the License.
+#
+############################################################################
+
+ifeq ($(CONFIG_ARCH_SETJMP_H),y)
+CSRCS += arch_setjmp.c
+endif
+
+DEPPATH += --dep-path machine/tricore
+VPATH += :machine/tricore

--- a/libs/libc/machine/tricore/arch_setjmp.c
+++ b/libs/libc/machine/tricore/arch_setjmp.c
@@ -1,0 +1,69 @@
+/****************************************************************************
+ * libs/libc/machine/tricore/arch_setjmp.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <string.h>
+
+#include <arch/setjmp.h>
+#include <nuttx/arch.h>
+
+#include <IfxCpu_reg.h>
+#include <IfxCpu_Intrinsics.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+int setjmp(jmp_buf env)
+{
+  uintptr_t *regs;
+  uintptr_t pcxi;
+
+  env->regs[JB_UA11] = (uintptr_t)__getA11();
+
+  pcxi = __mfcr(CPU_PCXI);
+  regs = tricore_csa2addr(pcxi);
+  memcpy(env, regs, TC_CONTEXT_SIZE);
+  return 0;
+}
+
+void longjmp(jmp_buf env, int val)
+{
+  void *func = (void *)env->regs[JB_UA11];
+  uintptr_t *regs;
+  uintptr_t pcxi;
+
+  pcxi = __mfcr(CPU_PCXI);
+  regs = tricore_csa2addr(pcxi);
+  memcpy(regs, env, TC_CONTEXT_SIZE);
+
+  if (val == 0)
+    {
+      val = 1;
+    }
+
+  __moveToDataParamRet(val);
+  __jumpToFunctionWithLink(func);
+}

--- a/libs/libc/machine/tricore/arch_setjmp.c
+++ b/libs/libc/machine/tricore/arch_setjmp.c
@@ -24,13 +24,10 @@
  * Included Files
  ****************************************************************************/
 
-#include <string.h>
+#include <nuttx/config.h>
 
+#include <nuttx/compiler.h>
 #include <arch/setjmp.h>
-#include <nuttx/arch.h>
-
-#include <IfxCpu_reg.h>
-#include <IfxCpu_Intrinsics.h>
 
 /****************************************************************************
  * Public Functions
@@ -38,32 +35,141 @@
 
 int setjmp(jmp_buf env)
 {
-  uintptr_t *regs;
-  uintptr_t pcxi;
-
-  env->regs[JB_UA11] = (uintptr_t)__getA11();
-
-  pcxi = __mfcr(CPU_PCXI);
-  regs = tricore_csa2addr(pcxi);
-  memcpy(env, regs, TC_CONTEXT_SIZE);
+  __asm__ __volatile__ (
+#ifdef CONFIG_TRICORE_TOOLCHAIN_TASKING
+    "st.a   [a4]12, a11\n\t"
+    "movh.a a11, #@HIS(.Lsaveregs)\n\t"
+    "lea    a11, [a11]@LOS(.Lsaveregs)\n\t"
+    "ret\n\t"
+    ".Lsaveregs:\n\t"
+    "st.a   [a4]8, sp\n\t"
+    "st.a   [a4]32, a12\n\t"
+    "st.a   [a4]36, a13\n\t"
+    "st.a   [a4]40, a14\n\t"
+    "st.a   [a4]44, a15\n\t"
+    "st.w   [a4]16, d8\n\t"
+    "st.w   [a4]20, d9\n\t"
+    "st.w   [a4]24, d10\n\t"
+    "st.w   [a4]28, d11\n\t"
+    "st.w   [a4]48, d12\n\t"
+    "st.w   [a4]52, d13\n\t"
+    "st.w   [a4]56, d14\n\t"
+    "st.w   [a4]60, d15\n\t"
+    "mfcr   d2, #0xfe00\n\t"
+    "st.w   [a4]0, d2\n\t"
+    "mfcr   d2, #0xfe04\n\t"
+    "st.w   [a4]4, d2\n\t"
+    "ld.a   a2, [a4]12\n\t"
+    "mov    d2, #0\n\t"
+    "ji     a2\n\t"
+#else
+    "st.a   [%%a4]12, %%a11\n\t"
+    "movh.a %%a11, hi:.Lsaveregs\n\t"
+    "lea    %%a11, [%%a11] lo:.Lsaveregs\n\t"
+    "ret\n\t"
+    ".Lsaveregs:\n\t"
+    "st.a   [%%a4]8, %%sp\n\t"
+    "st.a   [%%a4]32, %%a12\n\t"
+    "st.a   [%%a4]36, %%a13\n\t"
+    "st.a   [%%a4]40, %%a14\n\t"
+    "st.a   [%%a4]44, %%a15\n\t"
+    "st.w   [%%a4]16, %%d8\n\t"
+    "st.w   [%%a4]20, %%d9\n\t"
+    "st.w   [%%a4]24, %%d10\n\t"
+    "st.w   [%%a4]28, %%d11\n\t"
+    "st.w   [%%a4]48, %%d12\n\t"
+    "st.w   [%%a4]52, %%d13\n\t"
+    "st.w   [%%a4]56, %%d14\n\t"
+    "st.w   [%%a4]60, %%d15\n\t"
+    "mfcr   %%d2, 0xfe00\n\t"
+    "st.w   [%%a4]0, %%d2\n\t"
+    "mfcr   %%d2, 0xfe04\n\t"
+    "st.w   [%%a4]4, %%d2\n\t"
+    "ld.a   %%a2, [%%a4]12\n\t"
+    "mov    %%d2, 0\n\t"
+    "ji     %%a2\n\t"
+#endif
+    ::: "memory"
+  );
   return 0;
 }
 
 void longjmp(jmp_buf env, int val)
 {
-  void *func = (void *)env->regs[JB_UA11];
-  uintptr_t *regs;
-  uintptr_t pcxi;
+  __asm__ __volatile__ (
+#ifdef CONFIG_TRICORE_TOOLCHAIN_TASKING
+    "ld.w   d5, [a4]0\n\t"
+    ".Lloop:\n\t"
+    "mfcr   d2, #0xfe00\n\t"
+    "jne    d2, d5, .Lrelease\n\t"
+    "max.u  d2, d4, #1\n\t"
+    "ld.a   a2, [a4]12\n\t"
+    "ld.a   sp, [a4]8\n\t"
+    "ld.a   a12, [a4]32\n\t"
+    "ld.a   a13, [a4]36\n\t"
+    "ld.a   a14, [a4]40\n\t"
+    "ld.a   a15, [a4]44\n\t"
+    "ld.w   d8, [a4]16\n\t"
+    "ld.w   d9, [a4]20\n\t"
+    "ld.w   d10, [a4]24\n\t"
+    "ld.w   d11, [a4]28\n\t"
+    "ld.w   d12, [a4]48\n\t"
+    "ld.w   d13, [a4]52\n\t"
+    "ld.w   d14, [a4]56\n\t"
+    "ld.w   d15, [a4]60\n\t"
+    "ji     a2\n\t"
+    ".Lrelease:\n\t"
+    "jnz.t  d2, #20, .Lupper\n\t"
+    "mov.aa a15, a4\n\t"
+    "mov    d15, d4\n\t"
+    "mov    d14, d5\n\t"
+    "rslcx\n\t"
+    "mov    d4, d15\n\t"
+    "mov    d5, d14\n\t"
+    "mov.aa a4, a15\n\t"
+    "j      .Lloop\n\t"
+    ".Lupper:\n\t"
+    "movh.a a11, #@HIS(.Lloop)\n\t"
+    "lea    a11, [a11]@LOS(.Lloop)\n\t"
+    "ret\n\t"
+#else
+    "ld.w   %%d5, [%%a4]0\n\t"
+    ".Lloop:\n\t"
+    "mfcr   %%d2, 0xfe00\n\t"
+    "jne    %%d2, %%d5, .Lrelease\n\t"
+    "max.u  %%d2, %%d4, 1\n\t"
+    "ld.a   %%a2, [%%a4]12\n\t"
+    "ld.a   %%sp, [%%a4]8\n\t"
+    "ld.a   %%a12, [%%a4]32\n\t"
+    "ld.a   %%a13, [%%a4]36\n\t"
+    "ld.a   %%a14, [%%a4]40\n\t"
+    "ld.a   %%a15, [%%a4]44\n\t"
+    "ld.w   %%d8, [%%a4]16\n\t"
+    "ld.w   %%d9, [%%a4]20\n\t"
+    "ld.w   %%d10, [%%a4]24\n\t"
+    "ld.w   %%d11, [%%a4]28\n\t"
+    "ld.w   %%d12, [%%a4]48\n\t"
+    "ld.w   %%d13, [%%a4]52\n\t"
+    "ld.w %%d14, [%%a4]56\n\t"
+    "ld.w   %%d15, [%%a4]60\n\t"
+    "ji     %%a2\n\t"
+    ".Lrelease:\n\t"
+    "jnz.t  %%d2, 20, .Lupper\n\t"
+    "mov.aa %%a15, %%a4\n\t"
+    "mov    %%d15, %%d4\n\t"
+    "mov    %%d14, %%d5\n\t"
+    "rslcx\n\t"
+    "mov    %%d4, %%d15\n\t"
+    "mov    %%d5, %%d14\n\t"
+    "mov.aa %%a4, %%a15\n\t"
+    "j      .Lloop\n\t"
+    ".Lupper:\n\t"
+    "movh.a %%a11, hi:.Lloop\n\t"
+    "lea    %%a11, [%%a11] lo:.Lloop\n\t"
+    "ret\n\t"
+#endif
+    ::: "memory"
+  );
 
-  pcxi = __mfcr(CPU_PCXI);
-  regs = tricore_csa2addr(pcxi);
-  memcpy(regs, env, TC_CONTEXT_SIZE);
-
-  if (val == 0)
-    {
-      val = 1;
-    }
-
-  __moveToDataParamRet(val);
-  __jumpToFunctionWithLink(func);
+  __builtin_unreachable();
 }


### PR DESCRIPTION
## Summary

  * Why: TriCore architecture lacks setjmp/longjmp support, which is required by ostest and various POSIX-dependent applications.
  * What: Add setjmp.h header and arch_setjmp.c implementation for TriCore (both TC3xx and TC4xx).
  * How: First commit implements basic setjmp/longjmp using iLLD intrinsics to save/restore CSA chain. Second commit rewrites with pure inline assembly for correct no-return semantics and CSA chain recycling to prevent memory leaks.

## Impact

  * Is new feature added? Yes, setjmp/longjmp for TriCore architecture.
  * Impact on user (will user need to adapt to change)? NO
  * Impact on build (will build process change)? NO
  * Impact on hardware (will arch(s) / board(s) / driver(s) change)? YES, TriCore arch only.
  * Impact on documentation (is update required / provided)? NO
  * Impact on security (any sort of implications)? NO
  * Impact on compatibility (backward/forward/interoperability)? NO

## Testing

  I confirm that changes are verified on local setup and works as intended:
  * Build Host(s): Linux x86_64, tricore-elf-gcc 11.3.1
  * Target(s): tricore, triboard_tc4x9_com:nsh (TC4xx)

  Testing logs (build):

  ```
  LD: nuttx
  ```

  Testing logs (runtime, ostest on TC4D9 EVB):

  ```
  user_main: setjmp test
  setjmp_test: Initializing jmp_buf
  setjmp_test: Try jump
  setjmp_test: About to jump, longjmp with ret val: 123
  setjmp_test: Jump succeed
  setjmp_test: Try jump
  setjmp_test: About to jump, longjmp with ret val: 0
  setjmp_test: Jump succeed
  ...
  ostest_main: Exiting with status 0
  ```