### PR TITLE
arch/arm/gd32f4: fix missing CTL selector bits in up_disableusartint.

### DIFF
--- a/arch/arm/src/gd32f4/gd32f4xx_serial.c
+++ b/arch/arm/src/gd32f4/gd32f4xx_serial.c
@@ -1142,25 +1142,47 @@ static void up_disableusartint(struct up_dev_s *priv, uint32_t *ie)
     {
       uint32_t ctl;
 
+      ctl_ie = 0;
+
       /* Save interrupt in CTL0 register */
 
       ctl = up_serialin(priv, GD32_USART_CTL0_OFFSET);
-      ctl_ie = ((ctl & USART_CTL0_USED_INTS) >> USART_CFG_CTL0_INT_SHIFT);
+      if (ctl & USART_CTL0_USED_INTS)
+        {
+          ctl_ie |= ((ctl & USART_CTL0_USED_INTS) >>
+                       USART_CFG_CTL0_INT_SHIFT);
+          ctl_ie |= (USART_CFG_CTL0_INT << USART_CFG_SHIFT);
+        }
 
       /* Save interrupt in CTL1 register */
 
       ctl = up_serialin(priv, GD32_USART_CTL1_OFFSET);
-      ctl_ie |= ((ctl & USART_CTL1_USED_INTS) >> USART_CFG_CTL1_INT_SHIFT);
+      if (ctl & USART_CTL1_USED_INTS)
+        {
+          ctl_ie |= ((ctl & USART_CTL1_USED_INTS) >>
+                       USART_CFG_CTL1_INT_SHIFT);
+          ctl_ie |= (USART_CFG_CTL1_INT << USART_CFG_SHIFT);
+        }
 
       /* Save interrupt in CTL2 register */
 
       ctl = up_serialin(priv, GD32_USART_CTL2_OFFSET);
-      ctl_ie |= ((ctl & USART_CTL2_USED_INTS) << USART_CFG_CTL2_INT_SHIFT);
+      if (ctl & USART_CTL2_USED_INTS)
+        {
+          ctl_ie |= ((ctl & USART_CTL2_USED_INTS) <<
+                       USART_CFG_CTL2_INT_SHIFT);
+          ctl_ie |= (USART_CFG_CTL2_INT << USART_CFG_SHIFT);
+        }
 
       /* Save interrupt in CTL3 register */
 
       ctl = up_serialin(priv, GD32_USART_CTL3_OFFSET);
-      ctl_ie |= ((ctl & USART_CTL3_USED_INTS) << USART_CFG_CTL3_INT_SHIFT);
+      if (ctl & USART_CTL3_USED_INTS)
+        {
+          ctl_ie |= ((ctl & USART_CTL3_USED_INTS) <<
+                       USART_CFG_CTL3_INT_SHIFT);
+          ctl_ie |= (USART_CFG_CTL3_INT << USART_CFG_SHIFT);
+        }
 
       *ie = ctl_ie;
     }

--- a/arch/arm/src/gd32f4/gd32f4xx_serial.c
+++ b/arch/arm/src/gd32f4/gd32f4xx_serial.c
@@ -2763,7 +2763,7 @@ void arm_earlyserialinit(void)
 
   for (i = 0; i < GD32_NUSART; i++)
     {
-      if (g_uart_devs[i]->priv)
+      if (g_uart_devs[i] && g_uart_devs[i]->priv)
         {
           up_disableusartint(g_uart_devs[i]->priv, 0);
         }


### PR DESCRIPTION
## Summary

Fix a bug in `up_disableusartint()` where USART interrupt state is saved without CTL selector bits (bits 24-27), causing  `up_restoreusartint() ` to never restore interrupt enables.

## Problem

 `up_disableusartint() ` saves interrupt state from hardware CTL0-CTL3 registers into an encoded  `ie` value, but omits the CTL selector bits. When  `up_restoreusartint() ` later restores interrupts using  `ie >> 24 ` to determine which CTL register to write, this evaluates to 0, so no CTL register is updated and all interrupt enables (including RBNEIE) are permanently lost.

This causes RX interrupts to never fire after any call to  `up_putc() `  (e.g. via syslog), making the serial console unable to receive input on GD32F4 platforms.

## Impact

- Serial console TX works normally (output is visible)
- Serial console RX is completely broken (no input accepted, no NSH prompt)
- Affects all GD32F4 USART ports when syslog or  `up_putc() ` is used

## Fix

Add the corresponding CTL selector bit ( `USART_CFG_CTLx_INT << USART_CFG_SHIFT `) whenever a CTL register has active interrupt bits, so that  `up_restoreusartint() ` can correctly identify and restore the interrupt state.

## Testing

Tested on mplant-gd32f450 custom board (GD32F450ZGT6) with USART5 as serial console:
- Before fix: NSH can output debug prints but cannot accept input, no \
sh>\ prompt , like this
```
ASERIAL: up_setup done base=0x40011400 CTL0=0x0000200c BAUD=0x00000364
BD
SERIAL: up_attach base=0x40011400 irq=87
SERIAL: up_attach IRQ87 enabled OK
SERIAL: up_rxint enable=1 base=0x40011400 ie=0x00000000
SERIAL: up_rxint done ie=0x01000002
bringup: USART5@0x40011400
  STAT0=0x00000000
```
- After fix: NSH works correctly with both input and output, \
sh>\ prompt appears, like this
```
Nuttheartbeat: led task running
Shell (NSH)
Board: mplant-gd32f450 (GD32F450IK)
MCU:  GD32F450 200MHz, 112 KB SRAM

nsh> 
```