### PR TITLE
Fix issues about watchdog timers on ESP32, ESP32-S2 and ESP32-S3

### DIFF
--- a/arch/xtensa/src/esp32/esp32_wdt.c
+++ b/arch/xtensa/src/esp32/esp32_wdt.c
@@ -42,25 +42,25 @@
 
 /* Offset relative to each watchdog timer instance memory base */
 
-#define RWDT_CONFIG0_OFFSET         0x0098
+#define RWDT_CONFIG0_OFFSET         0x008c
 #define XTWDT_CONFIG0_OFFSET        0x0060
 
 /* RWDT */
 
-#define RWDT_STAGE0_TIMEOUT_OFFSET  0x009C
-#define RWDT_STAGE1_TIMEOUT_OFFSET  0x00A0
-#define RWDT_STAGE2_TIMEOUT_OFFSET  0x00A4
-#define RWDT_STAGE3_TIMEOUT_OFFSET  0x00A8
-#define RWDT_FEED_OFFSET            0x00AC
-#define RWDT_WP_REG                 0x00B0
-#define RWDT_INT_ENA_REG_OFFSET     0x0040
-#define RWDT_INT_CLR_REG_OFFSET     0x004c
+#define RWDT_STAGE0_TIMEOUT_OFFSET  0x0090
+#define RWDT_STAGE1_TIMEOUT_OFFSET  0x0094
+#define RWDT_STAGE2_TIMEOUT_OFFSET  0x0098
+#define RWDT_STAGE3_TIMEOUT_OFFSET  0x009c
+#define RWDT_FEED_OFFSET            0x00a0
+#define RWDT_WP_REG                 0x00a4
+#define RWDT_INT_ENA_REG_OFFSET     0x003c
+#define RWDT_INT_CLR_REG_OFFSET     0x0048
 
 /* XTWDT */
 
 #define XTWDT_TIMEOUT_OFFSET        0x00f8
 #define XTWDT_CLK_PRESCALE_OFFSET   0x00f4
-#define XTWDT_INT_ENA_REG_OFFSET    0x0040
+#define XTWDT_INT_ENA_REG_OFFSET    0x003c
 
 /* Helpers for converting from Q13.19 fixed-point format to float */
 

--- a/arch/xtensa/src/esp32/esp32_wdt.c
+++ b/arch/xtensa/src/esp32/esp32_wdt.c
@@ -554,6 +554,20 @@ static uint16_t esp32_rtc_clk(struct esp32_wdt_dev_s *dev)
 
   DEBUGASSERT(dev);
 
+  /* Ensure the XTAL frequency is known before calibration.
+   * rtc_clk_cal divides by xtal_freq internally and will crash
+   * with divide-by-zero if it hasn't been stored yet.
+   */
+
+  if (rtc_clk_xtal_freq_get() == 0)
+    {
+#ifdef CONFIG_ESP32_XTAL_26MHz
+      rtc_clk_xtal_freq_update(SOC_XTAL_FREQ_26M);
+#else
+      rtc_clk_xtal_freq_update(SOC_XTAL_FREQ_40M);
+#endif
+    }
+
   /* Check which clock is sourcing the slow_clk_rtc */
 
   slow_clk_rtc = rtc_clk_slow_src_get();

--- a/arch/xtensa/src/esp32/esp32_wdt_lowerhalf.c
+++ b/arch/xtensa/src/esp32/esp32_wdt_lowerhalf.c
@@ -193,6 +193,36 @@ static int esp32_wdt_start(struct watchdog_lowerhalf_s *lower)
 
       ESP32_WDT_UNLOCK(priv->wdt);
 
+      /* Re-apply the prescaler for MWDT in case the Timer Group
+       * registers were reset after initialization (e.g. by a
+       * constructor function that resets the peripheral).
+       */
+
+      if (priv->peripheral == TIMER)
+        {
+          ESP32_WDT_PRE(priv->wdt, PRE_VALUE);
+        }
+
+      /* Re-apply the timeout value */
+
+      if (priv->timeout > 0)
+        {
+          if (priv->peripheral == TIMER)
+            {
+              ESP32_WDT_STO(priv->wdt,
+                            priv->timeout * MS_CYCLES_TIMER, STAGE_0);
+            }
+          else
+            {
+              uint16_t rtc_cycles = ESP32_RWDT_CLK(priv->wdt);
+              if (rtc_cycles > 0)
+                {
+                  ESP32_WDT_STO(priv->wdt,
+                                priv->timeout * rtc_cycles, STAGE_0);
+                }
+            }
+        }
+
       /* No User Handler */
 
       if (priv->handler == NULL)
@@ -225,6 +255,8 @@ static int esp32_wdt_start(struct watchdog_lowerhalf_s *lower)
 
           ESP32_WDT_ENABLEINT(priv->wdt);
         }
+
+      ESP32_WDT_FEED(priv->wdt);
 
       flags = spin_lock_irqsave(&priv->lock);
       priv->lastreset = clock_systime_ticks();

--- a/arch/xtensa/src/esp32/esp32_wdt_lowerhalf.c
+++ b/arch/xtensa/src/esp32/esp32_wdt_lowerhalf.c
@@ -484,6 +484,12 @@ static int esp32_wdt_settimeout(struct watchdog_lowerhalf_s *lower,
   else
     {
       rtc_cycles = ESP32_RWDT_CLK(priv->wdt);
+      if (rtc_cycles == 0)
+        {
+          wderr("ERROR: RTC clock calibration returned 0 cycles/ms\n");
+          return -EIO;
+        }
+
       rtc_ms_max = (uint32_t)(FULL_STAGE / rtc_cycles);
 
       /* Is this timeout a valid value for RTC WDT? */

--- a/arch/xtensa/src/esp32s2/esp32s2_wdt_lowerhalf.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_wdt_lowerhalf.c
@@ -236,6 +236,33 @@ static int wdt_lh_start(struct watchdog_lowerhalf_s *lower)
 
       ESP32S2_WDT_UNLOCK(priv->wdt);
 
+      /* Re-apply the prescaler for MWDT in case the Timer Group
+       * registers were reset after initialization (e.g. by a
+       * constructor function that resets the peripheral).
+       */
+
+      if (priv->peripheral == TIMER)
+        {
+          ESP32S2_MWDT_PRE(priv->wdt, MWDT_CLK_PRESCALER_VALUE);
+        }
+
+      /* Re-apply the timeout value */
+
+      if (priv->timeout > 0)
+        {
+          if (priv->peripheral == TIMER)
+            {
+              ESP32S2_WDT_STO(priv->wdt, MWDT_TIMEOUT_MS(priv->timeout),
+                              ESP32S2_WDT_STAGE0);
+            }
+          else if (priv->peripheral == RTC)
+            {
+              uint16_t rtc_cycles = ESP32S2_RWDT_CLK(priv->wdt);
+              ESP32S2_WDT_STO(priv->wdt, priv->timeout * rtc_cycles,
+                              ESP32S2_WDT_STAGE0);
+            }
+        }
+
       /* No User Handler */
 
       if (priv->handler == NULL)
@@ -270,6 +297,8 @@ static int wdt_lh_start(struct watchdog_lowerhalf_s *lower)
           leave_critical_section(flags);
           ESP32S2_WDT_ENABLEINT(priv->wdt);
         }
+
+      ESP32S2_WDT_FEED(priv->wdt);
 
       flags = enter_critical_section();
       priv->lastreset = clock_systime_ticks();

--- a/arch/xtensa/src/esp32s3/esp32s3_wdt_lowerhalf.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_wdt_lowerhalf.c
@@ -237,6 +237,33 @@ static int wdt_lh_start(struct watchdog_lowerhalf_s *lower)
 
       ESP32S3_WDT_UNLOCK(priv->wdt);
 
+      /* Re-apply the prescaler for MWDT in case the Timer Group
+       * registers were reset after initialization (e.g. by a
+       * constructor function that resets the peripheral).
+       */
+
+      if (priv->peripheral == TIMER)
+        {
+          ESP32S3_MWDT_PRE(priv->wdt, MWDT_CLK_PRESCALER_VALUE);
+        }
+
+      /* Re-apply the timeout value */
+
+      if (priv->timeout > 0)
+        {
+          if (priv->peripheral == TIMER)
+            {
+              ESP32S3_WDT_STO(priv->wdt, MWDT_TIMEOUT_MS(priv->timeout),
+                              ESP32S3_WDT_STAGE0);
+            }
+          else if (priv->peripheral == RTC)
+            {
+              uint16_t rtc_cycles = ESP32S3_RWDT_CLK(priv->wdt);
+              ESP32S3_WDT_STO(priv->wdt, priv->timeout * rtc_cycles,
+                              ESP32S3_WDT_STAGE0);
+            }
+        }
+
       /* No User Handler */
 
       if (priv->handler == NULL)
@@ -271,6 +298,8 @@ static int wdt_lh_start(struct watchdog_lowerhalf_s *lower)
           spin_unlock_irqrestore(&priv->lock, flags);
           ESP32S3_WDT_ENABLEINT(priv->wdt);
         }
+
+      ESP32S3_WDT_FEED(priv->wdt);
 
       flags = spin_lock_irqsave(&priv->lock);
       priv->lastreset = clock_systime_ticks();


### PR DESCRIPTION
## Summary

Our internal CI spotted some bugs related to the watchdog timers. The general functionality was working as expected, but minor issues have appeared:

* xtensa/esp32: Fix RWDT register offsets.
 *  The RWDT register offsets were incorrectly set to ESP32-S3 values instead of ESP32 values. This was introduced when the code was
refactored from using the local NuttX header hardware/esp32_rtccntl.h which had the correct offsets) to using the HAL library headers, and
the offsets were moved inline into esp32_wdt.c with wrong values. Correct the offsets to match the actual ESP32 register layout from
soc/rtc_cntl_reg.h (RTC_CNTL_WDTCONFIG0_REG at 0x8c, INT_ENA at 0x3c, etc). Without this fix, all RWDT operations (enable, configure
timeout, enable interrupt, acknowledge interrupt, feed, write-protect) were targeting wrong memory addresses, rendering the RWDT completely
non-functional.

* xtensa/esp32: Fix divide-by-zero in RTC WDT clock calibration.
  * Under the BOARD_LATE_INITIALIZE boot flow, rtc_clk_xtal_freq_get() may return 0 (SOC_XTAL_FREQ_AUTO) because the XTAL frequency has
not yet been stored to the RTC register when the WDT driver is initialized. This causes rtc_clk_cal() to divide by zero internally (EXCCAUSE=0006) when computing the RTC slow clock period. Fix by explicitly calling rtc_clk_xtal_freq_update() with the board's configured crystal frequency if rtc_clk_xtal_freq_get() returns 0. Also add a guard in esp32_wdt_settimeout() to return -EIO if ESP32_RWDT_CLK() still returns 0 cycles/ms, preventing a subsequent divide-by-zero when computing the maximum timeout.

* xtensa/esp32: Re-apply WDT prescaler and timeout at start.
  *  Same issue as ESP32-S3/S2.

* xtensa/esp32s2: Re-apply WDT prescaler and timeout at start.
  * Same issue as ESP32-S3
  * 
* xtensa/esp32s3: Re-apply WDT prescaler and timeout at start.
  * With the BOARD_LATE_INITIALIZE flow, board_late_initialize() runs on a kernel thread and sets the MWDT0 prescaler. However, after it
returns, the init task (NSH) is spawned and lib_cxx_initialize() invokes constructor functions, including enable_timer_group0_for_calibration() from esp-hal-3rdparty which calls timg_ll_reset_register(0), resetting all Timer Group 0 registers (including the WDT prescaler) back to their defaults. Re-apply the prescaler, timeout, and feed the WDT counter in wdt_lh_start() just before enabling the timer. This ensures correct WDT configuration regardless of any intermediate register resets by external code.

## Impact

Impact on user: Yes. It prevented setting a watchdog handler on watchdog timer 0. Now fixed.

Impact on build: No.

Impact on hardware: Yes. Xtensa-based Espressif's SoCs. Now fixed.

Impact on documentation: No.

Impact on security: No.

Impact on compatibility: No.

## Testing

Just build the `watchdog` defconfig for such devices. For ESP32-S3, for instance:

### Building

```
make -j distclean
./tools/configure.sh -S esp32s3-devkit:watchdog
make flash ESPTOOL_PORT=/dev/ttyUSB0 -s -j$(nproc)
picocom -b 115200 /dev/ttyUSB0
```

### Running

Run `wdog -i /dev/watchdog0` to ensure watchdog is triggering properly.

### Results

```
nsh> wdog -i /dev/watchdog0
  ping elapsed=0
  ping elapsed=500
  ping elapsed=1000
  ping elapsed=1500
  ping elapsed=2000
  ping elapsed=2500
  ping elapsed=3000
  ping elapsed=3500
  ping elapsed=4000
  ping elapsed=4500
  NO ping elapsed=5000
  NO ping elapsed=5500
  NO ping elapsed=6000
ESP-ROM:esp32s3-20210327
Build:Mar 27 2021
rst:0x7 (TG0WDT_SYS_RST),boot:0x8 (SPI_FAST_FLASH_BOOT)
Saved PC:0x420257f6
SPIWP:0xee
mode:DIO, clock div:2
load:0x3fc8e560,len:0x167c
load:0x40374000,len:0x8224
load:0x50000000,len:0x24
SHA-256 comparison failed:
Calculated: b20c9f31f4bc9eaa14c7e93b25b388f5f4888e1aa350184ecc4246c6e449d543
Expected: 00000000f0660000000000000000000000000000000000000000000000000000
Attempting to boot anyway...
entry 0x40374ed0
*** Booting NuttX ***
dram: lma 0x00000020 vma 0x3fc8e560 len 0x167c   (5756)
iram: lma 0x000016a4 vma 0x40374000 len 0x8224   (33316)
rtc: lma 0x000098d0 vma 0x50000000 len 0x24     (36)
padd: lma 0x00009908 vma 0x00000000 len 0x66f0   (26352)
imap: lma 0x00010000 vma 0x42010000 len 0x163a0  (91040)
padd: lma 0x000263a8 vma 0x00000000 len 0x9c50   (40016)
dmap: lma 0x00030000 vma 0x3c040000 len 0x34a0   (13472)
total segments stored 7

NuttShell (NSH) NuttX-10.4.0
nsh> 
```