### PR TITLE
drivers/analog: fix dead free and memory leak in mcp48xx and mcp47x6.

### DIFF
--- a/drivers/analog/mcp47x6.c
+++ b/drivers/analog/mcp47x6.c
@@ -438,7 +438,6 @@ FAR struct dac_dev_s *mcp47x6_initialize(FAR struct i2c_master_s *i2c,
   if (priv == NULL)
     {
       aerr("ERROR: Failed to allocate mcp47x6_dev_s instance\n");
-      free(priv);
       return NULL;
     }
 
@@ -446,6 +445,7 @@ FAR struct dac_dev_s *mcp47x6_initialize(FAR struct i2c_master_s *i2c,
   if (dacdev == NULL)
     {
       aerr("ERROR: Failed to allocate dac_dev_s instance\n");
+      kmm_free(priv);
       return NULL;
     }
 

--- a/drivers/analog/mcp48xx.c
+++ b/drivers/analog/mcp48xx.c
@@ -344,7 +344,6 @@ FAR struct dac_dev_s *mcp48xx_initialize(FAR struct spi_dev_s *spi,
   if (priv == NULL)
     {
       aerr("ERROR: Failed to allocate mcp48xx_dev_s instance\n");
-      free(priv);
       return NULL;
     }
 
@@ -352,6 +351,7 @@ FAR struct dac_dev_s *mcp48xx_initialize(FAR struct spi_dev_s *spi,
   if (dacdev == NULL)
     {
       aerr("ERROR: Failed to allocate dac_dev_s instance\n");
+      kmm_free(priv);
       return NULL;
     }
 


### PR DESCRIPTION
## Summary

Fix two bugs in the allocation error paths of `mcp48xx_initialize()` and
`mcp47x6_initialize()`:

1. **Dead code** — when the first `kmm_malloc()` fails and `priv` is NULL,
   the original code calls `free(priv)` which is a no-op on NULL.  Remove
   the dead call.

2. **Memory leak** — when the second `kmm_malloc()` fails (`dacdev`), the
   original code returns NULL without freeing the already-allocated `priv`.
   Add `kmm_free(priv)` before the return.

Both drivers share the identical pattern, so both are fixed in this commit.

## Impact

- [x] Impact on user: NO — fixes an internal resource-management bug only
      visible in low-memory conditions.
- [x] Impact on build: NO
- [x] Impact on documentation: NO
- [x] Impact on security: NO — the leak is bounded (one allocation per
      failed init call) but still worth fixing.
- [x] Impact on compatibility: NO

## Testing

### Source verification

Before (mcp48xx.c lines 343-356, mcp47x6.c lines 437-450):

```c
priv = kmm_malloc(sizeof(struct mcp48xx_dev_s));
if (priv == NULL)
  {
    aerr("ERROR: Failed to allocate mcp48xx_dev_s instance\n");
    free(priv);       /* dead code: priv is NULL here */
    return NULL;
  }

dacdev = kmm_malloc(sizeof(struct dac_dev_s));
if (dacdev == NULL)
  {
    aerr("ERROR: Failed to allocate dac_dev_s instance\n");
    return NULL;       /* BUG: priv is leaked */
  }
```

After:

```c
priv = kmm_malloc(sizeof(struct mcp48xx_dev_s));
if (priv == NULL)
  {
    aerr("ERROR: Failed to allocate mcp48xx_dev_s instance\n");
    return NULL;       /* dead free(priv) removed */
  }

dacdev = kmm_malloc(sizeof(struct dac_dev_s));
if (dacdev == NULL)
  {
    aerr("ERROR: Failed to allocate dac_dev_s instance\n");
    kmm_free(priv);    /* fix: free previously allocated priv */
    return NULL;
  }
```

### Validation

```
$ ./tools/checkpatch.sh -g HEAD
✔️ All checks pass.
```

The fix is purely in the error path and does not change any
successful execution flow.

Signed-off-by: hanzj <hanzhijian@zepp.com>