### PR TITLE
video/fb: Handle case of multiple displays where some do not require update

### DIFF
--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -2047,18 +2047,20 @@ int fb_register_device(int display, int plane,
 #  ifdef CONFIG_FB_UPDATE
   if (fb->vtable->updatearea == NULL)
     {
-      goto errout_with_paninfo;
+      gerr("ERROR: updatearea() == NULL\n");
     }
-
-  area.x = 0;
-  area.y = 0;
-  area.w = vinfo.xres;
-  area.h = vinfo.yres;
-
-  ret = fb->vtable->updatearea(fb->vtable, &area);
-  if (ret < 0)
+  else
     {
-      goto errout_with_paninfo;
+      area.x = 0;
+      area.y = 0;
+      area.w = vinfo.xres;
+      area.h = vinfo.yres;
+
+      ret = fb->vtable->updatearea(fb->vtable, &area);
+      if (ret < 0)
+        {
+          goto errout_with_paninfo;
+        }
     }
 #  endif
 
@@ -2075,10 +2077,13 @@ int fb_register_device(int display, int plane,
     }
 
 #    ifdef CONFIG_FB_UPDATE
-  ret = fb->vtable->updatearea(fb->vtable, &area);
-  if (ret < 0)
+  if (fb->vtable->updatearea != NULL)
     {
-      goto errout_with_paninfo;
+      ret = fb->vtable->updatearea(fb->vtable, &area);
+      if (ret < 0)
+        {
+          goto errout_with_paninfo;
+        }
     }
 #    endif
 #  endif


### PR DESCRIPTION
## Summary

If multiple display configuration is used in which some displays require explicit update while others do not, `updatearea()` can be legitimately `NULL`.

If the `updatearea()` is `NULL`, produce log entry and skip the update instead of panicking.

This patch was originally suggested by @ppisa in https://github.com/apache/nuttx/pull/19047#issuecomment-4640390751.

## Impact

Multiple display configuration mixing those requiring explicit update and those that do not is now supported.

## Testing

Tested on ESP32C6-devkitc and ILI9341 LCD controller used as framebuffer device. Tested both with `updatearea()` set to `NULL` and set to `lcdfb_updateearea()`.