### PR TITLE
ci/platforms: Updated URL of kconfig-frontends src

### DIFF
--- a/tools/ci/platforms/darwin.sh
+++ b/tools/ci/platforms/darwin.sh
@@ -62,6 +62,7 @@ arm_gcc_toolchain() {
     local basefile
     basefile=arm-gnu-toolchain-13.2.rel1-darwin-x86_64-arm-none-eabi
     cd "${NUTTXTOOLS}"
+    # Download the latest ARM GCC toolchain prebuilt by ARM
     curl -O -L -s https://developer.arm.com/-/media/Files/downloads/gnu/13.2.rel1/binrel/${basefile}.tar.xz
     xz -d ${basefile}.tar.xz
     tar xf ${basefile}.tar
@@ -214,7 +215,7 @@ kconfig_frontends() {
   add_path "${NUTTXTOOLS}"/kconfig-frontends/bin
 
   if [ ! -f "${NUTTXTOOLS}/kconfig-frontends/bin/kconfig-conf" ]; then
-    git clone --depth 1 https://bitbucket.org/nuttx/tools.git "${NUTTXTOOLS}"/nuttx-tools
+    git clone --depth 1 https://github.com/patacongo/tools.git "${NUTTXTOOLS}"/nuttx-tools
     cd "${NUTTXTOOLS}"/nuttx-tools/kconfig-frontends
     ./configure --prefix="${NUTTXTOOLS}"/kconfig-frontends \
       --disable-kconfig --disable-nconf --disable-qconf \
@@ -435,6 +436,8 @@ install_build_tools() {
   rm -f /usr/local/bin/python3-config || :
   # same for openssl
   rm -f /usr/local/bin/openssl || :
+
+  brew update
 
   oldpath=$(cd . && pwd -P)
   for func in ${install}; do

--- a/tools/ci/platforms/darwin_arm64.sh
+++ b/tools/ci/platforms/darwin_arm64.sh
@@ -192,7 +192,7 @@ kconfig_frontends() {
   add_path "${NUTTXTOOLS}"/kconfig-frontends/bin
 
   if [ ! -f "${NUTTXTOOLS}/kconfig-frontends/bin/kconfig-conf" ]; then
-    git clone --depth 1 https://bitbucket.org/nuttx/tools.git "${NUTTXTOOLS}"/nuttx-tools
+    git clone --depth 1 https://github.com/patacongo/tools.git "${NUTTXTOOLS}"/nuttx-tools
     cd "${NUTTXTOOLS}"/nuttx-tools/kconfig-frontends
     ./configure --prefix="${NUTTXTOOLS}"/kconfig-frontends \
       --disable-kconfig --disable-nconf --disable-qconf \

--- a/tools/ci/platforms/linux.sh
+++ b/tools/ci/platforms/linux.sh
@@ -106,7 +106,7 @@ kconfig_frontends() {
   add_path "${NUTTXTOOLS}"/kconfig-frontends/bin
 
   if [ ! -f "${NUTTXTOOLS}/kconfig-frontends/bin/kconfig-conf" ]; then
-    git clone --depth 1 https://bitbucket.org/nuttx/tools.git "${NUTTXTOOLS}"/nuttx-tools
+    git clone --depth 1 https://github.com/patacongo/tools.git "${NUTTXTOOLS}"/nuttx-tools
     cd "${NUTTXTOOLS}"/nuttx-tools/kconfig-frontends
     ./configure --prefix="${NUTTXTOOLS}"/kconfig-frontends \
       --disable-kconfig --disable-nconf --disable-qconf \

--- a/tools/ci/platforms/ubuntu.sh
+++ b/tools/ci/platforms/ubuntu.sh
@@ -159,7 +159,7 @@ kconfig_frontends() {
   add_path "${NUTTXTOOLS}"/kconfig-frontends/bin
 
   if [ ! -f "${NUTTXTOOLS}/kconfig-frontends/bin/kconfig-conf" ]; then
-    git clone --depth 1 https://bitbucket.org/nuttx/tools.git "${NUTTXTOOLS}"/nuttx-tools
+    git clone --depth 1 https://github.com/patacongo/tools.git "${NUTTXTOOLS}"/nuttx-tools
     cd "${NUTTXTOOLS}"/nuttx-tools/kconfig-frontends
     ./configure --prefix="${NUTTXTOOLS}"/kconfig-frontends \
       --disable-kconfig --disable-nconf --disable-qconf \


### PR DESCRIPTION
## Summary

New Url https://github.com/patacongo/tools.git

- ci/platforms/darwin.sh
- ci/platforms/darwin_arm64.sh
- ci/platforms/linux.sh
- ci/platforms/ubuntu.sh

 https://github.com/apache/nuttx/pull/18883#issuecomment-4467204640


## Impact

Impact on user: No changes to user-facing functionality
Impact on build: Build process remains the same

## Testing

GitHub

macOS (macos)

```
+ '[' '!' -f /Users/runner/work/manual-nuttx-ci/manual-nuttx-ci/sources/tools/kconfig-frontends/bin/kconfig-conf ']'
+ git clone --depth 1 https://github.com/patacongo/tools.git /Users/runner/work/manual-nuttx-ci/manual-nuttx-ci/sources/tools/nuttx-tools
Cloning into '/Users/runner/work/manual-nuttx-ci/manual-nuttx-ci/sources/tools/nuttx-tools'...
+ cd /Users/runner/work/manual-nuttx-ci/manual-nuttx-ci/sources/tools/nuttx-tools/kconfig-frontends
+ ./configure --prefix=/Users/runner/work/manual-nuttx-ci/manual-nuttx-ci/sources/tools/kconfig-frontends --disable-kconfig --disable-nconf --disable-qconf --disable-gconf --disable-mconf --disable-static --disable-shared --disable-L10n
```

https://github.com/simbit18/manual-nuttx-ci/actions/runs/25997548433/job/76414646119#logs