### PR TITLE
{bp-19013} arch/arm/src/stm32hx/stm32_adc: Reset channel counter before conversions.

### DIFF
--- a/arch/arm/src/stm32h5/stm32_adc.c
+++ b/arch/arm/src/stm32h5/stm32_adc.c
@@ -1782,6 +1782,7 @@ static int adc_ioctl(struct adc_dev_s *dev, int cmd, unsigned long arg)
     {
       case ANIOC_TRIGGER:
         {
+          priv->current = 0;
           adc_startconv(priv, true);
         }
         break;

--- a/arch/arm/src/stm32h7/stm32_adc.c
+++ b/arch/arm/src/stm32h7/stm32_adc.c
@@ -1947,6 +1947,7 @@ static int adc_ioctl(struct adc_dev_s *dev, int cmd, unsigned long arg)
     {
       case ANIOC_TRIGGER:
         {
+          priv->current = 0;
           adc_startconv(priv, true);
         }
         break;


### PR DESCRIPTION
## Summary

When an ADC conversion sequence is triggered via the ANIOC_TRIGGER ioctl, the priv->current channel counter was not being reset before starting the conversion. This meant that if a previous conversion sequence had ended mid-way through the channel list (e.g., due to an error or partial read), subsequent triggers would resume dispatching au_receive callbacks from the wrong channel index, corrupting the channel-to-data mapping reported to the upper half.

This fix resets priv->current to 0 immediately before calling adc_startconv() in the ANIOC_TRIGGER handler, ensuring the interrupt handler always starts dispatching results from the first channel in the sequence. The same fix is applied consistently to both the STM32H5 and STM32H7 ADC drivers, which share the same architecture and bug.

## Impact

RELEASE

## Testing

CI