### PR TITLE
Dockerfile & Docs: Change bitbucket.org/nuttx/tools to github.com/patacongo/tools

### DIFF
--- a/Documentation/components/boards.rst
+++ b/Documentation/components/boards.rst
@@ -128,7 +128,7 @@ Configuration Variables
 
 At one time, this section provided a list of all NuttX configuration
 variables. However, NuttX has since converted to use the kconfig-frontends
-tools (See https://bitbucket.org/nuttx/tools/src/master/kconfig-frontends/.)
+tools (See https://github.com/patacongo/tools/tree/main/kconfig-frontends.)
 Now, the NuttX configuration is determined by a self-documenting set of
 Kconfig files.
 

--- a/Documentation/guides/etcromfs.rst
+++ b/Documentation/guides/etcromfs.rst
@@ -125,7 +125,7 @@ In order to modify the start-up behavior, there are three things to study:
         `http://romfs.sourceforge.net <http://romfs.sourceforge.net/>`__)
         or included within the NuttX buildroot toolchain. There is also a
         snapshot available in the NuttX tools repository
-        `here <https://bitbucket.org/nuttx/tools/src/master/genromfs-0.5.2.tar.gz>`__.
+        `here <https://github.com/patacongo/tools/blob/main/genromfs-0.5.2.tar.gz>`__.
 
      #. The ``xxd`` tool that is used to generate the C header files (xxd
         is a normal part of a complete Linux or Cygwin installation,

--- a/Documentation/implementation/simulation.rst
+++ b/Documentation/implementation/simulation.rst
@@ -146,7 +146,7 @@ The simulation's serial console is provided by wrapping host *stdin* and *stdout
 Host File System Access
 -----------------------
 
-Host file system access is supported via the *nxfuse* user-space file system that you can find in the NuttX https://bitbucket.org/nuttx/tools/src/master/nxfuse/ repository.  Instructions for using the *nxfuse* file system can be found in a https://bitbucket.org/nuttx/tools/src/master/nxfuse/README.txt in that repository directory.
+Host file system access is supported via the *nxfuse* user-space file system that you can find in the NuttX https://github.com/patacongo/tools/tree/main/nxfuse repository.  Instructions for using the *nxfuse* file system can be found in a https://github.com/patacongo/tools/blob/main/nxfuse/README.txt in that repository directory.
 
 Networking
 ----------
@@ -194,7 +194,7 @@ And you can enable some additional debug output with:
 
     Remove:  # CONFIG_DEBUG_SCHED is not set
     Add:     CONFIG_DEBUG_SCHED=y
-    
+
     Remove:  # CONFIG_SCHED_INSTRUMENTATION is not set
     Add:     CONFIG_SCHED_INSTRUMENTATION=y
 

--- a/Documentation/quickstart/install.rst
+++ b/Documentation/quickstart/install.rst
@@ -41,8 +41,8 @@ First, install the following set of system dependencies according to your Operat
       $ expat-devel gcc-c++ g++ picocom uboot-tools util-linux
 
   .. tab:: macOS
-  
-    Run the following command to install packages:  
+
+    Run the following command to install packages:
 
     .. code-block:: console
 
@@ -80,7 +80,7 @@ NuttX configuration system uses `KConfig <https://www.kernel.org/doc/Documentati
 which is exposed via a series of interactive menu-based *frontends*, part of the
 ``kconfig-frontends`` package. Depending on your OS you may use a precompiled
 package or you will have to build it from source, which is available in the
-`NuttX tools repository <https://bitbucket.org/nuttx/tools/src/master/kconfig-frontends/>`_:
+`NuttX tools repository <https://github.com/patacongo/tools/tree/main/kconfig-frontends>`_:
 
 .. tabs::
 
@@ -90,7 +90,7 @@ package or you will have to build it from source, which is available in the
 
   .. code-tab:: console Ubuntu 18.04 LTS and earlier
 
-    $ git clone https://bitbucket.org/nuttx/tools.git
+    $ git clone https://github.com/patacongo/tools
     $ cd tools/kconfig-frontends
     $ ./configure --enable-mconf --disable-nconf --disable-gconf --disable-qconf
     $ make
@@ -98,7 +98,7 @@ package or you will have to build it from source, which is available in the
 
   .. code-tab:: console Fedora
 
-    $ git clone https://bitbucket.org/nuttx/tools.git
+    $ git clone https://github.com/patacongo/tools
     $ cd tools/kconfig-frontends
     $ ./configure --enable-mconf --disable-nconf --disable-gconf --disable-qconf
     $ aclocal
@@ -108,7 +108,7 @@ package or you will have to build it from source, which is available in the
 
   .. code-tab:: console macOS
 
-    $ git clone https://bitbucket.org/nuttx/tools.git
+    $ git clone https://github.com/patacongo/tools
     $ cd tools/kconfig-frontends
     $ patch < ../kconfig-macos.diff -p 1
     $ ./configure --enable-mconf --disable-shared --enable-static --disable-gconf --disable-qconf --disable-nconf
@@ -158,13 +158,13 @@ ARM architecture:
     For 32 bit ARM targets, such as STM32:
 
     .. code-block:: console
-      
+
       $ brew install --cask gcc-arm-embedded
 
     For 64 bit ARM targets, such as Allwinner A64:
 
     .. code-block:: console
-      
+
       $ brew install --cask gcc-aarch64-embedded
 
   .. tab:: From arm.com
@@ -203,7 +203,7 @@ ARM architecture:
   architectures in the Apache NuttX CI helper
   `script <https://github.com/apache/nuttx/tree/master/tools/ci/cibuild.sh>`_
   and Docker `container <https://github.com/apache/nuttx/tree/master/tools/ci/docker/linux/Dockerfile>`_
-  
+
 .. todo::
   Required toolchain should be part of each arch documentation (see `relevant issue <https://github.com/apache/nuttx/issues/2409>`_).
 
@@ -221,7 +221,7 @@ repositories (recommended). Otherwise you can choose to download any
 .. tabs::
 
   .. tab:: Clone git repositories
-  
+
     .. code-block:: console
 
        $ mkdir nuttxspace
@@ -235,21 +235,21 @@ repositories (recommended). Otherwise you can choose to download any
 
        $ mkdir nuttxspace
        $ cd nuttxspace
-       $ curl -L https://github.com/apache/nuttx/tarball/master -o nuttx.tar.gz 
+       $ curl -L https://github.com/apache/nuttx/tarball/master -o nuttx.tar.gz
        $ curl -L https://github.com/apache/nuttx-apps/tarball/master -o apps.tar.gz
        $ tar zxf nuttx.tar.gz --one-top-level=nuttx --strip-components 1
        $ tar zxf apps.tar.gz --one-top-level=apps --strip-components 1
-       
+
     There are also ``.zip`` archives available (useful for Windows users): just replace ``tarball`` with
     ``zipball``.
 
   .. tab:: Download stable release
-  
+
     Go to `releases <https://nuttx.apache.org/download/>`_ and choose a version to download. The following
     example uses version 12.2.1:
 
     .. code-block:: console
-    
+
        $ mkdir nuttxspace
        $ cd nuttxspace
        $ curl -L https://www.apache.org/dyn/closer.lua/nuttx/12.2.1/apache-nuttx-12.2.1.tar.gz?action=download -o nuttx.tar.gz

--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -50,7 +50,7 @@ RUN mkdir -p /tools
 WORKDIR /tools
 
 RUN mkdir -p /tools/nuttx-tools
-RUN curl -s -L https://bitbucket.org/nuttx/tools/get/9ad3e1ee75c7.tar.gz \
+RUN curl -s -L https://github.com/patacongo/tools/archive/9ad3e1ee75c7d39bfee8019ce44f4fd035d89584.tar.gz \
   | tar -C nuttx-tools --strip-components=1 -xz
 
 RUN mkdir -p /tools/bloaty \

--- a/tools/ci/platforms/msys2.sh
+++ b/tools/ci/platforms/msys2.sh
@@ -109,7 +109,7 @@ gen_romfs() {
   add_path "${NUTTXTOOLS}"/genromfs/usr/bin
 
   if ! type genromfs > /dev/null 2>&1; then
-    git clone --depth 1 https://bitbucket.org/nuttx/tools.git "${NUTTXTOOLS}"/nuttx-tools
+    git clone --depth 1 https://github.com/patacongo/tools "${NUTTXTOOLS}"/nuttx-tools
     cd "${NUTTXTOOLS}"/nuttx-tools
     tar zxf genromfs-0.5.2.tar.gz
     cd genromfs-0.5.2


### PR DESCRIPTION
## Summary

The repo bitbucket.org/nuttx/tools is no longer available. This PR changes it to to github.com/patacongo/tools, as explained in https://github.com/apache/nuttx/pull/18890. This PR updates the URL in Dockerfile and Docs.

## Impact

Dockerfile now builds correctly. Previously the Dockerfile build failed like this:
```
Dockerfile:53
--------------------
  52 |     RUN mkdir -p /tools/nuttx-tools
  53 | >>> RUN curl -s -L https://bitbucket.org/nuttx/tools/get/9ad3e1ee75c7.tar.gz \
  54 | >>>   | tar -C nuttx-tools --strip-components=1 -xz
  55 |     
--------------------
ERROR: failed to build: failed to solve: process "/bin/sh -c curl -s -L https://bitbucket.org/nuttx/tools/get/9ad3e1ee75c7.tar.gz   | tar -C nuttx-tools --strip-components=1 -xz" did not complete successfully: exit code: 2
```
https://github.com/apache/nuttx/actions/runs/26381245708/job/77650769793?pr=18953

## Testing

This URL change has been tested earlier in https://github.com/apache/nuttx/pull/18890
