### PR TITLE
drivers/analog: Fix memory leak in ads1115_initialize.

### DIFF
--- a/drivers/analog/ads1115.c
+++ b/drivers/analog/ads1115.c
@@ -793,7 +793,7 @@ FAR struct adc_dev_s *ads1115_initialize(FAR struct i2c_master_s *i2c,
   if (ret != OK)
     {
       aerr("Failed to initialize ADS1115\n");
-      free(priv);
+      kmm_free(priv);
       return NULL;
     }
 
@@ -801,6 +801,7 @@ FAR struct adc_dev_s *ads1115_initialize(FAR struct i2c_master_s *i2c,
   if (adcdev == NULL)
     {
       aerr("ERROR: Failed to allocate adc_dev_s instance\n");
+      kmm_free(priv);
       return NULL;
     }
 


### PR DESCRIPTION
## Summary

Fix two issues in `ads1115_initialize()` in `drivers/analog/ads1115.c`:

### Bug 1: Memory leak — missing `kmm_free(priv)` on `adcdev` allocation failure (line 804)

```c
adcdev = kmm_malloc(sizeof(struct adc_dev_s));
if (adcdev == NULL)
  {
    aerr("ERROR: Failed to allocate adc_dev_s instance\n");
    return NULL;     // BUG: priv (allocated at line 780) is leaked
  }
```

**Fix:** Add `kmm_free(priv)` before `return NULL`.

### Bug 2: Inconsistent allocator — `free()` used for `kmm_malloc()` memory (line 796)

```c
ret = cmdbyte_init(priv);
if (ret != OK)
  {
    aerr("Failed to initialize ADS1115\n");
    free(priv);      // should be kmm_free(priv) to match kmm_malloc()
    return NULL;
  }
```

**Fix:** Change `free(priv)` to `kmm_free(priv)`.

## Impact

- [x] Impact on build: NO
- [x] Impact on hardware: NO
- [x] Impact on documentation: NO
- [x] Impact on security: NO (low-level resource leak on allocation failure only)
- [x] Impact on compatibility: NO

## Testing

- `checkpatch.sh -g HEAD`: All checks pass.
- `checkpatch.sh -f drivers/analog/ads1115.c`: All checks pass.
- Verified the error path logic:
  - First alloc fails → returns NULL (correct)
  - `cmdbyte_init()` fails → already had `free(priv)`, now uses `kmm_free(priv)` (consistent)
  - Second alloc fails → now correctly frees `priv` before returning

## Self-Check

- [x] PR title follows NuttX convention
- [x] Commit body explains both issues with code evidence
- [x] Signed-off-by present
- [x] checkpatch passes
- [x] Single file, minimal diff (+2/-1)