### PR TITLE
include/cxx/ctime: Add localtime to std namespace.

### DIFF
--- a/include/cxx/ctime
+++ b/include/cxx/ctime
@@ -46,6 +46,7 @@ namespace std
   using ::clock_settime;
   using ::clock_gettime;
   using ::mktime;
+  using ::localtime;
   using ::gmtime_r;
   using ::gmtime;
   using ::strftime;


### PR DESCRIPTION
*Note: Please adhere to [[Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md)](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Fix Bug #19063 .

`include/cxx/ctime` does not import `::localtime` into namespace `std`.

NuttX `time.h` provides `localtime` in the global namespace, but the C++ `<ctime>` shim only imports a subset of the C time API into `std`.

As a result, valid C++ code using `std::localtime` fails to compile, even though `::localtime` is available.

This change adds:

```cpp
using ::localtime;
```

to `include/cxx/ctime`.

## Impact

* Is new feature added? NO.
* Is existing feature changed? YES. `include/cxx/ctime` now exposes `std::localtime` when `::localtime` is available from NuttX `time.h`.
* Impact on user? NO user migration required. This fixes a C++ header compatibility issue.
* Impact on build? YES, positive impact. Valid C++ code using `std::localtime` can now compile with the NuttX C++ headers.
* Impact on hardware? NO hardware-specific behavior change. This is a C++ header-only fix.
* Impact on documentation? NO documentation update required.
* Impact on security? NO.
* Impact on compatibility? YES, positive compatibility impact. The C++ `<ctime>` wrapper becomes more consistent with the C time API exposed by NuttX.

## Testing

I confirm that changes are verified on local setup and work as intended.

* Build Host: Linux Docker container
* Target: ARM Cortex-M4, `xmc4800-relax`
* Toolchain: `arm-none-eabi-g++`
* C++ standard: `gnu++20`
* Configuration:

  * `CONFIG_CXX_STANDARD="gnu++20"`
  * NuttX C++ headers included through `/build/nuttx/include/cxx`
  * NuttX C headers included through `/build/nuttx/include`

### Reproducer

```cpp
#include <ctime>

int test_ctime_symbol()
{
  time_t t = 0;
  auto *tm = std::localtime(&t);
  return tm == nullptr;
}
```

Compile command:

```sh
arm-none-eabi-g++ \
  -std=gnu++20 \
  -mlittle-endian -march=armv7e-m -mtune=cortex-m4 \
  -mfpu=fpv4-sp-d16 -mfloat-abi=hard -mthumb \
  -DCONFIG_WCHAR_BUILTIN -D__NuttX__ \
  -isystem /build/nuttx/include/cxx \
  -isystem /build/nuttx/include \
  -c /tmp/test_ctime.cpp -o /tmp/test_ctime.o
```

### Testing logs before change

The standalone `<ctime>` reproducer fails because `std::localtime` is not available.

A real-world build failure was also observed while building Botan 3.11.1 against the NuttX C++ headers:

```text
src/lib/utils/os_utils/os_utils.cpp: In function 'std::string Botan::OS::format_time(time_t, const std::string&)':
src/lib/utils/os_utils/os_utils.cpp:355:23: error: 'localtime' is not a member of 'std'; did you mean 'locale'?
  355 |    if(auto tmp = std::localtime(&time)) {
      |                       ^~~~~~~~~
      |                       locale
```

The current `include/cxx/ctime` imports these symbols into namespace `std`:

```text
using ::time_t;
using ::timer_t;
using ::timespec;
using ::itimerspec;
using ::clock_settime;
using ::clock_gettime;
using ::mktime;
using ::gmtime_r;
using ::gmtime;
using ::strftime;
using ::timer_create;
using ::timer_delete;
using ::timer_settime;
using ::timer_gettime;
using ::timer_getoverrun;
```

but does not import `::localtime`.

### Testing logs after change

After adding `using ::localtime;` to `include/cxx/ctime`, the standalone `<ctime>` reproducer compiles successfully.

```sh
arm-none-eabi-g++ \
  -std=gnu++20 \
  -mlittle-endian -march=armv7e-m -mtune=cortex-m4 \
  -mfpu=fpv4-sp-d16 -mfloat-abi=hard -mthumb \
  -DCONFIG_WCHAR_BUILTIN -D__NuttX__ \
  -isystem /build/nuttx/include/cxx \
  -isystem /build/nuttx/include \
  -c /tmp/test_ctime.cpp -o /tmp/test_ctime.o
```

Result:

```text
Compilation succeeds.
```

I also resumed the external C++ dependency build that previously failed on `std::localtime`. The build now passes this compilation step.

Runtime hardware testing was not required for this specific change because it only affects C++ header symbol exposure at compile time and does not change generated runtime code paths.

## PR verification Self-Check

* [x] This PR introduces only one functional change.
* [x] I have updated all required description fields above.
* [x] My PR adheres to Contributing [[Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md)](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) and [[Documentation](https://nuttx.apache.org/docs/latest/contributing/index.html)](https://nuttx.apache.org/docs/latest/contributing/index.html) (git commit title and message, coding standard, etc).
* [ ] My PR is still work in progress (not ready for review).
* [x] My PR is ready for review and can be safely merged into a codebase.