### PR TITLE
drivers/mmcsd/mmcsd_sdio.c: guard SDIO_REGISTERCALLBACK use

### DIFF
--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -4531,7 +4531,9 @@ static int mmcsd_hwinitialize(FAR struct mmcsd_state_s *priv)
    * removed from the slot (Initially all callbacks are disabled).
    */
 
+#if defined(CONFIG_SCHED_WORKQUEUE) && defined(CONFIG_SCHED_HPWORK)
   SDIO_REGISTERCALLBACK(priv->dev, mmcsd_mediachange, (FAR void *)priv);
+#endif
 
   /* Is there a card in the slot now? For an MMC/SD card, there are three
    * possible card detect mechanisms:


### PR DESCRIPTION
  ## Summary

  Guard the `SDIO_REGISTERCALLBACK()` call in `mmcsd_sdio.c`.

  `SDIO_REGISTERCALLBACK` is only defined when both
  `CONFIG_SCHED_WORKQUEUE` and `CONFIG_SCHED_HPWORK` are enabled in
  `include/nuttx/sdio.h`. Guarding the call site keeps the source aligned
  with that API availability and avoids build issues when HPWORK support is
  not configured.

  ## Impact

  Build fix only.

  ## Testing

my config doesn't has CONFIG_SCHED_HPWORK, it reports compile error at first. with this no failure reported.
