### PR TITLE
armv7-m/armv8-m: honor SP modifications on exception return

### DIFF
--- a/arch/arm/src/armv7-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv7-m/arm_sigdeliver.c
@@ -27,6 +27,7 @@
 #include <nuttx/config.h>
 
 #include <stdint.h>
+#include <string.h>
 #include <sched.h>
 #include <assert.h>
 #include <debug.h>
@@ -57,6 +58,9 @@ void arm_sigdeliver(void)
 {
   struct tcb_s *rtcb = this_task();
   uint32_t *regs = rtcb->xcp.saved_regs;
+  uint32_t *new_regs;
+  uint32_t desired_sp;
+  uint32_t implied_sp;
 
 #ifdef CONFIG_SMP
   /* In the SMP case, we must terminate the critical section while the signal
@@ -162,6 +166,27 @@ retry:
 
   leave_critical_section(up_irq_save());
 #endif
+
+  /* If the signal handler modified SP (REG_R13), relocate the saved
+   * context so that the hardware exception return produces the correct SP.
+   *
+   * On ARMv7-M, the exception return path sets PSP to the HW frame address
+   * and hardware computes final SP = PSP + frame_size.  The implied SP is
+   * determined by the physical location of the context, not by REG_R13.
+   * To honor a modified SP, we memmove the entire context frame to the
+   * address where the end of the frame equals the desired SP.
+   */
+
+  desired_sp = regs[REG_R13];
+  implied_sp = (uint32_t)regs + XCPTCONTEXT_SIZE;
+
+  if (desired_sp != implied_sp)
+    {
+      new_regs = (uint32_t *)(desired_sp - XCPTCONTEXT_SIZE);
+      memmove(new_regs, regs, XCPTCONTEXT_SIZE);
+      regs = new_regs;
+      rtcb->xcp.saved_regs = new_regs;
+    }
 
   rtcb->xcp.regs = rtcb->xcp.saved_regs;
   arm_fullcontextrestore();

--- a/arch/arm/src/armv8-m/arm_sigdeliver.c
+++ b/arch/arm/src/armv8-m/arm_sigdeliver.c
@@ -27,6 +27,7 @@
 #include <nuttx/config.h>
 
 #include <stdint.h>
+#include <string.h>
 #include <sched.h>
 #include <assert.h>
 #include <debug.h>
@@ -57,6 +58,9 @@ void arm_sigdeliver(void)
 {
   struct tcb_s *rtcb = this_task();
   uint32_t *regs = rtcb->xcp.saved_regs;
+  uint32_t *new_regs;
+  uint32_t desired_sp;
+  uint32_t implied_sp;
 
 #ifdef CONFIG_SMP
   /* In the SMP case, we must terminate the critical section while the signal
@@ -162,6 +166,27 @@ retry:
 
   leave_critical_section(up_irq_save());
 #endif
+
+  /* If the signal handler modified SP (REG_R13), relocate the saved
+   * context so that the hardware exception return produces the correct SP.
+   *
+   * On ARMv8-M, the exception return path sets PSP to the HW frame address
+   * and hardware computes final SP = PSP + frame_size.  The implied SP is
+   * determined by the physical location of the context, not by REG_R13.
+   * To honor a modified SP, we memmove the entire context frame to the
+   * address where the end of the frame equals the desired SP.
+   */
+
+  desired_sp = regs[REG_R13];
+  implied_sp = (uint32_t)regs + XCPTCONTEXT_SIZE;
+
+  if (desired_sp != implied_sp)
+    {
+      new_regs = (uint32_t *)(desired_sp - XCPTCONTEXT_SIZE);
+      memmove(new_regs, regs, XCPTCONTEXT_SIZE);
+      regs = new_regs;
+      rtcb->xcp.saved_regs = new_regs;
+    }
 
   rtcb->xcp.regs = rtcb->xcp.saved_regs;
   arm_fullcontextrestore();


### PR DESCRIPTION
## Summary

On ARMv7-M and ARMv8-M, the exception return path in `arm_exception.S` writes PSP/MSP from the HW exception frame pointer (`r0`), ignoring any software modification to `REG_R13` in the saved register context. This means signal handlers that adjust SP (e.g., a managed runtime unwinding past a trampoline frame) have their SP change silently discarded.

**Root cause:** Hardware determines the final SP from the physical location of the HW exception frame (`PSP + frame_size`), not from the software-saved SP value. The existing code does `msr psp, r0` where `r0` points to the HW frame, so the restored SP is always `r0 + frame_size` regardless of what `regs[REG_R13]` says.

**Fix:** Add optional HW frame relocation (`CONFIG_ARMV7M_SP_CONTEXT_RESTORE` / `CONFIG_ARMV8M_SP_CONTEXT_RESTORE`, both default `n`) that compares the desired SP with the implied SP. If they differ, the HW exception frame is copied to `(desired_SP - frame_size)` so hardware exception return produces the correct final SP.

The relocation:
- Handles both copy directions (memmove semantics) for overlapping regions
- Determines frame size at runtime from EXC_RETURN bit 4 (32 bytes standard vs 104 bytes with FPU)
- Has zero cost when disabled (default) and minimal fast-path cost when enabled (cmp + beq on match)

Companion test PR: https://github.com/apache/nuttx-apps/pull/3536

## Impact

- **No impact when disabled** (default `n`): zero code change in the binary
- **When enabled:** adds a compare-and-branch on every exception return (taken only when SP was modified). The relocation loop runs only in the rare case where a signal handler modified SP.
- **Users affected:** managed runtimes (e.g., .NET NativeAOT) that need to adjust SP during signal/fault handling on Cortex-M
- **Architectures:** ARMv7-M and ARMv8-M only

## Testing

**Host:** Ubuntu 22.04 x86_64, arm-none-eabi-gcc 13.3, QEMU 8.2.2 (via Docker)

**Targets tested:**
- `lm3s6965-ek:qemu-flat` (ARMv7-M, Cortex-M3) with `CONFIG_ARMV7M_SP_CONTEXT_RESTORE=y`
- `mps2-an521:nsh` (ARMv8-M, Cortex-M33) with `CONFIG_ARMV8M_SP_CONTEXT_RESTORE=y`

**Test procedure:**
1. Verified bug exists (RED): without fix, test reports `popped value = 2, FAIL`
2. Applied fix (GREEN): test reports `popped value = 1, PASS`
3. Tested both slide directions (SP increase and SP decrease)
4. Ran ostest to verify no regressions

**Test log (ARMv7-M, lm3s6965evb):**
```
nsh> sig_sp_test
sig_sp_test: Signal SP restore test
sig_sp_test: push 1, push 2, alarm, handler SP+=4, pop => 1
sig_sp_test: handler - PC=0x00022770 SP=0x2000a9a8
sig_sp_test: handler - new SP=0x2000a9ac PC=0x000226ac
sig_sp_test: popped value = 1 (expected 1)
sig_sp_test: PASS
```

**Test log (ARMv8-M, mps2-an521):**
```
nsh> sig_sp_test
sig_sp_test: Signal SP restore test
sig_sp_test: push 1, push 2, alarm, handler SP+=4, pop => 1
sig_sp_test: handler - PC=0x1002b2b8 SP=0x38007b08
sig_sp_test: handler - new SP=0x38007b0c PC=0x1002b1fc
sig_sp_test: popped value = 1 (expected 1)
sig_sp_test: PASS
```
