### PR TITLE
Documentation: Document tee command.

### DIFF
--- a/Documentation/applications/system/tee/index.rst
+++ b/Documentation/applications/system/tee/index.rst
@@ -1,3 +1,85 @@
 ===================
 ``tee`` Tee Command
 ===================
+
+Overview
+========
+
+The ``tee`` command copies standard input to standard output and to each
+specified file.  It is useful in scripts or command pipelines when output
+needs to be displayed and saved at the same time.
+
+When no files are specified, ``tee`` copies standard input to standard
+output only.
+
+Configuration
+=============
+
+Enable the application with ``CONFIG_SYSTEM_TEE``.
+
+The task priority and stack size are controlled by:
+
+- ``CONFIG_SYSTEM_TEE_PRIORITY``
+- ``CONFIG_SYSTEM_TEE_STACKSIZE``
+
+Usage
+=====
+
+.. code-block:: console
+
+   tee [-a] [file ...]
+   tee -h
+
+Options
+=======
+
+.. list-table::
+   :header-rows: 1
+
+   * - Option
+     - Description
+   * - ``-a``
+     - Append to each output file instead of truncating it.
+   * - ``-h``
+     - Show command usage and exit.
+
+Arguments
+=========
+
+``file``
+  Optional output file.  Any number of files may be specified.  Output is
+  written to standard output in addition to each named file.
+
+Examples
+========
+
+Copy input to standard output and save it in ``output.txt``:
+
+.. code-block:: console
+
+   nsh> echo "hello" | tee output.txt
+   hello
+
+Append input to an existing log file while also displaying it:
+
+.. code-block:: console
+
+   nsh> echo "next line" | tee -a log.txt
+   next line
+
+Copy input to more than one file:
+
+.. code-block:: console
+
+   nsh> echo "sample" | tee first.txt second.txt
+   sample
+
+Notes
+=====
+
+The command opens each named file for writing.  Without ``-a``, existing
+files are truncated; with ``-a``, output is appended.  Files that do not
+already exist are created with mode ``0644``.
+
+If opening an output file, reading from standard input, or writing to an
+output destination fails, the command exits with failure status.


### PR DESCRIPTION
## Summary
- Document the `tee` system command page that was previously blank.
- Add configuration, usage, options, arguments, examples, and notes backed by `apps/system/tee/tee.c` and `apps/system/tee/Kconfig`.

## Impact
- Documentation only.
- No runtime behavior changes.

## Testing
- Verified source behavior in `apps/system/tee/tee.c` and configuration in `apps/system/tee/Kconfig`.
- Ran focused RST parse:
  ```bash
  python3 - <<'PY'
  from pathlib import Path
  from docutils.core import publish_doctree
  path = Path('Documentation/applications/system/tee/index.rst')
  publish_doctree(path.read_text(), source_path=str(path),
                  settings_overrides={'halt_level': 2, 'report_level': 2})
  print('docutils OK')
  PY
  ```
- Ran full documentation dummy build:
  ```bash
  cd Documentation
  PYTHONPATH=_extensions python3 -m sphinx -W -b dummy . /tmp/nuttx-docs-build-tee
  ```

## PR verification Self-Check
- [x] The change is limited to documentation.
- [x] The documented behavior is source-backed.
- [x] The documentation build completed without warnings.
- [x] No external dependency or board-specific setup is required.

Refs #11081
