### PR TITLE
arch/sim: Stop publishing stale X11 display during teardown.

### DIFF
--- a/arch/sim/src/sim/posix/sim_x11framebuffer.c
+++ b/arch/sim/src/sim/posix/sim_x11framebuffer.c
@@ -217,15 +217,24 @@ static int sim_x11untraperrors(Display *display)
 
 static void sim_x11uninit(void)
 {
+  Display *display;
+
   if (g_display == NULL)
     {
       return;
     }
 
+  /* Publish shutdown before tearing down the X connection so the event
+   * polling path stops touching a stale Display pointer.
+   */
+
+  display = g_display;
+  g_display = NULL;
+
 #ifndef CONFIG_SIM_X11NOSHM
   if (g_shmcheckpoint > 4)
     {
-      XShmDetach(g_display, &g_xshminfo);
+      XShmDetach(display, &g_xshminfo);
     }
 
   if (g_shmcheckpoint > 3)
@@ -251,10 +260,10 @@ static void sim_x11uninit(void)
 
 #if defined(CONFIG_SIM_TOUCHSCREEN) || defined(CONFIG_SIM_AJOYSTICK) || \
     defined(CONFIG_SIM_BUTTONS)
-  XUngrabButton(g_display, Button1, AnyModifier, g_window);
+  XUngrabButton(display, Button1, AnyModifier, g_window);
 #endif
 
-  XCloseDisplay(g_display);
+  XCloseDisplay(display);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

  * Fixes a shutdown ordering issue in the sim X11 framebuffer teardown path.
  * `sim_x11events()` may continue polling `g_display` from the idle loop while the X11 connection is being torn down.
  * Save the current `Display *` in a local variable, clear the global `g_display` before teardown, and use the local pointer for the remaining X11 cleanup calls.
  * Related NuttX Issue: none.
  * Related NuttX Apps Issue/Pull Request: none.

## Impact

  * Is new feature added? NO.
  * Is existing feature changed? YES: only the sim X11 framebuffer shutdown ordering is changed.
  * Impact on user? NO expected user-visible behavior change; the change avoids publishing a stale Display pointer during shutdown.
  * Impact on build? NO.
  * Impact on hardware? NO real hardware impact; this is limited to the simulator X11 framebuffer path.
  * Impact on documentation? NO.
  * Impact on security? NO.
  * Impact on compatibility? NO API, ABI, or configuration compatibility change.
  * Dependencies: none.

## Testing

  I confirm that changes are verified on local setup and work as intended:

  * Build Host(s): Linux DESKTOP-6B1686O 6.6.114.1-microsoft-standard-WSL2 x86_64, gcc (Ubuntu 10.5.0-1ubuntu1~20.04) 10.5.0.
  * Target(s): sim:nsh.
  * Static/style check: `./tools/checkpatch.sh -g HEAD~...HEAD`.
  * Build test: `./tools/configure.sh sim:nsh && make -j4`.
  * Runtime smoke test: booted `./nuttx`, ran `help`, `uname -a`, and `poweroff`.

  Testing logs before change:

  ```
  Code inspection: before this change, sim_x11uninit() kept g_display published while
  the teardown path called XShmDetach(), XUngrabButton(), and XCloseDisplay() through
  g_display. sim_x11events() also polls g_display from the idle loop, so the event
  path could observe a stale Display pointer during shutdown.
  ```

  Testing logs after change:

  ```
  $ ./tools/checkpatch.sh -g HEAD~...HEAD
  ✔️ All checks pass.

  $ ./tools/configure.sh sim:nsh
  # configuration written to .config

  $ make -j4
  LD:  nuttx
  Pac SIM with dynamic libs..
  SIM elf with dynamic libs archive in nuttx.tgz

  $ printf 'help\nuname -a\npoweroff\n' | timeout 10s ./nuttx
  NuttShell (NSH) NuttX-12.13.0
  nsh> help
  help usage:  help [-v] [<cmd>]
  ...
  nsh> uname -a
  NuttX 12.13.0 a1a048d9f6 May 25 2026 23:55:29 sim sim
  nsh> poweroff
  ```

## PR verification Self-Check

  * [x] This PR introduces only one functional change.
  * [x] I have updated all required description fields above.
  * [x] My PR adheres to Contributing [Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) and [Documentation](https://nuttx.apache.org/docs/latest/contributing/index.html) (git commit title and message, coding standard, etc).
  * [ ] My PR is still work in progress (not ready for review).
  * [x] My PR is ready for review and can be safely merged into a codebase.
