### PR TITLE
arch/arm/armv7-a: Fix L1 page table entry double-offset in addrenv create region

### DIFF
--- a/arch/arm/src/armv7-a/arm_addrenv_utils.c
+++ b/arch/arm/src/armv7-a/arm_addrenv_utils.c
@@ -107,8 +107,7 @@ int arm_addrenv_create_region(uintptr_t *l1table, unsigned int listlen,
 
       DEBUGASSERT(MM_ISALIGNED(paddr));
 
-      mmu_l1table_setentry(l1table, paddr, vaddr + i * SECTION_SIZE,
-                           MMU_L1_PGTABFLAGS);
+      mmu_l1table_setentry(l1table, paddr, vaddr, MMU_L1_PGTABFLAGS);
 
       /* Get the virtual address corresponding to the physical page address */
 


### PR DESCRIPTION
  * Fix a bug in `arm_addrenv_create_region()` where L1 page table entries
    for second and subsequent 1MB sections were offset by `i * SECTION_SIZE`,
    causing virtual address holes in the mapping.
  * The inner loop already advances `vaddr` by `MM_PGSIZE` for each mapped
    page, so after filling one L2 page table (i.e. `ENTRIES_PER_L2TABLE`
    pages), `vaddr` has naturally advanced to the start of the next 1MB
    section.
  * The redundant `vaddr + i * SECTION_SIZE` in `mmu_l1table_setentry()`
    caused each L1 entry after the first to skip one section per iteration,
    leaving unmapped gaps between sections.
  * Related NuttX Issue: N/A

## Impact

  * Is new feature added? Is existing feature changed? NO — bug fix only.
  * Impact on user (will user need to adapt to change)? NO.
  * Impact on build (will build process change)? NO.
  * Impact on hardware (will arch(s) / board(s) / driver(s) change)?
    YES — affects all ARMv7-A targets that use `arm_addrenv_create_region()`
    for address environment creation. Fixes incorrect virtual address
    mappings.
  * Impact on documentation (is update required / provided)? NO.
  * Impact on security (any sort of implications)? NO.
  * Impact on compatibility (backward/forward/interoperability)? NO.
  * Anything else to consider or add? None.

## Testing

  I confirm that changes are verified on local setup and works as intended:
  * Build Host(s): Linux, x86_64, GCC
  * Target(s): arm (ARMv7-A), qemu-armv7a:knsh
  * The fix produces contiguous L1 section mappings instead of leaving
    virtual address holes between sections.

Setup config:

```txt
diff --git a/boards/arm/qemu/qemu-armv7a/configs/knsh/defconfig b/boards/arm/qemu/qemu-armv7a/configs/knsh/defconfig
index 18b086834c..6cfe59b4da 100644
--- a/boards/arm/qemu/qemu-armv7a/configs/knsh/defconfig
+++ b/boards/arm/qemu/qemu-armv7a/configs/knsh/defconfig
@@ -14,10 +14,10 @@ CONFIG_ARCH_BOARD_QEMU_ARMV7A=y
 CONFIG_ARCH_CHIP="qemu"
 CONFIG_ARCH_CHIP_QEMU_ARM=y
 CONFIG_ARCH_CHIP_QEMU_CORTEXA7=y
-CONFIG_ARCH_DATA_NPAGES=256
-CONFIG_ARCH_DATA_VBASE=0x80100000
-CONFIG_ARCH_HEAP_NPAGES=256
-CONFIG_ARCH_HEAP_VBASE=0x80200000
+CONFIG_ARCH_DATA_NPAGES=512
+CONFIG_ARCH_DATA_VBASE=0x80200000
+CONFIG_ARCH_HEAP_NPAGES=512
+CONFIG_ARCH_HEAP_VBASE=0x80400000
 CONFIG_ARCH_INTERRUPTSTACK=2048
 CONFIG_ARCH_KERNEL_STACKSIZE=3072
 CONFIG_ARCH_LOWVECTORS=y
@@ -26,7 +26,7 @@ CONFIG_ARCH_PGPOOL_PBASE=0x40300000
 CONFIG_ARCH_PGPOOL_SIZE=13631488
 CONFIG_ARCH_PGPOOL_VBASE=0x40300000
 CONFIG_ARCH_STACKDUMP=y
-CONFIG_ARCH_TEXT_NPAGES=256
+CONFIG_ARCH_TEXT_NPAGES=512
 CONFIG_ARCH_TEXT_VBASE=0x80000000
 CONFIG_ARM_PSCI=y
 CONFIG_ARM_SEMIHOSTING_HOSTFS=y
```

Build and run:

```bash
cmake -B build -DBOARD_CONFIG=qemu-armv7a:knsh -GNinja && cmake --build build
qemu-system-arm -semihosting -M virt -m 128 -nographic -kernel ./build/nuttx
```

Logs before this change:

```
[    0.007000] arm_dataabort: Data abort. PC: 0000361c DFAR: 805ffffc DFSR: 00000805
[    0.007000] dump_assert_info: Current Version: NuttX  0.0.0 2be1345a7c-dirty Jun 19 2026 11:12:02 arm
[    0.007000] dump_assert_info: Assertion failed panic: at file: /arch/arm/src/armv7-a/arm_dataabort.c:174 task: AppBringUp process: Kernel 0x3b69
[    0.007000] up_dump_register: R0: 00000009 R1: 80400170 R2: 0000000b  R3: 80400178
[    0.007000] up_dump_register: R4: 80400000 R5: 805ffff8 R6: 001ffe90  FP: 400066dc
[    0.007000] up_dump_register: R8: 001ffe90 SB: 40006720 SL: 00000001 R11: 40006d50
[    0.007000] up_dump_register: IP: 00000000 SP: 400066b0 LR: 00002491  PC: 0000361c
[    0.007000] up_dump_register: CPSR: 2000007f
[    0.007000] dump_stackinfo: User Stack:
[    0.007000] dump_stackinfo:   base: 0x40005910
[    0.007000] dump_stackinfo:   size: 00004048
[    0.007000] dump_stackinfo:     sp: 0x400066b0
[    0.007000] stack_dump: 0x40006690: 400066dc 001ffe90 40006720 00000001 40006d50 00000000 0000361c 2000007f
[    0.007000] stack_dump: 0x400066b0: 80400000 80400170 00000000 0000370f 80400000 40006ae8 40006a58 40006714
[    0.007000] stack_dump: 0x400066d0: 40006710 00010165 80400000 00000000 00000000 80400000 00200000 00000001
[    0.007000] stack_dump: 0x400066f0: 40006a58 000098bf 00000006 00002465 40004000 40004000 40006918 0000375d
[    0.007000] stack_dump: 0x40006710: 40006be8 00000000 00000006 80400000 7379732f 2f6d6574 2f6e6962 74696e69
[    0.007000] stack_dump: 0x40006730: 7fffff00 00003261 40000668 40006ae8 00000000 0000377d 40006ae8 00001edd
[    0.007000] stack_dump: 0x40006750: 00000000 40006768 00000000 0000e36d 00000000 000096cb 80000000 80201000
[    0.007000] stack_dump: 0x40006770: 000099b8 000007a4 00000008 00000004 0000b4ec 00000000 00000000 000081ff
[    0.007000] stack_dump: 0x40006790: 464c457f 00010101 00000000 00000000 00280002 00000001 800000ed 00000034
[    0.007000] stack_dump: 0x400067b0: 0000b334 05000400 00200034 00280002 000a000b 00000000 00000000 00000000
[    0.007000] stack_dump: 0x400067d0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[    0.007000] stack_dump: 0x400067f0: 00000000 00000000 ffffffff 00000000 fffffffe 00000000 40006d50 00000000
[    0.007000] stack_dump: 0x40006810: 00000000 40000178 40006a58 00017343 00009671 00000000 40006a58 00017343
[    0.007000] stack_dump: 0x40006830: 400068a8 400068a4 00000000 00000000 00000000 000095d7 00000000 400068a8
[    0.007000] stack_dump: 0x40006850: 00000001 40006a20 40006918 00000000 400068a8 00000c00 00000064 00000000
[    0.007000] stack_dump: 0x40006870: 00000000 0000960b 00000000 00000000 400068a8 00000001 00000000 00003bc7
[    0.007000] stack_dump: 0x40006890: 00000000 00000000 400068a8 400068e0 00000000 00000000 00026400 00000000
[    0.007000] stack_dump: 0x400068b0: 00000000 00000c00 00000000 400057e0 00000002 00000000 00000000 000054c3
[    0.007000] stack_dump: 0x400068d0: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
[    0.007000] dump_tasks:    PID GROUP PRI POLICY   TYPE    NPX STATE   EVENT      SIGMASK          STACKBASE  STACKSIZE      USED   FILLED    COMMAND
[    0.007000] dump_tasks:   ----   --- --- -------- ------- --- ------- ---------- ---------------- 0x40001ab8      2048       120     5.8%    irq
[    0.007000] dump_task:       0     0   0 FIFO     Kthread -   Ready              0000000000000000 0x40003018      4072       704    17.2%    Idle_Task
[    0.007000] dump_task:       1     0 100 RR       Kthread -   Ready              0000000000000000 0x40004820      4024       328     8.1%    lpwork 0x400000d8 0x40000128
[    0.007000] dump_task:       2     0 240 RR       Kthread -   Running            0000000000000000 0x40005910      4048      1704    42.0%    AppBringUp
```

## PR verification Self-Check

* [x] This PR introduces only one functional change.
* [x] I have updated all required description fields above.
* [x] My PR adheres to Contributing Guidelines and Documentation (git commitandard, etc).
* [ ] My PR is still work in progress (not ready for review).
* [x] My PR is ready for review and can be safely merged into a codebase.