### PR TITLE
ci/docker: bump risc-v toolchain

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -251,7 +251,7 @@ RUN cd /tools/renesas-tools/build/gcc && \
 FROM nuttx-toolchain-base AS nuttx-toolchain-riscv
 # Download the latest RISCV GCC toolchain prebuilt by xPack
 RUN mkdir -p riscv-none-elf-gcc && \
-  curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v14.2.0-3/xpack-riscv-none-elf-gcc-14.2.0-3-linux-x64.tar.gz" \
+  curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v15.2.0-1/xpack-riscv-none-elf-gcc-15.2.0-1-linux-x64.tar.gz" \
   | tar -C riscv-none-elf-gcc --strip-components 1 -xz
 
 ###############################################################################


### PR DESCRIPTION
## Summary

Bump risc-v toolchain to 15.2.0-1
Update RISC-V gcc toolchain to recent version

## Impact
Support additional RISC-V extensions in updated binutils

```
* Add support for RISC-V standard extensions,
  Zicfiss v1.0, Zicfilp v1.0, Zcmp v1.0 (cm.mva01s and cm.mvsa01 instructions),
  Zcmt v1.0, Smrnmi v1.0, S[sm]dbltrp v1.0 and S[sm]ctr v1.0 (replaced the
  dropped sfence.vm encoding since privileged spec v1.10).

* Add support for RISC-V vendor extensions,
  CORE-V, xcvbitmanip v1.0 and xcvsimd v1.0.
  SiFive, xsfvqmaccdod v1.0, xsfvqmaccqoqv1.0 and xsfvfnrclipxfqf v1.0.
```

## Testing

rp2350-rv target compilation with `Zcmp` enabled