### PR TITLE
tools/nxstyle: Whitelist Micro XRCE-DDS uxrCustomTransport prefix

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -250,6 +250,13 @@ static const char *g_white_prefix[] =
   "UInt64",
   "Float32",
   "Float64",
+
+  /* Ref:  apps/system/microros/transport
+   * Micro XRCE-DDS Client custom transport struct exposed in the
+   * callback prototypes registered via rmw_uros_set_custom_transport().
+   */
+
+  "uxrCustom",           /* uxrCustomTransport */
   NULL
 };
 


### PR DESCRIPTION
## Summary

Follow-up to bc3a2596c8 (`tools/nxstyle: Whitelist ROS 2 message
type identifiers.`). The Micro XRCE-DDS Client custom-transport API
expects user callbacks of the form

```c
bool   open_cb (struct uxrCustomTransport *transport);
bool   close_cb(struct uxrCustomTransport *transport);
size_t write_cb(struct uxrCustomTransport *transport,
                const uint8_t *buf, size_t len, uint8_t *err);
size_t read_cb (struct uxrCustomTransport *transport,
                uint8_t *buf, size_t len, int timeout, uint8_t *err);
```

The `uxrCustomTransport` tag is fixed by the upstream public header
`<uxr/client/profile/transport/custom/custom_transport.h>` and cannot
be renamed without breaking the Micro XRCE-DDS C API.

Add the `uxrCustom` prefix to `g_white_prefix` so `nxstyle` stops
flagging every callback signature in the upcoming
`apps/system/microros/transport` backend with
`error: Mixed case identifier found`.

## Impact

- `tools/nxstyle` only. No build, runtime, or hardware effect.
- Pure relaxation of the style checker for a single, enumerated
  identifier prefix. No existing in-tree code becomes invalid.

## Dependencies

Companion to apache/nuttx-apps#3512 (`system/microros: Add UDP and
serial custom transports`). That PR's CI `nxstyle` step otherwise
fails on every `struct uxrCustomTransport *` parameter in the new
transport backend (~20 errors across 4 files).

## Testing

Local build of the patched `tools/nxstyle` and run against the four
transport files plus the publisher example in apache/nuttx-apps#3512:

```
$ gcc -O2 -o tools/nxstyle tools/nxstyle.c
$ for f in \
    apps/system/microros/transport/microros_transport.c \
    apps/system/microros/transport/microros_transport.h \
    apps/system/microros/transport/microros_transport_udp.c \
    apps/system/microros/transport/microros_transport_serial.c \
    apps/examples/microros_pub/microros_pub_main.c; do
    ./tools/nxstyle "$f"; done
(no output -> all clean)
```

Before this patch (same nxstyle build minus the new whitelist
entry):

```
microros_transport.h:58:32: error: Mixed case identifier found
microros_transport.h:59:33: error: Mixed case identifier found
microros_transport_udp.c:44:32: error: Mixed case identifier found
... (~20 errors total across the four files)
```
