### PR TITLE
arch/sim: Handle Darwin clock IDs in clock_gettime()

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -103,6 +103,10 @@ ifeq ($(CONFIG_WINDOWS_NATIVE),y)
   VPATH += :sim/win
 else
   VPATH += :sim/posix
+ifeq ($(CONFIG_HOST_MACOS),y)
+  CSRCS += sim/macos/sim_clock_gettime.c
+  REQUIREDOBJS += sim/macos/sim_clock_gettime$(OBJEXT)
+endif
 endif
 DEPPATH = $(patsubst %,--dep-path %,$(subst :, ,$(VPATH)))
 

--- a/arch/sim/src/sim/CMakeLists.txt
+++ b/arch/sim/src/sim/CMakeLists.txt
@@ -150,6 +150,13 @@ list(
   sim_hosttime.c
   sim_hostuart.c)
 
+if(CONFIG_HOST_MACOS)
+  # Provide a sim/macOS specific override of clock_gettime() that translates
+  # Darwin clock IDs to NuttX's CLOCK_MONOTONIC.  Keep all macOS specific logic
+  # in arch/sim/ instead of polluting sched/clock/clock_gettime.c.
+  list(APPEND SRCS macos/sim_clock_gettime.c)
+endif()
+
 if(CONFIG_HOST_MACOS AND CONFIG_HAVE_CXXINITIALIZE)
   # Keep classic __mod_init_func format so post-link lief patching works
   target_link_options(nuttx PRIVATE -Wl,-ld_classic,-no_fixup_chains)

--- a/arch/sim/src/sim/macos/sim_clock_gettime.c
+++ b/arch/sim/src/sim/macos/sim_clock_gettime.c
@@ -1,0 +1,97 @@
+/****************************************************************************
+ * arch/sim/src/sim/macos/sim_clock_gettime.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <time.h>
+#include <errno.h>
+
+#include <nuttx/clock.h>
+#include <nuttx/compiler.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Code built for the macOS host uses Darwin's libc clock IDs.  When such
+ * code is linked into the NuttX simulator, those Darwin-specific values
+ * reach NuttX's clock_gettime() instead of Darwin's one.  Translate
+ * the Darwin monotonic clock IDs here so that the common sched/clock
+ * implementation does not need to know about them.
+ */
+
+#define DARWIN_CLOCK_MONOTONIC_RAW        4
+#define DARWIN_CLOCK_MONOTONIC_RAW_APPROX 5
+#define DARWIN_CLOCK_MONOTONIC            6
+#define DARWIN_CLOCK_UPTIME_RAW           8
+#define DARWIN_CLOCK_UPTIME_RAW_APPROX    9
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: clock_gettime
+ *
+ * Description:
+ *   sim/macOS specific override of clock_gettime() that translates Darwin
+ *   monotonic clock IDs into NuttX's CLOCK_MONOTONIC before delegating
+ *   to nxclock_gettime().
+ *
+ *   The common POSIX clock_gettime() in sched/clock/clock_gettime.c is
+ *   declared as a weak symbol, so this strong definition takes precedence
+ *   when CONFIG_HOST_MACOS is enabled.
+ *
+ ****************************************************************************/
+
+visibility_hidden
+int clock_gettime(clockid_t clock_id, FAR struct timespec *tp)
+{
+  int ret;
+
+  switch (clock_id)
+    {
+    case DARWIN_CLOCK_MONOTONIC_RAW:
+    case DARWIN_CLOCK_MONOTONIC_RAW_APPROX:
+    case DARWIN_CLOCK_MONOTONIC:
+    case DARWIN_CLOCK_UPTIME_RAW:
+    case DARWIN_CLOCK_UPTIME_RAW_APPROX:
+      clock_id = CLOCK_MONOTONIC;
+      break;
+
+    default:
+      break;
+    }
+
+  ret = nxclock_gettime(clock_id, tp);
+  if (ret < 0)
+    {
+      set_errno(-ret);
+      return ERROR;
+    }
+
+  return OK;
+}

--- a/sched/clock/clock_gettime.c
+++ b/sched/clock/clock_gettime.c
@@ -215,7 +215,7 @@ int nxclock_gettime(clockid_t clock_id, FAR struct timespec *tp)
  *
  ****************************************************************************/
 
-int clock_gettime(clockid_t clock_id, FAR struct timespec *tp)
+int weak_function clock_gettime(clockid_t clock_id, FAR struct timespec *tp)
 {
   int ret;
 


### PR DESCRIPTION
## Summary

This PR fixes `clock_gettime()` compatibility for the macOS simulator when
Darwin-targeted code is linked into NuttX.

The fix adds a sim/macOS-specific `clock_gettime()` override that translates
Darwin monotonic clock IDs to NuttX `CLOCK_MONOTONIC` before calling
`nxclock_gettime()`.

* Make the common `clock_gettime()` weak.
* Add `arch/sim/src/sim/macos/sim_clock_gettime.c`.
* Translate Darwin monotonic clock IDs.
* Add the new source to both CMake and make builds.
* Add the make object to `REQUIREDOBJS` so the override is included in the final simulator link.

## Impact

Running `hello_rust_cargo` with nsh on macOS should no longer cause a panic.

## Testing

I confirm that changes are verified on local setup and works as intended:
* Build Host(s): OS (macOS 26.5), CPU(Apple M1), compiler(Apple clang version 21.0.0)
* Target(s): arch(sim)
* Ensure your PATH environment variable is properly configured to allow execution of: menuconfig, olddefconfig, savedefconfig, and setconfig.
* Use the Rust toolchain version prior to nightly-2026-04-29 to avoid errors related to lib/rustlib/src/rust/library/std/src/sys/net/connection/socket/unix.rs.
* This PR is a successor of PR #18883.
* To build using `make`, you need apps PR [#3501](https://github.com/apache/nuttx-apps/pull/3501) .

Configuration and Build:

```
rm -rf build-debug
make distclean
cmake -S . -B build-debug -DBOARD_CONFIG=sim:nsh -GNinja

printf "CONFIG_SYSTEM_TIME64=y
CONFIG_FS_LARGEFILE=y
CONFIG_TLS_NELEM=16
CONFIG_DEV_URANDOM=y
CONFIG_EXAMPLES_HELLO_RUST_CARGO=y
CONFIG_EXAMPLES_HELLO_RUST_CARGO_STACKSIZE=8192
" >> build-debug/.config

cmake --build build-debug -t olddefconfig
cmake --build build-debug
```

Testing logs before change:

```
NuttShell (NSH) NuttX-12.13.0
nsh> hello_rust_cargo
{"name":"John","age":30}
{"name":"Jane","age":25}
Deserialized: Alice is 28 years old
Pretty JSON:
{
  "name": "Alice",
  "age": 28
}

thread '<unnamed>' (1797510) panicked at /Users/toku/.rustup/toolchains/nightly-2026-04-29-aarch64-apple-darwin/lib/rustlib/src/rust/library/std/src/sys/pal/unix/time.rs:107:68:
called `Result::unwrap()` on an `Err` value: Os { code: 0, kind: Uncategorized, message: "Unknown error 0" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Testing logs after change:

```
NuttShell (NSH) NuttX-12.13.0
nsh> hello_rust_cargo
{"name":"John","age":30}
{"name":"Jane","age":25}
Deserialized: Alice is 28 years old
Pretty JSON:
{
  "name": "Alice",
  "age": 28
}
Hello world from tokio!
```

## PR verification Self-Check

* [x] My PR adheres to Contributing [Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) and [Documentation](https://nuttx.apache.org/docs/latest/contributing/index.html) (git commit title and message, coding standard, etc).
* [x] My PR is ready for review and can be safely merged into a codebase.
