### PR TITLE
arch/arm/stm32h5/i2c: Fix warning message about used but not initialized variables

### DIFF
--- a/arch/arm/src/stm32h5/stm32_i2c.c
+++ b/arch/arm/src/stm32h5/stm32_i2c.c
@@ -1204,11 +1204,11 @@ static void stm32_i2c_setclock(struct stm32_i2c_priv_s *priv,
   uint32_t t_presc_ns;
   uint32_t tsync1;
   uint32_t tsync2;
-  uint8_t scl_delay;
+  uint8_t scl_delay = 0;
   int32_t sda_delay_min;
-  uint8_t sda_delay;
-  uint16_t scl_h_period;
-  uint16_t scl_l_period;
+  uint8_t sda_delay = 0;
+  uint16_t scl_h_period = 0;
+  uint16_t scl_l_period = 0;
   uint8_t fmp = 0;
   uint8_t anfoff;
   uint8_t dnf;


### PR DESCRIPTION
## Summary

Fix "-Wmaybe-uninitialized" warning messages

## Impact

Reduce noise of STM32H5 devices

## Testing

```
nsh> i2c dev -b 1 03 77
NOTE: Some devices may not appear with this scan.
You may also try a scan with the -z flag to discover more devices using a zero-byte write request.
     0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
00:          -- -- -- -- -- -- -- -- -- -- -- -- -- 
10: -- -- -- -- -- -- -- -- -- -- -- -- -- -- 1e -- 
20: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
30: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
40: -- -- -- -- -- -- -- -- 48 -- -- -- -- -- -- -- 
50: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
60: -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- -- 
70: -- -- -- -- -- -- 76 --                         
nsh> i2c get -b 1 -a 0x76 -r 0x00
READ Bus: 1 Addr: 76 Subaddr: 00 Value: 60

```
BMP390 connected in 0x76

<img width="365" height="60" alt="image" src="https://github.com/user-attachments/assets/3790fdec-5422-4529-b5d4-1b86e0d865f9" />

