### PR TITLE
ci/test: Remove FTDI from CI to avoid failure

### DIFF
--- a/tools/ci/testlist/sim-02.dat
+++ b/tools/ci/testlist/sim-02.dat
@@ -1,6 +1,9 @@
 /sim/*/*/*/c[j-z]*
 /sim/*/*/*/[d-n]*
 
+# FTDI lib doesn't work on CI
+-sim:ft2232h_gpio
+
 # cURL error 60 SSL certificate expired
 -sim:cxxtest
 


### PR DESCRIPTION
## Summary

Removing sim:ft2232h_gpio from CI test because it depends on libftdi1 that doesn't work there.

## Impact

Allow PR https://github.com/apache/nuttx/pull/18951 to pass on CI.

## Testing

CI passed
