### PR TITLE
fs/binfmt: Enforce POSIX execute permissions prior to binary load

### DIFF
--- a/binfmt/CMakeLists.txt
+++ b/binfmt/CMakeLists.txt
@@ -41,6 +41,10 @@ list(
   binfmt_copyactions.c
   binfmt_dumpmodule.c)
 
+if(CONFIG_SCHED_USER_IDENTITY)
+  list(APPEND SRCS binfmt_checkexec.c)
+endif()
+
 if(CONFIG_BINFMT_LOADABLE)
   list(APPEND SRCS binfmt_exit.c)
 endif()

--- a/binfmt/Makefile
+++ b/binfmt/Makefile
@@ -28,6 +28,10 @@ CSRCS  = binfmt_globals.c binfmt_initialize.c binfmt_register.c binfmt_unregiste
 CSRCS += binfmt_loadmodule.c binfmt_unloadmodule.c binfmt_execmodule.c
 CSRCS += binfmt_exec.c binfmt_copyargv.c binfmt_copyactions.c binfmt_dumpmodule.c
 
+ifeq ($(CONFIG_SCHED_USER_IDENTITY),y)
+CSRCS += binfmt_checkexec.c
+endif
+
 ifeq ($(CONFIG_BINFMT_LOADABLE),y)
 CSRCS += binfmt_exit.c
 endif

--- a/binfmt/binfmt.h
+++ b/binfmt/binfmt.h
@@ -213,6 +213,26 @@ void binfmt_freeactions(FAR const posix_spawn_file_actions_t *copy);
 #  define binfmt_freeactions(copy)
 #endif
 
+#ifdef CONFIG_SCHED_USER_IDENTITY
+/****************************************************************************
+ * Name: binfmt_checkexecperm
+ *
+ * Description:
+ *   Verify that the calling task has execute permission on the file
+ *   described by 'bin'.  The file owner, group, and mode must already be
+ *   populated in the binary_s structure.
+ *
+ * Input Parameters:
+ *   bin - Load structure with uid, gid, and mode populated
+ *
+ * Returned Value:
+ *   Zero (OK) on success; -EACCES if execute permission is denied.
+ *
+ ****************************************************************************/
+
+int binfmt_checkexecperm(FAR struct binary_s *bin);
+#endif
+
 #ifdef CONFIG_BUILTIN
 /****************************************************************************
  * Name: builtin_initialize

--- a/binfmt/binfmt_checkexec.c
+++ b/binfmt/binfmt_checkexec.c
@@ -1,0 +1,100 @@
+/****************************************************************************
+ * binfmt/binfmt_checkexec.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/stat.h>
+#include <errno.h>
+
+#include <nuttx/sched.h>
+#include <nuttx/binfmt/binfmt.h>
+
+#include "binfmt.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: binfmt_checkexecperm
+ *
+ * Description:
+ *   Verify that the calling task has execute permission on the file
+ *   described by 'bin'.  The file owner, group, and mode must already be
+ *   populated in the binary_s structure before calling this function.
+ *
+ * Input Parameters:
+ *   bin - Pointer to the binary descriptor with uid, gid, and mode set.
+ *
+ * Returned Value:
+ *   Zero (OK) on success; -EACCES if execute permission is denied.
+ *
+ ****************************************************************************/
+
+int binfmt_checkexecperm(FAR struct binary_s *bin)
+{
+  FAR struct tcb_s *rtcb;
+  mode_t xbits;
+
+  rtcb = nxsched_self();
+
+  if (bin == NULL || rtcb == NULL || rtcb->group == NULL)
+    {
+      return OK;
+    }
+
+  if (rtcb->group->tg_euid == 0)
+    {
+      /* Root can execute any file that has at least one execute bit set */
+
+      if ((bin->mode & (S_IXUSR | S_IXGRP | S_IXOTH)) == 0)
+        {
+          return -EACCES;
+        }
+
+      return OK;
+    }
+
+  if (rtcb->group->tg_euid == bin->uid)
+    {
+      xbits = S_IXUSR;
+    }
+  else if (rtcb->group->tg_egid == bin->gid)
+    {
+      xbits = S_IXGRP;
+    }
+  else
+    {
+      xbits = S_IXOTH;
+    }
+
+  if ((bin->mode & xbits) == 0)
+    {
+      return -EACCES;
+    }
+
+  return OK;
+}

--- a/binfmt/binfmt_exec.c
+++ b/binfmt/binfmt_exec.c
@@ -31,7 +31,6 @@
 #include <errno.h>
 
 #include <nuttx/kmalloc.h>
-#include <nuttx/sched.h>
 #include <nuttx/binfmt/binfmt.h>
 
 #include "binfmt.h"
@@ -81,11 +80,13 @@ static int exec_internal(FAR const char *filename,
                          FAR const posix_spawnattr_t *attr, bool spawn)
 {
   FAR struct binary_s *bin;
-  int pid;
-  int ret;
 #ifndef CONFIG_BINFMT_LOADABLE
   struct binary_s sbin;
+#endif
+  int pid;
+  int ret;
 
+#ifndef CONFIG_BINFMT_LOADABLE
   bin = &sbin;
   memset(bin, 0, sizeof(*bin));
 #else

--- a/binfmt/binfmt_loadmodule.c
+++ b/binfmt/binfmt_loadmodule.c
@@ -134,6 +134,14 @@ static int load_absmodule(FAR struct binary_s *bin, FAR const char *filename,
           binfmt_dumpmodule(bin);
           break;
         }
+      else if (ret == -EACCES)
+        {
+          /* Access explicitly denied -- stop here; do not let a fallback
+           * loader bypass the execute-permission check that already ran.
+           */
+
+          break;
+        }
     }
 
   return ret;

--- a/binfmt/builtin.c
+++ b/binfmt/builtin.c
@@ -34,6 +34,8 @@
 #include <nuttx/binfmt/binfmt.h>
 #include <nuttx/lib/builtin.h>
 
+#include "binfmt.h"
+
 #ifdef CONFIG_BUILTIN
 
 /****************************************************************************
@@ -76,6 +78,9 @@ static int builtin_loadbinary(FAR struct binary_s *binp,
   FAR const struct builtin_s *builtin;
   FAR char *name;
   int index;
+#ifdef CONFIG_SCHED_USER_IDENTITY
+  int chk;
+#endif
 
   binfo("Loading file: %s\n", filename);
 
@@ -105,14 +110,21 @@ static int builtin_loadbinary(FAR struct binary_s *binp,
       return -ENOENT;
     }
 
+#ifdef CONFIG_SCHED_USER_IDENTITY
+  binp->uid  = builtin->uid;
+  binp->gid  = builtin->gid;
+  binp->mode = builtin->mode;
+
+  chk = binfmt_checkexecperm(binp);
+  if (chk < 0)
+    {
+      return chk;
+    }
+#endif
+
   binp->entrypt   = builtin->main;
   binp->stacksize = builtin->stacksize;
   binp->priority  = builtin->priority;
-#ifdef CONFIG_SCHED_USER_IDENTITY
-  binp->uid       = builtin->uid;
-  binp->gid       = builtin->gid;
-  binp->mode      = builtin->mode;
-#endif
 
   return OK;
 }

--- a/binfmt/elf.c
+++ b/binfmt/elf.c
@@ -37,6 +37,8 @@
 #include <nuttx/binfmt/binfmt.h>
 #include <nuttx/kmalloc.h>
 
+#include "binfmt.h"
+
 #ifdef CONFIG_ELF
 
 /****************************************************************************
@@ -109,6 +111,20 @@ static int elf_loadbinary(FAR struct binary_s *binp,
       berr("Failed to initialize to load ELF program binary: %d\n", ret);
       goto errout_with_init;
     }
+
+#ifdef CONFIG_SCHED_USER_IDENTITY
+  /* Save IDs and mode from file system before loading segments */
+
+  binp->uid  = loadinfo.fileuid;
+  binp->gid  = loadinfo.filegid;
+  binp->mode = loadinfo.filemode;
+
+  ret = binfmt_checkexecperm(binp);
+  if (ret < 0)
+    {
+      goto errout_with_init;
+    }
+#endif
 
   /* Load the program binary */
 
@@ -199,14 +215,6 @@ static int elf_loadbinary(FAR struct binary_s *binp,
 
   binp->mod.finiarr = loadinfo.finiarr;
   binp->mod.nfini   = loadinfo.nfini;
-#endif
-
-#ifdef CONFIG_SCHED_USER_IDENTITY
-  /* Save IDs and mode from file system */
-
-  binp->uid  = loadinfo.fileuid;
-  binp->gid  = loadinfo.filegid;
-  binp->mode = loadinfo.filemode;
 #endif
 
   libelf_dumpentrypt(&loadinfo);

--- a/binfmt/nxflat.c
+++ b/binfmt/nxflat.c
@@ -27,6 +27,7 @@
 #include <nuttx/config.h>
 
 #include <sys/param.h>
+#include <sys/stat.h>
 #include <sys/types.h>
 #include <stdint.h>
 #include <string.h>
@@ -36,9 +37,12 @@
 
 #include <arpa/inet.h>
 
+#include <nuttx/fs/fs.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/binfmt/binfmt.h>
 #include <nuttx/binfmt/nxflat.h>
+
+#include "binfmt.h"
 
 #ifdef CONFIG_NXFLAT
 
@@ -142,6 +146,9 @@ static int nxflat_loadbinary(FAR struct binary_s *binp,
                              int nexports)
 {
   struct nxflat_loadinfo_s loadinfo;  /* Contains globals for libnxflat */
+#ifdef CONFIG_SCHED_USER_IDENTITY
+  struct stat              st;
+#endif
   int                      ret;
 
   binfo("Loading file: %s\n", filename);
@@ -155,6 +162,25 @@ static int nxflat_loadbinary(FAR struct binary_s *binp,
       berr("Failed to initialize for load of NXFLAT program: %d\n", ret);
       goto errout;
     }
+
+#ifdef CONFIG_SCHED_USER_IDENTITY
+  ret = file_fstat(&loadinfo.file, &st);
+  if (ret < 0)
+    {
+      berr("Failed to stat NXFLAT program binary: %d\n", ret);
+      goto errout_with_init;
+    }
+
+  binp->uid  = st.st_uid;
+  binp->gid  = st.st_gid;
+  binp->mode = st.st_mode;
+
+  ret = binfmt_checkexecperm(binp);
+  if (ret < 0)
+    {
+      goto errout_with_init;
+    }
+#endif
 
   /* Load the program binary */
 


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

This change adds execute permission enforcement to the binfmt subsystem, ensuring that binaries can only be executed when the calling user has the appropriate execute permissions. Unauthorized execution attempts are rejected with 
-EACCES.

A new helper, `binfmt_checkexecperm()`, has been added in `binfmt_checkexec.c `to centralize execute permission evaluation. The helper handles the standard owner, group, other, and root permission checks in one place.

The permission check is performed directly within the binary loaders (such as ELF) immediately after the file metadata has been loaded. Since the loaders already have access to the file mode information through loadinfo.filemode, no additional stat() calls or VFS lookups are required. Unauthorized binaries are therefore rejected early with -EACCES, before any memory allocation or loading work begins.

To prevent bypasses through loader fallback logic, load_absmodule() now stops processing if a loader returns -EACCES. This ensures that once execution is denied due to permissions, the request cannot fall through to another loader.


## Impact

Brings the binfmt subsystem into stricter adherence with standard POSIX execution semantics.

## Testing

Hardware: ESP32-C3 SuperMini
Configuration: esp32c3-devkit:usbconsole
Enabled Flags: `CONFIG_ELF`, `CONFIG_FS_ROMFS`, `CONFIG_SCHED_USER_IDENTITY`, `CONFIG_FS_PERMISSION`

Methodology:
Compiled ELF binaries were embedded into a ROMFS image to guarantee static, immutable file permissions during the test. The tests verify that exec_internal() correctly evaluates the POSIX mode before handing the file off to the ELF loader.

### Test A: Execution Denied (Mode 0444)
- Setup: ROMFS ELF embedded with -r--r--r-- permissions.
- Result: The pre-load check successfully intercepts the call. It evaluates the mode, denies execution, and cleanly returns -EACCES. The system remains entirely stable with no memory allocated.

Actual log:
```
nsh> elf
checkexecperm: bin=0x3fc868d0 mode=0555 uid=0 gid=0 rtcb=0x3fc86f08 group=0x3fc86fd8 euid=0
Initial memory usage: 8528
Registering romdisk at /dev/ram1

Memory Usage after romdisk_register:
  Before:     8528 After:     8656 Change:      128
Mounting ROMFS filesystem at target=/mnt/elf/romfs with source=/dev/ram1

Memory Usage after mount:
  Before:     8656 After:     9352 Change:      696

****************************************************************************
* Executing errno
************************checkexecperm: bin=0x3fc884a8 mode=*100444 uid=*0 gid=0 rtcb=0x3fc86968 group=0x3fc86a38 euid=0
**************************************************


Memory Usage after exec:
  Before:     9352 After:     9352 Change:        0
ERROR: exec(errno) failed: Permission denied

Memory Usage after program execution:
  Before:     9352 After:     9352 Change:        0

****************************************************************************
* Executing hello
******************************c*heckexecperm: b*in=*0x3fc884a8 mode=*100444 uid=0 gid=0 rtcb=0x3fc86968 group=0x3fc86a38 euid=*0
*****************************************


Memory Usage after exec:
  Before:     9352 After:     9352 Change:        0
ERROR: exec(hello) failed: Permission denied

Memory Usage after program execution:
  Before:     9352 After:     9352 Change:        0

****************************************************************************
* Executing signal
************************checkexecperm: bin=0x**3fc884a8 mode=100444 uid=*0 gid=*0 rtcb=**0x3fc86968 group=*0x3fc86a38 euid=*0
********************************************


Memory Usage after exec:
  Before:     9352 After:     9352 Change:        0
ERROR: exec(signal) failed: Permission denied

Memory Usage after program execution:
  Before:     9352 After:     9352 Change:        0

****************************************************************************
* Executing struct
***************************checkexecperm: bin=****0x3fc884a8 mode=*100444 uid=*0 gid=0 rtcb=**0x3fc86968 group=**0x3fc86a38 euid=0
***************************************


Memory Usage after exec:
  Before:     9352 After:     9352 Change:        0
ERROR: exec(struct) failed: Permission denied

Memory Usage after program execution:
  Before:     9352 After:     9352 Change:        0

****************************************************************************
* Executing mutex
******************************c**heckexecperm: bin=*0x3fc884a8 mode=**100444 uid=*0 gid=0 rtcb=0x3fc86968 group=**0x3fc86a38 euid=0
**************************************


Memory Usage after exec:
  Before:     9352 After:     9352 Change:        0
ERROR: exec(mutex) failed: Permission denied

Memory Usage after program execution:
  Before:     9352 After:     9352 Change:        0

****************************************************************************
* Executing pthread
**************************c*heckexecperm: bin=**0x3fc884a8 mode=**100444 uid=0 gid=*0 rtcb=*0x3fc86968 group=**0x3fc86a38 euid=0
*****************************************


Memory Usage after exec:
  Before:     9352 After:     9352 Change:        0
ERROR: exec(pthread) failed: Permission denied

Memory Usage after program execution:
  Before:     9352 After:     9352 Change:        0

****************************************************************************
* Executing task
***********************c**heckexecperm: bin=**0x3fc884a8 mode=100444 uid=*0 gid=*0 rtcb=**0x3fc86968 group=0x3fc86a38 euid=0
*********************************************


Memory Usage after exec:
  Before:     9352 After:     9352 Change:        0
ERROR: exec(task) failed: Permission denied

Memory Usage after program execution:
  Before:     9352 After:     9352 Change:        0

Memory Usage End-of-Test:
  Before:     9352 After:     9352 Change:        0
nsh> 
```


### Test B: Execution Allowed (Mode 0555)

- Setup: ROMFS ELF embedded with -r-xr-xr-x permissions.
- Result: The pre-load check successfully validates the x bits and allows the execution to proceed to the ELF loader.

Actual Log:
```
nsh> elf
checkexecperm: bin=0x3fc868d0 mode=0555 uid=0 gid=0 rtcb=0x3fc86f08 group=0x3fc86fd8 euid=0
Initial memory usage: 8528
Registering romdisk at /dev/ram1

Memory Usage after romdisk_register:
  Before:     8528 After:     8656 Change:      128
Mounting ROMFS filesystem at target=/mnt/elf/romfs with source=/dev/ram1

Memory Usage after mount:
  Before:     8656 After:     9352 Change:      696

****************************************************************************
* Executing errno
*************************checkexecperm: bin=*0x3fc884a8 mode=*100555 uid=0 gid=0 rtcb=0x3fc86968 group=0x3fc86a38 euid=0
**********************riscv_exception: EXCEPTION: Instruction access fault. MCAUSE: 00000001, EPC: 3fc887a0, MTVAL: 3fc887a0
riscv_exception: PANIC!!! Exception = 00000001
dump_assert_info: Current Version: NuttX  12.13.0 ee2a5e7065-dirty Jun 12 2026 22:36:09 risc-v
dump_assert_info: Assertion failed panic: at file: :0 task: errno process: errno 0x3fc887a0
up_dump_register: EPC: 3fc887a0
up_dump_register: A0: 00000001 A1: 3fc88be0 A2: 3fc88be0 A3: 00000000
up_dump_register: A4: 00000002 A5: 3fc887a0 A6: 00000000 A7: 00000000
up_dump_register: T0: 00000000 T1: 00000000 T2: 00000000 T3: 00000000
up_dump_register: T4: 00000000 T5: 00000000 T6: 00000000
up_dump_register: S0: 3fc887a0 S1: 3fc88540 S2: 00000000 S3: 00000000
up_dump_register: S4: 00000000 S5: 00000000 S6: 00000000 S7: 00000000
up_dump_register: S8: 00000000 S9: 00000000 S10: 00000000 S11: 00000000
up_dump_register: SP: 3fc89390 FP: 3fc887a0 TP: 00000000 RA: 42008d0e
dump_stackinfo: User Stack:
dump_stackinfo:   base: 0x3fc88bf0
dump_stackinfo:   size: 00002000
dump_stackinfo:     sp: 0x3fc89390
stack_dump: 0x3fc89370: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00001881
stack_dump: 0x3fc89390: 00000000 00000000 3fc88be0 00000001 00000000 00000000 00000000 420052ea
stack_dump: 0x3fc893b0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
sched_dumpstack: backtrace| 3: 0x3fc887a0
dump_tasks:    PID GROUP PRI POLICY   TYPE    NPX STATE   EVENT      SIGMASK          STACKBASE  STACKSIZE   COMMAND
dump_tasks:   ----   --- --- -------- ------- --- ------- ---------- ---------------- 0x3fc84190      1536   irq
dump_task:       0     0   0 FIFO     Kthread -   Ready              0000000000000000 0x3fc85828      2016   Idle_Task
dump_task:       2     2 100 RR       Task    -   Waiting Semaphore  0000000000000000 0x3fc87300      1984   nsh_main
dump_task:       3     3 100 RR       Task    -   Running            0000000000000000 0x3fc88bf0      2000   errno
dump_task:       4     4 100 RR       Task    -   Waiting Semaphore  0000000000000000 0x3fc87af8      1992   elf
sched_dumpstack: backtrace| 0: 0x40380e2c
sched_dumpstack: backtrace| 2: 0x4200b3fa
sched_dumpstack: backtrace| 3: 0x3fc887a0
sched_dumpstack: backtrace| 4: 0x4200b3fa
```

Note on ESP32-C3 Hardware limitation: As shown in the trace, the execution successfully passes the permission gate (ALLOWED (root)), but then triggers an Instruction access fault. This is a known, separate ESP32-C3 platform limitation where the ELF loader currently allocates text segments to non-executable DRAM.  (https://github.com/apache/nuttx/issues/19120)

The crash confirms that the software permission gate successfully opened and handed the file to the loader.