### PR TITLE
{bp-19014} driver/serial: Fix/uart tcdrain bugs

### DIFF
--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -525,6 +525,14 @@ static int uart_tcdrain(FAR uart_dev_t *dev,
     {
       irqstate_t flags;
       clock_t start;
+      clock_t elapsed;
+
+      /* Take a single timestamp.  The caller-supplied timeout bounds the
+       * total time spent in this function, covering both the xmit-buffer
+       * drain wait below and the FIFO-empty polling loop further down.
+       */
+
+      start = clock_systime_ticks();
 
       /* Trigger emission to flush the contents of the tx buffer */
 
@@ -544,12 +552,11 @@ static int uart_tcdrain(FAR uart_dev_t *dev,
       else
 #endif
         {
-          /* Continue waiting while the TX buffer is not empty.
-           *
-           * NOTE: There is no timeout on the following loop.  In
-           * situations were this loop could hang (with hardware flow
-           * control, as an example),  the caller should call
-           * tcflush() first to discard this buffered Tx data.
+          /* Continue waiting while the TX buffer is not empty.  The wait is
+           * bounded by the caller-supplied timeout so this loop cannot hang
+           * indefinitely (e.g. on hardware-flow-control stalls).  The caller
+           * may still call tcflush() to discard the buffered Tx data on
+           * timeout.
            */
 
           ret = OK;
@@ -569,7 +576,17 @@ static int uart_tcdrain(FAR uart_dev_t *dev,
               uart_dmatxavail(dev);
 #endif
               uart_enabletxint(dev);
-              ret = nxsem_wait(&dev->xmitsem);
+
+              elapsed = clock_systime_ticks() - start;
+              if (elapsed >= timeout)
+                {
+                  ret = -ETIMEDOUT;
+                }
+              else
+                {
+                  ret = nxsem_tickwait(&dev->xmitsem, timeout - elapsed);
+                }
+
               uart_disabletxint(dev);
             }
         }
@@ -581,21 +598,15 @@ static int uart_tcdrain(FAR uart_dev_t *dev,
        * this event, so we have to do a busy wait poll.
        */
 
-      /* Set up for the timeout
-       *
-       * REVISIT:  This is a kludge.  The correct fix would be add an
+      /* REVISIT: This is a kludge.  The correct fix would be add an
        * interface to the lower half driver so that the tcflush() operation
        * all also cause the lower half driver to clear and reset the Tx FIFO.
        */
-
-      start = clock_systime_ticks();
 
       if (ret >= 0)
         {
           while (!uart_txempty(dev))
             {
-              clock_t elapsed;
-
               nxsched_usleep(POLL_DELAY_USEC);
 
               /* Check for a timeout */

--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -604,6 +604,11 @@ static int uart_tcdrain(FAR uart_dev_t *dev,
               if (elapsed >= timeout)
                 {
                   nxmutex_unlock(&dev->xmit.lock);
+                  if (cancelable)
+                    {
+                      leave_cancellation_point();
+                    }
+
                   return -ETIMEDOUT;
                 }
             }


### PR DESCRIPTION
## Summary

uart_tcdrain() has two latent bugs in its timeout handling:

    Cancellation point leak on timeout. uart_tcdrain() enters a
    cancellation point on entry (when cancelable=true) and the normal exit
    path calls leave_cancellation_point(). The early return -ETIMEDOUT
    from inside the FIFO-empty polling loop bypasses this, leaving
    tcb->cpcount permanently incremented. Repeated timeouts desync the
    counter and break subsequent pthread_cancel() /
    pthread_setcancelstate() semantics for the calling thread.
    Caller-supplied timeout does not bound the xmit-buffer drain. The
    timeout argument (e.g. 10 * TICK_PER_SEC from the TCDRN ioctl
    path) was only honored by the final FIFO polling loop. The earlier
    xmit-buffer drain loop called nxsem_wait(&dev->xmitsem) with no
    timeout, so any condition that prevents the lower half from posting
    xmitsem (a stuck DMA-completion path, a wedged hardware-flow-control
    stall, etc.) would block tcdrain() indefinitely regardless of the
    timeout the caller asked for. The pre-existing comment ("NOTE: There
    is no timeout on the following loop. ... the caller should call
    tcflush() first") openly acknowledged this hang.

This series fixes both:

    Patch 1 moves the missing leave_cancellation_point() onto the
    timeout return path so cancellation-point nesting stays balanced.
    Patch 2 takes a single timestamp on entry, replaces the bare
    nxsem_wait() with nxsem_tickwait() using the remaining time, and
    short-circuits to -ETIMEDOUT when the caller's budget is already
    exhausted. The caller's timeout now bounds the total time spent in
    uart_tcdrain() regardless of which phase stalls.

## Impact

RELEASE

## Testing

CI