### PR TITLE
drivers/video: use spinlock to replace critical section for goldfish_…

### DIFF
--- a/drivers/video/goldfish_fb.c
+++ b/drivers/video/goldfish_fb.c
@@ -29,6 +29,7 @@
 #include <nuttx/video/fb.h>
 #include <nuttx/irq.h>
 #include <nuttx/kmalloc.h>
+#include <nuttx/spinlock.h>
 
 /****************************************************************************
  * Pre-processor definitions
@@ -82,6 +83,7 @@ struct goldfish_fb_s
   struct fb_videoinfo_s videoinfo;
   FAR void *base;
   int irq;
+  spinlock_t lock;                  /* Lock for this framebuffer */
 };
 
 /****************************************************************************
@@ -166,7 +168,7 @@ static int goldfish_fb_interrupt(int irq, FAR void *dev_id, FAR void *arg)
   irqstate_t flags;
   uint32_t status;
 
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave(&fb->lock);
   status = getreg32(fb->base + GOLDFISH_FB_INT_STATUS);
   if (status & GOLDFISH_FB_INT_VSYNC)
     {
@@ -178,7 +180,7 @@ static int goldfish_fb_interrupt(int irq, FAR void *dev_id, FAR void *arg)
       goldfish_fb_framedone_irq(fb);
     }
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&fb->lock, flags);
   return OK;
 }
 

--- a/drivers/video/vnc/vnc_server.h
+++ b/drivers/video/vnc/vnc_server.h
@@ -41,6 +41,7 @@
 #include <nuttx/input/keyboard.h>
 #include <nuttx/net/net.h>
 #include <nuttx/semaphore.h>
+#include <nuttx/spinlock.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -210,6 +211,8 @@ struct vnc_session_s
   volatile bool bigendian;     /* True: Remote expect data in big-endian format */
   volatile bool rre;           /* True: Remote supports RRE encoding */
   FAR uint8_t *fb;             /* Allocated local frame buffer */
+
+  spinlock_t lock;             /* Lock for vnc updating */
 
   /* VNC client input support */
 

--- a/drivers/video/vnc/vnc_updater.c
+++ b/drivers/video/vnc/vnc_updater.c
@@ -192,15 +192,16 @@ vnc_alloc_update(FAR struct vnc_session_s *session)
    */
 
   vnc_sem_debug(session, "Before alloc", 0);
-  flags = enter_critical_section();
 
   nxsem_wait_uninterruptible(&session->freesem);
+
+  flags = spin_lock_irqsave(&session->lock);
 
   /* It is reserved.. go get it */
 
   update = (FAR struct vnc_fbupdate_s *)sq_remfirst(&session->updfree);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&session->lock, flags);
   vnc_sem_debug(session, "After alloc", 1);
 
   DEBUGASSERT(update != NULL);
@@ -232,7 +233,7 @@ static void vnc_free_update(FAR struct vnc_session_s *session,
    */
 
   vnc_sem_debug(session, "Before free", 1);
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave_nopreempt(&session->lock);
 
   /* Put the entry into the free list */
 
@@ -242,7 +243,7 @@ static void vnc_free_update(FAR struct vnc_session_s *session,
 
   nxsem_post(&session->freesem);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore_nopreempt(&session->lock, flags);
   vnc_sem_debug(session, "After free", 0);
 
   DEBUGASSERT(nxsem_get_value(&session->freesem, &sval) == 0 &&
@@ -278,9 +279,10 @@ vnc_remove_queue(FAR struct vnc_session_s *session)
    */
 
   vnc_sem_debug(session, "Before remove", 0);
-  flags = enter_critical_section();
 
   nxsem_wait_uninterruptible(&session->queuesem);
+
+  flags = spin_lock_irqsave(&session->lock);
 
   /* It is reserved.. go get it */
 
@@ -302,7 +304,7 @@ vnc_remove_queue(FAR struct vnc_session_s *session)
     }
 
 errout:
-  leave_critical_section(flags);
+  spin_unlock_irqrestore(&session->lock, flags);
   return rect;
 }
 
@@ -332,7 +334,7 @@ static void vnc_add_queue(FAR struct vnc_session_s *session,
    */
 
   vnc_sem_debug(session, "Before add", 1);
-  flags = enter_critical_section();
+  flags = spin_lock_irqsave_nopreempt(&session->lock);
 
   /* Put the entry into the list of queued rectangles. */
 
@@ -344,7 +346,7 @@ static void vnc_add_queue(FAR struct vnc_session_s *session,
 
   nxsem_post(&session->queuesem);
 
-  leave_critical_section(flags);
+  spin_unlock_irqrestore_nopreempt(&session->lock, flags);
   vnc_sem_debug(session, "After add", 0);
 
   DEBUGASSERT(nxsem_get_value(&session->queuesem, &sval) == 0 &&
@@ -611,12 +613,10 @@ int vnc_update_rectangle(FAR struct vnc_session_s *session,
        * the framebuffer since the last whole screen update.
        */
 
-      flags = enter_critical_section();
       if (!change && !session->change)
         {
           /* No.. ignore the client update.  We have nothing new to report. */
 
-          leave_critical_section(flags);
           return OK;
         }
 
@@ -636,9 +636,10 @@ int vnc_update_rectangle(FAR struct vnc_session_s *session,
               FAR struct vnc_fbupdate_s *next;
 
               updinfo("New whole screen update...\n");
-
+              flags = spin_lock_irqsave(&session->lock);
               curr = (FAR struct vnc_fbupdate_s *)session->updqueue.head;
               sq_init(&session->updqueue);
+              spin_unlock_irqrestore(&session->lock, flags);
               nxsem_reset(&session->queuesem, 0);
 
               for (; curr != NULL; curr = next)
@@ -681,8 +682,6 @@ int vnc_update_rectangle(FAR struct vnc_session_s *session,
                   intersection.x, intersection.y,
                   intersection.w, intersection.h);
         }
-
-      leave_critical_section(flags);
     }
 
   /* Since we ignore bad rectangles and wait for update structures, there is


### PR DESCRIPTION
Summary
On SMP systems, enter_critical_section()/leave_critical_section() only disables interrupts on the local CPU, leaving shared data structures (goldfish_fb interrupt status, VNC update queue) unprotected from concurrent access by other cores.

This patch replaces critical sections with per-device spinlocks (spin_lock_irqsave/spin_unlock_irqrestore) in:

goldfish_fb.c: interrupt handler
vnc_updater.c: update queue alloc/free/add/remove operations
The _nopreempt variants are used in vnc_free_update() and vnc_add_queue() where nxsem_post() is called under the lock, to avoid triggering preemption while the spinlock is held.

Impact
SMP correctness: Fixes potential race conditions on multi-core targets using goldfish_fb or VNC server.
Single-core: No functional change — spinlock degrades to interrupt disable on UP systems.
Compatibility: No API change. Internal locking only.