### PR TITLE
ci/docker: bump risc-v toolchain gcc14

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -251,7 +251,7 @@ RUN cd /tools/renesas-tools/build/gcc && \
 FROM nuttx-toolchain-base AS nuttx-toolchain-riscv
 # Download the latest RISCV GCC toolchain prebuilt by xPack
 RUN mkdir -p riscv-none-elf-gcc && \
-  curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v15.2.0-1/xpack-riscv-none-elf-gcc-15.2.0-1-linux-x64.tar.gz" \
+  curl -s -L "https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases/download/v14.3.0-1/xpack-riscv-none-elf-gcc-14.3.0-1-linux-x64.tar.gz" \
   | tar -C riscv-none-elf-gcc --strip-components 1 -xz
 
 ###############################################################################


### PR DESCRIPTION
## Summary

Revert to latest GCC14 due libcxx incompability with GCC15.
In https://github.com/apache/nuttx/pull/19030  risc-v toolchain was bumped to GCC15

We have old `17.0.6` LIBCXX with bunch of patches and it is incompatible with GCC15, stick for GCC14 

## Impact

Bring back failing risc-v builds with libcxx configs

