### PR TITLE
include/unistd: add dpopen/dpclose declarations

### DIFF
--- a/include/unistd.h
+++ b/include/unistd.h
@@ -397,6 +397,15 @@ FAR void *sbrk(intptr_t incr);
 int     pipe(int pipefd[2]);
 int     pipe2(int pipefd[2], int flags);
 
+/* Pipe-based process I/O.  These are not actually implemented in the OS.
+ * See apps/system/popen for implementation.
+ */
+
+#ifndef __KERNEL__
+int     dpopen(FAR const char *, int, FAR pid_t *);
+int     dpclose(int, pid_t);
+#endif
+
 /* Schedule an alarm */
 
 unsigned int alarm(unsigned int seconds);


### PR DESCRIPTION
## Summary

Add declarations for `dpopen()` and `dpclose()` to `unistd.h`. These are
the descriptor-based counterparts of `popen()`/`pclose()` declared in
`stdio.h`. The implementation lives in `apps/system/popen/dpopen.c`.

This is the header-side change. The implementation, no-shell mode support,
and tests are in the companion apps PR: apache/nuttx-apps#3515

## Impact

Header-only change; declares two new public interfaces.

## Testing

Built and tested together with the apps-side changes (see companion PR).