### PR TITLE
cmake/nuttx_toolchain.cmake: track preprocessed include deps

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,11 @@ if(POLICY CMP0115)
   cmake_policy(SET CMP0115 NEW)
 endif()
 
+if(POLICY CMP0116)
+  # transform DEPFILE paths correctly for Ninja custom commands
+  cmake_policy(SET CMP0116 NEW)
+endif()
+
 # Avoid warning about DOWNLOAD_EXTRACT_TIMESTAMP in CMake 3.24:
 
 if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.24.0")

--- a/cmake/nuttx_toolchain.cmake
+++ b/cmake/nuttx_toolchain.cmake
@@ -91,13 +91,32 @@ if(NOT NUTTX_TOOLCHAIN_PREPROCESS_DEFINED)
       ARGN
       ${ARGN})
 
+    set(depfile_args)
+    set(preprocess_depflags)
+
+    if((CMAKE_GENERATOR MATCHES "Ninja|Makefiles")
+       AND (CMAKE_C_COMPILER_ID STREQUAL "GNU" OR CMAKE_C_COMPILER_ID MATCHES
+                                                  "Clang"))
+      set(preprocess_depfile ${TARGET_FILE}.d)
+      list(
+        APPEND
+        preprocess_depflags
+        -MMD
+        -MT
+        ${TARGET_FILE}
+        -MF
+        ${preprocess_depfile})
+      list(APPEND depfile_args DEPFILE ${preprocess_depfile})
+    endif()
+
     add_custom_command(
       OUTPUT ${TARGET_FILE}
       COMMAND
-        ${PREPROCESS} ${DEFINES} -I${CMAKE_BINARY_DIR}/include
-        -I${NUTTX_DIR}/include -I${NUTTX_CHIP_ABS_DIR} ${SOURCE_FILE} >
-        ${TARGET_FILE}
-      DEPENDS ${SOURCE_FILE} ${DEPENDS})
+        ${PREPROCESS} ${DEFINES} ${preprocess_depflags}
+        -I${CMAKE_BINARY_DIR}/include -I${NUTTX_DIR}/include
+        -I${NUTTX_CHIP_ABS_DIR} ${SOURCE_FILE} > ${TARGET_FILE}
+      DEPENDS ${SOURCE_FILE} ${DEPENDS} ${depfile_args}
+      COMMAND_EXPAND_LISTS)
 
   endfunction()
 endif()


### PR DESCRIPTION
  ## Summary

  Make `nuttx_generate_preprocess_target()` emit depfiles for GNU/Clang
  Ninja/Makefile builds.

  This fixes stale generated outputs when a preprocessed source includes
  other files via `#include`. One practical case is board ROMFS init
  scripts like `rc.sysinit` including `rc.sysinit.ap`.

  Before this change, editing the included fragment might not regenerate
  the generated `rc.sysinit` and final ROMFS image.

  ## Impact

  Build system only.

  Improves dependency tracking for preprocess-generated files and avoids
  stale ROMFS/script outputs.

  ## Testing

  - Reviewed the ROMFS preprocess flow in:
    - `cmake/nuttx_toolchain.cmake`
    - `cmake/nuttx_add_romfs.cmake`
  - Verified the issue against a NuttX-based downstream board build that
    uses preprocessed `rc.sysinit` fragments
  - Confirmed that after the change, modifying an included init fragment
    regenerates:
    - generated `rc.sysinit`
    - `romfs_etc.c`
    - final image
