### PR TITLE
include/nuttx/semaphore.h: parenthesize NXSEM helper args

### DIFF
--- a/include/nuttx/semaphore.h
+++ b/include/nuttx/semaphore.h
@@ -61,7 +61,7 @@
 
 /* Macros to retrieve sem count and to check if nxsem is mutex */
 
-#define NXSEM_COUNT(s)        ((FAR atomic_t *)&(s)->val.semcount)
+#define NXSEM_COUNT(s)        ((FAR atomic_t *)&((s)->val.semcount))
 #define NXSEM_IS_MUTEX(s)     (((s)->flags & SEM_TYPE_MUTEX) != 0)
 
 /* Mutex related helper macros */
@@ -72,7 +72,7 @@
 
 /* Macro to retrieve mutex's atomic holder's ptr */
 
-#define NXSEM_MHOLDER(s)      ((FAR atomic_t *)&(s)->val.mholder)
+#define NXSEM_MHOLDER(s)      ((FAR atomic_t *)&((s)->val.mholder))
 
 /* Check if holder value (TID) is not NO_HOLDER or RESET */
 


### PR DESCRIPTION
 ## Summary

  Add stricter argument parentheses to the `NXSEM_COUNT()` and
  `NXSEM_MHOLDER()` helper macros.

  This makes the macros safer when the caller passes a more complex
  expression and improves macro style consistency in the public header.

  ## Impact

  Code style / macro safety only.

  No intended functional change.

  ## Testing

  - `./tools/checkpatch.sh -c -u -m -g HEAD~1..HEAD`
