### PR TITLE
arch/arm/rp23xx: Fix PWM frequency, duty cycle and API migration.

### DIFF
--- a/arch/arm/src/rp23xx/rp23xx_pwm.c
+++ b/arch/arm/src/rp23xx/rp23xx_pwm.c
@@ -359,9 +359,9 @@ int pwm_start(struct pwm_lowerhalf_s  * dev,
         }
     }
 #else
-  if (priv->duty != info[0].duty)
+  if (priv->duty != info->channels[0].duty)
     {
-      priv->duty = info[0].duty;
+      priv->duty = info->channels[0].duty;
     }
 #endif
 
@@ -465,51 +465,77 @@ int pwm_ioctl(struct pwm_lowerhalf_s  * dev,
  *
  ****************************************************************************/
 
-void setup_period(struct rp23xx_pwm_lowerhalf_s  * priv)
+void setup_period(struct rp23xx_pwm_lowerhalf_s *priv)
 {
   irqstate_t flags;
-  uint32_t max_freq = BOARD_SYS_FREQ / 0x10000; /* initially, with full range count */
   uint32_t frequency = priv->frequency;
+  uint32_t top;
+  uint32_t div16;
 
-  /* If we are running phase correct we double the frequency value
-   * since the PWM will generate a pulse chain at half what it
-   * would be in normal (non-phase correct) mode
-   */
+  /* Phase-correct mode halves output frequency */
 
   if (priv->flags & RP23XX_PWM_CSR_PH_CORRECT)
     {
       frequency *= 2;
     }
 
-  pwminfo("PWM%d freq %ld max %ld\n", priv->num, priv->frequency, max_freq);
+  /* Try to keep maximum resolution first */
 
-  if (frequency <= max_freq)
+  top = 0xffff;
+
+  /* Divider is 8.4 fixed-point:
+   *
+   *   div16 = divider * 16
+   *
+   * PWM frequency:
+   *
+   *   f_pwm = clk_sys / (divider * (TOP + 1))
+   *
+   * therefore:
+   *
+   *   div16 = (16 * clk_sys) / (f_pwm * (TOP + 1))
+   */
+
+  div16 = (16ULL * BOARD_SYS_FREQ) /
+          ((uint64_t)frequency * (top + 1));
+
+  /* Divider must be in valid hardware range:
+   * 1.0 -> 255.9375
+   * represented as:
+   * 0x10 -> 0xFFF
+   */
+
+  if (div16 < 0x10)
     {
-      /* We can keep full range count and slow clock down with divisor */
+      /* Divider too small:
+       * reduce TOP to increase frequency
+       */
 
-      priv->top = 0xffff;
+      div16 = 0x10;
+      top = (BOARD_SYS_FREQ /
+            ((div16 / 16.0) * frequency)) - 1;
+      if (top > 0xffff)
+        {
+          top = 0xffff;
+        }
     }
-    else
+  else if (div16 > 0xfff)
     {
-      /* we need to speed things up by reducing top */
-
-      priv->top = 0xffff / (frequency / max_freq);
-
-      /* compute new maximum frequency */
-
-      max_freq  = BOARD_SYS_FREQ / (priv->top + 1);
+      div16 = 0xfff;
     }
 
-  priv->divisor = 16 * max_freq / frequency;
+  priv->top     = top;
+  priv->divisor = div16;
 
-  pwminfo("PWM%d top 0x%08X div 0x%08lX\n",
-          priv->num,
-          priv->top,
-          priv->divisor);
+  pwminfo("PWM%d freq=%lu top=%lu div=%lu\n",
+         priv->num,
+         priv->frequency,
+         priv->top,
+         priv->divisor);
 
   flags = enter_critical_section();
 
-  putreg32(priv->top,     RP23XX_PWM_TOP(priv->num));
+  putreg32(priv->top, RP23XX_PWM_TOP(priv->num));
   putreg32(priv->divisor, RP23XX_PWM_DIV(priv->num));
 
   leave_critical_section(flags);
@@ -526,19 +552,43 @@ void setup_period(struct rp23xx_pwm_lowerhalf_s  * priv)
  *
  ****************************************************************************/
 
-void setup_pulse(struct rp23xx_pwm_lowerhalf_s  * priv)
+void setup_pulse(struct rp23xx_pwm_lowerhalf_s *priv)
 {
   irqstate_t flags;
 
 #if defined(CONFIG_PWM_NCHANNELS) && CONFIG_PWM_NCHANNELS == 2
-  uint32_t compare =
-             (0xffff * (uint32_t)priv->duty[0] / priv->top)
-          + ((0xffff * (uint32_t)priv->duty[1] / priv->top) << 16);
+
+  uint32_t level_a =
+      ((uint64_t)priv->duty[0] * (priv->top + 1)) / 65535;
+
+  uint32_t level_b =
+      ((uint64_t)priv->duty[1] * (priv->top + 1)) / 65535;
+
+  if (level_a > priv->top)
+    {
+      level_a = priv->top;
+    }
+
+  if (level_b > priv->top)
+    {
+      level_b = priv->top;
+    }
+
+  uint32_t compare = level_a | (level_b << 16);
+
 #else
-  uint32_t compare = 0xffff * (uint32_t)priv->duty / priv->top;
+
+  uint32_t compare =
+      ((uint64_t)priv->duty * (priv->top + 1)) / 65535;
+
+  if (compare > priv->top)
+    {
+      compare = priv->top;
+    }
+
 #endif
 
-  pwminfo("PWM%d compare 0x%08lX  flags 0x%08lX\n",
+  pwminfo("PWM%d compare=0x%08lx flags=0x%08lx\n",
           priv->num,
           compare,
           priv->flags);
@@ -548,11 +598,11 @@ void setup_pulse(struct rp23xx_pwm_lowerhalf_s  * priv)
   putreg32(compare, RP23XX_PWM_CC(priv->num));
 
   modreg32(priv->flags,
-            RP23XX_PWM_CSR_DIVMODE_MASK
-          | RP23XX_PWM_CSR_B_INV
-          | RP23XX_PWM_CSR_A_INV
-          | RP23XX_PWM_CSR_PH_CORRECT,
-          RP23XX_PWM_CSR(priv->num));
+           RP23XX_PWM_CSR_DIVMODE_MASK |
+           RP23XX_PWM_CSR_B_INV |
+           RP23XX_PWM_CSR_A_INV |
+           RP23XX_PWM_CSR_PH_CORRECT,
+           RP23XX_PWM_CSR(priv->num));
 
   leave_critical_section(flags);
 }


### PR DESCRIPTION
## Summary

Fix three bugs in the RP23XX PWM driver that produced incorrect frequency, duty cycle output, and build failure on real hardware:

* `setup_period`: The previous divisor calculation used integer arithmetic that caused overflow and loss of precision. The divider is now computed using 64-bit arithmetic and clamped to the valid hardware range (0x10 to 0xFFF).

* `setup_pulse`: The compare value was incorrectly scaled by TOP instead of 65535, producing wrong duty cycles for all values. The corrected formula is: `compare = (duty * (top + 1)) / 65535`, with an overflow guard.

* `pwm_start`: The driver was not updated as part of the breaking change introduced in commit 4df80e19 ("!drivers/pwm: remove PWM_MULTICHAN option"), which migrated the single-channel API from `info->XXX` to `info->channels[0].XXX`. This caused the driver to fail to compile
  with CONFIG_PWM=y and CONFIG_PWM_NCHANNELS=1.
  
  The fix was derived from the RP2350 PWM formula as per the RP2350 datasheet
(section 12.5.2.6, "Configuring PWM period"):

  f_pwm = f_sys / ((TOP + 1) * (CSR_PH_CORRECT + 1) * (DIV_INT + DIV_FRAC / 16))

Reference: https://pip-assets.raspberrypi.com/categories/1214-rp2350/documents/RP-008373-DS-2-rp2350-datasheet.pdf

## Impact

* Is new feature added? Is existing feature changed?
  NO. Bug fix only.
* Impact on user (will user need to adapt to change)?
  NO. The fix corrects silent hardware misconfiguration.
* Impact on build (will build process change)?
  YES. The driver previously failed to compile with CONFIG_PWM=y and CONFIG_PWM_NCHANNELS=1 due to missing API migration from commit 4df80e19.
* Impact on hardware (will arch(s) / board(s) / driver(s) change)?
  YES. Affects all RP23XX boards using the PWM driver.
* Impact on documentation (is update required / provided)?
  NO.
* Impact on security (any sort of implications)?
  NO.
* Impact on compatibility (backward/forward/interoperability)?
  NO.

## Testing

  I confirm that changes are verified on local setup and works as intended:
  * Build Host: Linux, GCC
  * Target: ARM Cortex-M33, raspberrypi-pico-2:nsh, PWM3 pin 6

  Verification at 25 kHz (f_sys = 150 MHz):
  Expected: TOP = 5999, DIV = 16 (1.0), f_pwm = 150e6 / (6000 * 1.0) = 25 kHz

  Testing logs before change (original driver, f_sys=150MHz, f_pwm=25kHz):

Duty 10%:
```sh
setup_period: PWM3 freq 25000 max 2288
setup_period: PWM3 top 0x00001999 div 0x0000000E
setup_pulse: PWM3 compare 0x0000FFFF flags 0x00000000
```

Duty 50%:
```sh
setup_period: PWM3 top 0x00001999 div 0x0000000E
setup_pulse: PWM3 compare 0x0005000F flags 0x00000000
```

Duty 100%:
```sh
setup_period: PWM3 top 0x00001999 div 0x0000000E
setup_pulse: PWM3 compare 0x000A0028 flags 0x00000000
```

  The original code produces incorrect results:
  * TOP=0x1999 (6553) instead of 5999: wrong frequency
  * DIV=0x0E (0.875) instead of 0x10 (1.0): further frequency error
  * compare at 10% duty = 0xFFFF (65535): equals 100% output
  * compare at 50% and 100%: overflow, values exceed TOP

  Testing logs after change:

  Duty 10% (duty=0x1999=6553, compare expected=0x0257=599):
```sh
nsh> pwm -d 10
pwm_start: PWM3
setup_period: PWM3 freq=25000 top=5999 div=16
setup_pulse: PWM3 compare=0x00000257 flags=0x00000000
```

  Duty 50% (duty=0x7fff=32767, compare expected=0x0BB7=2999):
```sh
nsh> pwm -d 50
pwm_start: PWM3
setup_period: PWM3 freq=25000 top=5999 div=16
setup_pulse: PWM3 compare=0x00000bb7 flags=0x00000000
```


  Duty 100% (duty=0xffff=65535, compare expected=0x176F=5999):
```sh
nsh> pwm -d 100
pwm_start: PWM3
setup_period: PWM3 freq=25000 top=5999 div=16
setup_pulse: PWM3 compare=0x0000176f flags=0x00000000
```

All compare values match the expected hardware calculations.


## PR verification Self-Check

  * [x] This PR introduces only one functional change.
  * [x] I have updated all required description fields above.
  * [x] My PR adheres to Contributing Guidelines and Documentation.
  * [ ] My PR is still work in progress (not ready for review).
  * [x] My PR is ready for review and can be safely merged into a codebase.
    