### PR TITLE
{bp-19115} arch/arm/src/stm32f7: remove duplicated stm32_exti_alarm.c source

### DIFF
--- a/arch/arm/src/stm32f7/CMakeLists.txt
+++ b/arch/arm/src/stm32f7/CMakeLists.txt
@@ -132,12 +132,6 @@ if(CONFIG_STM32F7_QUADSPI)
   list(APPEND SRCS stm32_qspi.c)
 endif()
 
-if(CONFIG_STM32F7_RTC)
-  if(CONFIG_RTC_ALARM)
-    list(APPEND SRCS stm32_exti_alarm.c)
-  endif()
-endif()
-
 if(CONFIG_STM32F7_ETHMAC)
   list(APPEND SRCS stm32_ethernet.c)
 endif()

--- a/arch/arm/src/stm32f7/Make.defs
+++ b/arch/arm/src/stm32f7/Make.defs
@@ -134,12 +134,6 @@ ifeq ($(CONFIG_STM32F7_QUADSPI),y)
 CHIP_CSRCS += stm32_qspi.c
 endif
 
-ifeq ($(CONFIG_STM32F7_RTC),y)
-ifeq ($(CONFIG_RTC_ALARM),y)
-CHIP_CSRCS += stm32_exti_alarm.c
-endif
-endif
-
 ifeq ($(CONFIG_STM32F7_ETHMAC),y)
 CHIP_CSRCS += stm32_ethernet.c
 endif


### PR DESCRIPTION
## Summary

stm32_exti_alarm.c was added twice in Make.defs and CMakeLists.txt. Drop the duplicate block

## Impact

RELEASE

## Testing

CI