### PR TITLE
{bp-19043} mm/kasan: Fix compile options applied to wrong target in SPLIT build

### DIFF
--- a/arch/arm/src/cmake/elf.cmake
+++ b/arch/arm/src/cmake/elf.cmake
@@ -46,4 +46,4 @@ if(CONFIG_DEBUG_OPT_UNUSED_SECTIONS)
   endif()
 endif()
 
-nuttx_elf_link_options(-e __start)
+nuttx_elf_link_options(-e _start)

--- a/arch/arm64/src/cmake/elf.cmake
+++ b/arch/arm64/src/cmake/elf.cmake
@@ -32,4 +32,4 @@ nuttx_elf_link_options_ifdef(CONFIG_BUILD_KERNEL -Bstatic)
 
 nuttx_elf_link_options_ifdef(CONFIG_DEBUG_OPT_UNUSED_SECTIONS --gc-sections)
 
-nuttx_elf_link_options(-e __start)
+nuttx_elf_link_options(-e _start)

--- a/arch/x86_64/src/cmake/elf.cmake
+++ b/arch/x86_64/src/cmake/elf.cmake
@@ -30,4 +30,4 @@ nuttx_mod_link_options(-r)
 
 nuttx_elf_link_options_ifdef(CONFIG_DEBUG_OPT_UNUSED_SECTIONS --gc-sections)
 
-nuttx_elf_link_options(-e __start)
+nuttx_elf_link_options(-e _start)

--- a/cmake/nuttx_add_application.cmake
+++ b/cmake/nuttx_add_application.cmake
@@ -195,7 +195,6 @@ function(nuttx_add_application)
       # loadable build requires applying ELF flags to all applications
 
       if(CONFIG_MODULES)
-        add_dependencies(nuttx_apps_mksymtab ${TARGET})
         target_compile_options(
           ${TARGET}
           PRIVATE

--- a/mm/kasan/CMakeLists.txt
+++ b/mm/kasan/CMakeLists.txt
@@ -34,4 +34,9 @@ if(CONFIG_MM_KASAN)
 endif()
 
 target_sources(mm PRIVATE ${SRCS})
-target_compile_options(mm PRIVATE ${FLAGS})
+
+if(CONFIG_BUILD_FLAT)
+  target_compile_options(mm PRIVATE ${FLAGS})
+else()
+  target_compile_options(kmm PRIVATE ${FLAGS})
+endif()


### PR DESCRIPTION
## Summary

cmake/elf: Fix ELF entry point from __start to _start — The ELF entry point on ARM/ARM64/x86_64 incorrectly used __start (kernel boot entry) instead of _start (C runtime entry in crt0.c). arm64 and x86_64 elf.cmake already used _start; ARM was the outlier.
mm/kasan: Fix compile options applied to wrong target in SPLIT build — In SPLIT build, the kmm target carries the kasan code, but compile options were mistakenly applied to the mm target. In flat build, the kmm target does not exist, causing a CMake configuration error.
build/fix: remove nonexistent target in cmake — The nuttx_apps_mksymtab target does not exist in the nuttx repository, causing build failure when CONFIG_MODULES is enabled.

## Impact

RELEASE

## Testing

CI