### PR TITLE
{bp-19139} drivers/can/ctucanfd_pci: Stack Overflow When Malformed CAN Data Is received

### DIFF
--- a/drivers/can/ctucanfd_pci.c
+++ b/drivers/can/ctucanfd_pci.c
@@ -760,6 +760,14 @@ static void ctucanfd_chardev_receive(FAR struct ctucanfd_can_s *priv)
 
       buff[0] = ctucanfd_getreg(priv, CTUCANFD_RXDATA);
 
+      /* buff[0] populated the frame->fmt.rwcnt. Check before use. */
+
+      if (frame->fmt.rwcnt > sizeof(buff) / sizeof(buff[0]))
+        {
+          canerr("ERROR: CAN read/write count is too large.  Dropped\n");
+          return;
+        }
+
       /* Read the rest of data */
 
       for (i = 0; i < frame->fmt.rwcnt; i++)
@@ -1248,6 +1256,14 @@ static FAR netpkt_t *ctucanfd_sock_recv(FAR struct netdev_lowerhalf_s *dev)
   /* RX buffer in automatic mode */
 
   buff[0] = ctucanfd_getreg(priv, CTUCANFD_RXDATA);
+
+  /* buff[0] populated the frame->fmt.rwcnt. Check before use. */
+
+  if (frame->fmt.rwcnt > sizeof(buff) / sizeof(buff[0]))
+    {
+      canerr("ERROR: CAN read/write count is too large.  Dropped\n");
+      return NULL;
+    }
 
   /* Read the rest of data */
 


### PR DESCRIPTION
## Summary

A malformed packet can trigger memory corruption in the kernel leading to a system crash or potentially arbitrary code execution in the kernel.

The CAN driver for the CTU CAN FD IP Core connected to the NuttX device via a PCI / PCI Express (PCIe) bus shows a lack of consideration for malformed data, assuming the CAN frames are always correct.

Ensure `frame->fmt.rwcnt` is 21 or less before it is used in the `for` loop.

A similar change was done in ctucanfd_sock_recv().

## Impact

RELEASE

## Testing

CI