### PR TITLE
net/bluetooth: poll sockets only on Bluetooth devices

### DIFF
--- a/net/bluetooth/bluetooth_poll.c
+++ b/net/bluetooth/bluetooth_poll.c
@@ -70,6 +70,18 @@ void bluetooth_poll(FAR struct net_driver_s *dev,
   FAR struct radio_driver_s *radio;
 
   DEBUGASSERT(dev != NULL && conn != NULL);
+
+  /* This function operates on Bluetooth radio devices only.  It casts the
+   * generic net_driver_s to radio_driver_s below, so do not allow generic
+   * IP, PPP, TUN, loopback, CAN, or other non-Bluetooth devices through.
+   */
+
+  if (dev->d_lltype != NET_LL_BLUETOOTH)
+    {
+      nwarn("WARNING: Bluetooth poll skipped for non-BT device\n");
+      return;
+    }
+
   radio = (FAR struct radio_driver_s *)dev;
 
   /* Verify that the packet connection is valid */

--- a/net/devif/devif_poll.c
+++ b/net/devif/devif_poll.c
@@ -336,6 +336,22 @@ devif_poll_bluetooth_connections(FAR struct net_driver_s *dev,
   FAR struct bluetooth_conn_s *bluetooth_conn = NULL;
   int bstop = 0;
 
+  DEBUGASSERT(dev != NULL);
+
+  /* Bluetooth sockets must only be polled on Bluetooth radio devices.
+   * bluetooth_poll() treats the generic net_driver_s as a radio_driver_s,
+   * which is only valid for NET_LL_BLUETOOTH devices.  Without this guard,
+   * any active PF_BLUETOOTH socket causes every netdev poll, including PPP
+   * or TUN devices, to enter the Bluetooth poll path and corrupt that
+   * device's poll state.
+   */
+
+  if (dev->d_lltype != NET_LL_BLUETOOTH)
+    {
+      nwarn("WARNING: Bluetooth poll skipped for non-BT device\n");
+      return 0;
+    }
+
   /* Traverse all of the allocated packet connections and perform the poll
    * action.
    */


### PR DESCRIPTION
## Summary

`devif_poll_bluetooth_connections()` is called for every registered network device during a poll cycle. `bluetooth_poll()` unconditionally casts its `net_driver_s *` argument to `radio_driver_s *`, which is only valid for `NET_LL_BLUETOOTH` devices. When a non-Bluetooth device (e.g. a PPP modem) triggers a poll while a `PF_BLUETOOTH` socket is active, the code enters the Bluetooth poll path with an incompatible device pointer and corrupts that device's TX poll state.

Add `d_lltype != NET_LL_BLUETOOTH` guards at the top of both `devif_poll_bluetooth_connections()` and `bluetooth_poll()` to return early on non-Bluetooth devices.

## Impact

Users of `PF_BLUETOOTH` sockets on systems with at least one non-Bluetooth netdev (e.g. PPP, loopback, TUN) will silently see poll state corruption on those devices when Bluetooth polling runs. This fix short-circuits the Bluetooth poll path for non-BT devices without any API, ABI, or Kconfig changes.

## Testing

Tested on a custom ARM Cortex-M33 board (STM32H5-based) with an STM32WB BLE co-processor connected over HCI UART. The board registers a PPP modem netdev alongside the BT netdev. With an open `PF_BLUETOOTH` socket, `devif_poll_bluetooth_connections()` was entered for the PPP device, corrupting its poll state and preventing UDP data from being sent. With this fix, the Bluetooth poll path is skipped for non-`NET_LL_BLUETOOTH` devices and UDP operation is unaffected.

Host: Linux x86_64, GCC ARM toolchain.