### PR TITLE
mm/kasan: Fix compile options applied to wrong target in SPLIT build

### DIFF
--- a/arch/arm/src/cmake/elf.cmake
+++ b/arch/arm/src/cmake/elf.cmake
@@ -46,4 +46,4 @@ if(CONFIG_DEBUG_OPT_UNUSED_SECTIONS)
   endif()
 endif()
 
-nuttx_elf_link_options(-e __start)
+nuttx_elf_link_options(-e _start)

--- a/arch/arm64/src/cmake/elf.cmake
+++ b/arch/arm64/src/cmake/elf.cmake
@@ -32,4 +32,4 @@ nuttx_elf_link_options_ifdef(CONFIG_BUILD_KERNEL -Bstatic)
 
 nuttx_elf_link_options_ifdef(CONFIG_DEBUG_OPT_UNUSED_SECTIONS --gc-sections)
 
-nuttx_elf_link_options(-e __start)
+nuttx_elf_link_options(-e _start)

--- a/arch/x86_64/src/cmake/elf.cmake
+++ b/arch/x86_64/src/cmake/elf.cmake
@@ -30,4 +30,4 @@ nuttx_mod_link_options(-r)
 
 nuttx_elf_link_options_ifdef(CONFIG_DEBUG_OPT_UNUSED_SECTIONS --gc-sections)
 
-nuttx_elf_link_options(-e __start)
+nuttx_elf_link_options(-e _start)

--- a/cmake/nuttx_add_application.cmake
+++ b/cmake/nuttx_add_application.cmake
@@ -195,7 +195,6 @@ function(nuttx_add_application)
       # loadable build requires applying ELF flags to all applications
 
       if(CONFIG_MODULES)
-        add_dependencies(nuttx_apps_mksymtab ${TARGET})
         target_compile_options(
           ${TARGET}
           PRIVATE

--- a/mm/kasan/CMakeLists.txt
+++ b/mm/kasan/CMakeLists.txt
@@ -34,4 +34,9 @@ if(CONFIG_MM_KASAN)
 endif()
 
 target_sources(mm PRIVATE ${SRCS})
-target_compile_options(mm PRIVATE ${FLAGS})
+
+if(CONFIG_BUILD_FLAT)
+  target_compile_options(mm PRIVATE ${FLAGS})
+else()
+  target_compile_options(kmm PRIVATE ${FLAGS})
+endif()


### PR DESCRIPTION
Summary

- cmake/elf: Fix ELF entry point from __start to _start — The ELF entry point on ARM/ARM64/x86_64 incorrectly used __start (kernel boot entry) instead of _start (C runtime entry in crt0.c). arm64 and x86_64 elf.cmake already used _start; ARM was the outlier.
- mm/kasan: Fix compile options applied to wrong target in SPLIT build — In SPLIT build, the kmm target carries the kasan code, but compile options were mistakenly applied to the mm target. In flat build, the kmm target does not exist, causing a CMake configuration error.
- build/fix: remove nonexistent target in cmake — The nuttx_apps_mksymtab target does not exist in the nuttx repository, causing build failure when CONFIG_MODULES is enabled.

Impact

- Impact on user: NO
- Impact on build: YES — Fixes CMake build failures in SPLIT build, flat sim build, and CONFIG_MODULES scenarios.
- Impact on hardware: NO
- Impact on documentation: NO
- Impact on security: NO
- Impact on compatibility: NO

Testing

- Build Host: Linux x86_64, GCC
- Target: sim/mtdrwb, sim/note, sim/nsh, sim/nxffs (CMake flat build) and qemu-armv7a:knsh (SPLIT kernel build)

Testing logs before change:

CMake Error at mm/kasan/CMakeLists.txt:37 (target_compile_options):
  Cannot specify compile options for target "kmm" which is not built by this project.

Testing logs after change:

Build succeeds for sim and qemu-armv7a configurations.

Testing Details:

build config:

```
diff --git a/boards/arm/qemu/qemu-armv7a/configs/knsh/defconfig b/boards/arm/qemu/qemu-armv7a/configs/knsh/defconfig
index 18b086834c..2f66e7df80 100644
--- a/boards/arm/qemu/qemu-armv7a/configs/knsh/defconfig
+++ b/boards/arm/qemu/qemu-armv7a/configs/knsh/defconfig
@@ -18,8 +18,8 @@ CONFIG_ARCH_DATA_NPAGES=256
 CONFIG_ARCH_DATA_VBASE=0x80100000
 CONFIG_ARCH_HEAP_NPAGES=256
 CONFIG_ARCH_HEAP_VBASE=0x80200000
-CONFIG_ARCH_INTERRUPTSTACK=2048
-CONFIG_ARCH_KERNEL_STACKSIZE=3072
+CONFIG_ARCH_INTERRUPTSTACK=8192
+CONFIG_ARCH_KERNEL_STACKSIZE=8192
 CONFIG_ARCH_LOWVECTORS=y
 CONFIG_ARCH_PGPOOL_MAPPING=y
 CONFIG_ARCH_PGPOOL_PBASE=0x40300000
@@ -39,7 +39,7 @@ CONFIG_DEBUG_ASSERTIONS=y
 CONFIG_DEBUG_FEATURES=y
 CONFIG_DEBUG_FULLOPT=y
 CONFIG_DEBUG_SYMBOLS=y
-CONFIG_DEFAULT_TASK_STACKSIZE=4096
+CONFIG_DEFAULT_TASK_STACKSIZE=8192
 CONFIG_ELF=y
 CONFIG_EXAMPLES_HELLO=m
 CONFIG_EXPERIMENTAL=y
@@ -48,7 +48,7 @@ CONFIG_FS_HOSTFS=y
 CONFIG_FS_PROCFS=y
 CONFIG_HAVE_CXX=y
 CONFIG_HAVE_CXXINITIALIZE=y
-CONFIG_IDLETHREAD_STACKSIZE=4096
+CONFIG_IDLETHREAD_STACKSIZE=8192
 CONFIG_INIT_FILEPATH="/system/bin/init"
 CONFIG_INIT_MOUNT=y
 CONFIG_INIT_MOUNT_DATA="fs=../apps"
@@ -56,7 +56,7 @@ CONFIG_INIT_MOUNT_FLAGS=0x1
 CONFIG_INIT_MOUNT_FSTYPE="hostfs"
 CONFIG_INIT_MOUNT_SOURCE=""
 CONFIG_INIT_MOUNT_TARGET="/system"
-CONFIG_INIT_STACKSIZE=3072
+CONFIG_INIT_STACKSIZE=8192
 CONFIG_INTELHEX_BINARY=y
 CONFIG_LIBC_ENVPATH=y
 CONFIG_LIBC_EXECFUNCS=y
@@ -66,7 +66,7 @@ CONFIG_NSH_FILE_APPS=y
 CONFIG_NSH_READLINE=y
 CONFIG_PATH_INITIAL="/system/bin"
 CONFIG_PREALLOC_TIMERS=4
-CONFIG_RAM_SIZE=16777216
+CONFIG_RAM_SIZE=33554432
 CONFIG_RAM_START=0x40000000
 CONFIG_RAM_VSTART=0x40000000
 CONFIG_RAW_BINARY=y
@@ -91,3 +91,5 @@ CONFIG_UART1_PL011=y
 CONFIG_UART1_SERIAL_CONSOLE=y
 CONFIG_UART_PL011=y
 CONFIG_USEC_PER_TICK=1000
+CONFIG_MM_KASAN=y
+CONFIG_MM_KASAN_INSTRUMENT_ALL=y
```

build and run:

```
cmake -B build -DBOARD_CONFIG=qemu-armv7a:knsh -GNinja && cmake --build build
mkdir -p ../apps/bin
ln -sf $(realpath build/bin)/* ../apps/bin/
qemu-system-arm -semihosting -M virt -m 128 -nographic -kernel ./build/nuttx
```

If built with cmake and kasan hook itself, it cannot launch into nsh