### PR TITLE
{bp-19068} sched/Kconfig: Fix ETC_ROMFS dependency

### DIFF
--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -534,9 +534,9 @@ endif # INIT_FILE
 menuconfig ETC_ROMFS
 	bool "Auto-mount etc baked-in ROMFS image"
 	default n
-	depends on !DISABLE_MOUNTPOINT && FS_ROMFS
+	depends on !DISABLE_MOUNTPOINT && (FS_ROMFS || FS_CROMFS)
 	---help---
-		Mount a ROMFS filesystem at /etc and provide a system init
+		Mount a ROMFS or a CROMFS filesystem at /etc and provide a system init
 		script at /etc/init.d/rc.sysinit and a startup script
 		at /etc/init.d/rcS.  The default system init script mounts
 		/tmp as TMPFS when FS_TMPFS is enabled, otherwise it can


### PR DESCRIPTION
## Summary

When using FS_CROMFS for etc, user typically don't need FS_ROMFS, they are completely separate filesystems. But both ETC_ROMFS and ETC_CROMFS are needed, the first one selects that the ETC needs to be mounted from ROM based filesystem, and ETC_CROMFS just specifies that the backing filesystem is actually the CROMFS.

Iow; make ETC_ROMFS depend on FS_ROMFS || FS_CROMFS, so that the user can drop FS_ROMFS when only FS_CROMFS is needed.

## Impact

RELEASE

## Testing

CI