### PR TITLE
sched/group: implement saved-set-UID/GID semantics

### DIFF
--- a/Documentation/implementation/index.rst
+++ b/Documentation/implementation/index.rst
@@ -38,4 +38,5 @@ Implementation Details
    tasks_vs_threads.rst
    tickless_os.rst
    tls.rst
+   user_identity.rst
    usb.rst

--- a/Documentation/implementation/tasks_vs_threads.rst
+++ b/Documentation/implementation/tasks_vs_threads.rst
@@ -69,6 +69,8 @@ reside within the task group structure struct ``task_group_s``:
 * Opened message queues.
 * ``pthread`` keys.
 * Support data for ``atexit()``, ``on_exit()``, and/or ``waitpid()``.
+* User and group identity when ``CONFIG_SCHED_USER_IDENTITY`` is enabled
+  (see :ref:`user-identity`).
 
 The exception is the PIC address space used with NXFLAT.
 It currently has its own data structure (struct ``dspace_s``,

--- a/Documentation/implementation/user_identity.rst
+++ b/Documentation/implementation/user_identity.rst
@@ -1,0 +1,71 @@
+.. _user-identity:
+
+=======================
+User and Group Identity
+=======================
+
+When ``CONFIG_SCHED_USER_IDENTITY`` is enabled, each task group maintains POSIX
+process credentials. All threads within a task group share the same credentials
+(see :ref:`tasks-vs-threads`).
+
+Credentials
+===========
+
+The full POSIX three-field credential model is stored in ``struct task_group_s``
+(``include/nuttx/sched.h``):
+
+* ``tg_uid`` / ``tg_gid`` — real user and group IDs.
+* ``tg_euid`` / ``tg_egid`` — effective IDs used for permission checks.
+* ``tg_suid`` / ``tg_sgid`` — saved set-IDs that allow a non-root process to
+  restore a previously held effective ID.
+
+All six fields are zero-initialized at task creation, so the initial task runs
+as root (UID/GID 0) unless explicitly changed.
+
+Inheritance
+===========
+
+When a new task is created, ``group_inherit_identity()`` in
+``sched/group/group_create.c`` copies all six credential fields from the parent
+task group to the child task group.
+
+Privilege Transitions
+=====================
+
+``setuid()`` and ``setgid()``
+-----------------------------
+
+When the effective ID is zero (root):
+
+* ``setuid(uid)`` sets ``tg_uid``, ``tg_euid``, and ``tg_suid`` to ``uid``.
+* ``setgid(gid)`` sets ``tg_gid``, ``tg_egid``, and ``tg_sgid`` to ``gid``.
+
+When the effective ID is non-zero:
+
+* The caller may only set the effective ID to the current real or saved value.
+* Any other value causes the function to return ``-1`` with ``errno`` set to
+  ``EPERM``.
+
+``seteuid()`` and ``setegid()``
+-------------------------------
+
+When the effective ID is zero, any value may be assigned as the new effective
+ID.
+
+When the effective ID is non-zero, the requested value must equal the real or
+the saved ID. Otherwise the function returns ``-1`` with ``errno`` set to
+``EPERM``.
+
+This implements the standard POSIX pattern of temporarily dropping privileges
+with ``seteuid()`` or ``setegid()`` and later restoring them to the saved value.
+
+Configuration
+=============
+
+``CONFIG_SCHED_USER_IDENTITY``
+  Enables per-task-group credential tracking. Without this option, stub
+  root-only versions of all credential interfaces are provided.
+
+``CONFIG_FS_PERMISSION``
+  Enables filesystem ownership and permission enforcement. Requires
+  ``CONFIG_SCHED_USER_IDENTITY``.

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -455,13 +455,13 @@ struct task_group_s
   pid_t tg_ppid;                    /* This is the ID of the parent thread      */
   uint8_t tg_flags;                 /* See GROUP_FLAG_* definitions             */
 
-  /* User identity **********************************************************/
+  /* User identity (POSIX real, effective, and saved-set IDs) ***************/
 
 #ifdef CONFIG_SCHED_USER_IDENTITY
-  uid_t   tg_uid;                   /* User identity                            */
-  gid_t   tg_gid;                   /* User group identity                      */
+  uid_t   tg_uid;                   /* Real user identity                       */
+  gid_t   tg_gid;                   /* Real group identity                      */
   uid_t   tg_euid;                  /* Effective user identity                  */
-  gid_t   tg_egid;                  /* Effective user group identity            */
+  gid_t   tg_egid;                  /* Effective group identity                 */
   uid_t   tg_suid;                  /* Saved set-user identity                  */
   gid_t   tg_sgid;                  /* Saved set-group identity                 */
 #endif

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -462,6 +462,8 @@ struct task_group_s
   gid_t   tg_gid;                   /* User group identity                      */
   uid_t   tg_euid;                  /* Effective user identity                  */
   gid_t   tg_egid;                  /* Effective user group identity            */
+  uid_t   tg_suid;                  /* Saved set-user identity                  */
+  gid_t   tg_sgid;                  /* Saved set-group identity                 */
 #endif
 
   /* Group membership *******************************************************/

--- a/sched/Kconfig
+++ b/sched/Kconfig
@@ -789,12 +789,19 @@ config SCHED_USER_IDENTITY
 	bool "Support per-task User Identity"
 	default n
 	---help---
-		This selection enables functionality of getuid(), setuid(), getgid(),
-		setgid().  If this option is not selected, then stub, root-only
-		versions of these interfaces are available.  When selected, these
-		interfaces will associate a UID and/or GID with each task group.
-		Those can then be managed using the interfaces.  Child tasks will
-		inherit the UID and GID of its parent.
+		Enable per-task-group POSIX user and group credentials.
+
+		When selected, each task group tracks real, effective, and saved-set
+		UID/GID values and provides getuid(), getgid(), geteuid(),
+		getegid(), setuid(), setgid(), seteuid(), and setegid().
+
+		Child tasks inherit all credential fields from the parent task
+		group.  setuid()/setgid() update real, effective, and saved-set
+		IDs when called with effective privileges; seteuid()/setegid()
+		implement the standard POSIX privilege transition rules.
+
+		If this option is not selected, stub root-only versions of these
+		interfaces are available instead.
 
 config SCHED_THREAD_LOCAL
 	bool "Support __thread/thread_local keyword"

--- a/sched/group/group_create.c
+++ b/sched/group/group_create.c
@@ -78,10 +78,12 @@ static inline void group_inherit_identity(FAR struct task_group_s *group)
   /* Inherit the user identity from the parent task group. */
 
   DEBUGASSERT(group != NULL);
-  group->tg_uid = rgroup->tg_uid;
-  group->tg_gid = rgroup->tg_gid;
+  group->tg_uid  = rgroup->tg_uid;
+  group->tg_gid  = rgroup->tg_gid;
   group->tg_euid = rgroup->tg_euid;
   group->tg_egid = rgroup->tg_egid;
+  group->tg_suid = rgroup->tg_suid;
+  group->tg_sgid = rgroup->tg_sgid;
 }
 #else
 #  define group_inherit_identity(group)

--- a/sched/group/group_setegid.c
+++ b/sched/group/group_setegid.c
@@ -78,9 +78,20 @@ int setegid(gid_t gid)
   rtcb   = this_task();
   rgroup = rtcb->group;
 
-  /* Set the task group's group identity. */
-
   DEBUGASSERT(rgroup != NULL);
-  rgroup->tg_egid = gid;
+
+  if (rgroup->tg_egid == 0 ||
+      gid == rgroup->tg_gid || gid == rgroup->tg_sgid)
+    {
+      /* Root may set any value; non-root may only set to real or saved. */
+
+      rgroup->tg_egid = gid;
+    }
+  else
+    {
+      set_errno(EPERM);
+      return ERROR;
+    }
+
   return OK;
 }

--- a/sched/group/group_seteuid.c
+++ b/sched/group/group_seteuid.c
@@ -80,9 +80,20 @@ int seteuid(uid_t uid)
   rtcb   = this_task();
   rgroup = rtcb->group;
 
-  /* Set the task group's group identity. */
-
   DEBUGASSERT(rgroup != NULL);
-  rgroup->tg_euid = uid;
+
+  if (rgroup->tg_euid == 0 ||
+      uid == rgroup->tg_uid || uid == rgroup->tg_suid)
+    {
+      /* Root may set any value; non-root may only set to real or saved. */
+
+      rgroup->tg_euid = uid;
+    }
+  else
+    {
+      set_errno(EPERM);
+      return ERROR;
+    }
+
   return OK;
 }

--- a/sched/group/group_setgid.c
+++ b/sched/group/group_setgid.c
@@ -79,9 +79,27 @@ int setgid(gid_t gid)
   rtcb   = this_task();
   rgroup = rtcb->group;
 
-  /* Set the task group's group identity. */
-
   DEBUGASSERT(rgroup != NULL);
-  rgroup->tg_gid = gid;
+
+  if (rgroup->tg_egid == 0)
+    {
+      /* Root: set real, effective, and saved set-group-ID. */
+
+      rgroup->tg_gid  = gid;
+      rgroup->tg_egid = gid;
+      rgroup->tg_sgid = gid;
+    }
+  else if (gid == rgroup->tg_gid || gid == rgroup->tg_sgid)
+    {
+      /* Non-root: may only set effective GID to real or saved value. */
+
+      rgroup->tg_egid = gid;
+    }
+  else
+    {
+      set_errno(EPERM);
+      return ERROR;
+    }
+
   return OK;
 }

--- a/sched/group/group_setuid.c
+++ b/sched/group/group_setuid.c
@@ -80,9 +80,27 @@ int setuid(uid_t uid)
   rtcb   = this_task();
   rgroup = rtcb->group;
 
-  /* Set the task group's group identity. */
-
   DEBUGASSERT(rgroup != NULL);
-  rgroup->tg_uid = uid;
+
+  if (rgroup->tg_euid == 0)
+    {
+      /* Root: set real, effective, and saved set-user-ID. */
+
+      rgroup->tg_uid  = uid;
+      rgroup->tg_euid = uid;
+      rgroup->tg_suid = uid;
+    }
+  else if (uid == rgroup->tg_uid || uid == rgroup->tg_suid)
+    {
+      /* Non-root: may only set effective UID to real or saved value. */
+
+      rgroup->tg_euid = uid;
+    }
+  else
+    {
+      set_errno(EPERM);
+      return ERROR;
+    }
+
   return OK;
 }


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Adds tg_suid and tg_sgid fields to task_group_s to complete the POSIX three-field identity model (real, effective, saved-set). Updates group_inherit_identity() to propagate the new fields from parent to child task group on task creation.

Fixes setuid(), setgid(), seteuid(), and setegid() to implement correct POSIX privilege transition logic:
- Root (euid==0): may set any value; all three IDs updated by setuid/setgid
- Non-root: may only set effective ID to real or saved value; else EPERM

## Impact

NuttX currently tracks only real and effective credentials. POSIX credential semantics require a saved set-user-ID and saved set-group-ID to support temporary privilege dropping and later restoration through seteuid()/setegid().

Adding saved IDs enables the standard privilege transition model used by setuid/setgid applications and provides the foundation for complete multi-user support. (https://github.com/apache/nuttx/issues/18458)

## Testing

<img width="877" height="811" alt="image" src="https://github.com/user-attachments/assets/ef727dee-0d5f-4fe9-b151-fe5830856c15" />
