### PR TITLE
drivers/segger: Download systemview from NuttX Mirror Repo

### DIFF
--- a/drivers/segger/CMakeLists.txt
+++ b/drivers/segger/CMakeLists.txt
@@ -27,7 +27,7 @@ if(CONFIG_SEGGER_RTT OR CONFIG_SEGGER_SYSVIEW)
       systemview
       DOWNLOAD_NAME "SystemView.zip"
       DOWNLOAD_DIR ${CMAKE_CURRENT_LIST_DIR}
-      URL "https://www.segger.com/downloads/systemview/SystemView_Src_V${CONFIG_SEGGER_SYSVIEW_TARGET_SOURCE}.zip"
+      URL "https://github.com/NuttX/nuttx/releases/download/systemview/SystemView_Src_V${CONFIG_SEGGER_SYSVIEW_TARGET_SOURCE}.zip"
           SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/SystemView
           BINARY_DIR

--- a/drivers/segger/Make.defs
+++ b/drivers/segger/Make.defs
@@ -80,7 +80,7 @@ ifeq ($(wildcard $(SGDIR)/SystemView/.git),)
 TARGET_ZIP = $(SGDIR)/$(SYSVIEW_ZIP)
 
 $(SGDIR)/$(SYSVIEW_ZIP):
-	$(call DOWNLOAD,https://www.segger.com/downloads/systemview,$(SYSVIEW_ZIP),$(TARGET_ZIP))
+	$(call DOWNLOAD,https://github.com/NuttX/nuttx/releases/download/systemview,$(SYSVIEW_ZIP),$(TARGET_ZIP))
 	$(Q) unzip -o $(TARGET_ZIP) -d $(SGDIR)/SystemView
 endif
 


### PR DESCRIPTION
## Summary

CI Builds for `stm32f429i-disco:systemview` and `nucleo-f446re:systemview` are failing, because www.segger.com is blocking our downloads for systemview. This PR updates the Segger Makefiles to download systemview from our Cached Dependency at NuttX Mirror Repo: https://github.com/NuttX/nuttx/releases/download/systemview/SystemView_Src_V356.zip

```
Configuration/Tool: nucleo-f446re/systemview,CONFIG_ARM_TOOLCHAIN_CLANG
CMake Error at /github/workspace/sources/nuttx/build/_deps/systemview-subbuild/systemview-populate-prefix/src/systemview-populate-stamp/download-systemview-populate.cmake:170 (message):
    error: downloading 'https://www.segger.com/downloads/systemview/SystemView_Src_V356.zip' failed
          status_code: 22
          status_string: "HTTP response code said error"
```

https://github.com/apache/nuttx-apps/actions/runs/26855455932/job/79197351538#step:10:1547

<img width="2319" height="1906" alt="Screenshot 2026-06-03 at 3 52 57 PM" src="https://github.com/user-attachments/assets/1955ad74-0564-4bbe-8a4f-050386d8316d" />

https://lupyuen.github.io/nuttx-github-jobs/build-monitor

## Impact

CI Builds will now succeed for `stm32f429i-disco:systemview` and `nucleo-f446re:systemview`. The affected PRs are:
- https://github.com/apache/nuttx/pull/19018
- https://github.com/apache/nuttx/pull/19024
- https://github.com/apache/nuttx/pull/19029
- https://github.com/apache/nuttx-apps/pull/3511
- https://github.com/apache/nuttx-apps/pull/3517

## Testing

(1) `nucleo-f446re:systemview` builds correctly with systemview: https://github.com/apache/nuttx/actions/runs/26868681448/job/79240417206?pr=19031#step:10:662
```
Cmake in present: nucleo-f446re/systemview,CONFIG_ARM_TOOLCHAIN_CLANG
  Building NuttX...
   TOOLS_DIR path is "/github/workspace/sources/nuttx"
   HOST = Linux
```

(2) `stm32f429i-disco:systemview` builds correctly with systemview: https://github.com/apache/nuttx/actions/runs/26868681448/job/79240417114?pr=19031#step:10:998
```
Configuration/Tool: stm32f429i-disco/systemview,CONFIG_ARM_TOOLCHAIN_CLANG
  Building NuttX...
  [1/1] Normalize stm32f429i-disco/systemview
```

(3) `at32f437-mini:systemview` builds correctly with systemview: https://github.com/apache/nuttx/actions/runs/26868681448/job/79240416180?pr=19031#step:10:357
```
Configuration/Tool: at32f437-mini/systemview,CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Building NuttX...
  [1/1] Normalize at32f437-mini/systemview
```

(4) `nrf52832-dk:nxscope_uart` builds correctly with systemview: https://github.com/apache/nuttx/actions/runs/26868681448/job/79240416270?pr=19031#step:10:519
```
Configuration/Tool: nrf52832-dk/nxscope_uart,CONFIG_ARM_TOOLCHAIN_GNU_EABI
  Building NuttX...
  [1/1] Normalize nrf52832-dk/nxscope_uart
```

