### PR TITLE
{bp-19025} workflows/build.yml: Fix Skipping sim\windows in the MSVC job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -451,7 +451,7 @@ jobs:
   msvc:
     needs: msvc-Arch
     if: ${{ needs.msvc-Arch.outputs.skip_all_builds != '1' }}
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v6
       # Set up Python environment and install kconfiglib


### PR DESCRIPTION
## Summary

Fix

==================================================================================== Cmake in present: sim\windows
Configuration/Tool: sim\windows
2026-06-02 12:57:35
------------------------------------------------------------------------------------
  Cleaning...
  Skipping: sim\windows
------------------------------------------------------------------------------------ End: 2026-06-02 12:57:35
====================================================================================

The "windows-latest" and “windows-2025” labels in GitHub Actions will be migrated to use Visual Studio 2026 by default. Customers needing Visual Studio 2022 must migrate to the windows-2022 image.

https://github.com/actions/runner-images/issues/14017

## Impact

RELEASE

## Testing

CI