### PR TITLE
drivers/contactless/pn532: Fix Stack Overflow in PN532 Contactless Dr…

### DIFF
--- a/drivers/contactless/pn532.c
+++ b/drivers/contactless/pn532.c
@@ -788,13 +788,18 @@ static int pn532_read_passive_target(FAR struct pn532_dev_s *dev,
 bool pn532_set_rf_config(struct pn532_dev_s * dev,
                          struct pn_rf_config_s * conf)
 {
+  /* cmd_buffer is sizeof(pn532_frame) + up to 16 bytes data */
+
   bool res = false;
-  uint8_t cmd_buffer[15 + 7];
+  uint8_t cmd_buffer[6 + 16];
   FAR struct pn532_frame *f = (FAR struct pn532_frame *) cmd_buffer;
 
   pn532_frame_init(f, PN532_COMMAND_RFCONFIGURATION);
   f->data[1] = conf->cfg_item;
-  DEBUGASSERT(conf->data_size <= 16);
+
+  /* only copy 16 bytes minus 1 byte for each: cmd and cfg_item */
+
+  DEBUGASSERT(conf->data_size <= 16 - 2);
   memcpy(&f->data[2], conf->config, conf->data_size);
   f->len += conf->data_size + 1;
   pn532_frame_finish(f);


### PR DESCRIPTION
drivers/contactless/pn532: Fix Stack Overflow in PN532 Contactless Driver

It addresses an earlier incomplete fix.
Tested locally, builds fine, simple fix.

## Summary

The PN532 driver contains a buffer overflow, in ioctl . Untrusted content is given to the
device in arg :

```c
static int _ioctl(FAR struct file *filep, int cmd, unsigned long arg)
{
...
switch (cmd)
{
...
  case PN532IOC_SET_RF_CONF:
    pn532_set_rf_config(dev, (FAR struct pn_rf_config_s*) arg);
    break;
... 
}
```

The RF Configuration command is described in Section 7.3.1 of the PN532 user guide (https://www.nxp.com/docs/en/user-guide/141520.pdf).

```c
begin_packed_struct struct pn532_frame
{
  uint8_t  preamble;    /* 0x00 */
  uint16_t start_code;  /* 0x00FF (BE) -> 0xFF00 (LE) */
  uint8_t  len;         /* 1 byte indicating the number of bytes in
                         * the data field */
  uint8_t  lcs;         /* 1 Packet Length Checksum LCS byte that satisfies
                         * the relation:  Lower byte of [LEN + LCS] = 00h */
  uint8_t  tfi;         /* Frame identifier 0xD4, 0xD5 */
  uint8_t  data[];      /* LEN-1 bytes of Packet Data Information.
                         * The first byte PD0 is the Command Code */
} end_packed_struct;
```

In the following structure conf is untrusted. The frame pointer `f` uses the `cmd_buffer` for
storage and the maximum `data` size it can write is 16 bytes (because the first 6 bytes are
used by `preamble` to `tfi`). Note however that attacker controlled `conf->data_size` length is used to write attacker controlled content `conf->config` into kernel stack memory, and may
be able to cause a privilege escalation.

```c
bool pn532_set_rf_config(struct pn532_dev_s * dev,
                         struct pn_rf_config_s * conf)
{
  bool res = false;
  uint8_t cmd_buffer[15 + 7];
  FAR struct pn532_frame *f = (FAR struct pn532_frame *) cmd_buffer;

  pn532_frame_init(f, PN532_COMMAND_RFCONFIGURATION);
  f->data[1] = conf->cfg_item;
  memcpy(&f->data[2], conf->config, conf->data_size);
  f->len += conf->data_size + 1;
  pn532_frame_finish(f);
```

## Impact

When calling Set RF Configuration command, a compromised user process can trigger memory corruption in the kernel. This can lead to a system crash or potentially arbitrary code execution in the kernel.

## Testing

Tested locally, after changes made with menuconfig to include the contactless driver in the build:

```bash
$ make
Create version.h
LD: nuttx
```

Signed-off-by: Catalin Visinescu <catalin_visinescu@yahoo.com>