### PR TITLE
drivers/can/ctucanfd_pci: Fix Stack Overflow When Malformed CAN Data Is Received

### DIFF
--- a/drivers/can/ctucanfd_pci.c
+++ b/drivers/can/ctucanfd_pci.c
@@ -760,6 +760,14 @@ static void ctucanfd_chardev_receive(FAR struct ctucanfd_can_s *priv)
 
       buff[0] = ctucanfd_getreg(priv, CTUCANFD_RXDATA);
 
+      /* buff[0] populated the frame->fmt.rwcnt. Check before use. */
+
+      if (frame->fmt.rwcnt > sizeof(buff) / sizeof(buff[0]))
+        {
+          canerr("ERROR: CAN read/write count is too large.  Dropped\n");
+          return;
+        }
+
       /* Read the rest of data */
 
       for (i = 0; i < frame->fmt.rwcnt; i++)
@@ -1248,6 +1256,14 @@ static FAR netpkt_t *ctucanfd_sock_recv(FAR struct netdev_lowerhalf_s *dev)
   /* RX buffer in automatic mode */
 
   buff[0] = ctucanfd_getreg(priv, CTUCANFD_RXDATA);
+
+  /* buff[0] populated the frame->fmt.rwcnt. Check before use. */
+
+  if (frame->fmt.rwcnt > sizeof(buff) / sizeof(buff[0]))
+    {
+      canerr("ERROR: CAN read/write count is too large.  Dropped\n");
+      return NULL;
+    }
 
   /* Read the rest of data */
 


### PR DESCRIPTION
drivers/can/ctucanfd_pci: Fix Stack Overflow When Malformed CAN Data Is Received

A malformed packet can trigger memory corruption in the kernel leading to a system crash or potentially arbitrary code execution in the kernel.

The CAN driver for the CTU CAN FD IP Core connected to the NuttX device via a PCI / PCI Express (PCIe) bus shows a lack of consideration for malformed data, assuming the CAN frames are always correct.

Ensure `frame->fmt.rwcnt` is 21 or less before it is used in the `for` loop.

Tested locally, builds fine.

## Summary

### Impact

A malformed packet can trigger memory corruption in the kernel leading to a system crash or potentially arbitrary code execution in the kernel.

### Description

The CAN driver for the CTU CAN FD IP Core connected to the NuttX device via a PCI / PCI Express (PCIe) bus shows a lack of consideration for malformed data, assuming the CAN frames are always correct.

```c
begin_packed_struct struct ctucanfd_frame_fmt_s
{
  uint32_t dlc:4;               /* DLC */
...
  uint32_t rwcnt:5;             /* Size without FRAME_FORMAT WORD */
...
  uint32_t _reserved:4;         /* Reserved */
} end_packed_struct;

begin_packed_struct struct ctucanfd_frame_s
{
  struct ctucanfd_frame_fmt_s fmt;       /* Frame format */
...
} end_packed_struct;
```

The size of `struct ctucanfd_frame_s` is 84 bytes, therefore, in the following code snippet, the `buff` array used by the `ctucanfd_chardev_receive()` has 21 `uint32_t` elements.  
The code uses `ctucanfd_getreg()` to read the first four bytes from the CAN bus line into the `ctucanfd_frame_s` structure (populates `fmt` structure member). Immediately after, it uses the data read in `frame->fmt.rwcnt` without validation in the `for` loop. The attacker controls the content, and `rwcnt` structure member is 5 bits long therefore it can store a maximum value of 2<sup>5</sup> - 1 = 31. Since the length of the `buff` array is 21 elements and attackers can write 10 `uint32_t` additional elements, they can cause a 40-byte overflow of `buff` array. Note that the attacker can also control the content retrieved in the overflowing bytes.

```c
/*****************************************************************************
 * Name: ctucanfd_chardev_receive
 * Description: Receive CAN frame
 *****************************************************************************/
static void ctucanfd_chardev_receive(FAR struct ctucanfd_can_s *priv)
{
  FAR struct can_dev_s        *dev    = (FAR struct can_dev_s *)priv;
  FAR struct ctucanfd_frame_s *frame;
  struct can_hdr_s             hdr;
  uint32_t                     buff[sizeof(struct ctucanfd_frame_s) / 4];
...
  uint32_t                     regval = 0;
  memset(&hdr, 0, sizeof(hdr));
....
      /* We use a pointer to buffer to avoid an unaligned pointer compiler errors */
      frame = (struct ctucanfd_frame_s *)&buff;

      /* RX buffer in automatic mode */  // NCC Group read the 4-byte "fmt" element
      buff[0] = ctucanfd_getreg(priv, CTUCANFD_RXDATA);

      /* Read the rest of data */
      for (i = 0; i < frame->fmt.rwcnt; i++) // NCC Group: uses the size without checking
        {
          buff[i + 1] = ctucanfd_getreg(priv, CTUCANFD_RXDATA); // NCC Group buffer overflow
        }
```

There is a similar issue in ctucanfd_sock_recv().

### Recommendation

Ensure `frame->fmt.rwcnt` is 21 or less before it is used in the `for` loop.

## Testing

```bash
$ make
Create version.h
LD: nuttx
```