### PR TITLE
arch/arm/nrf91: Fix OOB read/write in nrf91_usrsock_ioctl_handler

### DIFF
--- a/arch/arm/src/nrf91/nrf91_modem_sock.c
+++ b/arch/arm/src/nrf91/nrf91_modem_sock.c
@@ -1111,16 +1111,29 @@ static int nrf91_usrsock_ioctl_handler(struct nrf91_usrsock_s *usrsock,
 {
   const struct usrsock_request_ioctl_s *req = data;
   struct usrsock_message_datareq_ack_s *ack = NULL;
+  size_t                                copylen;
   int                                   ret = 0;
 
+  if (len < sizeof(*req))
+    {
+      return -EINVAL;
+    }
+
   ack = (struct usrsock_message_datareq_ack_s *)usrsock->out;
-  memcpy(ack + 1, req + 1, req->arglen);
+  copylen = req->arglen;
+  if (copylen > len - sizeof(*req) ||
+      copylen > sizeof(usrsock->out) - sizeof(*ack))
+    {
+      return -EINVAL;
+    }
+
+  memcpy(ack + 1, req + 1, copylen);
   ret = nrf91_usrsock_ioctl(req->usockid,
                             req->cmd,
                             (unsigned long)(ack + 1));
 
   return nrf91_usrsock_send_dack(usrsock, ack, req->head.xid, ret,
-                           req->arglen, req->arglen);
+                           copylen, copylen);
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Description

Fix out-of-bounds read and write in  caused by missing  validation before .  Fixes #18515.

### Problem

 copies  bytes from the request payload into the fixed-size  buffer (4096 bytes) without validating that:

1. The full request header is present ()
2. The payload fits the received data ()
3. The payload fits the destination buffer ()

A crafted ioctl request with an inflated  triggers:
- **OOB read** —  reads past the end of the received request, potentially disclosing adjacent memory.
- **OOB write** —  writes past the end of , corrupting adjacent fields in .

### Solution

Add three validation checks before the , consistent with the buffer-size check already performed by the  handler in the same file (line 892):



Also replace the raw  in the  call with the validated  for consistency.

### Verification

✅ **Checkpatch**: ✔️ All checks pass. — All checks pass
✅ **Code Review**: Three checks match the pattern used in  at line 892
✅ **Consistency**:  also uses the validated 

### References

- Issue: #18515

### Signed-off-by

hanzj <hanzjian@zepp.com>