### PR TITLE
arch/arm/stm32h5/stm32_ethernet: Add missing netdev_carrier calls

### DIFF
--- a/arch/arm/src/stm32h5/stm32_ethernet.c
+++ b/arch/arm/src/stm32h5/stm32_ethernet.c
@@ -2464,6 +2464,7 @@ static int stm32_ifup(struct net_driver_s *dev)
   up_enable_irq(STM32_IRQ_ETH);
 
   stm32_checksetup();
+  netdev_carrier_on(dev);
   return OK;
 }
 
@@ -2509,6 +2510,7 @@ static int stm32_ifdown(struct net_driver_s *dev)
   /* Mark the device "down" */
 
   priv->ifup = false;
+  netdev_carrier_off(dev);
   leave_critical_section(flags);
   return OK;
 }


### PR DESCRIPTION
This follows what was done in a7567677a8

## Summary

It appears that a7567677a8 did not update stm32_ethernet.

## Impact

Without this change the carrier does not become available.

## Testing

Current master:
```
nsh> ifconfig
eth0    Link encap:Ethernet HWaddr 00:e0:de:ad:be:ef at UP mtu 1486
        inet addr:0.0.0.0 DRaddr:10.0.0.1 Mask:255.255.255.0

lo      Link encap:Local Loopback at RUNNING mtu 1518
        inet addr:127.0.0.1 DRaddr:127.0.0.1 Mask:255.0.0.0

             IPv4   TCP   UDP  ICMP
Received     0000  0000  0000  0000
Dropped      0000  0000  0000  0000
  IPv4        VHL: 0000   Frg: 0000
  Checksum   0000  0000  0000  ----
  TCP         ACK: 0000   SYN: 0000
              RST: 0000  0000
  Type       0000  ----  ----  0000
Sent         0000  0000  0000  0000
  Rexmit     ----  0000  ----  ----
```

With this change:
```
nsh> ifconfig
eth0    Link encap:Ethernet HWaddr 00:e0:de:ad:be:ef at RUNNING mtu 1486
        inet addr:192.168.31.35 DRaddr:192.168.31.1 Mask:255.255.255.0

lo      Link encap:Local Loopback at RUNNING mtu 1518
        inet addr:127.0.0.1 DRaddr:127.0.0.1 Mask:255.0.0.0

             IPv4   TCP   UDP  ICMP
Received     0002  0000  0002  0000
Dropped      0000  0000  0000  0000
  IPv4        VHL: 0000   Frg: 0000
  Checksum   0000  0000  0000  ----
  TCP         ACK: 0000   SYN: 0000
              RST: 0000  0000
  Type       0000  ----  ----  0000
Sent         0003  0000  0003  0000
  Rexmit     ----  0000  ----  ----
```

As you can see, the addr works, dhcp gets the ip and the interface shows as RUNNING.
