### PR TITLE
mm gran reject oversized pools

### DIFF
--- a/mm/mm_gran/mm_graninit.c
+++ b/mm/mm_gran/mm_graninit.c
@@ -124,6 +124,14 @@ GRAN_HANDLE gran_initialize(FAR void *heapstart, size_t heapsize,
   alignedsize  = (heapend - alignedstart) & ~mask;
   ngranules    = alignedsize >> log2gran;
 
+  /* Reject oversized pools. */
+
+  DEBUGASSERT(ngranules > 0 && ngranules <= UINT16_MAX);
+  if (ngranules == 0 || ngranules > UINT16_MAX)
+    {
+      return NULL;
+    }
+
   /* Allocate the information structure with a granule table of the
    * correct size.
    */


### PR DESCRIPTION
## Summary

  Reject oversized granule heaps in `gran_initialize()`.

  `struct gran_s` and `struct graninfo_s` store granule counts in `uint16_t`, so
  a large pool with a small granule size can silently truncate `ngranules`
  during initialization and produce an invalid handle.

  This patch adds a debug assertion and returns `NULL` with `EINVAL` when the
  computed granule count does not fit.

  ## Changes

  - add a `DEBUGASSERT()` to catch oversized granule counts in debug builds
  - return `NULL` with `errno = EINVAL` when the computed `ngranules` is zero or
    exceeds `UINT16_MAX`

  ## Why this is needed

  For example, a 16 MiB pool with 64-byte granules computes:

  - `ngranules = 16 MiB / 64 = 262144`

  That does not fit in the current 16-bit `ngranules` fields and truncates,
  leading to a broken allocator handle.

  Failing early is safer than silently constructing an invalid granule heap.

  ## Impact

  - valid granule heaps are unchanged
  - oversized heaps now fail cleanly at initialization instead of failing later in
    less obvious ways
  ## Testing

  - code inspection against current `struct gran_s` / `struct graninfo_s`
    definitions
  - verified the guard is inserted before allocator metadata allocation
