### PR TITLE
boards/arm/stm32/nucleo: Fix BBSRAM compilation

### DIFF
--- a/boards/arm/stm32/nucleo-f429zi/src/stm32_bbsram.c
+++ b/boards/arm/stm32/nucleo-f429zi/src/stm32_bbsram.c
@@ -239,7 +239,7 @@ typedef struct
   int           lineno;                           /* __LINE__ to up_assert */
   pid_t         pid;                              /* Process ID */
   uint32_t      regs[XCPTCONTEXT_REGS];           /* Interrupt register save area */
-  stack_t       stacks;                           /* Stack info */
+  stacks_t      stacks;                           /* Stack info */
   char          name[CONFIG_TASK_NAME_SIZE + 1];  /* Task name (with NULL
                                                    * terminator) */
   char          filename[MAX_FILE_PATH_LENGTH];   /* the Last of chars in
@@ -426,9 +426,13 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
 
   if (up_interrupt_context())
     {
+#if CONFIG_ARCH_INTERRUPTSTACK > 3
       pdump->info.stacks.interrupt.sp = sp;
       pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT |
                             INTSTACK_PRESENT);
+#else
+      pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT);
+#endif
       memcpy(pdump->info.regs, running_regs(),
              sizeof(pdump->info.regs));
       pdump->info.stacks.user.sp = pdump->info.regs[REG_R13];

--- a/boards/arm/stm32f7/nucleo-f722ze/src/stm32_bbsram.c
+++ b/boards/arm/stm32f7/nucleo-f722ze/src/stm32_bbsram.c
@@ -239,7 +239,7 @@ typedef struct
   int           lineno;                           /* __LINE__ to up_assert */
   int           pid;                              /* Process ID */
   uint32_t      regs[XCPTCONTEXT_REGS];           /* Interrupt register save area */
-  stack_t       stacks;                           /* Stack info */
+  stacks_t      stacks;                           /* Stack info */
   char          name[CONFIG_TASK_NAME_SIZE + 1];  /* Task name (with NULL
                                                    * terminator) */
   char          filename[MAX_FILE_PATH_LENGTH];   /* the Last of chars in
@@ -426,9 +426,13 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
 
   if (up_interrupt_context())
     {
+#if CONFIG_ARCH_INTERRUPTSTACK > 3
       pdump->info.stacks.interrupt.sp = sp;
       pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT |
                             INTSTACK_PRESENT);
+#else
+      pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT);
+#endif
       memcpy(pdump->info.regs, running_regs(),
              sizeof(pdump->info.regs));
       pdump->info.stacks.user.sp = pdump->info.regs[REG_R13];

--- a/boards/arm/stm32f7/nucleo-f746zg/src/stm32_bbsram.c
+++ b/boards/arm/stm32f7/nucleo-f746zg/src/stm32_bbsram.c
@@ -239,7 +239,7 @@ typedef struct
   int           lineno;                           /* __LINE__ to up_assert */
   int           pid;                              /* Process ID */
   uint32_t      regs[XCPTCONTEXT_REGS];           /* Interrupt register save area */
-  stack_t       stacks;                           /* Stack info */
+  stacks_t      stacks;                           /* Stack info */
   char          name[CONFIG_TASK_NAME_SIZE + 1];  /* Task name (with NULL
                                                    * terminator) */
   char          filename[MAX_FILE_PATH_LENGTH];   /* the Last of chars in
@@ -426,9 +426,13 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
 
   if (up_interrupt_context())
     {
+#if CONFIG_ARCH_INTERRUPTSTACK > 3
       pdump->info.stacks.interrupt.sp = sp;
       pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT |
                             INTSTACK_PRESENT);
+#else
+      pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT);
+#endif
       memcpy(pdump->info.regs, running_regs(),
              sizeof(pdump->info.regs));
       pdump->info.stacks.user.sp = pdump->info.regs[REG_R13];

--- a/boards/arm/stm32f7/nucleo-f767zi/src/stm32_bbsram.c
+++ b/boards/arm/stm32f7/nucleo-f767zi/src/stm32_bbsram.c
@@ -239,7 +239,7 @@ typedef struct
   int           lineno;                           /* __LINE__ to up_assert */
   int           pid;                              /* Process ID */
   uint32_t      regs[XCPTCONTEXT_REGS];           /* Interrupt register save area */
-  stack_t       stacks;                           /* Stack info */
+  stacks_t      stacks;                           /* Stack info */
   char          name[CONFIG_TASK_NAME_SIZE + 1];  /* Task name (with NULL
                                                    * terminator) */
   char          filename[MAX_FILE_PATH_LENGTH];   /* the Last of chars in
@@ -426,9 +426,13 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
 
   if (up_interrupt_context())
     {
+#if CONFIG_ARCH_INTERRUPTSTACK > 3
       pdump->info.stacks.interrupt.sp = sp;
       pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT |
                             INTSTACK_PRESENT);
+#else
+      pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT);
+#endif
       memcpy(pdump->info.regs, running_regs(),
              sizeof(pdump->info.regs));
       pdump->info.stacks.user.sp = pdump->info.regs[REG_R13];


### PR DESCRIPTION
## Summary

Fix the compilation of stm32f4/7 nucleo boards with:
 CONFIG_STM32F7_BKPSRAM=y
 CONFIG_STM32F7_BBSRAM=y
 CONFIG_STM32F7_PWR=y
 CONFIG_STM32F7_SAVE_CRASHDUMP=y

## Impact

This fixes regression that the BBSRAM code doesn't compile any more. There are no configurations in CI enabling this, so the breakage has gone unnoticed.

## Testing

Tested with enabling the crash dump saving on nucleo-f767zi:nsh, boards/arm/stm32f7/nucleo-f767zi/configs/nsh/defconfig.

Building without the fix results:

```
./tools/configure.sh nucleo-f767zi:nsh
make

CC:  board/stm32_bbsram.c board/stm32_bbsram.c: In function 'board_crashdump':
board/stm32_bbsram.c:429:25: error: 'stack_t' has no member named 'interrupt'
  429 |       pdump->info.stacks.interrupt.sp = sp;
      |                         ^
board/stm32_bbsram.c:434:25: error: 'stack_t' has no member named 'user'
  434 |       pdump->info.stacks.user.sp = pdump->info.regs[REG_R13];
      |                         ^
board/stm32_bbsram.c:441:25: error: 'stack_t' has no member named 'user'
  441 |       pdump->info.stacks.user.sp = sp;
      |                         ^
board/stm32_bbsram.c:444:21: error: 'stack_t' has no member named 'user'
  444 |   pdump->info.stacks.user.top = (uint32_t)tcb->stack_base_ptr +
      |                     ^
board/stm32_bbsram.c:446:21: error: 'stack_t' has no member named 'user'
  446 |   pdump->info.stacks.user.size = (uint32_t)tcb->adj_stack_size;
      |                     ^
board/stm32_bbsram.c:482:61: error: 'stack_t' has no member named 'user'
  482 |       stack_word_t *ps = (stack_word_t *) pdump->info.stacks.user.sp;
      |                                                             ^
board/stm32_bbsram.c:489:27: error: 'stack_t' has no member named 'user'
  489 |   if (!(pdump->info.stacks.user.sp <= pdump->info.stacks.user.top &&
      |                           ^
board/stm32_bbsram.c:489:57: error: 'stack_t' has no member named 'user'
  489 |   if (!(pdump->info.stacks.user.sp <= pdump->info.stacks.user.top &&
      |                                                         ^
board/stm32_bbsram.c:490:27: error: 'stack_t' has no member named 'user'
  490 |         pdump->info.stacks.user.sp > pdump->info.stacks.user.top -
      |                           ^
board/stm32_bbsram.c:490:56: error: 'stack_t' has no member named 'user'
  490 |         pdump->info.stacks.user.sp > pdump->info.stacks.user.top -
      |                                                        ^
board/stm32_bbsram.c:491:29: error: 'stack_t' has no member named 'user'
  491 |           pdump->info.stacks.user.size))
      |                             ^
make[2]: *** [/home/jlaitine/nuttx/boards/Board.mk:100: stm32_bbsram.o] Error 1
make[1]: *** [Makefile:196: board/libboard.a] Error 2
make: *** [tools/Unix.mk:569: nuttx] Error 2
```

With the corrections, the code compiles again.
