### PR TITLE
fs/vfs: inherit ownership in pseudofile_create

### DIFF
--- a/fs/vfs/fs_pseudofile.c
+++ b/fs/vfs/fs_pseudofile.c
@@ -468,6 +468,10 @@ int pseudofile_create(FAR struct inode **node, FAR const char *path,
                       mode_t mode)
 {
   FAR struct fs_pseudofile_s *pf;
+#if defined(CONFIG_PSEUDOFS_ATTRIBUTES) && \
+    defined(CONFIG_SCHED_USER_IDENTITY)
+  FAR struct tcb_s *rtcb;
+#endif
   int ret;
 
   if (node == NULL || path == NULL)
@@ -493,6 +497,18 @@ int pseudofile_create(FAR struct inode **node, FAR const char *path,
   (*node)->i_flags = 1;
   (*node)->u.i_ops = &g_pseudofile_ops;
   (*node)->i_private = pf;
+
+#if defined(CONFIG_PSEUDOFS_ATTRIBUTES) && \
+    defined(CONFIG_SCHED_USER_IDENTITY)
+
+  rtcb = nxsched_self();
+  if (rtcb != NULL && rtcb->group != NULL)
+    {
+      (*node)->i_owner = rtcb->group->tg_euid;
+      (*node)->i_group = rtcb->group->tg_egid;
+    }
+#endif
+
   atomic_fetch_add(&(*node)->i_crefs, 1);
 
   inode_unlock();


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Initialize pseudo-file ownership from the creating task's effective credentials when a new pseudo-file is created through the O_CREAT path.
Part of GSoC https://github.com/apache/nuttx/issues/18458
## Impact

When both CONFIG_PSEUDOFS_ATTRIBUTES and CONFIG_SCHED_USER_IDENTITY are enabled, newly created pseudo-files now inherit:
- i_owner = tg_euid
- i_group = tg_egid

instead of remaining owned by the default root credentials.

## Testing

Tested with a custom test file.
<img width="783" height="305" alt="WhatsApp Image 2026-06-06 at 8 57 12 PM" src="https://github.com/user-attachments/assets/82859837-e633-4f94-b49c-f16e2be05f58" />

