### PR TITLE
Documentation: Document hostname command

### DIFF
--- a/Documentation/applications/system/hostname/index.rst
+++ b/Documentation/applications/system/hostname/index.rst
@@ -1,3 +1,99 @@
 ===============================
 ``hostname`` "hostname" command
 ===============================
+
+Overview
+========
+
+The ``hostname`` command displays or sets the system hostname. When called
+without arguments, it prints the current hostname. When called with a
+hostname argument, it sets the system hostname to the specified value.
+
+The hostname is stored in the kernel and can be retrieved by applications
+using the ``gethostname()`` system call. It is typically used to identify
+the system on a network and in shell prompts.
+
+Configuration
+=============
+
+Enable the command with ``CONFIG_SYSTEM_HOSTNAME``. This option has no
+additional dependencies.
+
+Usage
+=====
+
+.. code-block:: console
+
+   hostname
+
+Display the current system hostname.
+
+.. code-block:: console
+
+   hostname <hostname>
+
+Set the system hostname to ``<hostname>``.
+
+.. code-block:: console
+
+   hostname -F <file>
+
+Read the hostname from the specified file and set it as the system hostname.
+
+Options
+=======
+
+``-F <file>``
+  Read the hostname from the specified file. The first line of the file
+  is used as the hostname. Trailing newlines are stripped.
+
+``-h``
+  Display usage information and exit.
+
+Examples
+========
+
+Display the current hostname:
+
+.. code-block:: console
+
+   nsh> hostname
+   nuttx
+
+Set a new hostname:
+
+.. code-block:: console
+
+   nsh> hostname mydevice
+   nsh> hostname
+   mydevice
+
+Read hostname from a file:
+
+.. code-block:: console
+
+   nsh> cat /etc/hostname
+   embedded-device
+   nsh> hostname -F /etc/hostname
+   nsh> hostname
+   embedded-device
+
+Display usage information:
+
+.. code-block:: console
+
+   nsh> hostname -h
+   Usage: hostname [<hostname>|-F <file>]
+
+Notes
+=====
+
+- The hostname must be between 1 and ``HOST_NAME_MAX`` characters long.
+- Setting an empty hostname or a hostname longer than ``HOST_NAME_MAX``
+  will result in an error.
+- The hostname is stored in the kernel and persists until the system is
+  rebooted or the hostname is changed again.
+- The ``-F`` option reads only the first line of the specified file and
+  strips any trailing newline characters.
+- If both a hostname argument and the ``-F`` option are provided, the
+  ``-F`` option takes precedence.


### PR DESCRIPTION
## Summary

  * Add documentation for the `hostname` command.
  * The command displays or sets the system hostname.
  * Covers overview, configuration, usage, options, examples, and notes.
  * Related NuttX Issue: #11081

## Impact

  * Is new feature added? NO.
  * Is existing feature changed? NO.
  * Impact on user? NO.
  * Impact on build? NO.
  * Impact on hardware? NO.
  * Impact on documentation? YES: adds documentation for the hostname command.
  * Impact on security? NO.
  * Impact on compatibility? NO.
  * Dependencies: none.

## Testing

  I confirm that changes are verified on local setup and work as intended:

  * Build Host(s): Linux WSL2
  * Target(s): Documentation build only
  * Static/style check: RST syntax validation
  * Build test: `cd Documentation && make html`

  Testing logs after change:

  ```
  $ cd Documentation && DISPLAY= JAVA_TOOL_OPTIONS='-Djava.awt.headless=true' make html
  build succeeded.
  The HTML pages are in _build/html.
  ```

## PR verification Self-Check

  * [x] This PR introduces only one functional change.
  * [x] I have updated all required description fields above.
  * [x] My PR adheres to Contributing [Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) and [Documentation](https://nuttx.apache.org/docs/latest/contributing/index.html) (git commit title and message, coding standard, etc).
  * [ ] My PR is still work in progress (not ready for review).
  * [x] My PR is ready for review and can be safely merged into a codebase.