### PR TITLE
{bp-19031} drivers/segger: Download systemview from NuttX Mirror Repo

### DIFF
--- a/drivers/segger/CMakeLists.txt
+++ b/drivers/segger/CMakeLists.txt
@@ -27,7 +27,7 @@ if(CONFIG_SEGGER_RTT OR CONFIG_SEGGER_SYSVIEW)
       systemview
       DOWNLOAD_NAME "SystemView.zip"
       DOWNLOAD_DIR ${CMAKE_CURRENT_LIST_DIR}
-      URL "https://www.segger.com/downloads/systemview/SystemView_Src_V${CONFIG_SEGGER_SYSVIEW_TARGET_SOURCE}.zip"
+      URL "https://github.com/NuttX/nuttx/releases/download/systemview/SystemView_Src_V${CONFIG_SEGGER_SYSVIEW_TARGET_SOURCE}.zip"
           SOURCE_DIR
           ${CMAKE_CURRENT_LIST_DIR}/SystemView
           BINARY_DIR

--- a/drivers/segger/Make.defs
+++ b/drivers/segger/Make.defs
@@ -80,7 +80,7 @@ ifeq ($(wildcard $(SGDIR)/SystemView/.git),)
 TARGET_ZIP = $(SGDIR)/$(SYSVIEW_ZIP)
 
 $(SGDIR)/$(SYSVIEW_ZIP):
-	$(call DOWNLOAD,https://www.segger.com/downloads/systemview,$(SYSVIEW_ZIP),$(TARGET_ZIP))
+	$(call DOWNLOAD,https://github.com/NuttX/nuttx/releases/download/systemview,$(SYSVIEW_ZIP),$(TARGET_ZIP))
 	$(Q) unzip -o $(TARGET_ZIP) -d $(SGDIR)/SystemView
 endif
 


### PR DESCRIPTION
## Summary

CI Builds for `stm32f429i-disco:systemview` and `nucleo-f446re:systemview` are failing, because www.segger.com is blocking our downloads for systemview. This PR updates the Segger Makefiles to download systemview from our Cached Dependency at NuttX Mirror Repo: https://github.com/NuttX/nuttx/releases/download/systemview/SystemView_Src_V356.zip

```
Configuration/Tool: nucleo-f446re/systemview,CONFIG_ARM_TOOLCHAIN_CLANG
CMake Error at /github/workspace/sources/nuttx/build/_deps/systemview-subbuild/systemview-populate-prefix/src/systemview-populate-stamp/download-systemview-populate.cmake:170 (message):
    error: downloading 'https://www.segger.com/downloads/systemview/SystemView_Src_V356.zip' failed
          status_code: 22
          status_string: "HTTP response code said error"
```

https://github.com/apache/nuttx-apps/actions/runs/26855455932/job/79197351538#step:10:1547

## Impact

RELEASE

## Testing

CI