### PR TITLE
drivers/analog/dac7554: Add NULL checks after kmm_malloc in dac7554_initialize

### DIFF
--- a/drivers/analog/dac7554.c
+++ b/drivers/analog/dac7554.c
@@ -248,10 +248,23 @@ FAR struct dac_dev_s *dac7554_initialize(FAR struct spi_dev_s *spi,
   /* Initialize the DAC7554 device structure */
 
   priv = kmm_malloc(sizeof(struct dac7554_dev_s));
+  if (priv == NULL)
+    {
+      aerr("ERROR: Failed to allocate dac7554_dev_s instance\n");
+      return NULL;
+    }
+
   priv->spi = spi;
   priv->spidev = spidev;
 
   g_dacdev = kmm_malloc(sizeof(struct dac_dev_s));
+  if (g_dacdev == NULL)
+    {
+      aerr("ERROR: Failed to allocate dac_dev_s instance\n");
+      kmm_free(priv);
+      return NULL;
+    }
+
   g_dacdev->ad_ops = &g_dacops;
   g_dacdev->ad_priv = priv;
 


### PR DESCRIPTION
## Description

Add missing NULL checks after both `kmm_malloc` calls in `dac7554_initialize()` to prevent NULL pointer dereference on allocation failure.

### Problem

`dac7554_initialize()` calls `kmm_malloc` twice — first for `priv` (a `dac7554_dev_s`), then for `g_dacdev` (a `dac_dev_s`) — without checking either return value.  If either allocation fails, the code immediately dereferences the NULL pointer, causing a crash.

The function's doc comment states _"a NULL on failure"_, but the implementation never returns NULL.

### Solution

Add NULL checks for both allocations, following the same pattern already established in `mcp3008.c`, `mcp48xx.c`, and `mcp47x6.c`:

1. After the first `kmm_malloc` for `priv`: return NULL if it fails.
2. After the second `kmm_malloc` for `g_dacdev`: free `priv` and return NULL if it fails.

### Changes

**File**: `drivers/analog/dac7554.c` (+13 lines)

**Location** (\~line 250):
```c
  priv = kmm_malloc(sizeof(struct dac7554_dev_s));
+ if (priv == NULL)
+   {
+     aerr("ERROR: Failed to allocate dac7554_dev_s instance\n");
+     return NULL;
+   }
+
  priv->spi = spi;

  g_dacdev = kmm_malloc(sizeof(struct dac_dev_s));
+ if (g_dacdev == NULL)
+   {
+     aerr("ERROR: Failed to allocate dac_dev_s instance\n");
+     kmm_free(priv);
+     return NULL;
+   }
+
  g_dacdev->ad_ops = &g_dacops;
```

### Verification

✅ **Checkpatch**: `./tools/checkpatch.sh -g HEAD` — All checks pass
✅ **Code Review**: Pattern matches the existing fixes in `mcp3008_initialize()` (commit `dd5670ed`), `mcp48xx_initialize()` and `mcp47x6_initialize()` (commit `fa1589a6`).

| Scenario | Before | After |
|----------|--------|-------|
| `priv` alloc fails | NULL deref → crash | Returns NULL safely |
| `g_dacdev` alloc fails | NULL deref → crash | Frees `priv`, returns NULL |

### Signed-off-by

hanzj <hanzjian@zepp.com>