### PR TITLE
style: Fix typo in Documentation/components/boards.rst

### DIFF
--- a/Documentation/components/boards.rst
+++ b/Documentation/components/boards.rst
@@ -70,7 +70,7 @@ Summary of Files
 
 * ``include/`` -- This directory contains board specific header files.  This
   directory will be linked as include/arch/board at configuration time and
-  can be included via #include <arch/board/header.h>``.  These header file
+  can be included via ``#include <arch/board/header.h>``.  These header file
   can only be included by files in ``arch/<arch>include/`` and
   ``arch/<arch>/src``
 


### PR DESCRIPTION
## Summary

Fix style typo in Documentation/components/boards.rst

## Impact

Documentation only. No runtime behavior changes.

## Testing
