### PR TITLE
include/pthread: add wait_count to PTHREAD_COND_INITIALIZER

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -279,7 +279,7 @@ typedef struct pthread_cond_s pthread_cond_t;
 #  define __PTHREAD_COND_T_DEFINED 1
 #endif
 
-#define PTHREAD_COND_INITIALIZER {SEM_INITIALIZER(0), CLOCK_REALTIME }
+#define PTHREAD_COND_INITIALIZER {SEM_INITIALIZER(0), CLOCK_REALTIME, 0 }
 
 struct pthread_mutexattr_s
 {


### PR DESCRIPTION
## Summary

`PTHREAD_COND_INITIALIZER` was missing the initialization of the `wait_count` field in `struct pthread_cond_s`, causing a `-Wmissing-field-initializers` warning when statically initializing condition variables.

### Before
```c
struct pthread_cond_s
{
  sem_t sem;
  clockid_t clockid;
  int wait_count;       // ← not initialized
};

#define PTHREAD_COND_INITIALIZER {SEM_INITIALIZER(0), CLOCK_REALTIME }
```

### After
```c
#define PTHREAD_COND_INITIALIZER {SEM_INITIALIZER(0), CLOCK_REALTIME, 0 }
```

Fixes #19108

## Impact

Eliminates `-Wmissing-field-initializers` warning for `PTHREAD_COND_INITIALIZER`. No functional change since C guarantees zero-initialization for missing fields in partial initializers, but the explicit initialization is cleaner and silences the warning.

## Testing

Verified with `grep` that all fields of `struct pthread_cond_s` are now covered by the initializer.