### PR TITLE
include/pthread : initialize wait_count in PTHREAD_COND_INITIALIZER

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -279,7 +279,7 @@ typedef struct pthread_cond_s pthread_cond_t;
 #  define __PTHREAD_COND_T_DEFINED 1
 #endif
 
-#define PTHREAD_COND_INITIALIZER {SEM_INITIALIZER(0), CLOCK_REALTIME }
+#define PTHREAD_COND_INITIALIZER {SEM_INITIALIZER(0), CLOCK_REALTIME, 0}
 
 struct pthread_mutexattr_s
 {


### PR DESCRIPTION
# PR: Fix `PTHREAD_COND_INITIALIZER` missing `wait_count` initializer

## Summary

This PR patches NuttX 12.13.0 to fully initialize `pthread_cond_s` in `PTHREAD_COND_INITIALIZER`.

The patch updates:

```c
#define PTHREAD_COND_INITIALIZER {SEM_INITIALIZER(0), CLOCK_REALTIME }
```

to:

```c
#define PTHREAD_COND_INITIALIZER {SEM_INITIALIZER(0), CLOCK_REALTIME, 0}
```

## Motivation

During the NuttX 12.13.0 migration, strict builds emitted:

```text
warning: missing initializer for member 'pthread_cond_s::wait_count' [-Wmissing-field-initializers]
```

The warning is caused by the mismatch between the structure definition and the static initializer.

`pthread_cond_s` is defined with three fields:

```c
struct pthread_cond_s
{
  sem_t sem;
  clockid_t clockid;
  int wait_count;
};
```

but the initializer only covered `sem` and `clockid`.

## Fix

Initialize the third field explicitly:

```c
wait_count = 0
```

This makes `PTHREAD_COND_INITIALIZER` consistent with `struct pthread_cond_s`.

## Patch

File:

```text
OTSS/OS/nuttx/patches/0003-pthread_cond_initializer.patch
```

Change:

```diff
--- include/pthread.h
+++ include/pthread.h
@@ -279,7 +279,7 @@
 #  define __PTHREAD_COND_T_DEFINED 1
 #endif

-#define PTHREAD_COND_INITIALIZER {SEM_INITIALIZER(0), CLOCK_REALTIME }
+#define PTHREAD_COND_INITIALIZER {SEM_INITIALIZER(0), CLOCK_REALTIME, 0}

 struct pthread_mutexattr_s
 {
```

## Validation

Validated with a minimal compile test:

```c
#include <pthread.h>

pthread_cond_t cond = PTHREAD_COND_INITIALIZER;
```

The test now builds without the `pthread_cond_s::wait_count` missing-initializer warning.

Closes #19108
