### PR TITLE
Documentation: update references to nrfjprog

### DIFF
--- a/Documentation/platforms/arm/nrf53/index.rst
+++ b/Documentation/platforms/arm/nrf53/index.rst
@@ -167,19 +167,21 @@ Flashing locked device
 
 1. Unlock the network core::
 
-    nrfjprog --recover --coprocessor CP_NETWORK
+    nrfutil device recover --core network
 
 2. Unlock the application core::
 
-    nrfjprog --recover
+    nrfutil device recover --core application
 
 3. Flash the network core::
 
-    nrfjprog --coprocessor CP_NETWORK --program nuttx_net.hex --verify --chiperase
+    nrfutil device erase --core network
+    nrfutil device program --firmware nuttx_net.hex --core network
 
 4. Flash the application core::
 
-    nrfjprog --program nuttx_app.hex --verify --chiperase
+    nrfutil device erase --core application
+    nrfutil device program --firmware nuttx_app.hex --core application
 
 
 Supported Boards

--- a/Documentation/platforms/arm/nrf91/boards/nrf9160-dk/index.rst
+++ b/Documentation/platforms/arm/nrf91/boards/nrf9160-dk/index.rst
@@ -113,13 +113,14 @@ To get this configuration working with miniboot bootloader follow these steps:
 
 #. flash bootloader::
 
-     nrfjprog --program build_boot/nuttx.hex --chiperase --verify
+    nrfutil device erase
+    nrfutil device program --firmware build_boot/nuttx.hex
 
 #. flash modem image::
 
-     nrfjprog --program build_modem/nuttx.hex
+    nrfutil device program --firmware build_modem/nuttx.hex
 
 #. reset chip::
 
-     nrfjprog --reset
+    nrfutil device reset
 


### PR DESCRIPTION
## Summary

- Documentation: update references to nrfjprog
nrfjprog is no longer maintained. Change all nrfjprog commands to equivalent nrfutil commands

## Impact

Update doc

## Testing

CI
