### PR TITLE
{bp-19145} drivers/mtd: Make compile time check for sane mtd isbad/markbad confg

### DIFF
--- a/arch/arm/src/rp2040/rp2040_flash_mtd.c
+++ b/arch/arm/src/rp2040/rp2040_flash_mtd.c
@@ -185,8 +185,10 @@ static struct rp2040_flash_dev_s my_dev =
     NULL,
 #endif
     rp2040_flash_ioctl,
+#ifdef CONFIG_FTL_BBM
     NULL,
     NULL,
+#endif
     "rp_flash"
   },
   .lock = NXMUTEX_INITIALIZER,

--- a/drivers/mtd/Kconfig
+++ b/drivers/mtd/Kconfig
@@ -51,8 +51,8 @@ config FTL_READAHEAD
 	depends on DRVR_READAHEAD
 
 config FTL_BBM
-	bool "Enable bad block management in the FTL layer"
-	default y if MTD_NAND
+	bool
+	default n
 	---help---
 		Enable logical to physical erase-block mapping in the FTL layer for
 		MTD devices that expose bad blocks via the MTD isbad/markbad methods.
@@ -240,6 +240,7 @@ menuconfig MTD_NAND
 	bool "MTD NAND support"
 	depends on ALLOW_BSD_COMPONENTS
 	default n
+	select FTL_BBM
 	---help---
 		Enable support for NAND FLASH devices.
 
@@ -419,6 +420,7 @@ endif # RAMMTD
 config FILEMTD
 	bool "File-based MTD driver"
 	default n
+	select FTL_BBM
 	---help---
 		Build support for a File-based MTD driver.
 

--- a/drivers/mtd/ftl.c
+++ b/drivers/mtd/ftl.c
@@ -951,15 +951,6 @@ int ftl_initialize_by_path(FAR const char *path, FAR struct mtd_dev_s *mtd,
 
   finfo("path=\"%s\"\n", path);
 
-#ifndef CONFIG_FTL_BBM
-  /* It is likely a configuration error if the mtd driver implements
-   * the bad block management, but it is still disabled by the
-   * configuration.
-   */
-
-  DEBUGASSERT(mtd->isbad == NULL && mtd->markbad == NULL);
-#endif
-
   /* Allocate a FTL device structure */
 
   dev = kmm_zalloc(sizeof(struct ftl_struct_s));

--- a/drivers/mtd/mtd_partition.c
+++ b/drivers/mtd/mtd_partition.c
@@ -116,8 +116,10 @@ static ssize_t part_write(FAR struct mtd_dev_s *dev, off_t offset,
 #endif
 static int     part_ioctl(FAR struct mtd_dev_s *dev, int cmd,
                   unsigned long arg);
+#ifdef CONFIG_FTL_BBM
 static int     part_isbad(FAR struct mtd_dev_s *dev, off_t block);
 static int     part_markbad(FAR struct mtd_dev_s *dev, off_t block);
+#endif
 
 /* File system methods */
 
@@ -495,6 +497,7 @@ static int part_ioctl(FAR struct mtd_dev_s *dev, int cmd, unsigned long arg)
  *
  ****************************************************************************/
 
+#ifdef CONFIG_FTL_BBM
 static int part_isbad(FAR struct mtd_dev_s *dev, off_t block)
 {
   FAR struct mtd_partition_s *priv = (FAR struct mtd_partition_s *)dev;
@@ -540,6 +543,7 @@ static int part_markbad(FAR struct mtd_dev_s *dev, off_t block)
 
   return -ENOSYS;
 }
+#endif
 
 #if defined(CONFIG_FS_PROCFS) && !defined(CONFIG_PROCFS_EXCLUDE_PARTITIONS)
 
@@ -906,8 +910,10 @@ FAR struct mtd_dev_s *mtd_partition(FAR struct mtd_dev_s *mtd,
   part->child.bwrite  = part_bwrite;
   part->child.read    = mtd->read ? part_read : NULL;
   part->child.ioctl   = part_ioctl;
+#ifdef CONFIG_FTL_BBM
   part->child.isbad   = part_isbad;
   part->child.markbad = part_markbad;
+#endif
 #ifdef CONFIG_MTD_BYTE_WRITE
   part->child.write   = mtd->write ? part_write : NULL;
 #endif

--- a/drivers/mtd/mtd_progmem.c
+++ b/drivers/mtd/mtd_progmem.c
@@ -103,8 +103,10 @@ static struct progmem_dev_s g_progmem =
     progmem_write,
 #endif
     progmem_ioctl,
+#ifdef CONFIG_FTL_BBM
     NULL,
     NULL,
+#endif
     "progmem",
   }
 };

--- a/include/nuttx/mtd/mtd.h
+++ b/include/nuttx/mtd/mtd.h
@@ -97,8 +97,14 @@
 #define MTD_READ(d,s,n,b)  ((d)->read    ? (d)->read(d,s,n,b)   : (-ENOSYS))
 #define MTD_WRITE(d,s,n,b) ((d)->write   ? (d)->write(d,s,n,b)  : (-ENOSYS))
 #define MTD_IOCTL(d,c,a)   ((d)->ioctl   ? (d)->ioctl(d,c,a)    : (-ENOSYS))
-#define MTD_ISBAD(d,b)     ((d)->isbad   ? (d)->isbad(d,b)      : (-ENOSYS))
-#define MTD_MARKBAD(d,b)   ((d)->markbad ? (d)->markbad(d,b)    : (-ENOSYS))
+
+#ifdef CONFIG_FTL_BBM
+#  define MTD_ISBAD(d,b)   ((d)->isbad   ? (d)->isbad(d,b)      : (-ENOSYS))
+#  define MTD_MARKBAD(d,b) ((d)->markbad ? (d)->markbad(d,b)    : (-ENOSYS))
+#else
+#  define MTD_ISBAD(d,b)   (-ENOSYS)
+#  define MTD_MARKBAD(d,b) (-ENOSYS)
+#endif
 
 /* If any of the low-level device drivers declare they want sub-sector erase
  * support, then define MTD_SUBSECTOR_ERASE.
@@ -220,8 +226,10 @@ struct mtd_dev_s
 
   /* Check/Mark bad block for the specified block number */
 
+#ifdef CONFIG_FTL_BBM
   CODE int (*isbad)(FAR struct mtd_dev_s *dev, off_t block);
   CODE int (*markbad)(FAR struct mtd_dev_s *dev, off_t block);
+#endif
 
   /* Name of this MTD device */
 


### PR DESCRIPTION
## Summary

This removes the DEBUGASSERT in ftl_initialize_by_path. Instead, check compile time that FTL is enabled in case some of the drivers implement the isbad and markbad functions.

Also select the FTL_BBM for those drivers as they require it.

## Impact

RELEASE

## Testing

CI