### PR TITLE
tools/nxstyle: Whitelist lifecycle_msgs GetState/State identifiers.

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -240,6 +240,8 @@ static const char *g_white_prefix[] =
   "nav_msgs",            /* nav_msgs__msg__Odometry, ... */
   "builtin_interfaces",  /* builtin_interfaces__msg__Time, ... */
   "rcl_interfaces",      /* rcl_interfaces__msg__Log, ... */
+  "lifecycle_msgs",      /* lifecycle_msgs__srv__GetState, ... */
+  "rosidl_runtime_c",    /* rosidl_runtime_c__String__assign, ... */
   "Int8",                /* ROSIDL_GET_MSG_TYPE_SUPPORT(_, _, Int8) */
   "Int16",
   "Int32",


### PR DESCRIPTION
## Summary

Phase 8 of the micro-ROS on NuttX integration adds GetState service serverand client examples under `apps/examples/microros_{srv,cli}` (paired apps PR). The `rosidl` token-pasting macros generate identifiers such as:

```
lifecycle_msgs__srv__GetState_Request
lifecycle_msgs__srv__GetState_Response
lifecycle_msgs__msg__State__PRIMARY_STATE_ACTIVE
ROSIDL_GET_SRV_TYPE_SUPPORT(lifecycle_msgs, srv, GetState)
rosidl_runtime_c__String__assign
```

CamelCase tokens (`GetState`, `State`, `String`) cannot be renamed without breaking the public ROS C client API. Adds them, the `lifecycle_msgs` package prefix, and the `rosidl_runtime_c` runtime prefix to the existing `g_white_prefix` whitelist seeded for Int32/std_msgs identifiers in earlier phases.

Paired apps PR: `examples/microros_{srv,cli}: Add minimal lifecycle GetState service example.` (apache/nuttx-apps). This nuttx PR must merge first — otherwise the apps PR fails nxstyle CI on the new examples.

## Impact

- **Users:** None. nxstyle whitelist is checkpatch-only; no runtime code
  affected.
- **Build:** None.
- **Hardware:** None.
- **Docs / Security / Compatibility:** None.

## Testing

Host: Ubuntu 22.04 jammy on AWS EC2 m7i-flex.large, gcc-12.

```
$ tools/checkpatch.sh -g 445a59a048
... no nxstyle errors on tools/nxstyle.c diff ...
```

Built the apps examples (`microros_srv`, `microros_cli`) on top of `sim:nsh` against this whitelist — both compile clean and pass `tools/checkpatch.sh` after this change. Without this change, `tools/nxstyle` flags identifier-naming violations on every rosidl-generated `lifecycle_msgs__*` symbol the new examples reference.

Runtime behavior of the examples themselves is covered in the paired apps PR Testing section (GetState round-trip with `ros2 service call` against a docker `micro-ros-agent:jazzy`).