### PR TITLE
net/devif: harden devif_conn_event() against list mutation

### DIFF
--- a/net/devif/devif_callback.c
+++ b/net/devif/devif_callback.c
@@ -455,12 +455,26 @@ uint32_t devif_conn_event(FAR struct net_driver_s *dev, uint32_t flags,
 
       if (list->event != NULL && devif_event_trigger(flags, list->flags))
         {
+          list->free_flags |= DEVIF_CB_DONT_FREE;
+
           /* Yes.. perform the callback.  Actions perform by the callback
            * may delete the current list entry or add a new list entry to
            * beginning of the list (which will be ignored on this pass)
            */
 
           flags = list->event(dev, list->priv, flags);
+          list->free_flags &= ~DEVIF_CB_DONT_FREE;
+
+          /* update the next callback to prevent previously recorded the
+           * next callback from being deleted
+           */
+
+          next = list->nxtconn;
+          if ((list->free_flags & DEVIF_CB_PEND_FREE) != 0)
+            {
+              list->free_flags &= ~DEVIF_CB_PEND_FREE;
+              devif_callback_free(dev, list, NULL, NULL);
+            }
         }
 
       /* Set up for the next time through the loop */


### PR DESCRIPTION
## Summary
This change hardens `devif_conn_event()` against callback-driven mutation of the connection callback list and aligns its iterator behavior with `devif_dev_event()`.

## Problem
`devif_conn_event()` saves `list->nxtconn` before invoking the current callback. If the callback mutates its callback list during execution, the saved local successor may no longer match the post-callback list topology.

## Fix
- protect the current callback with `DEVIF_CB_DONT_FREE`
- refresh `next` after the callback returns
- defer freeing the current node until iteration is safe

## Notes
This does not change behavior for non-mutating callbacks. It only makes connection-event iteration use the same deferred-free semantics already used by device-event iteration.

## Test
It's a very random trap that happened once.
<details><summary>Details</summary>
<p>

[ 1945.002700] [63] [apc1] IMS_ZOS: INFO: sock<16> unlock.
[ 1945.002700] [63] [apc1] IMS_ZOS: INFO: close sock<16> refCnt:1 ucTaskProcing:1
[ 1945.002900] [ 4] [apc1] arm_busfault: PANIC!!! Bus Fault:
[ 1945.002900] [ 4] [apc1] arm_busfault:        IRQ: 5 regs: 0x1acf3b1c
[ 1945.002900] [ 4] [apc1] arm_busfault:        BASEPRI: 00000000 PRIMASK: 00000000 IPSR: 00000005 CONTROL: 0000000c
[ 1945.003100] [ 4] [apc1] arm_busfault:        CFSR: 00000100 HFSR: 00000000 DFSR: 00000000 BFAR: 168366ee AFSR: 00200000
[ 1945.003200] [ 4] [apc1] arm_busfault: Bus Fault Reason:
[ 1945.003200] [ 4] [apc1] arm_busfault:        Instruction bus error
[ 1945.005600] [ 4] [apc1] dump_assert_info: Current Version: NuttX BES NuttX EVB 12.6.0 9864b94aa05 Jun 10 2026 10:47:40 arm
[ 1945.005700] [ 4] [apc1] dump_assert_info: Assertion failed panic: at file: armv8-m/arm_busfault.c:113 task: lpwork process: Kernel 0xc922d
[ 1945.005700] [ 4] [apc1] up_dump_register: R0: 1acc93c4 R1: 00000004 R2: 00000050  R3: 0000ffff
[ 1945.005900] [ 4] [apc1] up_dump_register: R4: 00000050 R5: 1af00278 R6: 1acc93c4  FP: 00000001
[ 1945.005900] [ 4] [apc1] up_dump_register: R8: 00000020 SB: 1a999065 SL: 00000000 R11: 00000000
[ 1945.006100] [ 4] [apc1] up_dump_register: IP: 003cc226 SP: 1acf3b90 LR: 1a998b25  PC: 00000020
[ 1945.006300] [ 4] [apc1] up_dump_register: xPSR: 201f0000 BASEPRI: 00000000 CONTROL: 0000000c
[ 1945.006400] [ 4] [apc1] up_dump_register: EXC_RETURN: ffffffed
[ 1945.006400] [ 4] [apc1] dump_stackinfo: User Stack:
[ 1945.006400] [ 4] [apc1] dump_stackinfo:   base: 0x1acf3548
[ 1945.006400] [ 4] [apc1] dump_stackinfo:   size: 00001920
[ 1945.006600] [ 4] [apc1] dump_stackinfo:     sp: 0x1acf3b90
[ 1945.006600] [ 4] [apc1] stack_dump: 0x1acf3b70: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 1acf34c8
[ 1945.010700] [ 4] [apc1] stack_dump: 0x1acf3b90: 1acc93c4 00000004 00000050 0000ffff 003cc226 1a998b25 00000020 201f0000
[ 1945.011200] [ 4] [apc1] stack_dump: 0x1acf3bb0: 00000074 1ac5a358 00000000 00000000 00000000 00000000 00000000 00000000
[ 1945.011800] [ 4] [apc1] stack_dump: 0x1acf3bd0: 00000000 00000000 00000000 41f00000 00000000 3fdcf8cb e0000000 73e32f80
[ 1945.012300] [ 4] [apc1] stack_dump: 0x1acf3bf0: 00040010 00000000 1ac9b1b4 1acd5138 1acc93c4 00000010 00000000 1a99717d
[ 1945.012800] [ 4] [apc1] stack_dump: 0x1acf3c10: 1acc93c4 1a99c477 00000000 00000000 00000000 1acd5138 1acc93c4 1a999065
[ 1945.013300] [ 4] [apc1] stack_dump: 0x1acf3c30: 1a901e3d 00000000 1a999065 00000000 00000000 1a99551b 1acc93c4 1acd5138
[ 1945.013700] [ 4] [apc1] stack_dump: 0x1acf3c50: 1acc93c4 1a99918f 1acc93c4 00000000 1accae60 1a999261 1acc9350 00000000
[ 1945.014300] [ 4] [apc1] stack_dump: 0x1acf3c70: 20002070 00000000 00000080 20002078 00000000 1a901ec5 20002038 000c928d
[ 1945.014800] [ 4] [apc1] stack_dump: 0x1acf3c90: 00000003 00000001 1acf3518 00000002 1acf33d0 00000000 00000000 00000000
[ 1945.015300] [ 4] [apc1] stack_dump: 0x1acf3cb0: 00000000 000c8003 00000000 00000000 00000000 00000000 00000000 00000000
[ 1945.015900] [ 4] [apc1] sched_dumpstack: backtrace:
[ 1945.015900] [ 4] [apc1] sched_dumpstack: [ 4] [<0x20>] Unknown+0x20/0xc0001
[ 1945.016200] [ 4] [apc1] sched_dumpstack: [ 4] [<0x20>] Unknown+0x20/0xc0001
[ 1945.016600] [ 4] [apc1] sched_dumpstack: [ 4] [<0x1a997178>] tcp_callback+0x19/0x190
[ 1945.016900] [ 4] [apc1] sched_dumpstack: [ 4] [<0x1a99c472>] net_iobtimedalloc+0x5/0x32
[ 1945.017300] [ 4] [apc1] sched_dumpstack: [ 4] [<0x1a995516>] tcp_poll+0x55/0x70
[ 1945.017600] [ 4] [apc1] sched_dumpstack: [ 4] [<0x1a99918a>] devif_poll_connections+0x3b/0xde
[ 1945.018000] [ 4] [apc1] sched_dumpstack: [ 4] [<0x1a99925c>] devif_poll+0x2f/0x84
[ 1945.018400] [ 4] [apc1] sched_dumpstack: [ 4] [<0x1a901ec0>] modem_txavail_work+0x17/0x30
[ 1945.018500] [ 4] [apc1] sched_dumpstack: [ 4] [<0xc928a>] work_thread+0x5d/0xa8
[ 1945.018900] [ 4] [apc1] sched_dumpstack: [ 4] [<0xc8000>] nxtask_start+0x2b/0x58


</p>
</details> 