### PR TITLE
tools/rust: Move NuttX Rust target specs into nuttx

### DIFF
--- a/tools/aarch64-unknown-nuttx.json
+++ b/tools/aarch64-unknown-nuttx.json
@@ -1,0 +1,42 @@
+{
+  "arch": "aarch64",
+  "crt-objects-fallback": "false",
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i8:8:32-i16:16:32-i64:64-i128:128-n32:64-S128-Fn32",
+  "default-uwtable": true,
+  "disable-redzone": true,
+  "features": "+v8a,+strict-align,+neon",
+  "linker": "rust-lld",
+  "linker-flavor": "gnu-lld",
+  "llvm-target": "aarch64-unknown-nuttx",
+  "max-atomic-width": 128,
+  "metadata": {
+    "description": "aarch64 target for NuttX RTOS",
+    "host_tools": false,
+    "std": true,
+    "tier": 3
+  },
+  "os": "nuttx",
+  "panic-strategy": "abort",
+  "pre-link-args": {
+    "gnu": [
+      "--fix-cortex-a53-843419"
+    ],
+    "gnu-lld": [
+      "--fix-cortex-a53-843419"
+    ]
+  },
+  "relocation-model": "static",
+  "stack-probes": {
+    "kind": "inline"
+  },
+  "supported-sanitizers": [
+    "kcfi",
+    "kernel-address",
+    "kernel-hwaddress"
+  ],
+  "supports-xray": true,
+  "target-family": [
+    "unix"
+  ],
+  "target-pointer-width": 64
+}

--- a/tools/i486-unknown-nuttx.json
+++ b/tools/i486-unknown-nuttx.json
@@ -1,0 +1,33 @@
+{
+  "arch": "x86",
+  "cpu": "i486",
+  "crt-objects-fallback": "false",
+  "data-layout": "e-m:e-p:32:32-p270:32:32-p271:32:32-p272:64:64-i128:128-f64:32:64-f80:32-n8:16:32-S128",
+  "features": "-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-avx,-avx2,+soft-float",
+  "default-dwarf-version": 2,
+  "dynamic-linking": true,
+  "has-rpath": true,
+  "has-thread-local": true,
+  "linker-flavor": "gnu-lld",
+  "llvm-target": "i486-unknown-nuttx",
+  "max-atomic-width": 64,
+  "metadata": {
+    "description": "32-bit x86, resricted to i486",
+    "host_tools": false,
+    "std": true,
+    "tier": 3
+  },
+  "no-default-libraries": true,
+  "os": "nuttx",
+  "position-independent-executables": false,
+  "relro-level": "full",
+  "rustc-abi": "x86-softfloat",
+  "stack-probes": {
+    "kind": "inline"
+  },
+  "target-family": [
+    "unix"
+  ],
+  "target-mcount": "__mcount",
+  "target-pointer-width": 32
+}

--- a/tools/x86_64-unknown-nuttx.json
+++ b/tools/x86_64-unknown-nuttx.json
@@ -1,0 +1,36 @@
+{
+  "arch": "x86_64",
+  "cpu": "x86-64",
+  "crt-objects-fallback": "false",
+  "data-layout": "e-m:e-p270:32:32-p271:32:32-p272:64:64-i64:64-i128:128-f80:128-n8:16:32:64-S128",
+  "disable-redzone": true,
+  "features": "-mmx,-sse,-sse2,-sse3,-ssse3,-sse4.1,-sse4.2,-avx,-avx2,+soft-float",
+  "linker": "rust-lld",
+  "linker-flavor": "gnu-lld",
+  "llvm-target": "x86_64-unknown-nuttx",
+  "max-atomic-width": 64,
+  "metadata": {
+    "description": "x86_64 target for NuttX RTOS with softfloat",
+    "host_tools": false,
+    "std": true,
+    "tier": 3
+  },
+  "panic-strategy": "abort",
+  "plt-by-default": false,
+  "position-independent-executables": true,
+  "relro-level": "full",
+  "rustc-abi": "x86-softfloat",
+  "stack-probes": {
+    "kind": "inline"
+  },
+  "static-position-independent-executables": true,
+  "supported-sanitizers": [
+    "kcfi",
+    "kernel-address"
+  ],
+  "os": "nuttx",
+  "target-family": [
+    "unix"
+  ],
+  "target-pointer-width": 64
+}


### PR DESCRIPTION
## Summary

Move the NuttX-specific Rust target specification files into `nuttx/tools`.

This keeps files with the same purpose in one place. The macOS simulator aarch64 Mach-O Rust target spec already lives in `nuttx/tools`, so this change adds the remaining NuttX Rust target specs there as well:

* `aarch64-unknown-nuttx.json`
* `i486-unknown-nuttx.json`
* `x86_64-unknown-nuttx.json`

A follow-up apps change will update the Rust build helpers to reference these files from the NuttX tree instead of `apps/tools`.

## Testing

I confirm that changes are verified on local setup and works as intended:
* Build Host(s): OS (macOS 26.5), CPU(Apple M1), compiler(Apple clang version 21.0.0)
* Target(s): arch(sim)
* Ensure your PATH environment variable is properly configured to allow execution of: menuconfig, olddefconfig, savedefconfig, and setconfig.
* Use the Rust toolchain version prior to nightly-2026-04-29 to avoid errors related to lib/rustlib/src/rust/library/std/src/sys/net/connection/socket/unix.rs.
* Related PRs
  * nuttx: [#18992](https://github.com/apache/nuttx/pull/18992)
  * apps: [#3510](https://github.com/apache/nuttx-apps/pull/3510)

## PR verification Self-Check

* [x] My PR adheres to Contributing [Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) and [Documentation](https://nuttx.apache.org/docs/latest/contributing/index.html) (git commit title and message, coding standard, etc).
* [x] My PR is ready for review and can be safely merged into a codebase.
