### PR TITLE
Documentation: conf: Ignore .venv

### DIFF
--- a/Documentation/conf.py
+++ b/Documentation/conf.py
@@ -87,6 +87,7 @@ exclude_patterns = [
     ".DS_Store",
     "legacy_README.md",
     "venv",
+    ".venv",
 ]
 
 # list of documentation versions to offer (besides latest). this will be


### PR DESCRIPTION
## Summary

uv creates virtual environments in `.venv`

## Impact

Fix:
```
nuttx/Documentation/.venv/lib/python3.10/site-packages/sphinx/ext/autosummary/templates/autosummary/base.rst:3:Unknown directive type "currentmodule"
```

Sphinx is scanning `.venv`

## Testing

After fixing:
```
The HTML pages are in _build/html.                                                                                             
```
