### PR TITLE
drivers/video: add HWCURSOR related config

### DIFF
--- a/drivers/video/Kconfig
+++ b/drivers/video/Kconfig
@@ -38,6 +38,32 @@ config FB_OVERLAY_BLIT
 	depends on FB_OVERLAY
 	default n
 
+config FB_HWCURSOR
+	bool "Hardware cursor support"
+	default n
+	---help---
+		Enable hardware cursor support for framebuffer devices.
+		Set this if the video controller hardware supports a
+		hardware cursor.
+
+config FB_HWCURSORIMAGE
+	bool "Hardware cursor image support"
+	default n
+	depends on FB_HWCURSOR
+	---help---
+		Enable support for user-provided hardware cursor images.
+		If set, the cursor image can be set via FBIOPUT_CURSOR
+		ioctl command.
+
+config FB_HWCURSORSIZE
+	bool "Hardware cursor size support"
+	default n
+	depends on FB_HWCURSOR
+	---help---
+		Enable support for changing hardware cursor size.
+		If set, the cursor size can be changed via FBIOPUT_CURSOR
+		ioctl command.
+
 menuconfig DRIVERS_VIDEO
 	bool "Video Device Support"
 	default n


### PR DESCRIPTION

## Summary

Add Kconfig definitions for FB_HWCURSOR, FB_HWCURSORIMAGE, and FB_HWCURSORSIZE in drivers/video/Kconfig.
These three config symbols are referenced in 129 places across the codebase (#ifdef CONFIG_FB_HWCURSOR etc.) and depended on by NX_HWCURSOR in graphics/Kconfig and SAMA5_LCDC_HCR in arch/arm/src/sama5/Kconfig, but have never had a Kconfig definition since the framebuffer interface was introduced in 2008 (before NuttX adopted Kconfig in 2012).

## Impact

- Users can now enable hardware cursor support via menuconfig
- FB_HWCURSORIMAGE and FB_HWCURSORSIZE properly depend on FB_HWCURSOR
- No functional change when these options remain disabled (default)
- Enabling these options may expose pre-existing compilation errors in driver code that was previously unreachable dead code (e.g., sim_framebuffer.c). Those should be addressed in follow-up patches.

## Testing

- sim:fb with FB_HWCURSOR=n (default): builds successfully, no regression
- sim:fb with FB_HWCURSOR=y: Kconfig resolves correctly, sub-options appear/disappear as expected
- olddefconfig validates without warnings
