### PR TITLE
arch/risc-v: Fix Espressif timer registering ID

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_gptimer.c
+++ b/arch/risc-v/src/common/espressif/esp_gptimer.c
@@ -601,7 +601,7 @@ int esp_timer_initialize(int group_id)
       return -ENOMEM;
     }
 
-  snprintf(devpath, PATH_MAX, "/dev/timer%" PRIu32, lower->hal.timer_id);
+  snprintf(devpath, PATH_MAX, "/dev/timer%d", group_id);
 
   /* Initialize the elements of lower half state structure */
 


### PR DESCRIPTION
## Summary

* arch/risc-v: Fix Espressif timer registering ID
  * Fix Espressif timer registering ID. Espressif's general purpose timers are grouped in different Timer Groups, which may contain more than one general purpose timer. The current implementation is related to the timer groups (timer0 refers to Timer Group 0, for instance), but previous registering method was referring to the timer inside each group, which caused it to fail when more than one timer group was being selected because only the first timer on each group is being actually registered.

## Impact

Impact on user: Yes. Enable registering two general purpose timers at a time.

Impact on build: No.

Impact on hardware: RISC-V-based Espressif SoCs.

Impact on documentation: No.

Impact on security: No.

Impact on compatibility: No.

## Testing

Before applying this patch, only one general purpose was being properly registered at `/dev/timer0` (no `/dev/timer1`) 

### Building

Check it by building the same firmware before and after applying this patch. For `esp32p4-function-ev-board:timers`:

```
make -j distclean && ./tools/configure.sh -S esp32p4-function-ev-board:timers && kconfig-tweak -d ONESHOT && kconfig-tweak -d EXAMPLES_ONESHOT && make flash ESPTOOL_PORT=/dev/ttyACM0 -s -j$(nproc) && picocom -b 115200 /dev/ttyUSB1
```

### Running

Check timers registered at `/dev/`.

### Results

#### Before this patch

Only `/dev/timer0` is registered:

```
nsh> ls /dev/
/dev:
 console
 null
 random
 timer0
 ttyS0
 zero
```

#### After this patch

Both `/dev/timer0` and `/dev/timer1` are registered:

```
nsh> ls /dev/
/dev:
 console
 null
 random
 timer0
 timer1
 ttyS0
 zero
```