### PR TITLE
{bp-19121} libs/libc/pthread/pthread_mutex: Fix robust mutex initialization

### DIFF
--- a/libs/libc/pthread/pthread_mutex_init.c
+++ b/libs/libc/pthread/pthread_mutex_init.c
@@ -86,7 +86,7 @@ int pthread_mutex_init(FAR pthread_mutex_t *mutex,
   mutex->flags = attr && attr->robust == PTHREAD_MUTEX_ROBUST ?
                  _PTHREAD_MFLAGS_ROBUST : 0;
 #  else
-  mutex->flags = 0;
+  mutex->flags = _PTHREAD_MFLAGS_ROBUST;
 #  endif
 #endif
 


### PR DESCRIPTION
## Summary

This fixes an issue where ostest robust mutex test gets stuck.

In CONFIG_PTHREAD_MUTEX_ROBUST mode, every NORMAL mutex is robust by definition, so the robust flag must be set to allow the mutex to be tracked in the holder's mutex list.

Otherwise, pthread_mutex_add() will not record the mutex and pthread_mutex_inconsistent() will not be able to mark it as inconsistent or wake waiters when the holder thread terminates.

## Impact

RELEASE

## Testing

CI