### PR TITLE
sched/Kconfig: Fix ETC_ROMFS dependency

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -534,9 +534,9 @@ endif # INIT_FILE
 menuconfig ETC_ROMFS
 	bool "Auto-mount etc baked-in ROMFS image"
 	default n
-	depends on !DISABLE_MOUNTPOINT && FS_ROMFS
+	depends on !DISABLE_MOUNTPOINT && (FS_ROMFS || FS_CROMFS)
 	---help---
-		Mount a ROMFS filesystem at /etc and provide a system init
+		Mount a ROMFS or a CROMFS filesystem at /etc and provide a system init
 		script at /etc/init.d/rc.sysinit and a startup script
 		at /etc/init.d/rcS.  The default system init script mounts
 		/tmp as TMPFS when FS_TMPFS is enabled, otherwise it can


### PR DESCRIPTION
## Summary

I found a configuration issue on many PX4 targets. They use FS_CROMFS for /etc, but still pull in all the FS_ROMFS code, even though this is completely different, and unused, filesystem. CROMFS is not used in any of the nuttx upstream boards, afaik, so this PR is somewhat specific to downstream projects using CROMFS.

This PR makes ETC_ROMFS depend on FS_ROMFS || FS_CROMFS, so that the user can drop FS_ROMFS when only FS_CROMFS is needed.

Reminder, FS_ROMFS and FS_CROMFS are completely separate flags/filesystems. ETC_ROMFS and ETC_CROMFS are not; in order to use ETC_CROMFS also ETC_ROMFS needs to be defined - it enables other common flags/functionality for both.

For PX4, this allows configuring ETC_ROMFS, ETC_CROMFS and FS_CROMFS. Previously also FS_ROMFS was needed only to enable ETC_ROMFS+ETC_CROMFS. Dropping the un-used FS_ROMFS saves 3kB of flash.

## Impact

Doesn't impact any of the current NuttX boards. Only affects (downstream project) boards using FS_CROMFS and ETC_CROMFS so that they can drop CONFIG_FS_ROMFS to flash.

## Testing

Tested on pixhawk4 board & px4 build.

Build info with CONFIG_FS_ROMFS enabled (mandatory without this fix):

```
Memory region         Used Size  Region Size  %age Used
      FLASH_ITCM:          0 GB      2016 KB      0.00%
      FLASH_AXIM:     2008000 B      2016 KB     97.27%
        ITCM_RAM:          0 GB        16 KB      0.00%
        DTCM_RAM:          0 GB       128 KB      0.00%
           SRAM1:       54028 B       368 KB     14.34%
           SRAM2:          0 GB        16 KB      0.00%
```
Link info with CONFIG_FS_ROMFS disabled:

```
Memory region         Used Size  Region Size  %age Used
      FLASH_ITCM:          0 GB      2016 KB      0.00%
      FLASH_AXIM:     2005024 B      2016 KB     97.12%
        ITCM_RAM:          0 GB        16 KB      0.00%
        DTCM_RAM:          0 GB       128 KB      0.00%
           SRAM1:       54028 B       368 KB     14.34%
           SRAM2:          0 GB        16 KB      0.00%

```

Flash memory saving for this board is 2.9KB.
