### PR TITLE
{bp-19132} drivers/contactless/pn532: Fix Stack Overflow in PN532 driver

### DIFF
--- a/drivers/contactless/pn532.c
+++ b/drivers/contactless/pn532.c
@@ -788,13 +788,18 @@ static int pn532_read_passive_target(FAR struct pn532_dev_s *dev,
 bool pn532_set_rf_config(struct pn532_dev_s * dev,
                          struct pn_rf_config_s * conf)
 {
+  /* cmd_buffer is sizeof(pn532_frame) + up to 16 bytes data */
+
   bool res = false;
-  uint8_t cmd_buffer[15 + 7];
+  uint8_t cmd_buffer[6 + 16];
   FAR struct pn532_frame *f = (FAR struct pn532_frame *) cmd_buffer;
 
   pn532_frame_init(f, PN532_COMMAND_RFCONFIGURATION);
   f->data[1] = conf->cfg_item;
-  DEBUGASSERT(conf->data_size <= 16);
+
+  /* only copy 16 bytes minus 1 byte for each: cmd and cfg_item */
+
+  DEBUGASSERT(conf->data_size <= 16 - 2);
   memcpy(&f->data[2], conf->config, conf->data_size);
   f->len += conf->data_size + 1;
   pn532_frame_finish(f);


### PR DESCRIPTION
## Summary

When calling Set RF Configuration command, a compromised user process can trigger memory corruption in the kernel. This can lead to a system crash or potentially arbitrary code execution in the kernel.

It addresses an earlier incomplete fix.

## Impact

RELEASE

## Testing

CI