### PR TITLE
tools/espressif: Add UF2 output support

### DIFF
--- a/Documentation/platforms/risc-v/esp32c3/index.rst
+++ b/Documentation/platforms/risc-v/esp32c3/index.rst
@@ -131,6 +131,12 @@ where:
 * ``ESPTOOL_BINDIR=./`` is the path of the externally-built 2nd stage bootloader and the partition table (if applicable): when built using the ``make bootloader``, these files are placed into ``nuttx`` folder.
 * ``ESPTOOL_BAUD`` is able to change the flash baud rate if desired.
 
+To create and flash with UF2 (USB Flashing Format) binary, ``UF2=1`` option needs to be set during build phase
+(e.g ``make UF2=1 -j8``). This flag will create UF2 format file addition to binary. This output can be used to
+flash the device with `ESP USB Bridge <https://github.com/espressif/esp-usb-bridge>`__.
+To flash using ESP USB Bridge, either drag and drop the generated UF2 file onto the flasher's
+mass storage device, or use the ``UF2=1`` flag during flashing (e.g. ``make flash ESPTOOL_PORT=<port> ESPTOOL_BINDIR=./ UF2=1``)
+
 Flashing NSH Example
 --------------------
 

--- a/Documentation/platforms/risc-v/esp32c6/index.rst
+++ b/Documentation/platforms/risc-v/esp32c6/index.rst
@@ -131,6 +131,12 @@ where:
 * ``ESPTOOL_BINDIR=./`` is the path of the externally-built 2nd stage bootloader and the partition table (if applicable): when built using the ``make bootloader``, these files are placed into ``nuttx`` folder.
 * ``ESPTOOL_BAUD`` is able to change the flash baud rate if desired.
 
+To create and flash with UF2 (USB Flashing Format) binary, ``UF2=1`` option needs to be set during build phase
+(e.g ``make UF2=1 -j8``). This flag will create UF2 format file addition to binary. This output can be used to
+flash the device with `ESP USB Bridge <https://github.com/espressif/esp-usb-bridge>`__.
+To flash using ESP USB Bridge, either drag and drop the generated UF2 file onto the flasher's
+mass storage device, or use the ``UF2=1`` flag during flashing (e.g. ``make flash ESPTOOL_PORT=<port> ESPTOOL_BINDIR=./ UF2=1``)
+
 Flashing NSH Example
 --------------------
 

--- a/Documentation/platforms/risc-v/esp32h2/index.rst
+++ b/Documentation/platforms/risc-v/esp32h2/index.rst
@@ -131,6 +131,12 @@ where:
 * ``ESPTOOL_BINDIR=./`` is the path of the externally-built 2nd stage bootloader and the partition table (if applicable): when built using the ``make bootloader``, these files are placed into ``nuttx`` folder.
 * ``ESPTOOL_BAUD`` is able to change the flash baud rate if desired.
 
+To create and flash with UF2 (USB Flashing Format) binary, ``UF2=1`` option needs to be set during build phase
+(e.g ``make UF2=1 -j8``). This flag will create UF2 format file addition to binary. This output can be used to
+flash the device with `ESP USB Bridge <https://github.com/espressif/esp-usb-bridge>`__.
+To flash using ESP USB Bridge, either drag and drop the generated UF2 file onto the flasher's
+mass storage device, or use the ``UF2=1`` flag during flashing (e.g. ``make flash ESPTOOL_PORT=<port> ESPTOOL_BINDIR=./ UF2=1``)
+
 Flashing NSH Example
 --------------------
 

--- a/Documentation/platforms/xtensa/esp32/index.rst
+++ b/Documentation/platforms/xtensa/esp32/index.rst
@@ -148,6 +148,12 @@ where:
 * ``ESPTOOL_BINDIR=./`` is the path of the externally-built 2nd stage bootloader and the partition table (if applicable): when built using the ``make bootloader``, these files are placed into ``nuttx`` folder.
 * ``ESPTOOL_BAUD`` is able to change the flash baud rate if desired.
 
+To create and flash with UF2 (USB Flashing Format) binary, ``UF2=1`` option needs to be set during build phase
+(e.g ``make UF2=1 -j8``). This flag will create UF2 format file addition to binary. This output can be used to
+flash the device with `ESP USB Bridge <https://github.com/espressif/esp-usb-bridge>`__.
+To flash using ESP USB Bridge, either drag and drop the generated UF2 file onto the flasher's
+mass storage device, or use the ``UF2=1`` flag during flashing (e.g. ``make flash ESPTOOL_PORT=<port> ESPTOOL_BINDIR=./ UF2=1``)
+
 Flashing NSH Example
 --------------------
 

--- a/Documentation/platforms/xtensa/esp32s2/index.rst
+++ b/Documentation/platforms/xtensa/esp32s2/index.rst
@@ -141,6 +141,12 @@ where:
 * ``ESPTOOL_BINDIR=./`` is the path of the externally-built 2nd stage bootloader and the partition table (if applicable): when built using the ``make bootloader``, these files are placed into ``nuttx`` folder.
 * ``ESPTOOL_BAUD`` is able to change the flash baud rate if desired.
 
+To create and flash with UF2 (USB Flashing Format) binary, ``UF2=1`` option needs to be set during build phase
+(e.g ``make UF2=1 -j8``). This flag will create UF2 format file addition to binary. This output can be used to
+flash the device with `ESP USB Bridge <https://github.com/espressif/esp-usb-bridge>`__.
+To flash using ESP USB Bridge, either drag and drop the generated UF2 file onto the flasher's
+mass storage device, or use the ``UF2=1`` flag during flashing (e.g. ``make flash ESPTOOL_PORT=<port> ESPTOOL_BINDIR=./ UF2=1``)
+
 Flashing NSH Example
 --------------------
 

--- a/Documentation/platforms/xtensa/esp32s3/index.rst
+++ b/Documentation/platforms/xtensa/esp32s3/index.rst
@@ -149,6 +149,12 @@ where:
 * ``ESPTOOL_BINDIR=./`` is the path of the externally-built 2nd stage bootloader and the partition table (if applicable): when built using the ``make bootloader``, these files are placed into ``nuttx`` folder.
 * ``ESPTOOL_BAUD`` is able to change the flash baud rate if desired.
 
+To create and flash with UF2 (USB Flashing Format) binary, ``UF2=1`` option needs to be set during build phase
+(e.g ``make UF2=1 -j8``). This flag will create UF2 format file addition to binary. This output can be used to
+flash the device with `ESP USB Bridge <https://github.com/espressif/esp-usb-bridge>`__.
+To flash using ESP USB Bridge, either drag and drop the generated UF2 file onto the flasher's
+mass storage device, or use the ``UF2=1`` flag during flashing (e.g. ``make flash ESPTOOL_PORT=<port> ESPTOOL_BINDIR=./ UF2=1``)
+
 Flashing NSH Example
 --------------------
 

--- a/tools/esp32/Config.mk
+++ b/tools/esp32/Config.mk
@@ -349,6 +349,13 @@ endef
 endif
 endif
 
+# MAKEUF2 -- Merge raw binary files into uf2 format
+
+define MAKEUF2
+	esptool.py -c $(CHIP_SERIES) merge_bin --format uf2 -o nuttx.merged.uf2 -fs $(FLASH_SIZE) -fm $(FLASH_MODE) $(ESPTOOL_BINS)
+	$(Q) echo "Generated: nuttx.merged.uf2"
+endef
+
 # POSTBUILD -- Perform post build operations
 
 define POSTBUILD
@@ -356,6 +363,7 @@ define POSTBUILD
 	$(if $(CONFIG_ESPRESSIF_BOOTLOADER_MCUBOOT),$(call MAKE_VIRTUAL_EFUSE_BIN))
 	$(if $(CONFIG_ESP32_SECURE_FLASH_ENC_ENABLED),$(call FLASH_ENC))
 	$(if $(CONFIG_ESP32_MERGE_BINS),$(call MERGEBIN))
+	$(if $(UF2),$(call MAKEUF2))
 endef
 
 # ESPTOOL_BAUD -- Serial port baud rate used when flashing/reading via esptool.py
@@ -373,5 +381,12 @@ define FLASH
 
 	$(if $(CONFIG_ESP32_SECURE_FLASH_ENC_ENABLED),$(call BURN_EFUSES))
 	$(eval ESPTOOL_OPTS := -c esp32 -p $(ESPTOOL_PORT) -b $(ESPTOOL_BAUD) $(ESPTOOL_RESET_OPTS))
-	esptool.py $(ESPTOOL_OPTS) write_flash $(ESPTOOL_WRITEFLASH_OPTS) $(ESPTOOL_BINS)
+	$(Q) if [ -z $(UF2) ]; then \
+		esptool.py $(ESPTOOL_OPTS) write_flash $(ESPTOOL_WRITEFLASH_OPTS) $(ESPTOOL_BINS); \
+	else \
+		echo "Flashing using UF2 file."; \
+		cp nuttx.merged.uf2 $(ESPTOOL_PORT); \
+		sync; \
+	fi
+
 endef

--- a/tools/esp32s2/Config.mk
+++ b/tools/esp32s2/Config.mk
@@ -317,6 +317,13 @@ endef
 endif
 endif
 
+# MAKEUF2 -- Merge raw binary files into uf2 format
+
+define MAKEUF2
+	esptool.py -c $(CHIP_SERIES) merge_bin --format uf2 -o nuttx.merged.uf2 -fs $(FLASH_SIZE) -fm $(FLASH_MODE) $(ESPTOOL_BINS)
+	$(Q) echo "Generated: nuttx.merged.uf2"
+endef
+
 # POSTBUILD -- Perform post build operations
 
 define POSTBUILD
@@ -324,6 +331,7 @@ define POSTBUILD
 	$(if $(CONFIG_ESPRESSIF_BOOTLOADER_MCUBOOT),$(call MAKE_VIRTUAL_EFUSE_BIN))
 	$(if $(CONFIG_ESP32S2_SECURE_FLASH_ENC_ENABLED),$(call FLASH_ENC))
 	$(if $(CONFIG_ESP32S2_MERGE_BINS),$(call MERGEBIN))
+	$(if $(UF2),$(call MAKEUF2))
 endef
 
 # ESPTOOL_BAUD -- Serial port baud rate used when flashing/reading via esptool.py
@@ -341,5 +349,13 @@ define FLASH
 
 	$(if $(CONFIG_ESP32S2_SECURE_FLASH_ENC_ENABLED),$(call BURN_EFUSES))
 	$(eval ESPTOOL_OPTS := -c esp32s2 -p $(ESPTOOL_PORT) -b $(ESPTOOL_BAUD) $(ESPTOOL_RESET_OPTS) $(if $(CONFIG_ESP32S2_ESPTOOLPY_NO_STUB),--no-stub))
-	esptool.py $(ESPTOOL_OPTS) write_flash $(ESPTOOL_WRITEFLASH_OPTS) $(ESPTOOL_BINS)
+
+	$(Q) if [ -z $(UF2) ]; then \
+		esptool.py $(ESPTOOL_OPTS) write_flash $(ESPTOOL_WRITEFLASH_OPTS) $(ESPTOOL_BINS); \
+	else \
+		echo "Flashing using UF2 file."; \
+		cp nuttx.merged.uf2 $(ESPTOOL_PORT); \
+		sync; \
+	fi
+
 endef

--- a/tools/esp32s3/Config.mk
+++ b/tools/esp32s3/Config.mk
@@ -282,6 +282,13 @@ define MKIMAGE
 endef
 endif
 
+# MAKEUF2 -- Merge raw binary files into uf2 format
+
+define MAKEUF2
+	esptool.py -c $(CHIP_SERIES) merge_bin --format uf2 -o nuttx.merged.uf2 -fs $(FLASH_SIZE) -fm $(FLASH_MODE) $(ESPTOOL_BINS)
+	$(Q) echo "Generated: nuttx.merged.uf2"
+endef
+
 # PREBUILD -- Perform pre build operations
 
 ifeq ($(CONFIG_BUILD_PROTECTED),y)
@@ -299,6 +306,7 @@ define POSTBUILD
 	$(if $(CONFIG_ESPRESSIF_BOOTLOADER_MCUBOOT),$(call MAKE_VIRTUAL_EFUSE_BIN))
 	$(if $(CONFIG_ESPRESSIF_SECURE_FLASH_ENC_ENABLED),$(call FLASH_ENC))
 	$(if $(CONFIG_ESP32S3_MERGE_BINS),$(call MERGEBIN))
+	$(if $(UF2),$(call MAKEUF2))
 endef
 
 # ESPTOOL_BAUD -- Serial port baud rate used when flashing/reading via esptool.py
@@ -315,5 +323,12 @@ define FLASH
 	fi
 	$(if $(CONFIG_ESPRESSIF_SECURE_FLASH_ENC_ENABLED),$(call BURN_EFUSES))
 	$(eval ESPTOOL_OPTS := -c esp32s3 -p $(ESPTOOL_PORT) -b $(ESPTOOL_BAUD) $(if $(CONFIG_ESP32S3_ESPTOOLPY_NO_STUB),--no-stub))
-	esptool.py $(ESPTOOL_OPTS) write_flash $(ESPTOOL_WRITEFLASH_OPTS) $(ESPTOOL_BINS)
+
+	$(Q) if [ -z $(UF2) ]; then \
+		esptool.py $(ESPTOOL_OPTS) write_flash $(ESPTOOL_WRITEFLASH_OPTS) $(ESPTOOL_BINS); \
+	else \
+		echo "Flashing using UF2 file."; \
+		cp nuttx.merged.uf2 $(ESPTOOL_PORT); \
+		sync; \
+	fi
 endef

--- a/tools/espressif/Config.mk
+++ b/tools/espressif/Config.mk
@@ -262,6 +262,13 @@ define MKIMAGE
 endef
 endif
 
+# MAKEUF2 -- Merge raw binary files into uf2 format
+
+define MAKEUF2
+	esptool.py -c $(CHIP_SERIES) merge_bin --format uf2 -o nuttx.merged.uf2 -fs $(FLASH_SIZE) -fm $(FLASH_MODE) $(ESPTOOL_BINS)
+	$(Q) echo "Generated: nuttx.merged.uf2"
+endef
+
 # POSTBUILD -- Perform post build operations
 
 define POSTBUILD
@@ -269,6 +276,7 @@ define POSTBUILD
 	$(if $(CONFIG_ESPRESSIF_BOOTLOADER_MCUBOOT),$(call MAKE_VIRTUAL_EFUSE_BIN))
 	$(if $(CONFIG_ESPRESSIF_SECURE_FLASH_ENC_ENABLED),$(call FLASH_ENC))
 	$(if $(CONFIG_ESPRESSIF_MERGE_BINS),$(call MERGEBIN))
+	$(if $(UF2),$(call MAKEUF2))
 endef
 
 # ESPTOOL_BAUD -- Serial port baud rate used when flashing/reading via esptool.py
@@ -287,5 +295,12 @@ define FLASH
 	$(if $(CONFIG_ESPRESSIF_SECURE_FLASH_ENC_ENABLED),$(call BURN_EFUSES))
 	$(eval ESPTOOL_OPTS := -c $(CHIP_SERIES) -p $(ESPTOOL_PORT) -b $(ESPTOOL_BAUD) $(if $(CONFIG_ESPRESSIF_ESPTOOLPY_NO_STUB),--no-stub))
 	$(eval WRITEFLASH_OPTS := $(if $(CONFIG_ESPRESSIF_MERGE_BINS),$(ESPTOOL_WRITEFLASH_OPTS) 0x0 nuttx.merged.bin,$(ESPTOOL_WRITEFLASH_OPTS) $(ESPTOOL_BINS)))
-	esptool.py $(ESPTOOL_OPTS) write_flash $(WRITEFLASH_OPTS)
+
+	$(Q) if [ -z $(UF2) ]; then \
+		esptool.py $(ESPTOOL_OPTS) write_flash $(WRITEFLASH_OPTS); \
+	else \
+		echo "Flashing using UF2 file."; \
+		cp nuttx.merged.uf2 $(ESPTOOL_PORT); \
+		sync; \
+	fi
 endef

--- a/tools/espressif/espressif_mkimage.cmake
+++ b/tools/espressif/espressif_mkimage.cmake
@@ -27,6 +27,10 @@
 # (contains .config and nuttx ELF) SOURCE_DIR       - CMake source directory
 # (NuttX root)
 #
+# Optional (matches make UF2=1): UF2              - If set to 1/on/yes/true, run
+# MAKEUF2 (esptool merge_bin --format uf2). May also be set via the UF2
+# environment variable when invoking cmake -P.
+#
 # All CONFIG_* variables are automatically loaded from .config file.
 
 # ##############################################################################
@@ -57,6 +61,22 @@ endif()
 nuttx_export_kconfig(${DOTCONFIG})
 
 include(${SOURCE_DIR}/tools/espressif/espressif_esptool_common.cmake)
+
+# ##############################################################################
+# UF2 output (tools/espressif/Config.mk MAKEUF2; make UF2=1)
+# ##############################################################################
+
+if(NOT DEFINED UF2)
+  set(UF2 "$ENV{UF2}")
+endif()
+
+set(UF2_ENABLED FALSE)
+if(NOT "${UF2}" STREQUAL "")
+  string(TOLOWER "${UF2}" _uf2_lower)
+  if(_uf2_lower MATCHES "^(1|on|yes|true|y)$")
+    set(UF2_ENABLED TRUE)
+  endif()
+endif()
 
 # ##############################################################################
 # Find required tools for the post build process
@@ -272,6 +292,53 @@ if(CONFIG_ESPRESSIF_SECURE_FLASH_ENC_ENABLED)
 endif()
 
 # ##############################################################################
+# Set address/bin variable for esptool
+# ##############################################################################
+
+set(ESPTOOL_BINS "")
+
+if(CONFIG_ESPRESSIF_BOOTLOADER_MCUBOOT)
+  # MCUboot configuration
+
+  if(EXISTS "${SOURCE_DIR}/mcuboot-${CHIP_SERIES}.bin")
+    message(
+      STATUS
+        "Merge bin: ${BL_OFFSET} -> ${SOURCE_DIR}/mcuboot-${CHIP_SERIES}.bin")
+    list(APPEND ESPTOOL_BINS ${BL_OFFSET}
+         "${SOURCE_DIR}/mcuboot-${CHIP_SERIES}.bin")
+  else()
+    message(FATAL_ERROR "mcuboot-${CHIP_SERIES}.bin not found in ${SOURCE_DIR}")
+  endif()
+
+  # Create empty vefuse.bin if it doesn't exist
+  if(NOT EXISTS "${BINARY_DIR}/vefuse.bin")
+    file(WRITE "${BINARY_DIR}/vefuse.bin" "")
+  endif()
+  list(APPEND ESPTOOL_BINS ${EFUSE_OFFSET} "${BINARY_DIR}/vefuse.bin")
+  message(STATUS "Merge bin: ${EFUSE_OFFSET} -> ${BINARY_DIR}/vefuse.bin")
+
+  list(APPEND ESPTOOL_BINS ${MCUBOOT_APP_OFFSET} "${BINARY_DIR}/nuttx.bin")
+  message(STATUS "Merge bin: ${MCUBOOT_APP_OFFSET} -> ${BINARY_DIR}/nuttx.bin")
+
+  if(CONFIG_ESPRESSIF_SECURE_FLASH_ENC_ENABLED AND CONFIG_ESPRESSIF_SPIFLASH)
+    list(APPEND ESPTOOL_BINS ${CONFIG_ESPRESSIF_STORAGE_MTD_OFFSET}
+         "${BINARY_DIR}/enc_mtd.bin")
+    message(
+      STATUS
+        "Merge bin: ${CONFIG_ESPRESSIF_STORAGE_MTD_OFFSET} -> ${BINARY_DIR}/enc_mtd.bin"
+    )
+  endif()
+
+elseif(CONFIG_ESPRESSIF_SIMPLE_BOOT)
+  # Simple boot: same base offset as BL_OFFSET (0x2000 on ESP32-P4, else 0x0)
+  list(APPEND ESPTOOL_BINS ${BL_OFFSET} "${BINARY_DIR}/nuttx.bin")
+
+else()
+  # Legacy boot: application at offset 0
+  list(APPEND ESPTOOL_BINS 0x0000 "${BINARY_DIR}/nuttx.bin")
+endif()
+
+# ##############################################################################
 # Merge binaries (optional)
 # ##############################################################################
 
@@ -283,50 +350,6 @@ if(CONFIG_ESPRESSIF_MERGE_BINS)
   endif()
 
   # Build the list of binaries to merge Format: offset1 file1 offset2 file2 ...
-  set(ESPTOOL_BINS "")
-
-  if(CONFIG_ESPRESSIF_BOOTLOADER_MCUBOOT)
-    # MCUboot configuration
-
-    if(EXISTS "${SOURCE_DIR}/mcuboot-${CHIP_SERIES}.bin")
-      message(
-        STATUS
-          "Merge bin: ${BL_OFFSET} -> ${SOURCE_DIR}/mcuboot-${CHIP_SERIES}.bin")
-      list(APPEND ESPTOOL_BINS ${BL_OFFSET}
-           "${SOURCE_DIR}/mcuboot-${CHIP_SERIES}.bin")
-    else()
-      message(
-        FATAL_ERROR "mcuboot-${CHIP_SERIES}.bin not found in ${SOURCE_DIR}")
-    endif()
-
-    # Create empty vefuse.bin if it doesn't exist
-    if(NOT EXISTS "${BINARY_DIR}/vefuse.bin")
-      file(WRITE "${BINARY_DIR}/vefuse.bin" "")
-    endif()
-    list(APPEND ESPTOOL_BINS ${EFUSE_OFFSET} "${BINARY_DIR}/vefuse.bin")
-    message(STATUS "Merge bin: ${EFUSE_OFFSET} -> ${BINARY_DIR}/vefuse.bin")
-
-    list(APPEND ESPTOOL_BINS ${MCUBOOT_APP_OFFSET} "${BINARY_DIR}/nuttx.bin")
-    message(
-      STATUS "Merge bin: ${MCUBOOT_APP_OFFSET} -> ${BINARY_DIR}/nuttx.bin")
-
-    if(CONFIG_ESPRESSIF_SECURE_FLASH_ENC_ENABLED AND CONFIG_ESPRESSIF_SPIFLASH)
-      list(APPEND ESPTOOL_BINS ${CONFIG_ESPRESSIF_STORAGE_MTD_OFFSET}
-           "${BINARY_DIR}/enc_mtd.bin")
-      message(
-        STATUS
-          "Merge bin: ${CONFIG_ESPRESSIF_STORAGE_MTD_OFFSET} -> ${BINARY_DIR}/enc_mtd.bin"
-      )
-    endif()
-
-  elseif(CONFIG_ESPRESSIF_SIMPLE_BOOT)
-    # Simple boot: same base offset as BL_OFFSET (0x2000 on ESP32-P4, else 0x0)
-    list(APPEND ESPTOOL_BINS ${BL_OFFSET} "${BINARY_DIR}/nuttx.bin")
-
-  else()
-    # Legacy boot: application at offset 0
-    list(APPEND ESPTOOL_BINS 0x0000 "${BINARY_DIR}/nuttx.bin")
-  endif()
 
   # Execute merge_bin
   execute_process(
@@ -341,4 +364,26 @@ if(CONFIG_ESPRESSIF_MERGE_BINS)
 
   message(STATUS "Generated: nuttx.merged.bin")
   file(APPEND "${BINARY_DIR}/nuttx.manifest" "nuttx.merged.bin\n")
+endif()
+
+# ##############################################################################
+# UF2 image (optional; Config.mk MAKEUF2)
+# ##############################################################################
+
+if(UF2_ENABLED)
+  message(STATUS "MAKEUF2: Creating UF2 flash image")
+
+  execute_process(
+    COMMAND
+      ${ESPTOOL} -c ${CHIP_SERIES} merge-bin --format uf2 -o
+      ${BINARY_DIR}/nuttx.merged.uf2 -fs ${FLASH_SIZE} -fm ${FLASH_MODE}
+      ${ESPTOOL_BINS}
+    RESULT_VARIABLE MAKEUF2_RESULT
+    WORKING_DIRECTORY ${BINARY_DIR})
+
+  if(NOT MAKEUF2_RESULT EQUAL 0)
+    message(FATAL_ERROR "esptool merge-bin --format uf2 failed")
+  endif()
+
+  message(STATUS "Generated: nuttx.merged.uf2")
 endif()


### PR DESCRIPTION
## Summary

<!-- This field should contain a summary of the changes. It will be pre-filled with the commit's message and descriptions. Adjust it accordingly -->

* tools/espressif: Add UF2 output support

Add UF2 file output support for Espressif devices

* Docs/platforms/xtensa: Add UF2 file format docs

Add UF2 file format docs for Xtensa based Espressif devices

* Docs/platforms/espressif: Add UF2 file format docs

Add UF2 file format docs for RISC-V based Espressif devices

## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: No, new output file option added
<!-- Does it impact user's applications? How? -->

Impact on build: Yes, new output file option added 
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: No
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: Yes, related docs added for that output
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: No
<!-- Does it impact NuttX's security? -->

Impact on compatibility: No
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

## Testing
<!-- Please provide all the testing procedure. Consider that upstream reviewers should be able to reproduce the same testing performed internally -->

`esp32c6-devkitc:nsh` config used to test

### Building
<!-- Provide how to build the test for each SoC being tested -->

Used command to build:

```
make -j distclean && ./tools/configure.sh esp32c6-devkitc:nsh && make -j UF2=1
```

Output should be like this:

```
Generated: nuttx.bin
esptool.py -c esp32c6 merge_bin --format uf2 -o nuttx.merged.uf2 -fs 4MB -fm dio 0x0000 nuttx.bin 
esptool.py v4.9.0
Adding nuttx.bin at 0x0
Wrote 0x48000 bytes to file nuttx.merged.uf2, ready to be flashed with any ESP USB Bridge
Generated: nuttx.merged.uf2
```

### Running
<!-- Provide how to run the test for each SoC being tested -->

After build operation, here is the connection diagram

| Target Device | Flashing Device |
|---------------|-----------------|
| TX            | TX              |
| RX            | RX              |
| BOOT (GPIO9)  | IO0             |
| RST           | EN              |
| VCC           | VCC             |
| GND           | GND             |


After the connection `.uf2` format should drag and drop to flashing device

### Results
<!-- Provide tests' results and runtime logs -->

After build operation it should run as usual like it flashed with `make flash` command.