### PR TITLE
arch/sim: Add MM_FILL_ALLOCATIONS support to sim customized heap.

### DIFF
--- a/arch/sim/src/sim/sim_ummheap.c
+++ b/arch/sim/src/sim/sim_ummheap.c
@@ -316,6 +316,10 @@ static void delay_free(struct mm_heap_s *heap, void *mem, bool delay)
   else
     {
       node = (struct mm_allocnode_s *)((uintptr_t)mem - MM_ALLOCNODE_SIZE);
+#ifdef CONFIG_MM_FILL_ALLOCATIONS
+      memset(mem, MM_FREE_MAGIC,
+             node->size - MM_ALLOCNODE_SIZE - node->padding);
+#endif
       update_stats(heap, mem, node->size, false);
       sched_note_heap(NOTE_HEAP_FREE, heap, mem, node->size, 0);
       host_free(node->allocmem);
@@ -329,6 +333,7 @@ static void *reallocate(void *oldmem, size_t alignment, size_t size)
   void *new_alloc_addr;
   struct mm_allocnode_s *old_node;
   size_t old_size;
+  size_t old_user_size;
   void *old_alloc_addr;
   void *mem = oldmem;
 
@@ -373,6 +378,10 @@ static void *reallocate(void *oldmem, size_t alignment, size_t size)
 
       mem = init_allocnode(g_mmheap, new_alloc_addr, aligned_size,
                            padding_size);
+#ifdef CONFIG_MM_FILL_ALLOCATIONS
+      memset(mem, MM_ALLOC_MAGIC,
+             aligned_size - MM_ALLOCNODE_SIZE - padding_size);
+#endif
       sched_note_heap(NOTE_HEAP_ALLOC, g_mmheap, mem, aligned_size, 0);
       return mem;
     }
@@ -391,6 +400,8 @@ static void *reallocate(void *oldmem, size_t alignment, size_t size)
              ((uintptr_t)oldmem - MM_ALLOCNODE_SIZE);
   old_alloc_addr = old_node->allocmem;
   old_size = old_node->size;
+  old_user_size = old_size - MM_ALLOCNODE_SIZE - old_node->padding;
+  UNUSED(old_user_size);
 
   update_stats(g_mmheap, oldmem, old_size, false);
 
@@ -411,12 +422,28 @@ static void *reallocate(void *oldmem, size_t alignment, size_t size)
       old_node->padding = padding_size;
       MM_ADD_BACKTRACE(g_mmheap, old_node);
       update_stats(g_mmheap, oldmem, aligned_size, true);
+#ifdef CONFIG_MM_FILL_ALLOCATIONS
+      if (aligned_size > old_size)
+        {
+          memset(oldmem + old_user_size, MM_ALLOC_MAGIC,
+                 aligned_size - old_size);
+        }
+#endif
+
       sched_note_heap(NOTE_HEAP_ALLOC, g_mmheap, mem, aligned_size, 0);
       return oldmem;
     }
 
   sched_note_heap(NOTE_HEAP_FREE, g_mmheap, oldmem, old_size, 0);
   mem = init_allocnode(g_mmheap, new_alloc_addr, aligned_size, padding_size);
+#ifdef CONFIG_MM_FILL_ALLOCATIONS
+  if (aligned_size > old_size)
+    {
+      memset(mem + old_user_size, MM_ALLOC_MAGIC,
+             aligned_size - old_size);
+    }
+#endif
+
   sched_note_heap(NOTE_HEAP_ALLOC, g_mmheap, mem, aligned_size, 0);
   return mem;
 }


### PR DESCRIPTION
## Summary

When CONFIG_MM_UMM_CUSTOMIZE_MANAGER is enabled, the sim heap bypasses mm_heap/tlsf entirely and calls host malloc/free directly, so MM_FILL_ALLOCATIONS has no effect. Add fill pattern support directly in sim_ummheap.c:
- malloc: fill user region with 0xaa
- free: fill user region with 0x55
- realloc: fill extended region with 0xaa

This helps detect uninitialized reads in sim environment, which ASan does not support.

## Impact

 Only affects sim arch when both CONFIG_MM_UMM_CUSTOMIZE_MANAGER and CONFIG_MM_FILL_ALLOCATIONS are enabled.

## Testing

Host: Linux x86_64 (Ubuntu)
  Board: sim (simulator)
  Config: sim:ostest with CONFIG_MM_UMM_CUSTOMIZE_MANAGER=y and CONFIG_MM_FILL_ALLOCATIONS=y
  Toolchain: GCC

  Test case :
```c
  #define TEST_SIZE       64
  #define REALLOC_SIZE    128
  #define MAGIC_ALLOC     0xaa
  #define MAGIC_FREE      0x55

  /* Test 1: malloc fills user region with 0xaa */
  static void test_malloc_fill(void)
  {
    unsigned char *p = malloc(TEST_SIZE);
    assert(check_pattern(p, MAGIC_ALLOC, TEST_SIZE) == 0);
    free(p);
  }

  /* Test 2: free fills user region with 0x55 */
  static void test_free_fill(void)
  {
    unsigned char *p = malloc(TEST_SIZE);
    unsigned char *saved = p;
    memset(p, 0x12, TEST_SIZE);
    free(p);
    assert(check_pattern(saved, MAGIC_FREE, TEST_SIZE) == 0);
  }

  /* Test 3: realloc extend fills grown region with 0xaa */
  static void test_realloc_extend_fill(void)
  {
    unsigned char *p = malloc(TEST_SIZE);
    memset(p, 0x12, TEST_SIZE);
    p = realloc(p, REALLOC_SIZE);
    assert(check_pattern(p, 0x12, TEST_SIZE) == 0);          /* old data preserved */
    assert(check_pattern(p + TEST_SIZE, MAGIC_ALLOC,
                         REALLOC_SIZE - TEST_SIZE) == 0);     /* extended region filled */
    free(p);
  }

  /* Test 4: realloc shrink preserves data */
  static void test_realloc_shrink_no_corrupt(void)
  {
    unsigned char *p = malloc(REALLOC_SIZE);
    memset(p, 0x34, REALLOC_SIZE);
    p = realloc(p, TEST_SIZE);
    assert(check_pattern(p, 0x34, TEST_SIZE) == 0);
    free(p);
  }

int main(int argc, FAR char *argv[])
{
  printf("\n=== MM_FILL_ALLOCATIONS Test ===\n\n");

  test_malloc_fill();
  test_free_fill();
  test_realloc_extend_fill();
  test_realloc_shrink_no_corrupt();

  printf("\n=== Test Complete ===\n");
  return 0;
}

```

  Test log:

  === MM_FILL_ALLOCATIONS Test ===

  TEST: malloc fill 0xaa ... PASS
  TEST: free fill 0x55 ... PASS
  TEST: realloc extend fill 0xaa ... PASS
  TEST: realloc shrink preserves data ... PASS

  === Test Complete ===

  All 4 tests pass.
