### PR TITLE
docs: Fix duplicate toctree references causing build warnings

### DIFF
--- a/Documentation/guides/changing_systemclockconfig.rst
+++ b/Documentation/guides/changing_systemclockconfig.rst
@@ -166,7 +166,4 @@ recalculate their frequency related settings.
 
 Here is some Power Management documentation:
 
-.. toctree::
-  :maxdepth: 1
-
-  /components/drivers/special/power/pm/index.rst
+- :doc:`/components/drivers/special/power/pm/index`

--- a/Documentation/platforms/arm/goldfish/index.rst
+++ b/Documentation/platforms/arm/goldfish/index.rst
@@ -6,6 +6,7 @@ GOLDFISH
    :maxdepth: 1
 
    goldfish_timer.rst
+   goldfish_sensor.rst
 
 Supported Boards
 ================

--- a/Documentation/platforms/arm/index.rst
+++ b/Documentation/platforms/arm/index.rst
@@ -8,4 +8,5 @@ The following ARM SoC are supported:
    :maxdepth: 1
    :glob:
 
-   */*
+   */index
+

--- a/Documentation/platforms/index.rst
+++ b/Documentation/platforms/index.rst
@@ -12,4 +12,5 @@ series and boards supported in NuttX:
    :maxdepth: 3
    :titlesonly:
    
-   */*
+   */index
+


### PR DESCRIPTION
## Summary

Fix Sphinx documentation build warnings caused by documents referenced in multiple toctrees.

Fixes #14785

## Problem

Several `.rst` files are referenced by both a parent toctree (via glob pattern) and a child toctree (explicit entry), causing Sphinx warnings:

```
document is referenced in multiple toctrees: [...], selecting: [...]
```

Affected files:
- `components/drivers/special/power/pm/index.rst`
- `platforms/arm/goldfish/goldfish_timer.rst`
- `platforms/arm/nrf52/ieee802154.rst`
- `platforms/sim/network_linux.rst`
- `platforms/sim/network_vpnkit.rst`

## Fix

1. **`platforms/arm/index.rst`**: Narrow glob pattern from `*/*` to `*/index` — only match subdirectory index files, not their children.

2. **`platforms/index.rst`**: Same glob narrowing from `*/*` to `*/index`.

3. **`guides/changing_systemclockconfig.rst`**: Replace `.. toctree::` directive with `:doc:` cross-reference, since this is a guide page that links to PM docs, not a structural parent.

These are the only non-index `.rst` files at the affected directory levels, so the narrowed globs remain functionally equivalent while eliminating the duplicate references.

## Testing

Verified that no other non-index `.rst` files exist at the affected directory levels that would be missed by the narrowed glob patterns.