### PR TITLE
drivers: Fix comment typos — 'register' → 'registered' across drivers.

### DIFF
--- a/drivers/i2c/i2c_driver.c
+++ b/drivers/i2c/i2c_driver.c
@@ -386,7 +386,7 @@ static int i2cdrvr_unlink(FAR struct inode *inode)
  *     where N is the minor number
  *
  * Returned Value:
- *   OK if the driver was successfully register; A negated errno value is
+ *   OK if the driver was successfully registered; A negated errno value is
  *   returned on any failure.
  *
  ****************************************************************************/

--- a/drivers/i2s/i2schar.c
+++ b/drivers/i2s/i2schar.c
@@ -609,7 +609,7 @@ static int i2schar_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
  *     registers as /dev/i2scharN where N is the minor number
  *
  * Returned Value:
- *   OK if the driver was successfully register; A negated errno value is
+ *   OK if the driver was successfully registered; A negated errno value is
  *   returned on any failure.
  *
  ****************************************************************************/

--- a/drivers/i3c/i3c_driver.c
+++ b/drivers/i3c/i3c_driver.c
@@ -357,7 +357,7 @@ static int i3cdrvr_unlink(FAR struct inode *inode)
  *     where N is the minor number
  *
  * Returned Value:
- *   OK if the driver was successfully register; A negated errno value is
+ *   OK if the driver was successfully registered; A negated errno value is
  *   returned on any failure.
  *
  ****************************************************************************/

--- a/drivers/i3c/master.c
+++ b/drivers/i3c/master.c
@@ -2171,7 +2171,7 @@ void i3c_master_detach_i2c_dev(FAR struct i3c_master_controller *master,
  *     -ENOTSUP if set to true since secondary masters are not yet supported
  *
  * return:
- *   OK if the driver was successfully register; A negated errno value is
+ *   OK if the driver was successfully registered; A negated errno value is
  *   returned on any failure.
  *
  ****************************************************************************/

--- a/drivers/motor/motor.c
+++ b/drivers/motor/motor.c
@@ -535,7 +535,7 @@ errout:
  *           as the driver persists.
  *
  * Returned Value:
- *   OK if the driver was successfully register; A negated errno value is
+ *   OK if the driver was successfully registered; A negated errno value is
  *   returned on any failure.
  *
  ****************************************************************************/

--- a/drivers/motor/stepper.c
+++ b/drivers/motor/stepper.c
@@ -303,7 +303,7 @@ static int stepper_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
  *           as long as the driver persists.
  *
  * Returned Value:
- *   OK if the driver was successfully register; A negated errno value is
+ *   OK if the driver was successfully registered; A negated errno value is
  *   returned on any failure.
  *
  ****************************************************************************/

--- a/drivers/rc/lirc_dev.c
+++ b/drivers/rc/lirc_dev.c
@@ -766,7 +766,7 @@ static ssize_t lirc_read(FAR struct file *filep, FAR char *buffer,
  *           devno already exists, -EEXIST will be returned.
  *
  * Returned Value:
- *   OK if the driver was successfully register; A negated errno value is
+ *   OK if the driver was successfully registered; A negated errno value is
  *   returned on any failure.
  *
  ****************************************************************************/

--- a/drivers/sensors/gnss_uorb.c
+++ b/drivers/sensors/gnss_uorb.c
@@ -747,7 +747,7 @@ static void gnss_push_event(FAR void *priv, FAR const void *data,
  *   count   - The array size of nbuffer.
  *
  * Returned Value:
- *   OK if the driver was successfully register; A negated errno value is
+ *   OK if the driver was successfully registered; A negated errno value is
  *   returned on any failure.
  *
  ****************************************************************************/

--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -1376,7 +1376,7 @@ void sensor_remap_vector_raw16(FAR const int16_t *in, FAR int16_t *out,
  *           devno already exists, -EEXIST will be returned.
  *
  * Returned Value:
- *   OK if the driver was successfully register; A negated errno value is
+ *   OK if the driver was successfully registered; A negated errno value is
  *   returned on any failure.
  *
  ****************************************************************************/
@@ -1422,7 +1422,7 @@ int sensor_register(FAR struct sensor_lowerhalf_s *lower, int devno)
  *   esize - The element size of intermediate circular buffer.
  *
  * Returned Value:
- *   OK if the driver was successfully register; A negated errno value is
+ *   OK if the driver was successfully registered; A negated errno value is
  *   returned on any failure.
  *
  ****************************************************************************/

--- a/drivers/spi/spi_driver.c
+++ b/drivers/spi/spi_driver.c
@@ -344,7 +344,7 @@ static int spidrvr_unlink(FAR struct inode *inode)
  *     where N is the minor number
  *
  * Returned Value:
- *   OK if the driver was successfully register; A negated errno value is
+ *   OK if the driver was successfully registered; A negated errno value is
  *   returned on any failure.
  *
  ****************************************************************************/

--- a/drivers/timers/ptp_clock.c
+++ b/drivers/timers/ptp_clock.c
@@ -412,7 +412,7 @@ int ptp_clockid_to_filep(clockid_t clock_id, FAR struct file **filep)
  *   devno   - The user specifies number of device. ex: /dev/ptpX.
  *
  * Returned Value:
- *   OK if the driver was successfully register; A negated errno value is
+ *   OK if the driver was successfully registered; A negated errno value is
  *   returned on any failure.
  *
  ****************************************************************************/

--- a/drivers/timers/ptp_clock_dummy.c
+++ b/drivers/timers/ptp_clock_dummy.c
@@ -181,7 +181,7 @@ static int ptp_clock_dummy_getres(FAR struct ptp_lowerhalf_s *lower,
  *   devno - The user specifies number of device. ex: /dev/ptpX.
  *
  * Returned Value:
- *   OK if the driver was successfully initialize; A negated errno value is
+ *   OK if the driver was successfully initialized; A negated errno value is
  *   returned on any failure.
  *
  ****************************************************************************/

--- a/drivers/video/mipidsi/mipi_dsi.h
+++ b/drivers/video/mipidsi/mipi_dsi.h
@@ -58,7 +58,7 @@ extern "C"
  *   host - An instance of the struct mipi_dsi_host
  *
  * Returned Value:
- *   OK if the driver was successfully register; A negated errno value is
+ *   OK if the driver was successfully registered; A negated errno value is
  *   returned on any failure.
  *
  ****************************************************************************/
@@ -78,7 +78,7 @@ int mipi_dsi_host_driver_register(FAR struct mipi_dsi_host *host);
  *   device - An instance of the struct mipi_dsi_device
  *
  * Returned Value:
- *   OK if the driver was successfully register; A negated errno value is
+ *   OK if the driver was successfully registered; A negated errno value is
  *   returned on any failure.
  *
  ****************************************************************************/

--- a/drivers/video/mipidsi/mipi_dsi_device.c
+++ b/drivers/video/mipidsi/mipi_dsi_device.c
@@ -998,8 +998,8 @@ int mipi_dsi_dcs_get_display_brightness(FAR struct mipi_dsi_device *device,
  *   channel - The channel used by dsi device
  *
  * Returned Value:
- *   struct mipi_dsi_device* if the driver was successfully register; NULL is
- *   returned on any failure.
+ *   struct mipi_dsi_device* if the driver was successfully registered;
+ *   NULL is returned on any failure.
  *
  ****************************************************************************/
 

--- a/drivers/video/mipidsi/mipi_dsi_device_driver.c
+++ b/drivers/video/mipidsi/mipi_dsi_device_driver.c
@@ -196,7 +196,7 @@ static int dsi_dev_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
  *   device - An instance of the struct mipi_dsi_device
  *
  * Returned Value:
- *   OK if the driver was successfully register; A negated errno value is
+ *   OK if the driver was successfully registered; A negated errno value is
  *   returned on any failure.
  *
  ****************************************************************************/

--- a/drivers/video/mipidsi/mipi_dsi_host.c
+++ b/drivers/video/mipidsi/mipi_dsi_host.c
@@ -94,7 +94,7 @@ static bool mipi_dsi_host_exist(int bus)
  *   host - An instance of the dsi host
  *
  * Returned Value:
- *   OK if the driver was successfully register; A negated errno value is
+ *   OK if the driver was successfully registered; A negated errno value is
  *   returned on any failure.
  *
  ****************************************************************************/

--- a/drivers/video/mipidsi/mipi_dsi_host_driver.c
+++ b/drivers/video/mipidsi/mipi_dsi_host_driver.c
@@ -173,7 +173,7 @@ static int dsi_host_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
  *   host - An instance of the struct mipi_dsi_host
  *
  * Returned Value:
- *   OK if the driver was successfully register; A negated errno value is
+ *   OK if the driver was successfully registered; A negated errno value is
  *   returned on any failure.
  *
  ****************************************************************************/


### PR DESCRIPTION
## Summary

Fix grammatical error in `Returned Value` documentation comments across 17 driver files. The verb form was missing the past participle ending:

- `successfully register` → `successfully registered` (18 occurrences)
- `successfully initialize` → `successfully initialized` (1 occurrence, `ptp_clock_dummy.c`)

All changes are in comment blocks only — no functional code is modified.

## Affected Files

| Subsystem | File | Fix |
|-----------|------|-----|
| i2c | `drivers/i2c/i2c_driver.c` | register → registered |
| i2s | `drivers/i2s/i2schar.c` | register → registered |
| i3c | `drivers/i3c/i3c_driver.c` | register → registered |
| i3c | `drivers/i3c/master.c` | register → registered |
| motor | `drivers/motor/motor.c` | register → registered |
| motor | `drivers/motor/stepper.c` | register → registered |
| rc | `drivers/rc/lirc_dev.c` | register → registered |
| sensors | `drivers/sensors/gnss_uorb.c` | register → registered |
| sensors | `drivers/sensors/sensor.c` | register → registered (×2) |
| spi | `drivers/spi/spi_driver.c` | register → registered |
| timers | `drivers/timers/ptp_clock.c` | register → registered |
| timers | `drivers/timers/ptp_clock_dummy.c` | initialize → initialized |
| video | `drivers/video/mipidsi/mipi_dsi.h` | register → registered (×2) |
| video | `drivers/video/mipidsi/mipi_dsi_device.c` | register → registered |
| video | `drivers/video/mipidsi/mipi_dsi_device_driver.c` | register → registered |
| video | `drivers/video/mipidsi/mipi_dsi_host.c` | register → registered |
| video | `drivers/video/mipidsi/mipi_dsi_host_driver.c` | register → registered |

## Impact

- [x] Impact on build: NO
- [x] Impact on hardware: NO
- [x] Impact on documentation: NO (these are source-code comments, not Sphinx docs)
- [x] Impact on security: NO
- [x] Impact on compatibility: NO

## Testing

- `checkpatch.sh -g HEAD`: All checks pass.
- All 17 changed files individually pass `checkpatch.sh -f`.
- One line wrap applied in `mipi_dsi_device.c:1001` to stay within 78-column limit after the longer word.

## Self-Check

- [x] PR title follows NuttX convention
- [x] Commit body lists all affected files and explains the change
- [x] Signed-off-by present
- [x] checkpatch passes
- [x] Comment-only changes, zero functional impact