### PR TITLE
nuttx/ci: Add libftdi1-dev to get FT2232H working on CI

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -q
   gawk \
   git \
   gperf \
+  libftdi1-dev \
   libncurses5-dev \
   make \
   ninja-build \


### PR DESCRIPTION
## Summary

This commit is needed to get PR #18951 passing on CI test. I think this USB Device could be used in the future to do real hardware tests, including automated tests on our CI.

## Impact

FT2232H CI will pass and it could be use to do HW tests in the future.

## Testing

CI itself.