### PR TITLE
boards/arm/s32k3xx/mr-canhubk3: Add missing sram.ld linker script

### DIFF
--- a/boards/arm/s32k3xx/mr-canhubk3/scripts/sram.ld
+++ b/boards/arm/s32k3xx/mr-canhubk3/scripts/sram.ld
@@ -1,0 +1,155 @@
+/****************************************************************************
+ * boards/arm/s32k3xx/mr-canhubk3/scripts/sram.ld
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/* Copyright 2022 NXP */
+
+/* TO DO: ADD DESCRIPTION
+ *
+ *   0x00400000 - 0x007fffff  4194304  Program Flash (last 64K sBAF)
+ *   0x10000000 - 0x1003ffff   262144  Data Flash (last 32K HSE_NVM)
+ *   0x20400000 - 0x20408000    32768  Standby RAM_0 (32K)
+ *   0x20400000 - 0x20427fff   163840  SRAM_0
+ *   0x20428000 - 0x2044ffff   163840  SRAM_1
+ *
+ *   Last  48 KB of SRAM_1 reserved by HSE Firmware
+ *   Last 128 KB of CODE_FLASH_3 reserved by HSE Firmware
+ *   Last 128 KB of DATA_FLASH reserved by HSE Firmware (not supported in this linker file)
+ *
+ *   Note Standby RAM and SRAM overlaps in NuttX since we dont use the Standby functionality
+ *
+ */
+
+MEMORY
+{
+  sram0_stdby (rwx) : ORIGIN = 0x20400000, LENGTH = 32K
+  sram        (rwx) : ORIGIN = 0x20400000, LENGTH = 272K
+  itcm        (rwx) : ORIGIN = 0x00000000, LENGTH = 64K
+  dtcm        (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
+}
+
+OUTPUT_ARCH(arm)
+EXTERN(_vectors)
+ENTRY(_stext)
+
+SECTIONS
+{
+
+  .text :
+  {
+    _stext = ABSOLUTE(.);
+    *(.vectors)
+    *(.text.__start)
+    *(.text .text.*)
+    *(.fixup)
+    *(.gnu.warning)
+    *(.rodata .rodata.*)
+    *(.gnu.linkonce.t.*)
+    *(.glue_7)
+    *(.glue_7t)
+    *(.got)
+    *(.gcc_except_table)
+    *(.gnu.linkonce.r.*)
+    _etext = ABSOLUTE(.);
+  } > sram
+
+  .init_section :
+  {
+    _sinit = ABSOLUTE(.);
+    KEEP(*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+    KEEP(*(.init_array EXCLUDE_FILE(*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o) .ctors))
+    _einit = ABSOLUTE(.);
+  } > sram
+
+  .ARM.extab :
+  {
+    *(.ARM.extab*)
+  } > sram
+
+  .ARM.exidx :
+  {
+    __exidx_start = ABSOLUTE(.);
+    *(.ARM.exidx*)
+    __exidx_end = ABSOLUTE(.);
+  } > sram
+
+  /* Due ECC initialization sequence __data_start__ and __data_end__ should be aligned on 8 bytes */
+  .data :
+  {
+    . = ALIGN(8);
+    _sdata = ABSOLUTE(.);
+    *(.data .data.*)
+    *(.gnu.linkonce.d.*)
+    CONSTRUCTORS
+    . = ALIGN(8);
+    _edata = ABSOLUTE(.);
+  } > sram
+
+  _eronly = LOADADDR(.data);
+
+  .ramfunc ALIGN(8):
+  {
+    _sramfuncs = ABSOLUTE(.);
+    *(.ramfunc  .ramfunc.*)
+    _eramfuncs = ABSOLUTE(.);
+  } > sram
+
+  _framfuncs = LOADADDR(.ramfunc);
+
+  /* Due ECC initialization sequence __bss_start__ and __bss_end__ should be aligned on 8 bytes */
+  .bss :
+  {
+    . = ALIGN(8);
+    _sbss = ABSOLUTE(.);
+    *(.bss .bss.*)
+    *(.gnu.linkonce.b.*)
+    *(COMMON)
+    . = ALIGN(8);
+    _ebss = ABSOLUTE(.);
+  } > sram
+
+  CM7_0_START_ADDRESS = ORIGIN(sram);
+
+  /* Stabs debugging sections. */
+
+  .stab 0 : { *(.stab) }
+  .stabstr 0 : { *(.stabstr) }
+  .stab.excl 0 : { *(.stab.excl) }
+  .stab.exclstr 0 : { *(.stab.exclstr) }
+  .stab.index 0 : { *(.stab.index) }
+  .stab.indexstr 0 : { *(.stab.indexstr) }
+  .comment 0 : { *(.comment) }
+  .debug_abbrev 0 : { *(.debug_abbrev) }
+  .debug_info 0 : { *(.debug_info) }
+  .debug_line 0 : { *(.debug_line) }
+  .debug_pubnames 0 : { *(.debug_pubnames) }
+  .debug_aranges 0 : { *(.debug_aranges) }
+
+  SRAM_BASE_ADDR         = ORIGIN(sram);
+  SRAM_END_ADDR          = ORIGIN(sram) + LENGTH(sram);
+  SRAM_STDBY_BASE_ADDR   = ORIGIN(sram0_stdby);
+  SRAM_STDBY_END_ADDR    = ORIGIN(sram0_stdby) + LENGTH(sram0_stdby);
+  SRAM_INIT_END_ADDR     = ORIGIN(sram) + 320K;
+  ITCM_BASE_ADDR         = ORIGIN(itcm);
+  ITCM_END_ADDR          = ORIGIN(itcm) + LENGTH(itcm);
+  DTCM_BASE_ADDR         = ORIGIN(dtcm);
+  DTCM_END_ADDR          = ORIGIN(dtcm) + LENGTH(dtcm);
+}


### PR DESCRIPTION
## Summary

Add missing  linker script for  configuration.

The  references  when , but the file was missing, causing build failures.

This script places all sections (.text, .data, .bss) in SRAM instead of Flash, enabling execution from SRAM.

Fixes: #18365

## Impact

* Is new feature added? Is existing feature changed? NO
* Impact on user (will user need to adapt to change)? NO
* Impact on build (will build process change)? NO
* Impact on hardware (will arch(s) / board(s) / driver(s) change)? YES - mr-canhubk3 board now supports CONFIG_BOOT_RUNFROMISRAM
* Impact on documentation (is update required / provided)? NO
* Impact on security (any sort of implications)? NO
* Impact on compatibility (backward/forward/interoperability)? NO

## Testing

I confirm that changes are verified on local setup and works as intended:

* Build Host(s): Linux x86_64
* Target(s): sim:nsh (for verification)

The linker script follows the same structure as flash.ld but places all sections in SRAM instead of Flash.