### PR TITLE
Documentation: Document taskset command.

### DIFF
--- a/Documentation/applications/system/taskset/index.rst
+++ b/Documentation/applications/system/taskset/index.rst
@@ -1,3 +1,83 @@
 ===========================
 ``taskset`` Taskset Command
 ===========================
+
+Overview
+========
+
+The ``taskset`` command displays or changes the CPU affinity mask for a
+running task, or starts a command after applying an affinity mask to the
+``taskset`` process.  It is intended for SMP configurations where tasks can
+be constrained to a subset of CPUs.
+
+The mask argument is a decimal CPU affinity bit mask.  Bit 0 selects CPU 0,
+bit 1 selects CPU 1, and so on.  The command accepts masks greater than zero
+and less than ``1 << CONFIG_SMP_NCPUS``.
+
+Configuration
+=============
+
+Enable the application with ``CONFIG_SYSTEM_TASKSET``.  This option depends
+on ``CONFIG_SMP`` and ``CONFIG_SYSTEM_SYSTEM``.
+
+The program name, task priority, and stack size are controlled by:
+
+- ``CONFIG_SYSTEM_TASKSET_PROGNAME``
+- ``CONFIG_SYSTEM_TASKSET_PRIORITY``
+- ``CONFIG_SYSTEM_TASKSET_STACKSIZE``
+
+Usage
+=====
+
+.. code-block:: console
+
+   taskset <mask> <command> [args ...]
+   taskset -p [mask] <pid>
+   taskset -h
+
+Forms
+=====
+
+``taskset <mask> <command> [args ...]``
+  Applies ``mask`` to the ``taskset`` process and then runs ``command`` with
+  any remaining arguments through ``system()``.
+
+``taskset -p <pid>``
+  Prints the current CPU affinity mask for ``pid``.
+
+``taskset -p <mask> <pid>``
+  Sets the CPU affinity mask for ``pid`` and then prints the task's current
+  mask.
+
+``taskset -h``
+  Prints command usage.
+
+Examples
+========
+
+Show the current affinity mask for task ID 4:
+
+.. code-block:: console
+
+   nsh> taskset -p 4
+   pid 4's current affinity mask: 0x2
+
+Set task ID 4 to affinity mask 3 and print the resulting mask:
+
+.. code-block:: console
+
+   nsh> taskset -p 3 4
+   pid 4's current affinity mask: 0x3
+
+Start ``busyloop`` after applying affinity mask 1 to the command process:
+
+.. code-block:: console
+
+   nsh> taskset 1 busyloop &
+
+Notes
+=====
+
+The command reports scheduler affinity errors on standard error.  The exact
+set of valid mask values depends on ``CONFIG_SMP_NCPUS`` for the target
+configuration.


### PR DESCRIPTION
## Summary

  * Fill the blank `Documentation/applications/system/taskset/index.rst` command reference page.
  * Document the source-backed command forms: `taskset <mask> <command> [args ...]`, `taskset -p [mask] <pid>`, and `taskset -h`.
  * Document the `CONFIG_SYSTEM_TASKSET` enable option, its `CONFIG_SMP && CONFIG_SYSTEM_SYSTEM` dependency, and the related program name / priority / stack-size options.
  * Keep the patch documentation-only and scoped to one `.rst` file.
  * Refs #11081.

## Impact

  * Is new feature added? NO.
  * Is existing feature changed? NO.
  * Impact on user (will user need to adapt to change)? NO; this only adds missing documentation for an existing command.
  * Impact on build (will build process change)? NO.
  * Impact on hardware (will arch(s) / board(s) / driver(s) change)? NO.
  * Impact on documentation (is update required / provided)? YES; the previously blank `taskset` command page is filled.
  * Impact on security (any sort of implications)? NO.
  * Impact on compatibility (backward/forward/interoperability)? NO.
  * Anything else to consider or add? Documentation claims were checked against `apps/system/taskset/taskset.c` and `apps/system/taskset/Kconfig` from `nuttx-apps` upstream master.

## Testing

  I confirm that changes are verified on local setup and work as intended:
  * Build Host(s): WSL2 Linux x86_64 (`Linux DESKTOP-6B1686O 6.6.114.1-microsoft-standard-WSL2`), Python 3.8.10, Sphinx 7.1.2, PlantUML available on `PATH`.
  * Target(s): documentation-only change; no hardware target needed.
  * Source verification:
    * `git -C /home/hanzj/workspace/nuttxspace/apps show upstream/master:system/taskset/taskset.c`
    * `git -C /home/hanzj/workspace/nuttxspace/apps show upstream/master:system/taskset/Kconfig`

  Testing logs before change:

  ```
  Documentation/applications/system/taskset/index.rst contained only the page title.
  Duplicate check found no open PR specifically documenting taskset.
  ```

  Testing logs after change:

  ```
  $ cd Documentation
  $ DISPLAY= JAVA_TOOL_OPTIONS='-Djava.awt.headless=true' make html
  Running Sphinx v7.1.2
  ...
  build succeeded.

  The HTML pages are in _build/html.
  ```

## PR verification Self-Check

  * [x] This PR introduces only one functional change.
  * [x] I have updated all required description fields above.
  * [x] My PR adheres to Contributing [Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) and [Documentation](https://nuttx.apache.org/docs/latest/contributing/index.html) (git commit title and message, coding standard, etc).
  * [ ] My PR is still work in progress (not ready for review).
  * [x] My PR is ready for review and can be safely merged into a codebase.

