### PR TITLE
arch/arm/gd32f4: fix NULL pointer dereference in arm_earlyserialinit.

### DIFF
--- a/arch/arm/src/gd32f4/gd32f4xx_serial.c
+++ b/arch/arm/src/gd32f4/gd32f4xx_serial.c
@@ -2763,7 +2763,7 @@ void arm_earlyserialinit(void)
 
   for (i = 0; i < GD32_NUSART; i++)
     {
-      if (g_uart_devs[i]->priv)
+      if (g_uart_devs[i] && g_uart_devs[i]->priv)
         {
           up_disableusartint(g_uart_devs[i]->priv, 0);
         }


### PR DESCRIPTION
## Summary
Add NULL check for g_uart_devs[i] before accessing ->priv in arm_earlyserialinit() loop. When a USART is not enabled in defconfig, g_uart_devs[i] is NULL, causing a HardFault crash during early boot.

The bug occurs because the original code only checked g_uart_devs[i]->priv without first verifying g_uart_devs[i] is not NULL. On Cortex-M4, NULL pointer dereference reads from Flash vector table (0x00000000 maps to 0x08000000), returning a function pointer that causes BusFault when written to.

This fix matches the existing NULL check pattern used in arm_serialinit() at line 2835 of the same file.

## Impact
- GD32F4 serial driver - Fixes boot crash when not all USARTs are enabled in defconfig
- No API changes - Pure bug fix, backward compatible
- No documentation changes required
## Testing
### Host Environment
- OS: Windows
- Toolchain: ARM GCC
- Build command: make olddefconfig && make
### Hardware Target
- Board: mplant-gd32f450 (GD32F450)
- Config: Only USART5 enabled
```
# CONFIG_GD32F4_USART0 is not set
CONFIG_GD32F4_USART5=y
CONFIG_USART5_SERIAL_CONSOLE=y
```
### Test Results
Before fix - HardFault crash at boot:
```
irq_unexpected_isr: === UNEXPECTED ISR ===
irq_unexpected_isr: IRQ: 3 (expected handler not registered)
irq_unexpected_isr: IPSR: 00000003 (current exception number)
irq_unexpected_isr: PC: 080003e0 LR: 080008ef
irq_unexpected_isr: R0: 08001a05 R1: 0f000000 R2: 00000000 R3: 80000000
irq_unexpected_isr: ======================
dump_assert_info: Assertion failed panic: at file: :0 task: <noname> process: Kernel 0x8001a05
```
After fix - Normal boot to NSH Shell:
```
nx_start: Entry
mm_initialize_heap: Heap: name=Umem, start=0x20002478 size=187272
uart_register: Registering /dev/console
uart_register: Registering /dev/ttyS0
task_spawn: name=nsh_main
nx_start: CPU0: Beginning Idle Loop
```
### Verification Steps
1. Built nuttx with mplant-gd32f450 defconfig (only USART5 enabled)
2. Flashed firmware to mplant-gd32f450 board
3. Verified system boots to NSH Shell without HardFault
4. Confirmed serial console (/dev/console) and /dev/ttyS0 registered correctly