### PR TITLE
drivers/clk: use uintptr_t for register addresses to fix GCC15 warnings

### DIFF
--- a/drivers/clk/clk.h
+++ b/drivers/clk/clk.h
@@ -49,14 +49,14 @@
  * Inline Functions
  ****************************************************************************/
 
-static inline void clk_write(uint32_t reg, uint32_t value)
+static inline void clk_write(uintptr_t reg, uint32_t value)
 {
-  *((volatile uint32_t *)(uintptr_t)reg) = value;
+  *((volatile uint32_t *)reg) = value;
 }
 
-static inline uint32_t clk_read(uint32_t reg)
+static inline uint32_t clk_read(uintptr_t reg)
 {
-  return *((volatile uint32_t *)(uintptr_t)reg);
+  return *((volatile uint32_t *)reg);
 }
 
 static inline bool clk_is_best_rate_closest(uint32_t rate, uint32_t now,

--- a/drivers/clk/clk_divider.c
+++ b/drivers/clk/clk_divider.c
@@ -363,7 +363,7 @@ const struct clk_ops_s g_clk_divider_ops =
 
 FAR struct clk_s *clk_register_divider(FAR const char *name,
                                        FAR const char *parent_name,
-                                       uint8_t flags, uint32_t reg,
+                                       uint8_t flags, uintptr_t reg,
                                        uint8_t shift, uint8_t width,
                                        uint16_t clk_divider_flags)
 {

--- a/drivers/clk/clk_fractional_divider.c
+++ b/drivers/clk/clk_fractional_divider.c
@@ -159,7 +159,7 @@ const struct clk_ops_s g_clk_fractional_divider_ops =
 FAR struct clk_s *
 clk_register_fractional_divider(FAR const char *name,
                                 FAR const char *parent_name,
-                                uint8_t flags, uint32_t reg,
+                                uint8_t flags, uintptr_t reg,
                                 uint8_t mshift, uint8_t mwidth,
                                 uint8_t nshift, uint8_t nwidth,
                                 uint8_t clk_divider_flags)

--- a/drivers/clk/clk_gate.c
+++ b/drivers/clk/clk_gate.c
@@ -119,7 +119,7 @@ const struct clk_ops_s g_clk_gate_ops =
 
 FAR struct clk_s *clk_register_gate(FAR const char *name,
                                     FAR const char *parent_name,
-                                    uint8_t flags, uint32_t reg,
+                                    uint8_t flags, uintptr_t reg,
                                     uint8_t bit_idx,
                                     uint8_t clk_gate_flags)
 {

--- a/drivers/clk/clk_multiplier.c
+++ b/drivers/clk/clk_multiplier.c
@@ -227,7 +227,7 @@ const struct clk_ops_s g_clk_multiplier_ops =
 
 FAR struct clk_s *clk_register_multiplier(FAR const char *name,
                                           FAR const char *parent_name,
-                                          uint8_t flags, uint32_t reg,
+                                          uint8_t flags, uintptr_t reg,
                                           uint8_t shift,
                                           uint8_t width,
                                           uint8_t clk_multiplier_flags)

--- a/drivers/clk/clk_mux.c
+++ b/drivers/clk/clk_mux.c
@@ -177,7 +177,7 @@ const struct clk_ops_s g_clk_mux_ro_ops =
 FAR struct clk_s *clk_register_mux(FAR const char *name,
                                    FAR const char * const *parent_names,
                                    uint8_t num_parents,
-                                   uint8_t flags, uint32_t reg,
+                                   uint8_t flags, uintptr_t reg,
                                    uint8_t shift, uint8_t width,
                                    uint8_t clk_mux_flags)
 {

--- a/drivers/clk/clk_phase.c
+++ b/drivers/clk/clk_phase.c
@@ -92,7 +92,7 @@ const struct clk_ops_s g_clk_phase_ops =
 
 FAR struct clk_s *clk_register_phase(FAR const char *name,
                                      FAR const char *parent_name,
-                                     uint8_t flags, uint32_t reg,
+                                     uint8_t flags, uintptr_t reg,
                                      uint8_t shift, uint8_t width,
                                      uint8_t clk_phase_flags)
 {

--- a/include/nuttx/clk/clk_provider.h
+++ b/include/nuttx/clk/clk_provider.h
@@ -134,7 +134,7 @@ struct clk_ops_s
 
 struct clk_gate_s
 {
-  uint32_t            reg;
+  uintptr_t           reg;
   uint8_t             bit_idx;
   uint8_t             flags;
 };
@@ -153,7 +153,7 @@ struct clk_fixed_factor_s
 
 struct clk_divider_s
 {
-  uint32_t            reg;
+  uintptr_t           reg;
   uint8_t             shift;
   uint8_t             width;
   uint16_t            flags;
@@ -161,7 +161,7 @@ struct clk_divider_s
 
 struct clk_phase_s
 {
-  uint32_t            reg;
+  uintptr_t           reg;
   uint8_t             shift;
   uint8_t             width;
   uint8_t             flags;
@@ -169,7 +169,7 @@ struct clk_phase_s
 
 struct clk_fractional_divider_s
 {
-  uint32_t            reg;
+  uintptr_t           reg;
   uint8_t             mwidth;
   uint8_t             nwidth;
   uint8_t             mshift;
@@ -179,7 +179,7 @@ struct clk_fractional_divider_s
 
 struct clk_multiplier_s
 {
-  uint32_t            reg;
+  uintptr_t           reg;
   uint8_t             shift;
   uint8_t             width;
   uint8_t             flags;
@@ -187,7 +187,7 @@ struct clk_multiplier_s
 
 struct clk_mux_s
 {
-  uint32_t            reg;
+  uintptr_t           reg;
   uint8_t             width;
   uint8_t             shift;
   uint8_t             flags;
@@ -205,7 +205,7 @@ FAR struct clk_s *clk_register(FAR const char *name,
 
 FAR struct clk_s *clk_register_gate(FAR const char *name,
                                     FAR const char *parent_name,
-                                    uint8_t flags, uint32_t reg,
+                                    uint8_t flags, uintptr_t reg,
                                     uint8_t bit_idx,
                                     uint8_t clk_gate_flags);
 
@@ -221,34 +221,34 @@ FAR struct clk_s *clk_register_fixed_factor(FAR const char *name,
 
 FAR struct clk_s *clk_register_divider(FAR const char *name,
                                        FAR const char *parent_name,
-                                       uint8_t flags, uint32_t reg,
+                                       uint8_t flags, uintptr_t reg,
                                        uint8_t shift, uint8_t width,
                                        uint16_t clk_divider_flags);
 
 FAR struct clk_s *clk_register_phase(FAR const char *name,
                                      FAR const char *parent_name,
-                                     uint8_t flags, uint32_t reg,
+                                     uint8_t flags, uintptr_t reg,
                                      uint8_t shift, uint8_t width,
                                      uint8_t clk_phase_flags);
 
 FAR struct clk_s *
 clk_register_fractional_divider(FAR const char *name,
                                 FAR const char *parent_name,
-                                uint8_t flags, uint32_t reg,
+                                uint8_t flags, uintptr_t reg,
                                 uint8_t mshift, uint8_t mwidth,
                                 uint8_t nshift, uint8_t nwidth,
                                 uint8_t clk_divider_flags);
 
 FAR struct clk_s *clk_register_multiplier(FAR const char *name,
                                           FAR const char *parent_name,
-                                          uint8_t flags, uint32_t reg,
+                                          uint8_t flags, uintptr_t reg,
                                           uint8_t shift, uint8_t width,
                                           uint8_t clk_multiplier_flags);
 
 FAR struct clk_s *clk_register_mux(FAR const char *name,
                                    FAR const char * const *parent_names,
                                    uint8_t num_parents, uint8_t flags,
-                                   uint32_t reg, uint8_t shift,
+                                   uintptr_t reg, uint8_t shift,
                                    uint8_t width, uint8_t clk_mux_flags);
 
 #ifdef CONFIG_CLK_RPMSG


### PR DESCRIPTION
## Summary

Change the `reg` field type from `uint32_t` to `uintptr_t` in all clock provider structs and their `clk_register_*()` function prototypes. Update `clk_write()` / `clk_read()` inline helpers accordingly.

Fixes #16896 (sub-item: `drivers/clk/clk.h` int-to-pointer cast warning).

## Changes

**`drivers/clk/clk.h`** (2 functions):
- `clk_write(uint32_t reg, ...)` → `clk_write(uintptr_t reg, ...)`
- `clk_read(uint32_t reg)` → `clk_read(uintptr_t reg)`
- Remove redundant `(uintptr_t)` cast in function bodies

**`include/nuttx/clk/clk_provider.h`** (6 structs + 6 prototypes):
- `uint32_t reg` → `uintptr_t reg` in: `clk_gate_s`, `clk_divider_s`, `clk_phase_s`, `clk_fractional_divider_s`, `clk_multiplier_s`, `clk_mux_s`
- Matching change in all `clk_register_gate/divider/phase/fractional_divider/multiplier/mux()` prototypes

## Impact

- **Build**: Fixes `-Wint-to-pointer-cast` warning on 64-bit targets (e.g. `sim`). GCC15 promotes this warning to an error.
- **User**: No functional change on 32-bit embedded targets (`uintptr_t == uint32_t`).
- **Hardware**: No change.
- **Documentation**: No change.
- **Security**: No change.
- **Compatibility**: ABI-compatible on all 32-bit targets. On 64-bit targets the struct layout changes (field width 4→8 bytes) but the clock framework is not used on 64-bit hardware.

## Why `uintptr_t`

The `reg` field holds a memory-mapped register address. Using `uintptr_t` is the semantically correct type for storing addresses in C. All callers pass address values, and the inline functions already cast through `(uintptr_t)` before dereferencing.

## Testing

Verified with `sim:nsh` build (the primary 64-bit target that triggers the warning):

```bash
./tools/configure.sh sim:nsh
make -j$(nproc)
# Before: warning: cast to pointer from integer of different size [-Wint-to-pointer-cast]
# After: clean build, no warnings from clk.h
```

Also verified ARM cross-compilation has no regression:

```bash
./tools/configure.sh stm32f4discovery:nsh
make -j$(nproc)  # clean build
```