### PR TITLE
arch/risc-v/espressif: Fix CMake build issues for new peripheral support

### DIFF
--- a/arch/risc-v/src/common/espressif/CMakeLists.txt
+++ b/arch/risc-v/src/common/espressif/CMakeLists.txt
@@ -188,6 +188,14 @@ if(CONFIG_CRYPTO_CRYPTODEV_HARDWARE)
   list(APPEND SRCS esp_crypto.c)
 endif()
 
+if(CONFIG_ESPRESSIF_TOUCH)
+  list(APPEND SRCS esp_touch.c)
+endif()
+
+if(CONFIG_COMP)
+  list(APPEND SRCS esp_ana_cmpr.c)
+endif()
+
 if(CONFIG_ESPRESSIF_USE_LP_CORE)
   message(
     WARNING


### PR DESCRIPTION
## Summary

<!-- This field should contain a summary of the changes. It will be pre-filled with the commit's message and descriptions. Adjust it accordingly -->

* arch/risc-v/espressif: Fix CMake build issues for new peripheral support

Fix CMake build issues

## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: Yes, analog comparator support added 
<!-- Does it impact user's applications? How? -->

Impact on build: No
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: Yes, analog comparator support added
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: Yes, related docs added
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: No
<!-- Does it impact NuttX's security? -->

Impact on compatibility: No
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

## Testing
<!-- Please provide all the testing procedure. Consider that upstream reviewers should be able to reproduce the same testing performed internally -->

- Analog Comparator
Config used:
```
esp32p4-function-ev-board:analog_cmpr
esp32h2-devkit:analog_cmpr
```

With these options added into defconfig:
```
CONFIG_DEBUG_ANALOG
CONFIG_DEBUG_ANALOG_ERROR
CONFIG_DEBUG_ANALOG_INFO
CONFIG_DEBUG_ANALOG_WARN
CONFIG_DEBUG_FEATURES
```

- Touch Sensor
`esp32p4-function-ev-board:buttons` config used with these options (added into defconfig)

```
CONFIG_ESPRESSIF_TOUCH=y
CONFIG_ESP_TOUCH_CHANNEL1=y
CONFIG_ESP_TOUCH_IRQ=y
```

### Building
<!-- Provide how to build the test for each SoC being tested -->

Command to build:

- Analog Comparator

```
ntxbuild start esp32p4-function-ev-board analog_cmpr --use-cmake && ntxbuild build && ESPTOOL_PORT=/dev/ttyUSB0 cmake --build build -t flash
```

- Touch Sensor

```
ntxbuild start esp32p4-function-ev-board buttons --use-cmake && ntxbuild build && ESPTOOL_PORT=/dev/ttyUSB0 cmake --build build -t flash
```

### Running
<!-- Provide how to run the test for each SoC being tested -->

- Analog Comparator

SRC pin of comparator (GPIO52->P4 GPIO11->H2) connected to GND at first, after that pin connected to 3v3

Snippet used to test is looking like this:

```
#include <nuttx/config.h>
#include <nuttx/analog/comp.h>
#include <inttypes.h>
#include <stdio.h>
#include <fcntl.h>
#include <unistd.h>
#include <syslog.h>
#include <sys/types.h>
#include <sys/ioctl.h>
#include <stdlib.h>
#include <string.h>
#include <errno.h>
#include <debug.h>
#include <driver/gpio.h>


int main(int argc, FAR char *argv[])
{
  int fd;
  int ret;
  int res;

  fd = open("/dev/anacmpr0", O_RDONLY);

  while(1)
    {
      ret = read(fd, &res, sizeof(res));
      if (ret != 0)
        {
           printf("Result: %ld\n", res);
        }
    }
  ret = read(fd, &res, sizeof(res));

  return OK;
}

```

- Touch Sensor

`buttons` example run and then touched to the GPIO2 pin 

### Results
<!-- Provide tests' results and runtime logs -->

Output:

- Analog Comparator

```
nsh> ls /dev
/dev:
 anacmpr0
...
nsh>  custom_app
Result: 0
esp_ana_cmpr_callback: Comparator unit0: Positive cross event triggered
Result: 1
esp_ana_cmpr_callback: Comparator unit0: Negative cross event triggered
Result: 0
```


- Touch Sensor

Output should look like this:

```
nsh> buttons
buttons_main: Starting the button_daemon
btn_supported: NUM_BUTTONS: 02
board_buttons: Reading button 0
board_buttons: b=0 n=0
board_buttons: Reading button 1
board_buttons: b=0 n=0
btn_enable: press: 0f release: 0f handler: 0x40021da0 arg: 0x4ff2b6d0
board_button_irq: Attach 0x400218b0 to touch pad 1
btn_supported: NUM_BUTTONS: 02
btn_enable: press: 0f release: 0f handler: 0x40021da0 arg: 0x4ff2b6d0
board_button_irq: Attach 0x400218b0 to touch pad 1
buttons_main: button_daemon started
button_daemon: Running
button_daemon: Opening /dev/buttons
button_daemon: Supported BUTTONs 0x03
nsh> board_buttons: Reading button 0
board_buttons: b=0 n=0
board_buttons: Reading button 1
board_buttons: b=0 n=0
btn_supported: NUM_BUTTONS: 02
BUTTON1 was pressed
```