### PR TITLE
drivers/net: Fix typo in lan9250_set_txavailable function name.

### DIFF
--- a/drivers/net/lan9250.c
+++ b/drivers/net/lan9250.c
@@ -280,8 +280,8 @@ static inline void lan9250_send_buffer(FAR struct lan9250_driver_s *priv,
 static void lan9250_enable_sqi(FAR struct lan9250_driver_s *priv);
 #endif
 static inline void lan9250_sw_reset(FAR struct lan9250_driver_s *priv);
-static void lan9250_set_txavailabe(FAR struct lan9250_driver_s *priv,
-                                   bool enable);
+static void lan9250_set_txavailable(FAR struct lan9250_driver_s *priv,
+                                    bool enable);
 static int lan9250_reset(FAR struct lan9250_driver_s *priv);
 static void lan9250_set_macaddr(FAR struct lan9250_driver_s *priv);
 
@@ -1088,7 +1088,7 @@ static inline void lan9250_sw_reset(FAR struct lan9250_driver_s *priv)
 }
 
 /****************************************************************************
- * Name: lan9250_set_txavailabe
+ * Name: lan9250_set_txavailable
  *
  * Description:
  *   Enable or disable TX data FIFO available interrupt.
@@ -1102,8 +1102,8 @@ static inline void lan9250_sw_reset(FAR struct lan9250_driver_s *priv)
  *
  ****************************************************************************/
 
-static void lan9250_set_txavailabe(FAR struct lan9250_driver_s *priv,
-                                   bool enable)
+static void lan9250_set_txavailable(FAR struct lan9250_driver_s *priv,
+                                    bool enable)
 {
   uint32_t regval;
 
@@ -1241,7 +1241,7 @@ static int lan9250_reset(FAR struct lan9250_driver_s *priv)
 
   /* Disable TX data FIFO available interrupt */
 
-  lan9250_set_txavailabe(priv, false);
+  lan9250_set_txavailable(priv, false);
 
   /* Configure RX:
    *
@@ -1445,7 +1445,7 @@ static int lan9250_transmit(FAR struct lan9250_driver_s *priv)
         {
           /* Enable TX data FIFO available interrupt */
 
-          lan9250_set_txavailabe(priv, true);
+          lan9250_set_txavailable(priv, true);
 
           /* Enable the TX timeout watchdog (perhaps restarting the timer)
            * when free data space is not enough.
@@ -1602,7 +1602,7 @@ static void lan9250_txavailable_isr(FAR struct lan9250_driver_s *priv)
 
   /* Disable TX data FIFO available interrupt */
 
-  lan9250_set_txavailabe(priv, false);
+  lan9250_set_txavailable(priv, false);
 
   /* If no further xmits are pending, then cancel the TX timeout */
 


### PR DESCRIPTION
## Summary

Fix a spelling error in the static function name `lan9250_set_txavailabe()` → `lan9250_set_txavailable()` in `drivers/net/lan9250.c`. The letter 'l' was missing from "available".

This is a static (file-scope) function used only within `drivers/net/lan9250.c`, so there is no API or ABI impact.

## Impact

- [x] Impact on build: NO
- [x] Impact on hardware: NO (no functional change)
- [x] Impact on documentation: NO
- [x] Impact on security: NO
- [x] Impact on compatibility: NO — static function, no external callers

## Testing

- `checkpatch.sh -g HEAD`: All checks pass.
- `checkpatch.sh -f drivers/net/lan9250.c`: All checks pass.
- Verified all 6 occurrences of the misspelled function name were renamed:
  - Line 283: forward declaration
  - Line 1091: comment block (Name:)
  - Line 1105: function definition
  - Lines 1244, 1448, 1605: call sites
- Confirmed `lan9250_txavailable_isr` and `lan9250_txavail` were already correctly spelled and untouched.

## Self-Check

- [x] PR title follows NuttX convention: `<subsystem>: <description>.`
- [x] Commit body explains what changed, how, and why
- [x] Signed-off-by present
- [x] checkpatch passes
- [x] Single file, no build impact