### PR TITLE
drivers/rpmsg: Fix typo rpmsg_device_destory -> rpmsg_device_destroy

### DIFF
--- a/drivers/rpmsg/rpmsg.c
+++ b/drivers/rpmsg/rpmsg.c
@@ -445,7 +445,7 @@ void rpmsg_device_created(FAR struct rpmsg_s *rpmsg)
 #endif
 }
 
-void rpmsg_device_destory(FAR struct rpmsg_s *rpmsg)
+void rpmsg_device_destroy(FAR struct rpmsg_s *rpmsg)
 {
   FAR struct rpmsg_device *rdev = rpmsg_get_rdev_by_rpmsg(rpmsg);
   FAR struct metal_list *node;

--- a/drivers/rpmsg/rpmsg.h
+++ b/drivers/rpmsg/rpmsg.h
@@ -53,7 +53,7 @@ void rpmsg_ns_unbind(FAR struct rpmsg_device *rdev,
                      FAR const char *name, uint32_t dest);
 
 void rpmsg_device_created(FAR struct rpmsg_s *rpmsg);
-void rpmsg_device_destory(FAR struct rpmsg_s *rpmsg);
+void rpmsg_device_destroy(FAR struct rpmsg_s *rpmsg);
 
 int rpmsg_register(FAR const char *path, FAR struct rpmsg_s *rpmsg,
                    FAR const struct rpmsg_ops_s *ops);

--- a/drivers/rpmsg/rpmsg_port.c
+++ b/drivers/rpmsg/rpmsg_port.c
@@ -824,7 +824,7 @@ void rpmsg_port_unregister(FAR struct rpmsg_port_s *port)
 
   snprintf(name, sizeof(name), "/dev/rpmsg/%s", port->rpmsg.cpuname);
 
-  rpmsg_device_destory(&port->rpmsg);
+  rpmsg_device_destroy(&port->rpmsg);
   rpmsg_unregister(name, &port->rpmsg);
 }
 

--- a/drivers/rpmsg/rpmsg_router_edge.c
+++ b/drivers/rpmsg/rpmsg_router_edge.c
@@ -525,7 +525,7 @@ static void rpmsg_router_edge_destroy(FAR struct rpmsg_router_edge_s *edge)
                             rpmsg_router_edge_match,
                             rpmsg_router_edge_bind);
   rpmsg_unregister(edge->name, &edge->rpmsg);
-  rpmsg_device_destory(&edge->rpmsg);
+  rpmsg_device_destroy(&edge->rpmsg);
   kmm_free(edge);
 }
 

--- a/drivers/rpmsg/rpmsg_virtio.c
+++ b/drivers/rpmsg/rpmsg_virtio.c
@@ -791,7 +791,7 @@ void rpmsg_virtio_remove(FAR struct virtio_device *vdev)
 
   /* Destroy all the rpmsg services */
 
-  rpmsg_device_destory(&priv->rpmsg);
+  rpmsg_device_destroy(&priv->rpmsg);
 
   /* Reset the rpmsg virtio device for driver */
 


### PR DESCRIPTION
## Description

Rename `rpmsg_device_destory()` to `rpmsg_device_destroy()` to fix a spelling error in the function name.

### Problem

The function `rpmsg_device_destory()` has a typo — `destory` should be `destroy`.  This is inconsistent with the correct spelling used in other similar functions in the codebase (e.g., `noterpmsg_device_destroy`, `uinput_rpmsg_device_destroy`, `syslog_rpmsg_device_destroy`, `uart_rpmsg_device_destroy`).

### Solution

Rename the function across all files where it is defined, declared, and called.  The function is declared in the private header `drivers/rpmsg/rpmsg.h` and used only within the `drivers/rpmsg/` subsystem, so there is no public API or ABI impact.

### Changes

| File | Change |
|------|--------|
| `drivers/rpmsg/rpmsg.h` | Declaration: `destory` → `destroy` |
| `drivers/rpmsg/rpmsg.c` | Definition: `destory` → `destroy` |
| `drivers/rpmsg/rpmsg_virtio.c` | Call site: `destory` → `destroy` |
| `drivers/rpmsg/rpmsg_router_edge.c` | Call site: `destory` → `destroy` |
| `drivers/rpmsg/rpmsg_port.c` | Call site: `destory` → `destroy` |

### Verification

✅ **Checkpatch**: `./tools/checkpatch.sh -g HEAD` — All checks pass
✅ **Scope**: Function is private to `drivers/rpmsg/` — no external callers found via `grep -rn rpmsg_device_destory --include="*.c" --include="*.h"` outside the subsystem
✅ **Consistency**: All other `*_device_destroy()` functions in the rpmsg ecosystem use the correct spelling

### Signed-off-by

hanzj <hanzjian@zepp.com>