### PR TITLE
golfish_gpu_fb: clear fb when initialization

### DIFF
--- a/drivers/video/goldfish_gpu_fb.c
+++ b/drivers/video/goldfish_gpu_fb.c
@@ -576,6 +576,10 @@ int goldfish_gpu_fb_register(int display)
   fb->vtable.getplaneinfo = goldfish_gpu_fb_getplaneinfo;
   fb->vtable.getvideoinfo = goldfish_gpu_fb_getvideoinfo;
 
+  /* Clear goldfish_gpu_fb */
+
+  goldfish_gpu_fb_commit(fb, fb->planeinfo.fbmem);
+
   /* Create the vsync thread */
 
   snprintf(arg1, 32, "%p", fb);


### PR DESCRIPTION
Commit an initial blank frame during goldfish_gpu_fb_register() to avoid rendering a stale frame from the emulator after reboot.
Summary
After a reboot, the Goldfish GPU emulator retains the last rendered frame in its display buffer. When the guest OS re-registers the framebuffer driver, this stale frame is briefly visible on screen before the first real frame is rendered by the application.

This patch adds a goldfish_gpu_fb_commit() call with the freshly allocated (zeroed) framebuffer during goldfish_gpu_fb_register(), which pushes a blank frame to the emulator immediately at initialization time, eliminating the visual artifact.

Impact
Users: No more stale/garbage frame flash on screen during boot on Goldfish GPU targets.
Build: No new Kconfig options; the change is unconditional for CONFIG_GOLDFISH_GPU_FB.
Compatibility: No API or ABI change. Only affects the Goldfish GPU FB driver initialization path.
Testing
Host: Ubuntu 22.04 x86_64
Board: goldfish-armeabi-v7a (QEMU emulator)
Steps:
Boot NuttX with CONFIG_GOLDFISH_GPU_FB=y and run lvgldemo widgets.
Issue reboot command from NSH.
Observe the screen during the second boot.
Before: A stale frame from the previous session flickers on screen for ~1-2 vsync periods before LVGL renders the first frame.
After: Screen stays blank (black) from driver registration until the first application frame is committed. No stale frame observed.