### PR TITLE
cmake: Fix SIM_TOOLCHAIN using CMake on macOS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -355,6 +355,10 @@ if(NOT EXISTS ${CMAKE_BINARY_DIR}/.config OR NOT "${NUTTX_DEFCONFIG}" STREQUAL
 
   set(ENV{KCONFIG_CONFIG} ${CMAKE_BINARY_DIR}/.config.compressed)
 
+  # Define host before the first olddefconfig so host-dependent defaults, such
+  # as the sim toolchain choice on macOS, resolve the same way as configure.sh.
+  nuttx_sethost(CONFIG_FILE ${CMAKE_BINARY_DIR}/.config.compressed)
+
   # Do olddefconfig step to expand the abbreviated defconfig into normal config
   nuttx_olddefconfig()
 
@@ -378,9 +382,6 @@ if(NOT EXISTS ${CMAKE_BINARY_DIR}/.config OR NOT "${NUTTX_DEFCONFIG}" STREQUAL
   # store original expanded .config
   configure_file(${CMAKE_BINARY_DIR}/.config ${CMAKE_BINARY_DIR}/.config.orig
                  COPYONLY)
-
-  # We define host
-  nuttx_sethost()
 
   set(NUTTX_DEFCONFIG_SAVED
       ${NUTTX_DEFCONFIG}

--- a/cmake/nuttx_kconfig.cmake
+++ b/cmake/nuttx_kconfig.cmake
@@ -231,9 +231,25 @@ function(nuttx_olddefconfig)
 endfunction()
 
 function(nuttx_setconfig)
-  set(ENV{KCONFIG_CONFIG} ${CMAKE_BINARY_DIR}/.config)
+  cmake_parse_arguments(SETCONFIG "" "CONFIG_FILE" "SETTINGS" ${ARGN})
+
+  if(SETCONFIG_UNPARSED_ARGUMENTS)
+    message(
+      FATAL_ERROR
+        "nuttx_setconfig: unknown arguments: ${SETCONFIG_UNPARSED_ARGUMENTS}")
+  endif()
+
+  if(NOT SETCONFIG_SETTINGS)
+    message(FATAL_ERROR "nuttx_setconfig: SETTINGS is required")
+  endif()
+
+  if(NOT SETCONFIG_CONFIG_FILE)
+    set(SETCONFIG_CONFIG_FILE ${CMAKE_BINARY_DIR}/.config)
+  endif()
+
+  set(ENV{KCONFIG_CONFIG} ${SETCONFIG_CONFIG_FILE})
   execute_process(
-    COMMAND setconfig ${ARGN} --kconfig ${NUTTX_DIR}/Kconfig
+    COMMAND setconfig ${SETCONFIG_SETTINGS} --kconfig ${NUTTX_DIR}/Kconfig
     ERROR_VARIABLE KCONFIG_ERROR
     OUTPUT_VARIABLE KCONFIG_OUTPUT
     RESULT_VARIABLE KCONFIG_STATUS

--- a/cmake/nuttx_sethost.cmake
+++ b/cmake/nuttx_sethost.cmake
@@ -23,6 +23,18 @@
 include(nuttx_kconfig)
 
 function(nuttx_sethost)
+  set(config_file ${CMAKE_BINARY_DIR}/.config)
+  cmake_parse_arguments(SETHOST "" "CONFIG_FILE" "" ${ARGN})
+
+  if(SETHOST_UNPARSED_ARGUMENTS)
+    message(
+      FATAL_ERROR
+        "nuttx_sethost: unknown arguments: ${SETHOST_UNPARSED_ARGUMENTS}")
+  endif()
+
+  if(SETHOST_CONFIG_FILE)
+    set(config_file ${SETHOST_CONFIG_FILE})
+  endif()
 
   if(CMAKE_HOST_WIN32)
     # https://learn.microsoft.com/en-us/windows/win32/winprog64/wow64-implementation-details
@@ -104,5 +116,5 @@ function(nuttx_sethost)
     endif()
   endif()
   # message("  nuttx_setconfig: ${NUTTX_SYSTEM_SETHOST}")
-  nuttx_setconfig("${NUTTX_SYSTEM_SETHOST}")
+  nuttx_setconfig(CONFIG_FILE ${config_file} SETTINGS ${NUTTX_SYSTEM_SETHOST})
 endfunction()


### PR DESCRIPTION
## Summary

Set host-specific Kconfig values before the initial `olddefconfig` step in the CMake build, and clarify the helper arguments used for that setup.

On macOS, `sim:nsh` needs `HOST_MACOS=y` to be present before the sim toolchain choice is resolved. Without that, the first `olddefconfig` may select the default GCC toolchain instead of the macOS-specific Clang default.

As a result, you encounter the error `ld: library not found for -lgcov`.

This PR updates the CMake initialization flow so `nuttx_sethost()` can apply host settings to the temporary `.config.compressed` before the first `olddefconfig`.

The helper functions were also refactored to use named arguments:

```cmake
nuttx_sethost(CONFIG_FILE ...)
nuttx_setconfig(CONFIG_FILE ... SETTINGS ...)
```

## Impact

`CONFIG_SIM_TOOLCHAIN_CLANG=y` is enabled, which resolves linker errors.

## Testing

I confirm that changes are verified on local setup and works as intended:
* Build Host(s): OS (macOS 26.5), CPU(Apple M1), compiler(Apple clang version 21.0.0)
* Target(s): arch(sim)
* Ensure your PATH environment variable is properly configured to allow execution of: menuconfig, olddefconfig, savedefconfig, and setconfig.
* Use the Rust toolchain version prior to nightly-2026-04-29 to avoid errors related to lib/rustlib/src/rust/library/std/src/sys/net/connection/socket/unix.rs.

Configuration:

```
rm -rf build-debug
make distclean
cmake -S . -B build-debug -DBOARD_CONFIG=sim:nsh -GNinja

printf "CONFIG_SYSTEM_TIME64=y
CONFIG_FS_LARGEFILE=y
CONFIG_TLS_NELEM=16
CONFIG_DEV_URANDOM=y
CONFIG_EXAMPLES_HELLO_RUST_CARGO=y
CONFIG_EXAMPLES_HELLO_RUST_CARGO_STACKSIZE=8192
" >> build-debug/.config

cmake --build build-debug -t olddefconfig
```

Testing logs before change:

```
...
   Compiling proc_macro v0.0.0 (/Users/toku/.rustup/toolchains/nightly-2026-04-29-aarch64-apple-darwin/lib/rustlib/src/rust/library/proc_macro)
   Compiling itoa v1.0.18
   Compiling pin-project-lite v0.2.17
   Compiling memchr v2.8.0
   Compiling tokio v1.52.3
   Compiling hello v0.1.0 (/Users/toku/nuttxspace/apps/examples/rust/hello)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 21.46s
[1224/1229] Linking C executable nuttx
FAILED: [code=1] nuttx
: && /usr/bin/cc -arch arm64 -Wl,-search_paths_first -Wl,-headerpad_max_install_names -Wl,-dead_strip -Wl,-ld_classic,-no_fixup_chains @CMakeFiles/nuttx.rsp -o nuttx && :
ld: warning: -ld_classic is deprecated and will be removed in a future release
ld: library not found for -lgcov
clang: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```

Testing logs after change:

```
...
   Compiling proc_macro v0.0.0 (/Users/toku/.rustup/toolchains/nightly-2026-04-29-aarch64-apple-darwin/lib/rustlib/src/rust/library/proc_macro)
   Compiling itoa v1.0.18
   Compiling pin-project-lite v0.2.17
   Compiling memchr v2.8.0
   Compiling tokio v1.52.3
   Compiling hello v0.1.0 (/Users/toku/nuttxspace/apps/examples/rust/hello)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 21.63s
[1222/1227] Linking C executable nuttx
ld: warning: -ld_classic is deprecated and will be removed in a future release
[1224/1227] Generating System.map
```

## PR verification Self-Check

* [x] My PR adheres to Contributing [Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) and [Documentation](https://nuttx.apache.org/docs/latest/contributing/index.html) (git commit title and message, coding standard, etc).
* [x] My PR is ready for review and can be safely merged into a codebase.
