### PR TITLE
drivers/analog: Fix memory leak and dead code in mcp3008_initialize.

### DIFF
--- a/drivers/analog/mcp3008.c
+++ b/drivers/analog/mcp3008.c
@@ -379,7 +379,6 @@ FAR struct adc_dev_s *mcp3008_initialize(FAR struct spi_dev_s *spi)
   if (priv == NULL)
     {
       aerr("ERROR: Failed to allocate mcp3008_dev_s instance\n");
-      free(priv);
       return NULL;
     }
 
@@ -393,6 +392,7 @@ FAR struct adc_dev_s *mcp3008_initialize(FAR struct spi_dev_s *spi)
   if (adcdev == NULL)
     {
       aerr("ERROR: Failed to allocate adc_dev_s instance\n");
+      kmm_free(priv);
       return NULL;
     }
 


### PR DESCRIPTION
## Summary

Fix two bugs in `mcp3008_initialize()` in `drivers/analog/mcp3008.c`:

### Bug 1: Dead code — `free(priv)` when `priv` is NULL (line 382)

```c
priv = kmm_malloc(sizeof(struct mcp3008_dev_s));
if (priv == NULL)
  {
    aerr("ERROR: Failed to allocate mcp3008_dev_s instance\n");
    free(priv);      // BUG: priv is NULL here, free(NULL) is a no-op
    return NULL;
  }
```

**Fix:** Remove the dead `free(priv)` call.

### Bug 2: Memory leak — missing `kmm_free(priv)` on `adcdev` allocation failure (line 396)

```c
adcdev = kmm_malloc(sizeof(struct adc_dev_s));
if (adcdev == NULL)
  {
    aerr("ERROR: Failed to allocate adc_dev_s instance\n");
    return NULL;     // BUG: priv (allocated above) is leaked
  }
```

**Fix:** Add `kmm_free(priv)` before `return NULL`.

## Impact

- [x] Impact on build: NO
- [x] Impact on hardware: NO
- [x] Impact on documentation: NO
- [x] Impact on security: NO (low-level resource leak on allocation failure only)
- [x] Impact on compatibility: NO

## Testing

- `checkpatch.sh -g HEAD`: All checks pass.
- `checkpatch.sh -f drivers/analog/mcp3008.c`: All checks pass.
- Verified the error path logic:
  - First alloc fails → returns NULL (correct, nothing to free)
  - Second alloc fails → now correctly frees `priv` before returning

## Self-Check

- [x] PR title follows NuttX convention
- [x] Commit body explains both bugs with before/after code
- [x] Signed-off-by present
- [x] checkpatch passes
- [x] Single file, minimal diff (+1/-1 net)