### PR TITLE
{bp-19040} arch/arm/gd32f4: fix NULL pointer dereference in arm_earlyserialinit.

### DIFF
--- a/arch/arm/src/gd32f4/gd32f4xx_serial.c
+++ b/arch/arm/src/gd32f4/gd32f4xx_serial.c
@@ -2763,7 +2763,7 @@ void arm_earlyserialinit(void)
 
   for (i = 0; i < GD32_NUSART; i++)
     {
-      if (g_uart_devs[i]->priv)
+      if (g_uart_devs[i] && g_uart_devs[i]->priv)
         {
           up_disableusartint(g_uart_devs[i]->priv, 0);
         }


### PR DESCRIPTION
## Summary
Add NULL check for g_uart_devs[i] before accessing ->priv in arm_earlyserialinit() loop. When a USART is not enabled in defconfig, g_uart_devs[i] is NULL, causing a HardFault crash during early boot.

The bug occurs because the original code only checked g_uart_devs[i]->priv without first verifying g_uart_devs[i] is not NULL. On Cortex-M4, NULL pointer dereference reads from Flash vector table (0x00000000 maps to 0x08000000), returning a function pointer that causes BusFault when written to.

This fix matches the existing NULL check pattern used in arm_serialinit() at line 2835 of the same file.

Tested on mplant-gd32f450 board with only USART5 enabled in defconfig. Before fix: HardFault at boot (IPSR=3, PC=0x080003e0) After fix: System boots normally to NSH Shell

## Impact

RELEASE

## Testing

CI