### PR TITLE
drivers/usbhost_hidmouse: fix button detection in touchscreen example

### DIFF
--- a/drivers/usbhost/usbhost_hidmouse.c
+++ b/drivers/usbhost/usbhost_hidmouse.c
@@ -276,6 +276,7 @@ struct usbhost_state_s
   struct work_s           work;         /* For cornercase error handling by the worker thread */
   struct mouse_sample_s   sample;       /* Last sampled mouse data */
   usbhost_ep_t            epin;         /* Interrupt IN endpoint */
+  size_t                  packet_len;
 
   /* The following is a list if poll structures of threads waiting for
    * driver events. The 'struct pollfd' reference for each open is also
@@ -820,7 +821,7 @@ static bool usbhost_touchscreen(FAR struct usbhost_state_s *priv,
        * small, then ignore the event.
        */
 
-      else if (!usbhost_xythreshold(priv))
+      else if (!usbhost_threshold(priv))
         {
           return false;
         }
@@ -988,7 +989,7 @@ static int usbhost_mouse_poll(int argc, FAR char *argv[])
        */
 
       nbytes = DRVR_TRANSFER(hport->drvr, priv->epin,
-                             priv->tbuffer, priv->tbuflen);
+                             priv->tbuffer, priv->packet_len);
 
       /* Check for errors -- Bail if an excessive number of consecutive
        * errors are encountered.
@@ -1477,6 +1478,8 @@ static inline int usbhost_cfgdesc(FAR struct usbhost_state_s *priv,
                     epindesc.interval     = epdesc->interval;
                     epindesc.mxpacketsize =
                       usbhost_getle16(epdesc->mxpacketsize);
+
+                    priv->packet_len = (size_t)epindesc.mxpacketsize;
 
                     uinfo("Interrupt IN EP addr:%d mxpacketsize:%d\n",
                           epindesc.addr, epindesc.mxpacketsize);


### PR DESCRIPTION
## Summary

Fix an issue where button presses were missed in the touchscreen example due to incorrect packet processing.

Previously, the driver waited to accumulate a batch of packets but only processed the first one, effectively discarding the rest. The driver now reads and processes packets one at a time to ensure no input events are lost.

## Impact

## Testing

Before this change nothing happened when buttons were pressed.

To test, I ran tc and:
Pressed and released left button
Pressed and released middle button
Pressed and released right button

                                                       
nsh> tc                                                                                                
tc [8:100]                                                                                             
nsh> tc_main: nsamples: 0                                                                              
tc_main: Opening /dev/mouse0       

nsh> Sample     :                                                                                      
   buttons : 01                                                                                        
         x : 3                                                                                         
         y : 134                                                                                       
Sample     :                                                                                           
   buttons : 00                                                                                        
         x : 3                                                                                         
         y : 134    
Sample     :                                                                                           
   buttons : 04                                                                                        
         x : 3                                                                                         
         y : 134                                                                                       
Sample     :                                                                                           
   buttons : 00                                                                                        
         x : 3                                                                                         
         y : 134   
Sample     :                                                                                           
   buttons : 02                                                                                        
         x : 2                                                                                         
         y : 139                                                                                       
Sample     :                                                                                           
   buttons : 00                                                                                        
         x : 1                                                                                         
         y : 140   