### PR TITLE
arch/risc-v/espressif: Add TWAI2 support for esp32p4

### DIFF
--- a/Documentation/platforms/risc-v/esp32p4/index.rst
+++ b/Documentation/platforms/risc-v/esp32p4/index.rst
@@ -341,7 +341,7 @@ Bit Scrambler      No
 SD/MMC Host        No
 H264 Encoder       No
 2D-DMA             No
-TWAI (CAN)         Yes     TWAI0/1
+TWAI (CAN)         Yes     TWAI0/1/2
 Pulse Counter      Yes     Implemented as Quadrature Encoder
 RMT                Yes
 USB Serial/JTAG    Yes

--- a/arch/risc-v/src/common/espressif/Kconfig
+++ b/arch/risc-v/src/common/espressif/Kconfig
@@ -1645,6 +1645,14 @@ config ESPRESSIF_TWAI1
 	select ARCH_HAVE_CAN_ERRORS
 	select CAN
 
+config ESPRESSIF_TWAI2
+	bool "TWAI2 (CAN)"
+	default n
+	depends on ARCH_CHIP_ESP32P4
+	select ESPRESSIF_TWAI
+	select ARCH_HAVE_CAN_ERRORS
+	select CAN
+
 config ESPRESSIF_USBSERIAL
 	bool "USB-Serial-JTAG Driver"
 	default n
@@ -3437,6 +3445,48 @@ config ESPRESSIF_TWAI1_SAM
 		to spikes on the bus-line).
 
 endif # ESPRESSIF_TWAI1
+
+if ESPRESSIF_TWAI2
+
+config ESPRESSIF_TWAI2_TXPIN
+	int "TWAI2 TX Pin"
+	default 6
+
+config ESPRESSIF_TWAI2_RXPIN
+	int "TWAI2 RX Pin"
+	default 7
+
+choice ESPRESSIF_TWAI2_TIMING
+	prompt "TWAI2 Timing config"
+	default TWAI2_TIMING_100KBITS
+	---help---
+		These options control timing of TWAI2.
+
+config TWAI2_TIMING_100KBITS
+	bool "100 KBits"
+
+config TWAI2_TIMING_125KBITS
+	bool "125 KBits"
+
+config TWAI2_TIMING_250KBITS
+	bool "250 KBits"
+
+config TWAI2_TIMING_500KBITS
+	bool "500 KBits"
+
+config TWAI2_TIMING_800KBITS
+	bool "800 KBits"
+
+endchoice # ESPRESSIF_TWAI2_TIMING
+
+config ESPRESSIF_TWAI2_SAM
+	bool "TWAI2 sampling"
+	default n
+	---help---
+		The bus is sampled 3 times (recommended for low to medium speed buses
+		to spikes on the bus-line).
+
+endif # ESPRESSIF_TWAI2
 
 config ESPRESSIF_TWAI_TEST_MODE
 	bool "TWAI character driver loopback test mode (for testing only)"

--- a/arch/risc-v/src/common/espressif/esp_twai.c
+++ b/arch/risc-v/src/common/espressif/esp_twai.c
@@ -99,6 +99,20 @@
 #  endif
 #endif
 
+#ifdef CONFIG_ESPRESSIF_TWAI2
+#  ifdef CONFIG_TWAI2_TIMING_100KBITS
+#    define TWAI2_TIMING_CONFIG TWAI_TIMING_CONFIG_100KBITS()
+#  elif CONFIG_TWAI2_TIMING_125KBITS
+#    define TWAI2_TIMING_CONFIG TWAI_TIMING_CONFIG_125KBITS()
+#  elif CONFIG_TWAI2_TIMING_250KBITS
+#    define TWAI2_TIMING_CONFIG TWAI_TIMING_CONFIG_250KBITS()
+#  elif CONFIG_TWAI2_TIMING_500KBITS
+#    define TWAI2_TIMING_CONFIG TWAI_TIMING_CONFIG_500KBITS()
+#  else
+#    define TWAI2_TIMING_CONFIG TWAI_TIMING_CONFIG_800KBITS()
+#  endif
+#endif
+
 #if defined(CONFIG_ARCH_CHIP_ESP32C3)
 #  define INT_ENA_REG(hw)       hw->interrupt_enable_reg.val
 #elif defined(CONFIG_ARCH_CHIP_ESP32P4)
@@ -225,6 +239,24 @@ static struct can_dev_s g_twai1dev =
   .cd_priv          = &g_twai1priv,
 };
 #endif /* CONFIG_ESPRESSIF_TWAI1 */
+
+#ifdef CONFIG_ESPRESSIF_TWAI2
+static struct esp_twai_dev_s g_twai2priv =
+{
+  .port             = 2,
+  .cpuint           = -ENOMEM,
+  .t_config         = TWAI2_TIMING_CONFIG,
+#ifdef CONFIG_PM
+  .pm_lock          = NULL,
+#endif
+};
+
+static struct can_dev_s g_twai2dev =
+{
+  .cd_ops           = &g_twaiops,
+  .cd_priv          = &g_twai2priv,
+};
+#endif /* CONFIG_ESPRESSIF_TWAI2 */
 
 static const twai_filter_config_t f_config = TWAI_FILTER_CONFIG_ACCEPT_ALL();
 
@@ -861,6 +893,25 @@ struct can_dev_s *esp_twaiinitialize(int port)
       esp_configgpio(CONFIG_ESPRESSIF_TWAI1_RXPIN, RX_PIN_ATTR);
 
       dev = &g_twai1dev;
+    }
+  else
+#endif
+
+#ifdef CONFIG_ESPRESSIF_TWAI2
+  if (port == 2)
+    {
+      int tx_sig = twai_periph_signals[2].tx_sig;
+      int rx_sig = twai_periph_signals[2].rx_sig;
+
+      /* Configure CAN GPIO pins */
+
+      esp_gpio_matrix_out(CONFIG_ESPRESSIF_TWAI2_TXPIN, tx_sig, 0, 0);
+      esp_configgpio(CONFIG_ESPRESSIF_TWAI2_TXPIN, TX_PIN_ATTR);
+
+      esp_gpio_matrix_in(CONFIG_ESPRESSIF_TWAI2_RXPIN, rx_sig, 0);
+      esp_configgpio(CONFIG_ESPRESSIF_TWAI2_RXPIN, RX_PIN_ATTR);
+
+      dev = &g_twai2dev;
     }
   else
 #endif

--- a/boards/risc-v/esp32c6/common/src/esp_board_twai.c
+++ b/boards/risc-v/esp32c6/common/src/esp_board_twai.c
@@ -27,6 +27,7 @@
 #include <nuttx/config.h>
 
 #include <errno.h>
+#include <stdio.h>
 #include <nuttx/debug.h>
 
 #include <nuttx/can/can.h>
@@ -39,6 +40,9 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
+#define DEVNAME_FMT    "/dev/can%d"
+#define DEVNAME_FMTLEN (8 + 3 + 1)
 
 /****************************************************************************
  * Public Functions
@@ -63,6 +67,7 @@ int board_twai_setup(int port)
 {
 #ifdef CONFIG_ESPRESSIF_TWAI
   struct can_dev_s *twai;
+  char devname[DEVNAME_FMTLEN];
   int ret;
 
   /* Call esp_twaiinitialize() to get an instance of the TWAI
@@ -72,31 +77,18 @@ int board_twai_setup(int port)
   twai = esp_twaiinitialize(port);
   if (twai == NULL)
     {
-      canerr("ERROR:  Failed to get TWAI interface\n");
+      canerr("ERROR: Failed to get TWAI interface for port %d\n", port);
       return -ENODEV;
     }
 
-#ifdef CONFIG_ESPRESSIF_TWAI0
-  /* Register the TWAI driver at "/dev/can0" */
+  snprintf(devname, sizeof(devname), DEVNAME_FMT, port);
 
-  ret = can_register("/dev/can0", twai);
+  ret = can_register(devname, twai);
   if (ret < 0)
     {
-      canerr("ERROR: TWAI0 register failed: %d\n", ret);
+      canerr("ERROR: TWAI%d register failed: %d\n", port, ret);
       return ret;
     }
-#endif /* CONFIG_ESPRESSIF_TWAI0 */
-
-#ifdef CONFIG_ESPRESSIF_TWAI1
-  /* Register the TWAI driver at "/dev/can1" */
-
-  ret = can_register("/dev/can1", twai);
-  if (ret < 0)
-    {
-      canerr("ERROR: TWAI1 register failed: %d\n", ret);
-      return ret;
-    }
-#endif /* CONFIG_ESPRESSIF_TWAI1 */
 
   return OK;
 #else

--- a/boards/risc-v/esp32p4/common/src/esp_board_twai.c
+++ b/boards/risc-v/esp32p4/common/src/esp_board_twai.c
@@ -27,6 +27,7 @@
 #include <nuttx/config.h>
 
 #include <errno.h>
+#include <stdio.h>
 #include <nuttx/debug.h>
 
 #include <nuttx/can/can.h>
@@ -39,6 +40,9 @@
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
+
+#define DEVNAME_FMT    "/dev/can%d"
+#define DEVNAME_FMTLEN (8 + 3 + 1)
 
 /****************************************************************************
  * Public Functions
@@ -63,6 +67,7 @@ int board_twai_setup(int port)
 {
 #ifdef CONFIG_ESPRESSIF_TWAI
   struct can_dev_s *twai;
+  char devname[DEVNAME_FMTLEN];
   int ret;
 
   /* Call esp_twaiinitialize() to get an instance of the TWAI
@@ -72,42 +77,18 @@ int board_twai_setup(int port)
   twai = esp_twaiinitialize(port);
   if (twai == NULL)
     {
-      canerr("ERROR:  Failed to get TWAI interface\n");
+      canerr("ERROR: Failed to get TWAI interface for port %d\n", port);
       return -ENODEV;
     }
 
-#ifdef CONFIG_ESPRESSIF_TWAI0
-  /* Register the TWAI driver at "/dev/can0" */
+  snprintf(devname, sizeof(devname), DEVNAME_FMT, port);
 
-  ret = can_register("/dev/can0", twai);
+  ret = can_register(devname, twai);
   if (ret < 0)
     {
-      canerr("ERROR: TWAI0 register failed: %d\n", ret);
+      canerr("ERROR: TWAI%d register failed: %d\n", port, ret);
       return ret;
     }
-#endif /* CONFIG_ESPRESSIF_TWAI0 */
-
-#ifdef CONFIG_ESPRESSIF_TWAI1
-  /* Register the TWAI driver at "/dev/can1" */
-
-  ret = can_register("/dev/can1", twai);
-  if (ret < 0)
-    {
-      canerr("ERROR: TWAI1 register failed: %d\n", ret);
-      return ret;
-    }
-#endif /* CONFIG_ESPRESSIF_TWAI1 */
-
-#ifdef CONFIG_ESPRESSIF_TWAI2
-  /* Register the TWAI driver at "/dev/can2" */
-
-  ret = can_register("/dev/can2", twai);
-  if (ret < 0)
-    {
-      canerr("ERROR: TWAI2 register failed: %d\n", ret);
-      return ret;
-    }
-#endif /* CONFIG_ESPRESSIF_TWAI2 */
 
   return OK;
 #else

--- a/boards/risc-v/esp32p4/common/src/esp_board_twai.c
+++ b/boards/risc-v/esp32p4/common/src/esp_board_twai.c
@@ -98,6 +98,17 @@ int board_twai_setup(int port)
     }
 #endif /* CONFIG_ESPRESSIF_TWAI1 */
 
+#ifdef CONFIG_ESPRESSIF_TWAI2
+  /* Register the TWAI driver at "/dev/can2" */
+
+  ret = can_register("/dev/can2", twai);
+  if (ret < 0)
+    {
+      canerr("ERROR: TWAI2 register failed: %d\n", ret);
+      return ret;
+    }
+#endif /* CONFIG_ESPRESSIF_TWAI2 */
+
   return OK;
 #else
   return -ENODEV;

--- a/boards/risc-v/esp32p4/esp32p4-function-ev-board/src/esp32p4_bringup.c
+++ b/boards/risc-v/esp32p4/esp32p4-function-ev-board/src/esp32p4_bringup.c
@@ -401,6 +401,17 @@ int esp_bringup(void)
     }
 #endif
 
+#ifdef CONFIG_ESPRESSIF_TWAI2
+
+  /* Initialize TWAI and register the TWAI driver. */
+
+  ret = board_twai_setup(2);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: TWAI2 board_twai_setup failed: %d\n", ret);
+    }
+#endif
+
 #ifdef CONFIG_DEV_GPIO
   ret = esp_gpio_init();
   if (ret < 0)


### PR DESCRIPTION
## Summary

Unnecessary select lines and free to choose `ESPRESSIF_TWAI` option (which should not be) handled to have clearer Kconfig option system

<!-- This field should contain a summary of the changes. It will be pre-filled with the commit's message and descriptions. Adjust it accordingly -->

* Docs/platforms/risc-v: Add TWAI2 docs for esp32p4
    
Add TWAI2 docs for esp32p4
  

* boards/risc-v/esp32p4: Add TWAI2 support for esp32p4
    
Add TWAI2 support for esp32p4


* arch/risc-v/espressif: Add TWAI2 support for esp32p4
    
Enable TWAI2 support for esp32p4

## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: Yes, twai2 can be used with ESP32-P4
<!-- Does it impact user's applications? How? -->

Impact on build: No
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: Yes, twai2 peripheral supported for ESP32-P4
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: Yes, related docs added
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: No
<!-- Does it impact NuttX's security? -->

Impact on compatibility: No
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

## Testing
<!-- Please provide all the testing procedure. Consider that upstream reviewers should be able to reproduce the same testing performed internally -->

`esp32p4-function-ev-board:twai` config used with `CAN_LOOPBACK` and  `ESPRESSIF_TWAI2` options enabled

### Building
<!-- Provide how to build the test for each SoC being tested -->

Command to build:

```
make distclean && ./tools/configure.sh esp32p4-function-ev-board:twai && kconfig-tweak -e CAN_LOOPBACK && kconfig-tweak -e  ESPRESSIF_TWAI2 && make olddefconfig && make -j && make download ESPTOOL_PORT=/dev/ttyUSB0
```

### Running
<!-- Provide how to run the test for each SoC being tested -->

`can -n 5` command used to test with connecting PIN 6-7 with a cable

### Results
<!-- Provide tests' results and runtime logs -->



```
nsh> can -n 5
nmsgs: 5
min ID: 1 max ID: 2047
Bit timing:
   Baud: 909090
  TSEG1: 16
  TSEG2: 5
    SJW: 4
  ID:    1 DLC: 1
  ID:    1 DLC: 1
  ID:    1 DLC: 1 -- OK
  ID:    2 DLC: 2
  ID:    2 DLC: 2
  ID:    2 DLC: 2 -- OK
  ID:    3 DLC: 3
  ID:    3 DLC: 3
  ID:    3 DLC: 3 -- OK
  ID:    4 DLC: 4
  ID:    4 DLC: 4
  ID:    4 DLC: 4 -- OK
  ID:    5 DLC: 5
  ID:    5 DLC: 5
  ID:    5 DLC: 5 -- OK
Terminating!
nsh> 
```