### PR TITLE
docs/nxinit: Document configurable file path

### DIFF
--- a/Documentation/applications/system/nxinit/index.rst
+++ b/Documentation/applications/system/nxinit/index.rst
@@ -12,7 +12,9 @@ NSH and NSH_LIBRARY is relatively large, and NSH lacks management
 capabilities for daemons/services (such as restarting services).
 
 NXInit was created by Xiaomi to solve these issues. It is compatible with
-most of the syntax of Android Init.
+most of the syntax of Android Init, which you can read about here:
+https://android.googlesource.com/platform/system/core/+/master/init/README.md
+
 It is lightweight, supports command execution triggered by events, supports
 service/daemon management and many more.
 

--- a/Documentation/applications/system/nxinit/index.rst
+++ b/Documentation/applications/system/nxinit/index.rst
@@ -19,7 +19,8 @@ service/daemon management and many more.
 The ``init.rc`` consists of five categories of statements, all line-oriented with
 parameters separated by spaces. The content is processed by a preprocessor,
 following C language specifications for escape rules and comment formats.
-File path: /etc/init.d/init.rc.
+
+File path configured by ``CONFIG_SYSTEM_NXINIT_RC_FILE_PATH``.
 
 1. Actions and Commands
 -----------------------


### PR DESCRIPTION
## Summary

Document that the init.rc file path is now configurable.

As of PR https://github.com/apache/nuttx-apps/pull/3506

## Impact

Accurate docs.

## Testing

Documentation build passes.