### PR TITLE
{bp-19027} docs: Fix duplicate toctree references causing build warnings

### DIFF
--- a/Documentation/guides/changing_systemclockconfig.rst
+++ b/Documentation/guides/changing_systemclockconfig.rst
@@ -166,7 +166,4 @@ recalculate their frequency related settings.
 
 Here is some Power Management documentation:
 
-.. toctree::
-  :maxdepth: 1
-
-  /components/drivers/special/power/pm/index.rst
+- :doc:`/components/drivers/special/power/pm/index`

--- a/Documentation/platforms/arm/goldfish/index.rst
+++ b/Documentation/platforms/arm/goldfish/index.rst
@@ -6,6 +6,7 @@ GOLDFISH
    :maxdepth: 1
 
    goldfish_timer.rst
+   goldfish_sensor.rst
 
 Supported Boards
 ================

--- a/Documentation/platforms/arm/index.rst
+++ b/Documentation/platforms/arm/index.rst
@@ -8,4 +8,5 @@ The following ARM SoC are supported:
    :maxdepth: 1
    :glob:
 
-   */*
+   */index
+

--- a/Documentation/platforms/index.rst
+++ b/Documentation/platforms/index.rst
@@ -12,4 +12,5 @@ series and boards supported in NuttX:
    :maxdepth: 3
    :titlesonly:
    
-   */*
+   */index
+


### PR DESCRIPTION
## Summary

Several documentation files are referenced in multiple toctrees, causing Sphinx build warnings like:

  document is referenced in multiple toctrees: [...], selecting: [...]

Fix by narrowing glob patterns in parent toctrees to only match subdirectory index files, and replacing a toctree directive with a :doc: cross-reference:

- platforms/arm/index.rst: glob */* -> */index
- platforms/index.rst: glob */* -> */index
- guides/changing_systemclockconfig.rst: toctree -> :doc: ref

Fixes #14785

## Impact

RELEASE

## Testing

CI