### PR TITLE
libs/libc/pthread/pthread_mutex: Fix robust mutex initialization

### DIFF
--- a/libs/libc/pthread/pthread_mutex_init.c
+++ b/libs/libc/pthread/pthread_mutex_init.c
@@ -86,7 +86,7 @@ int pthread_mutex_init(FAR pthread_mutex_t *mutex,
   mutex->flags = attr && attr->robust == PTHREAD_MUTEX_ROBUST ?
                  _PTHREAD_MFLAGS_ROBUST : 0;
 #  else
-  mutex->flags = 0;
+  mutex->flags = _PTHREAD_MFLAGS_ROBUST;
 #  endif
 #endif
 


### PR DESCRIPTION
## Summary

This fixes an issue where ostest robust mutex test gets stuck.

I found this issue while working on another signals PR, ostest was getting stuck in robust mutex test:

```
...
robust_test: Initializing mutex
robust_test: Starting thread
robust_waiter: Taking mutex
robust_waiter: Exiting with mutex
<stuck forever>
```
In this config:

```
# CONFIG_PTHREAD_MUTEX_TYPES is not set
CONFIG_PTHREAD_MUTEX_ROBUST=y
# CONFIG_PTHREAD_MUTEX_UNSAFE is not set
# CONFIG_PTHREAD_MUTEX_BOTH is not set
# CONFIG_PTHREAD_MUTEX_DEFAULT_PRIO_NONE is not set
CONFIG_PTHREAD_MUTEX_DEFAULT_PRIO_INHERIT=y
```

In CONFIG_PTHREAD_MUTEX_ROBUST mode, every NORMAL mutex is robust by definition, so the robust flag must be set to allow the mutex to be tracked in the holder's mutex list.

Otherwise, pthread_mutex_add() will not record the mutex and pthread_mutex_inconsistent() will not be able to mark it as inconsistent or wake waiters when the holder thread terminates.

This looks like a regression from

```
commit 6e8ae12ef1c52e42932b5223ad41399f062bc0c6
Author: hujun5 <hujun5@xiaomi.com>
Date:   Sun Aug 17 10:47:26 2025 +0800

    pthread: make PTHREAD_MUTEX_DEFAULT_UNSAFE default true
```

## Impact

Fixes robust mutexes in all platforms, checked with stm32f7 and sim platforms.

## Testing

Tested on ostest in sim and stm32f7 platforms. Attached a log from ostest after this fix. Before the fix, the ostest gets stuck in robust mutex test.
[pixhawk4_ostest_partial_signal.txt](https://github.com/user-attachments/files/28840978/pixhawk4_ostest_partial_signal.txt)
