### PR TITLE
arch/sim: Add dependencies for Rust cargo in make builds

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -362,6 +362,7 @@ $(foreach lib,$(notdir $(wildcard $(APPDIR)$(DELIM)staging$(DELIM)*$(LIBEXT))), 
 
 EXTRA_LIBS := $(filter-out $(NAMEFULL_LIBS) $(NAMESPEC_LIBS),$(EXTRA_LIBS))
 EXTRA_LIBS += $(wildcard $(APPDIR)$(DELIM)staging$(DELIM)*$(LIBEXT))
+EXTRA_LIB_DEPS := $(wildcard $(filter-out -%,$(EXTRA_LIBS)))
 
 # Override in Make.defs if linker is not 'ld'
 
@@ -480,7 +481,7 @@ endef
 # stuff doesn't work there as we expect.
 # Note: _stext stuff is for CONFIG_CXX_INITIALIZE_SINIT, which in not
 # necessary for macOS.
-nuttx$(EXEEXT): libarch$(LIBEXT) board/libboard$(LIBEXT) $(HEADOBJ) $(LINKOBJS) $(HOSTOBJS) nuttx-names.dat
+nuttx$(EXEEXT): libarch$(LIBEXT) board/libboard$(LIBEXT) $(HEADOBJ) $(LINKOBJS) $(HOSTOBJS) nuttx-names.dat $(EXTRA_LIB_DEPS)
 	$(Q) echo "LD:  nuttx$(EXEEXT)"
 	$(Q) $(LD) -r $(LDLINKFLAGS) $(RELPATHS) $(EXTRA_LIBPATHS) $(EXTRALINKCMDS) \
 	     -o nuttx.rel $(REQUIREDOBJS) $(LDSTARTGROUP) $(RELLIBS) $(EXTRA_LIBS) $(LDENDGROUP)


### PR DESCRIPTION
## Summary

This updates the simulator link rule so `nuttx$(EXEEXT)` depends on `$(EXTRA_LIBS)`.

With this dependency in place, changes to extra application libraries, including Rust static libraries rebuilt by Cargo, cause the simulator `nuttx` binary to be relinked.

## Testing

I confirm that changes are verified on local setup and works as intended:
* Build Host(s): OS (macOS 26.5), CPU(Apple M1), compiler(Apple clang version 21.0.0)
* Target(s): arch(sim)
* Ensure your PATH environment variable is properly configured to allow execution of: menuconfig, olddefconfig, savedefconfig, and setconfig.
* Use the Rust toolchain version prior to nightly-2026-04-29 to avoid errors related to lib/rustlib/src/rust/library/std/src/sys/net/connection/socket/unix.rs.
* Depends on the corresponding apps-side PR. [#3522](https://github.com/apache/nuttx-apps/pull/3522)

## PR verification Self-Check

* [x] My PR adheres to Contributing [Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) and [Documentation](https://nuttx.apache.org/docs/latest/contributing/index.html) (git commit title and message, coding standard, etc).
* [x] My PR is ready for review and can be safely merged into a codebase.
