### PR TITLE
arch/nrf91: expose GNSS priority as a control ioctl

### DIFF
--- a/arch/arm/src/nrf91/Kconfig
+++ b/arch/arm/src/nrf91/Kconfig
@@ -769,16 +769,4 @@ config NRF91_MODEM_PREFERENCE
 		For details look at "nRF9160 AT Commands Command Reference Guid" from Nordic,
 		section "5.27 System mode"
 
-if NRF91_MODEM_GNSS
-
-config NRF91_MODEM_GNSS_BOOST_PRIO
-	bool "Modem GNSS support for priority boost"
-	default y
-	---help---
-		Enables GNSS priority boos over LTE idle mode.
-		For details look at nrf_modem_gnss_prio_mode_enable() documentation
-		in sdk-nrfxlib/nrf_modem/include/nrf_modem_gnss.h
-
-endif # NRF91_MODEM_GNSS
-
 endif # NRF91_MODEM

--- a/arch/arm/src/nrf91/nrf91_modem_gnss.c
+++ b/arch/arm/src/nrf91/nrf91_modem_gnss.c
@@ -34,6 +34,7 @@
 #include <time.h>
 
 #include <nuttx/sensors/gnss.h>
+#include <nuttx/sensors/ioctl.h>
 #include <nuttx/sensors/sensor.h>
 
 #include "nrf_modem.h"
@@ -58,6 +59,7 @@
 
 #define NRF91_GNSS_USE_CASE     NRF_MODEM_GNSS_USE_CASE_MULTIPLE_HOT_START
 #define NRF91_GNSS_POWER_MODE   NRF_MODEM_GNSS_PSM_DISABLED
+
 #ifdef NRF91_GNSS_NMEA
 #  define NRF91_GNSS_NMEA_MASK  (NRF_MODEM_GNSS_NMEA_GGA_MASK | \
                                  NRF_MODEM_GNSS_NMEA_GLL_MASK | \
@@ -85,7 +87,6 @@ struct nrf91_gnss_s
   struct gnss_lowerhalf_s               lower;
   bool                                  running;
   bool                                  singlefix;
-  int                                   notime_cntr;
   sem_t                                 rx_sem;
 
   /* PVT support */
@@ -131,9 +132,6 @@ static ssize_t nrf91_gnss_inject_data(struct gnss_lowerhalf_s *lower,
 static int nrf91_gnss_configure(void);
 static bool nrf91_gnss_isactive(int cfun);
 static int nrf91_gnss_enable(struct nrf91_gnss_s *priv, bool enable);
-#ifdef CONFIG_NRF91_MODEM_GNSS_BOOST_PRIO
-static void nrf91_gnss_boost_prio(struct nrf91_gnss_s *priv);
-#endif
 static void nrf91_gnss_pvt_event(struct nrf91_gnss_s *priv);
 static void nrf91_gnss_event_handler(int event);
 static int nrf91_gnss_thread(int argc, char** argv);
@@ -352,9 +350,30 @@ static int nrf91_gnss_control(struct gnss_lowerhalf_s *lower,
                               struct file *filep,
                               int cmd, unsigned long arg)
 {
-  /* TODO */
+  int ret;
 
-  return 0;
+  switch (cmd)
+    {
+      case SNIOC_GNSS_SET_PRIORITY:
+
+        /* Give GNSS priority over LTE idle (the "boost") or drop it. */
+
+        if (arg != 0)
+          {
+            ret = nrf_modem_gnss_prio_mode_enable();
+          }
+        else
+          {
+            ret = nrf_modem_gnss_prio_mode_disable();
+          }
+        break;
+
+      default:
+        ret = -ENOTTY;
+        break;
+    }
+
+  return ret;
 }
 
 /****************************************************************************
@@ -369,33 +388,6 @@ static ssize_t nrf91_gnss_inject_data(struct gnss_lowerhalf_s *lower,
 
   return 0;
 }
-
-#ifdef CONFIG_NRF91_MODEM_GNSS_BOOST_PRIO
-/****************************************************************************
- * Name: nrf91_gnss_boost_prio
- ****************************************************************************/
-
-static void nrf91_gnss_boost_prio(struct nrf91_gnss_s *priv)
-{
-  int ret;
-
-  /* Boost GNSS priority only once - we don't want to block LTE too long */
-
-  if (priv->notime_cntr != -1)
-    {
-      if (priv->notime_cntr > 5)
-        {
-          ret = nrf_modem_gnss_prio_mode_enable();
-          if (ret < 0)
-            {
-              snerr("nrf_modem_gnss_prio_mode_enable failed %d!", ret);
-            }
-
-          priv->notime_cntr = -1;
-        }
-    }
-}
-#endif
 
 /****************************************************************************
  * Name: nrf91_gnss_pvt_event
@@ -495,25 +487,6 @@ static void nrf91_gnss_pvt_event(struct nrf91_gnss_s *priv)
   if (priv->pvt.flags & NRF_MODEM_GNSS_PVT_FLAG_DEADLINE_MISSED)
     {
       snerr("GNSS DEADLINE_MISSED!");
-    }
-
-  if (priv->pvt.flags & NRF_MODEM_GNSS_PVT_FLAG_NOT_ENOUGH_WINDOW_TIME)
-    {
-      snerr("GNSS NOT_ENOUGH_WINDOW_TIME!");
-
-#ifdef CONFIG_NRF91_MODEM_GNSS_BOOST_PRIO
-      /* GNSS priority boost over LTE idle */
-
-      nrf91_gnss_boost_prio(priv);
-#endif
-
-      priv->notime_cntr++;
-    }
-  else
-    {
-      /* Reset counter */
-
-      priv->notime_cntr = 0;
     }
 }
 

--- a/include/nuttx/sensors/ioctl.h
+++ b/include/nuttx/sensors/ioctl.h
@@ -493,7 +493,7 @@
  * Description:  Sets the baud rate of the sensor.
  */
 
-#define SNIOC_SET_BAUD                _SNIOC(0x00A4)      
+#define SNIOC_SET_BAUD                _SNIOC(0x00A4)
 
 /* IOCTL commands unique to the L86XXX and other GNSS modules */
 
@@ -508,6 +508,15 @@
  */
 
 #define SNIOC_SET_NONWAKEUP           _SNIOC(0x00A9)
+
+/* Command:      SNIOC_GNSS_SET_PRIORITY
+ * Description:  Give GNSS priority over other radio activity (e.g. LTE idle)
+ *               so it can acquire satellite window time. The decision of
+ *               when to use it is left to the application.
+ * Argument:     Non-zero enables GNSS priority, zero disables it.
+ */
+
+#define SNIOC_GNSS_SET_PRIORITY       _SNIOC(0x00AA)
 
 /****************************************************************************
  * Public types


### PR DESCRIPTION
## Summary

- arch/nrf91: expose GNSS priority as a control ioctl
    
  Coexistence policy does not belong in the driver. Replace the in-driver
  priority-boost arbitration (the NRF91_MODEM_GNSS_BOOST_PRIO knob and the
  NOT_ENOUGH_WINDOW_TIME counter heuristic) with a user space mechanism:
  SNIOC_GNSS_SET_PRIORITY toggles nrf_modem_gnss priority mode on request,
  leaving the when-to-use-it decision to the application.

## Impact

user-space is now responsible for switching between GNSS and LTE. Otherwise, a situation could arise where GNSS occupies the entire antenna time and LTE is not responsible.

## Testing

thingy91 with lwm2m over LTE and GNSS
