### PR TITLE
{bp-19038} drivers/mmcsd/mmcsd_sdio.c: guard SDIO_REGISTERCALLBACK use

### DIFF
--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -4509,7 +4509,9 @@ static int mmcsd_hwinitialize(FAR struct mmcsd_state_s *priv)
    * removed from the slot (Initially all callbacks are disabled).
    */
 
+#if defined(CONFIG_SCHED_WORKQUEUE) && defined(CONFIG_SCHED_HPWORK)
   SDIO_REGISTERCALLBACK(priv->dev, mmcsd_mediachange, (FAR void *)priv);
+#endif
 
   /* Is there a card in the slot now? For an MMC/SD card, there are three
    * possible card detect mechanisms:


### PR DESCRIPTION
## Summary

SDIO_REGISTERCALLBACK is only defined when both CONFIG_SCHED_WORKQUEUE and CONFIG_SCHED_HPWORK are enabled. Guard the callback registration call in mmcsd_sdio.c so the source matches the SDIO callback API availability and avoids build issues when HPWORK support is not configured.

## Impact

RELEASE

## Testing

CI