### PR TITLE
fs/vfs/fs_lock.c: fix behavior according to manual and support SHM

### DIFF
--- a/fs/vfs/fs_lock.c
+++ b/fs/vfs/fs_lock.c
@@ -102,10 +102,13 @@ static int file_lock_get_path(FAR struct file *filep, FAR char *path)
   FAR struct tcb_s *tcb = this_task();
   bool is_allowed_type;
 
-  /* We only apply file lock on mountpt and driver (f_inode won't be NULL). */
+  /* We only apply file lock on mountpt, driver or shm
+   * (f_inode won't be NULL).
+   */
 
   is_allowed_type = INODE_IS_MOUNTPT(filep->f_inode) ||
-                    INODE_IS_DRIVER(filep->f_inode);
+                    INODE_IS_DRIVER(filep->f_inode) ||
+                    INODE_IS_SHM(filep->f_inode);
 
   if (!is_allowed_type || tcb->flags & TCB_FLAG_SIGNAL_ACTION)
     {

--- a/fs/vfs/fs_lock.c
+++ b/fs/vfs/fs_lock.c
@@ -260,18 +260,20 @@ static void file_lock_delete_bucket(FAR struct file_lock_bucket_s *bucket,
  ****************************************************************************/
 
 static bool file_lock_is_conflict(FAR struct flock *request,
-                                  FAR struct flock *internal)
+                                  FAR struct file *request_filep,
+                                  FAR struct file_lock_s *internal)
 {
   /* If the request is not exactly to the left or right of the internal,
    * then there is an overlap.
    */
 
-  if (request->l_start <= internal->l_end && request->l_end >=
-      internal->l_start)
+  if (request->l_start <= internal->fl_lock.l_end && request->l_end >=
+      internal->fl_lock.l_start)
     {
-      if (request->l_type == F_WRLCK || internal->l_type == F_WRLCK)
+      if (request->l_type == F_WRLCK || internal->fl_lock.l_type == F_WRLCK)
         {
-          return request->l_pid != internal->l_pid;
+          return request->l_pid != internal->fl_lock.l_pid ||
+                 request_filep != internal->fl_file;
         }
     }
 
@@ -371,8 +373,8 @@ static int file_lock_modify(FAR struct file *filep,
     {
       if (request->l_pid != file_lock->fl_lock.l_pid)
         {
-          /* Only file locks with the same pid need to be processed, so the
-           * lookup is skipped.
+          /* Only file locks with the same thread id need to be
+           * processed, so the lookup is skipped.
            */
 
           if (find)
@@ -598,7 +600,7 @@ int file_getlk(FAR struct file *filep, FAR struct flock *flock)
       list_for_every_entry(&bucket->list, file_lock, struct file_lock_s,
                            fl_node)
         {
-          if (file_lock_is_conflict(flock, &file_lock->fl_lock))
+          if (file_lock_is_conflict(flock, filep, file_lock))
             {
               memcpy(flock, &file_lock->fl_lock, sizeof(*flock));
               goto out;
@@ -677,7 +679,7 @@ int file_setlk(FAR struct file *filep, FAR struct flock *flock,
       goto out_free;
     }
 
-  request.l_pid = getpid();
+  request.l_pid = gettid();
 
   nxmutex_lock(&g_protect_lock);
 
@@ -709,7 +711,7 @@ retry:
       list_for_every_entry(&bucket->list, file_lock, struct file_lock_s,
                            fl_node)
         {
-          if (file_lock_is_conflict(&request, &file_lock->fl_lock))
+          if (file_lock_is_conflict(&request, filep, file_lock))
             {
               if (nonblock)
                 {


### PR DESCRIPTION
## Summary

Two commits:

**fs/vfs/fs_lock.c: fix flock behavior for more threads and fds**
We need to use gettid instead of getpid, otherwise flocks applied
from different threads are considered as single thread lock and are
ignored (or updated).

Also fix the behavior if process opens the file multiple times
Linux/BSD manual states multiple file descriptors opened by a single
process shall be treated independently. Therefore we also need to
compare struct file pointer to determine whether the lock applies
to the same descriptor or not.

**fs/vfs/fs_lock.c: support flock for SHM driver**
We can apply file lock on SHM inode as well. Ensure `file_lock_get_path`
function passes and doesn't return EBADF errno.

## Impact

Fixes `flock` behavior according to the manual and allows the usage of the function on SHM.

## Testing
Testing first commit (behavior fix) on standard files with two threads:

```c
#include <fcntl.h>
#include <pthread.h>
#include <stdio.h>
#include <sys/file.h>
#include <sys/mman.h>
#include <sys/stat.h>
#include <unistd.h>

static const char *name = "/tmp/test.txt";

static void *t(void *arg) {
	const mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP;
	int fd = open(name, O_RDWR | O_CREAT, mode);
	int ret = flock(fd, LOCK_SH | LOCK_NB);
	printf("2: should not lock: %d\n", ret);
	sleep(1);
	ret = flock(fd, LOCK_EX);
	printf("2: should lock: %d\n", ret);

	close(fd);
	return NULL;
}

int main(int argc, char *argv[]) {
	const mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP;
	int fd = open(name, O_RDWR | O_CREAT, mode);
	int ret = flock(fd, LOCK_SH);
	printf("1: should lock: %d\n", ret);
	ret = flock(fd, LOCK_EX);
	printf("1: should lock as EX even though locked: %d\n", ret);

	pthread_t thread;
	pthread_create(&thread, NULL, t, NULL);

	sleep(5);
	ret = flock(fd, LOCK_UN);
	printf("1: should unlock: %d\n", ret);
	close(fd);
	pthread_join(thread, NULL);
	return 0;
}
```

Linux output:

```
1: should lock: 0
1: should lock as EX even though locked: 0
2: should not lock: -1
1: should unlock: 0
2: should lock: 0
```

NuttX output (didn't lock before the change):

```
1: should lock: 0
1: should lock as EX even though locked: 0
2: should not lock: -1
1: should unlock: 0
2: should lock: 0
```

Testing first commit (behavior fix) on separate FDs within one thread:

```c
#include <fcntl.h>
#include <stdio.h>
#include <sys/file.h>
#include <sys/mman.h>
#include <sys/stat.h>
#include <unistd.h>

static const char *name = "/tmp/test.txt";

int main(int argc, char *argv[]) {
	const mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP;
	int fd = open(name, O_RDWR | O_CREAT, mode);
	int fd2 = open(name, O_RDWR | O_CREAT, mode);
	int ret = flock(fd, LOCK_SH);
	printf("1: should lock: %d\n", ret);
	ret = flock(fd2, LOCK_EX);
	printf("1: should lock as EX even though locked: %d\n", ret);

	sleep(5);
	ret = flock(fd, LOCK_UN);
	printf("1: should unlock: %d\n", ret);
	close(fd);
	return 0;
}
```

Linux output (blocked indefinitely)

```
1: should lock: 0
```

NuttX output (didn't block before the change)

```
1: should lock: 0
```

SHM test:

```c
#include <fcntl.h>
#include <pthread.h>
#include <stdio.h>
#include <sys/file.h>
#include <sys/mman.h>
#include <sys/stat.h>
#include <unistd.h>

static const char *name = "shm-test";

struct shared {
	int value;
};

static void *t(void *arg) {
	const mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP;
	int fd = shm_open(name, O_RDWR | O_CREAT, mode);

	void *res = mmap(
		NULL, sizeof(struct shared), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);
	int ret = flock(fd, LOCK_SH | LOCK_NB);
	printf("2: should not lock: %d\n", ret);
	sleep(1);
	ret = flock(fd, LOCK_EX);
	printf("2: should lock: %d\n", ret);

	close(fd);
	return NULL;
}

int main(int argc, char *argv[]) {
	const mode_t mode = S_IRUSR | S_IWUSR | S_IRGRP | S_IWGRP;
	int fd = shm_open(name, O_RDWR | O_CREAT, mode);

	void *res = mmap(
		NULL, sizeof(struct shared), PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0);

	int ret = flock(fd, LOCK_SH);
	printf("1: should lock: %d\n", ret);
	ret = flock(fd, LOCK_EX);
	printf("1: should lock as EX even though locked: %d\n", ret);

	pthread_t thread;
	pthread_create(&thread, NULL, t, NULL);

	sleep(5);
	ret = flock(fd, LOCK_UN);
	printf("1: should unlock: %d\n", ret);
	close(fd);
	pthread_join(thread, NULL);
	return 0;
}
```

Linux output

```
1: should lock: 0
1: should lock as EX even though locked: 0
2: should not lock: -1
1: should unlock: 0
2: should lock: 0
```

NuttX output (failed with `EBADF` errno before the change)

```
1: should lock: 0
1: should lock as EX even though locked: 0
2: should not lock: -1
1: should unlock: 0
2: should lock: 0
```