### PR TITLE
{bp-19109} include/pthread : initialize wait_count in PTHREAD_COND_INITIALIZER

### DIFF
--- a/include/pthread.h
+++ b/include/pthread.h
@@ -279,7 +279,7 @@ typedef struct pthread_cond_s pthread_cond_t;
 #  define __PTHREAD_COND_T_DEFINED 1
 #endif
 
-#define PTHREAD_COND_INITIALIZER {SEM_INITIALIZER(0), CLOCK_REALTIME }
+#define PTHREAD_COND_INITIALIZER {SEM_INITIALIZER(0), CLOCK_REALTIME, 0}
 
 struct pthread_mutexattr_s
 {


### PR DESCRIPTION
## Summary

struct pthread_cond_s contains three fields: sem, clockid, and wait_count. However, PTHREAD_COND_INITIALIZER only initialized the first two fields, which triggers -Wmissing-field-initializers when a condition variable is statically initialized.

Initialize wait_count explicitly to zero so the macro matches the structure definition and remains warning-free with strict compiler flags.

Validated with a minimal compile test using:

pthread_cond_t cond = PTHREAD_COND_INITIALIZER;

## Impact

RELEASE

## Testing

CI