### PR TITLE
Documentation/examples/uid: Add documentation for uid example

### DIFF
--- a/Documentation/applications/examples/uid/index.rst
+++ b/Documentation/applications/examples/uid/index.rst
@@ -2,4 +2,114 @@
 ``uid`` UID/GID example
 =======================
 
-TODO
+This example demonstrates how to query user and group information using the
+POSIX ``getpwuid_r()``, ``getpwnam_r()``, ``getgrgid_r()``, and
+``getgrnam_r()`` functions.
+
+**Command Syntax**::
+
+  uid -uid <uid>
+  uid -uname <name>
+  uid -gid <gid>
+  uid -gname <name>
+  uid -h
+
+**Synopsis**. The ``uid`` command queries and displays user or group
+information from the system's password and group databases.
+
+**Options**
+
+===================  ====================================================
+``-uid <uid>``       Show user information by numeric user ID.
+``-uname <name>``    Show user information by user name.
+``-gid <gid>``       Show group information by numeric group ID.
+``-gname <name>``    Show group information by group name.
+``-h``               Show help statement with all available options.
+===================  ====================================================
+
+Query User by ID
+----------------
+
+To query user information by numeric UID::
+
+  nsh> uid -uid 0
+  Name:   root
+  UID:    0
+  GID:    0
+  Home:   /
+  Shell:  /bin/sh
+
+The output displays:
+
+- **Name**: The login name
+- **UID**: The numeric user ID
+- **GID**: The primary group ID
+- **Home**: The home directory
+- **Shell**: The default shell
+
+Query User by Name
+------------------
+
+To query user information by login name::
+
+  nsh> uid -uname root
+  Name:   root
+  UID:    0
+  GID:    0
+  Home:   /
+  Shell:  /bin/sh
+
+Query Group by ID
+-----------------
+
+To query group information by numeric GID::
+
+  nsh> uid -gid 0
+  Name:    root
+  Passwd:  
+  GID:     0
+  Members: 
+
+The output displays:
+
+- **Name**: The group name
+- **Passwd**: The group password (usually empty)
+- **GID**: The numeric group ID
+- **Members**: Comma-separated list of group members
+
+Query Group by Name
+-------------------
+
+To query group information by group name::
+
+  nsh> uid -gname root
+  Name:    root
+  Passwd:  
+  GID:     0
+  Members: 
+
+Help
+----
+
+To display usage information::
+
+  nsh> uid -h
+  USAGE:
+  	uid -uid <uid>    - Show user info by ID
+  	uid -uname <name> - Show user info by name
+  	uid -gid <gid>    - Show group info by ID
+  	uid -gname <name> - Show group info by name
+  	uid -h            - Show this help info
+
+Configuration
+-------------
+
+The ``uid`` example can be enabled in the NuttX configuration::
+
+  CONFIG_EXAMPLES_UID=y
+
+Optional configuration:
+
+- ``CONFIG_EXAMPLES_UID_PROGNAME`` – Program name. Default ``uid``.
+- ``CONFIG_EXAMPLES_UID_PRIORITY`` – Task priority. Default ``100``.
+- ``CONFIG_EXAMPLES_UID_STACKSIZE`` – Stack size. Default ``DEFAULT_TASK_STACKSIZE``.


### PR DESCRIPTION
## Summary

Adds documentation for the `uid` example, which was previously missing (only had "TODO" in the documentation).

The `uid` example is a utility for querying user and group information from the system's password and group databases using POSIX functions (`getpwuid_r()`, `getpwnam_r()`, `getgrgid_r()`, `getgrnam_r()`).

**File changed**: `Documentation/applications/examples/uid/index.rst` (+111 lines)

Documentation added:
- Introduction explaining the tool's purpose and the POSIX functions it uses
- Command syntax showing all available command formats
- Synopsis describing what the tool does
- Options table listing all available flags with descriptions
- Usage examples for each query type (`-uid`, `-uname`, `-gid`, `-gname`, `-h`)
- Configuration section listing Kconfig options

The documentation is based on the actual source code in `apps/examples/uid/uid_main.c`.

## Impact

*Is new feature added?* No — documentation only.

*Impact on user:* None (no functional changes).
*Impact on build:* None.
*Impact on hardware:* None.
*Impact on documentation:* YES — fills in the missing `uid` example documentation.
*Impact on security:* None.
*Impact on compatibility:* None.

## Testing

Verified with `make html` — builds without warnings or errors.

RST syntax validated — no formatting issues detected.

Content accuracy confirmed by cross-referencing with `apps/examples/uid/uid_main.c` source code:
- Options extracted from `show_usage()` function (lines 42-51)
- Output format extracted from `show_pwd()` and `show_grp()` functions
- Configuration extracted from `apps/examples/uid/Kconfig`

Host: Linux (Ubuntu), `nuttx` repo master branch.

Signed-off-by: hanzj <hanzjian@zepp.com>