### PR TITLE
{bp-19107} timers/rtc: Fix non-atomic clock read when splitting tv_sec/tv_nsec

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_rtc.c
+++ b/arch/risc-v/src/common/espressif/esp_rtc.c
@@ -612,6 +612,7 @@ static int esp_rtc_rdalarm(struct rtc_lowerhalf_s *lower,
   struct timespec ts;
   struct alm_cbinfo_s *cbinfo;
   irqstate_t flags;
+  uint64_t time_us;
 
   DEBUGASSERT(lower != NULL);
   DEBUGASSERT(alarminfo != NULL);
@@ -625,10 +626,11 @@ static int esp_rtc_rdalarm(struct rtc_lowerhalf_s *lower,
 
   cbinfo = &priv->alarmcb[alarminfo->id];
 
-  ts.tv_sec = (esp_hr_timer_time_us() + g_rtc_save->offset +
-              cbinfo->deadline_us) / USEC_PER_SEC;
-  ts.tv_nsec = ((esp_hr_timer_time_us() + g_rtc_save->offset +
-              cbinfo->deadline_us) % USEC_PER_SEC) * NSEC_PER_USEC;
+  time_us = esp_hr_timer_time_us() + g_rtc_save->offset +
+            cbinfo->deadline_us;
+
+  ts.tv_sec = time_us / USEC_PER_SEC;
+  ts.tv_nsec = (time_us % USEC_PER_SEC) * NSEC_PER_USEC;
 
   localtime_r(&ts.tv_sec, (struct tm *)alarminfo->time);
 

--- a/arch/risc-v/src/esp32c3-legacy/esp32c3_rtc.c
+++ b/arch/risc-v/src/esp32c3-legacy/esp32c3_rtc.c
@@ -3383,6 +3383,7 @@ int up_rtc_rdalarm(struct timespec *tp, uint32_t alarmid)
 {
   irqstate_t flags;
   struct alm_cbinfo_s *cbinfo;
+  uint64_t time_us;
   DEBUGASSERT(tp != NULL);
   DEBUGASSERT((RTC_ALARM0 <= alarmid) &&
               (alarmid < RTC_ALARM_LAST));
@@ -3393,10 +3394,11 @@ int up_rtc_rdalarm(struct timespec *tp, uint32_t alarmid)
 
   cbinfo = &g_alarmcb[alarmid];
 
-  tp->tv_sec = (rt_timer_time_us() + g_rtc_save->offset +
-              cbinfo->deadline_us) / USEC_PER_SEC;
-  tp->tv_nsec = ((rt_timer_time_us() + g_rtc_save->offset +
-              cbinfo->deadline_us) % USEC_PER_SEC) * NSEC_PER_USEC;
+  time_us = rt_timer_time_us() + g_rtc_save->offset +
+            cbinfo->deadline_us;
+
+  tp->tv_sec = time_us / USEC_PER_SEC;
+  tp->tv_nsec = (time_us % USEC_PER_SEC) * NSEC_PER_USEC;
 
   spin_unlock_irqrestore(&g_rtc_lock, flags);
 

--- a/arch/xtensa/src/common/espressif/esp_rtc.c
+++ b/arch/xtensa/src/common/espressif/esp_rtc.c
@@ -611,6 +611,7 @@ static int esp_rtc_rdalarm(struct rtc_lowerhalf_s *lower,
   struct timespec ts;
   struct alm_cbinfo_s *cbinfo;
   irqstate_t flags;
+  uint64_t time_us;
 
   DEBUGASSERT(lower != NULL);
   DEBUGASSERT(alarminfo != NULL);
@@ -624,10 +625,11 @@ static int esp_rtc_rdalarm(struct rtc_lowerhalf_s *lower,
 
   cbinfo = &priv->alarmcb[alarminfo->id];
 
-  ts.tv_sec = (esp_hr_timer_time_us() + g_rtc_save->offset +
-              cbinfo->deadline_us) / USEC_PER_SEC;
-  ts.tv_nsec = ((esp_hr_timer_time_us() + g_rtc_save->offset +
-              cbinfo->deadline_us) % USEC_PER_SEC) * NSEC_PER_USEC;
+  time_us = esp_hr_timer_time_us() + g_rtc_save->offset +
+            cbinfo->deadline_us;
+
+  ts.tv_sec = time_us / USEC_PER_SEC;
+  ts.tv_nsec = (time_us % USEC_PER_SEC) * NSEC_PER_USEC;
 
   localtime_r(&ts.tv_sec, (struct tm *)alarminfo->time);
 

--- a/drivers/timers/arch_timer.c
+++ b/drivers/timers/arch_timer.c
@@ -289,11 +289,14 @@ int weak_function up_timer_gettick(FAR clock_t *ticks)
 int weak_function up_timer_gettime(struct timespec *ts)
 {
   int ret = -EAGAIN;
+  uint64_t usec;
 
   if (g_timer.lower != NULL)
     {
-      ts->tv_sec  = current_usec() / USEC_PER_SEC;
-      ts->tv_nsec = (current_usec() % USEC_PER_SEC) * NSEC_PER_USEC;
+      usec = current_usec();
+
+      ts->tv_sec  = usec / USEC_PER_SEC;
+      ts->tv_nsec = (usec % USEC_PER_SEC) * NSEC_PER_USEC;
       ret = OK;
     }
 


### PR DESCRIPTION
## Summary

up_timer_gettime() and the Espressif RTC rdalarm handlers built a timespec by calling a free-running microsecond timer twice — once for tv_sec (/ USEC_PER_SEC) and once for tv_nsec (% USEC_PER_SEC). The timer advances between the two reads, so a cal boundary returns an inconsistent, possibly backwards time.

Fixed in 4 places by reading the timer once into a local variable and deriving both fields from that single snapshot:

    drivers/timers/arch_timer.c : up_time
    arch/xtensa/.../espressif/esp_rtc.c : esp_rtc_rdalarm (esp_hr_timer_time_us)
    arch/risc-v/.../espressif/esp_rtc.c : esp_rtus)
    arch/risc-v/.../esp32c3-legacy/esp32c3_rtc.c : up_rtc_rdalarm (rt_timer_time_us)

## Impact

RELEASE

## Testing

CI