### PR TITLE
bcm2711/fb: Use physical device resolution OR force resolution

### DIFF
--- a/Documentation/platforms/arm64/bcm2711/boards/raspberrypi-4b/index.rst
+++ b/Documentation/platforms/arm64/bcm2711/boards/raspberrypi-4b/index.rst
@@ -253,12 +253,12 @@ colourful rectangles on the screen.
    ``memcpy``'d to the frame buffer, the image will be clear. I have not
    modified the frame buffer example though since this is its own limitation.
 
-.. todo::
+.. note::
 
-   The frame-buffer driver always sets the physical and virtual display
-   resolution to 1080 x 1920 pixels with a depth of 32 bits per pixel. Other
-   options cannot yet be configured via Kconfig, nor is there any kind of
-   negotiation with the display to agree on some maximum quality options.
+   The frame buffer driver currently uses the resolution obtained by querying
+   the physical display. It is also possible to use
+   ``CONFIG_BCM2711_FB_FORCE_RESOLUTION=y`` to force the request of your
+   configured default resolution instead.
 
 lvgl
 ----

--- a/arch/arm64/src/bcm2711/Kconfig
+++ b/arch/arm64/src/bcm2711/Kconfig
@@ -340,6 +340,26 @@ config BCM2711_FRAMEBUFFER
 	---help---
 		Support for the VideoCore frame buffer interface.
 
+config BCM2711_FB_WIDTH
+	int "Default x resolution (width)"
+	default 1920
+	---help---
+		The x resolution (width) of the frame buffer.
+
+config BCM2711_FB_HEIGHT
+	int "Default y resolution (height)"
+	default 1080
+	---help---
+		The y resolution (height) of the frame buffer.
+
+config BCM2711_FB_FORCE_RESOLUTION
+	bool "Force resolution"
+	depends on VIDEO_FB
+	default n
+	---help---
+		Force the frame buffer allocation to use the default resolution instead
+		of querying the physical display and using that.
+
 endmenu # Broadcom BCM2711 Peripheral Selection
 
 endif # ARCH_CHIP_BCM2711

--- a/arch/arm64/src/bcm2711/bcm2711_fb.c
+++ b/arch/arm64/src/bcm2711/bcm2711_fb.c
@@ -46,11 +46,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* Screen resolution */
-
-#define FB_WIDTH (1920)
-#define FB_HEIGHT (1080)
-
 /* Bits per pixel (32 for RGB) */
 
 #define FB_BPP (32)
@@ -344,8 +339,8 @@ int up_fbinitialize(int display)
 {
   int err;
   uint8_t tries = 0;
-  uint32_t xres = FB_WIDTH;
-  uint32_t yres = FB_HEIGHT;
+  uint32_t xres = CONFIG_BCM2711_FB_WIDTH;
+  uint32_t yres = CONFIG_BCM2711_FB_HEIGHT;
   uint32_t bpp = FB_BPP;
   struct bcm2711_fb_s *priv;
 
@@ -371,6 +366,24 @@ int up_fbinitialize(int display)
   priv->fb = NULL;
   priv->fbsize = 0;
 
+#ifndef CONFIG_BCM2711_FB_FORCE_RESOLUTION
+  /* Ask for physical resolution to choose the frame buffer resolution */
+
+  err = bcm2711_mbox_getdisp(&xres, &yres);
+  if (err < 0)
+    {
+      gerr("Couldn't get display dimensions: %d", err);
+      return err;
+    }
+
+  err = bcm2711_mbox_getdepth(&bpp);
+  if (err < 0)
+    {
+      gerr("Couldn't get display depth: %d", err);
+      return err;
+    }
+#endif
+
   /* Initialize the frame-buffer in a bulk request. Doing this piece-wise
    * never seems to work, always resulting a virtual resolution of 2x2 px.
    * This attempts the initialization three times since the operation always
@@ -391,12 +404,14 @@ int up_fbinitialize(int display)
       return err;
     }
 
-  if (xres != FB_WIDTH || yres != FB_HEIGHT)
+#ifdef CONFIG_BCM2711_FB_FORCE_RESOLUTION
+  if (xres != CONFIG_BCM2711_FB_WIDTH || yres != CONFIG_BCM2711_FB_HEIGHT)
     {
       gerr("Display mismatch: wanted %u x %u px, but got %u x %u px",
-           FB_WIDTH, FB_HEIGHT, xres, yres);
+           CONFIG_BCM2711_FB_WIDTH, CONFIG_BCM2711_FB_HEIGHT, xres, yres);
       return -EIO;
     }
+#endif
 
   if (bpp != FB_BPP)
     {


### PR DESCRIPTION
## Summary

This change causes the frame buffer allocation to use the connected device's physical resolution by default. The user also has the option to force a request for a different, compile-time selected resolution if the physical display can support something else the user would prefer.

Part of GSoC #18507 

## Impact

* Closes #17301
* Users now get the resolution supported by their display
* Users can override resolution selection for devices with a known, fixed display
* Documentation contains updated information

## Testing

Using my "Pico Projector" as the display device and the `fb` example, here is the output when the physical display resolution is used (`CONFIG_BCM2711_FB_FORCE_RESOLUTION=n`):

```console
nsh> fb
VideoInfo:
      fmt: 21
     xres: 1824
     yres: 984
  nplanes: 1
PlaneInfo (plane 0):
    fbmem: 0x3e513000
    fblen: 7237632
   stride: 7296
  display: 0
      bpp: 32
Mapped FB: 0x3e513000
 0: (  0,  0) (1824,984)
 1: (165, 89) (1494,806)
 2: (330,178) (1164,628)
 3: (495,267) (834,450)
 4: (660,356) (504,272)
 5: (825,445) (174, 94)
Test finished
```

And with `CONFIG_BCM2711_FB_FORCE_RESOLUTION=y`:

```console
nsh> fb
VideoInfo:
      fmt: 21
     xres: 1920
     yres: 1080
  nplanes: 1
PlaneInfo (plane 0):
    fbmem: 0x3e402000
    fblen: 8355840
   stride: 7680
  display: 0
      bpp: 32
Mapped FB: 0x3e402000
 0: (  0,  0) (1920,1080)
 1: (174, 98) (1572,884)
 2: (348,196) (1224,688)
 3: (522,294) (876,492)
 4: (696,392) (528,296)
 5: (870,490) (180,100)
Test finished
```