### PR TITLE
{bp-19023} boards/arm/stm32/nucleo: Fix BBSRAM compilation

### DIFF
--- a/boards/arm/stm32/nucleo-f429zi/src/stm32_bbsram.c
+++ b/boards/arm/stm32/nucleo-f429zi/src/stm32_bbsram.c
@@ -239,7 +239,7 @@ typedef struct
   int           lineno;                           /* __LINE__ to up_assert */
   pid_t         pid;                              /* Process ID */
   uint32_t      regs[XCPTCONTEXT_REGS];           /* Interrupt register save area */
-  stack_t       stacks;                           /* Stack info */
+  stacks_t      stacks;                           /* Stack info */
   char          name[CONFIG_TASK_NAME_SIZE + 1];  /* Task name (with NULL
                                                    * terminator) */
   char          filename[MAX_FILE_PATH_LENGTH];   /* the Last of chars in
@@ -426,9 +426,13 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
 
   if (up_interrupt_context())
     {
+#if CONFIG_ARCH_INTERRUPTSTACK > 3
       pdump->info.stacks.interrupt.sp = sp;
       pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT |
                             INTSTACK_PRESENT);
+#else
+      pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT);
+#endif
       memcpy(pdump->info.regs, running_regs(),
              sizeof(pdump->info.regs));
       pdump->info.stacks.user.sp = pdump->info.regs[REG_R13];

--- a/boards/arm/stm32f7/nucleo-f722ze/src/stm32_bbsram.c
+++ b/boards/arm/stm32f7/nucleo-f722ze/src/stm32_bbsram.c
@@ -239,7 +239,7 @@ typedef struct
   int           lineno;                           /* __LINE__ to up_assert */
   int           pid;                              /* Process ID */
   uint32_t      regs[XCPTCONTEXT_REGS];           /* Interrupt register save area */
-  stack_t       stacks;                           /* Stack info */
+  stacks_t      stacks;                           /* Stack info */
   char          name[CONFIG_TASK_NAME_SIZE + 1];  /* Task name (with NULL
                                                    * terminator) */
   char          filename[MAX_FILE_PATH_LENGTH];   /* the Last of chars in
@@ -426,9 +426,13 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
 
   if (up_interrupt_context())
     {
+#if CONFIG_ARCH_INTERRUPTSTACK > 3
       pdump->info.stacks.interrupt.sp = sp;
       pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT |
                             INTSTACK_PRESENT);
+#else
+      pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT);
+#endif
       memcpy(pdump->info.regs, running_regs(),
              sizeof(pdump->info.regs));
       pdump->info.stacks.user.sp = pdump->info.regs[REG_R13];

--- a/boards/arm/stm32f7/nucleo-f746zg/src/stm32_bbsram.c
+++ b/boards/arm/stm32f7/nucleo-f746zg/src/stm32_bbsram.c
@@ -239,7 +239,7 @@ typedef struct
   int           lineno;                           /* __LINE__ to up_assert */
   int           pid;                              /* Process ID */
   uint32_t      regs[XCPTCONTEXT_REGS];           /* Interrupt register save area */
-  stack_t       stacks;                           /* Stack info */
+  stacks_t      stacks;                           /* Stack info */
   char          name[CONFIG_TASK_NAME_SIZE + 1];  /* Task name (with NULL
                                                    * terminator) */
   char          filename[MAX_FILE_PATH_LENGTH];   /* the Last of chars in
@@ -426,9 +426,13 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
 
   if (up_interrupt_context())
     {
+#if CONFIG_ARCH_INTERRUPTSTACK > 3
       pdump->info.stacks.interrupt.sp = sp;
       pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT |
                             INTSTACK_PRESENT);
+#else
+      pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT);
+#endif
       memcpy(pdump->info.regs, running_regs(),
              sizeof(pdump->info.regs));
       pdump->info.stacks.user.sp = pdump->info.regs[REG_R13];

--- a/boards/arm/stm32f7/nucleo-f767zi/src/stm32_bbsram.c
+++ b/boards/arm/stm32f7/nucleo-f767zi/src/stm32_bbsram.c
@@ -239,7 +239,7 @@ typedef struct
   int           lineno;                           /* __LINE__ to up_assert */
   int           pid;                              /* Process ID */
   uint32_t      regs[XCPTCONTEXT_REGS];           /* Interrupt register save area */
-  stack_t       stacks;                           /* Stack info */
+  stacks_t      stacks;                           /* Stack info */
   char          name[CONFIG_TASK_NAME_SIZE + 1];  /* Task name (with NULL
                                                    * terminator) */
   char          filename[MAX_FILE_PATH_LENGTH];   /* the Last of chars in
@@ -426,9 +426,13 @@ void board_crashdump(uintptr_t sp, struct tcb_s *tcb,
 
   if (up_interrupt_context())
     {
+#if CONFIG_ARCH_INTERRUPTSTACK > 3
       pdump->info.stacks.interrupt.sp = sp;
       pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT |
                             INTSTACK_PRESENT);
+#else
+      pdump->info.flags |= (REGS_PRESENT | USERSTACK_PRESENT);
+#endif
       memcpy(pdump->info.regs, running_regs(),
              sizeof(pdump->info.regs));
       pdump->info.stacks.user.sp = pdump->info.regs[REG_R13];


### PR DESCRIPTION
## Summary

Fix the compilation of stm32f4/7 nucleo boards with:
 CONFIG_STM32F7_BKPSRAM=y
 CONFIG_STM32F7_BBSRAM=y
 CONFIG_STM32F7_PWR=y
 CONFIG_STM32F7_SAVE_CRASHDUMP=y

## Impact

RELEASE

## Testing

CI