### PR TITLE
{bp-19051} drivers/contactless/pn532: Fix potential overflow

### DIFF
--- a/drivers/contactless/pn532.c
+++ b/drivers/contactless/pn532.c
@@ -794,6 +794,7 @@ bool pn532_set_rf_config(struct pn532_dev_s * dev,
 
   pn532_frame_init(f, PN532_COMMAND_RFCONFIGURATION);
   f->data[1] = conf->cfg_item;
+  DEBUGASSERT(conf->data_size <= 16);
   memcpy(&f->data[2], conf->config, conf->data_size);
   f->len += conf->data_size + 1;
   pn532_frame_finish(f);


### PR DESCRIPTION
## Summary

Fixes a potential overflow where more than 16 bytes are written to the cmd_buffer.

## Impact

RELEASE

## Testing

CI