### PR TITLE
ci/docker: fix No package 'libftdi1' found

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -37,7 +37,6 @@ RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" apt-get install -y -q
   gawk \
   git \
   gperf \
-  libftdi1-dev \
   libncurses5-dev \
   make \
   ninja-build \
@@ -359,6 +358,7 @@ RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" TZ=Etc/UTC apt-get in
   libpython2.7 \
   libtinfo5 \
   libusb-1.0-0-dev libusb-1.0-0-dev:i386 \
+  libftdi1-dev \
   libv4l-dev libv4l-dev:i386 \
   libx11-dev libx11-dev:i386 \
   libxext-dev libxext-dev:i386 \

--- a/tools/ci/testlist/sim-02.dat
+++ b/tools/ci/testlist/sim-02.dat
@@ -1,9 +1,6 @@
 /sim/*/*/*/c[j-z]*
 /sim/*/*/*/[d-n]*
 
-# FTDI lib doesn't work on CI
--sim:ft2232h_gpio
-
 # cURL error 60 SSL certificate expired
 -sim:cxxtest
 


### PR DESCRIPTION
## Summary
Dockerfile:
   libftdi1-dev has been moved to the correct stage in the Dockerfile
   Fix
   https://github.com/apache/nuttx/pull/18951#issuecomment-4708056829

sim-02.dat enabled sim:ft2232h_gpio

## Impact

Impact on user: NO

Impact on build: NO

Impact on hardware: NO

Impact on documentation: NO

Impact on security: NO

Impact on compatibility: NO

## Testing

GitHub

Nuttx repository: acassis/incubator-nuttx
    Nuttx branch: sim_ft2232h
 Apps repository: apache/nuttx-apps
     Apps branch: master
          Config: sim:ft2232h_gpio
    Build system: all

```

echo "LD:  nuttx"
LD:  nuttx
ld -r -z noexecstack -L"/github/workspace/sources/nuttx/staging" -L board   \
     -o nuttx.rel sim_head.o sim_doirq.o --start-group -lsched -ldrivers -lboards -lc -lmm -larch -lapps -lfs -lbinfmt -lboard  --end-group
objcopy --redefine-syms=nuttx-names.dat nuttx.rel
cc "-g" -fomit-frame-pointer -fprofile-arcs -ftest-coverage -fno-inline -fno-common -fvisibility=hidden -ffunction-sections -fdata-sections -Wall -Wstrict-prototypes -Wshadow -Wundef -Wno-attributes -Wno-unknown-pragmas -fno-pic -mcmodel=medium -isystem /github/workspace/sources/nuttx/include -D__NuttX__ -DNDEBUG -U_AIX -U_WIN32 -U__APPLE__ -U__FreeBSD__ -U__NetBSD__ -U__linux__ -U__sun__ -U__unix__ -U__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ -D__KERNEL__  -I "/github/workspace/sources/apps/include" -I /github/workspace/sources/nuttx/arch/sim/src -I /github/workspace/sources/nuttx/arch/sim/src/chip -I /github/workspace/sources/nuttx/sched -fvisibility=default -Wl,-verbose 2>&1 | \
     sed -e '/====/,/====/!d;//d' \
         -e '/__executable_start/s/$/PROVIDE(_stext = .);/' \
         -e 's/^\(\s\+\)\(\.init_array\)/\1\2 : { }\n\1.sinit/g' \
         -e 's/^\(\s\+\)\(\.fini_array\)/\1\2 : { }\n\1.einit/g' \
         -e 's/__init_array_start/_sinit/g' -e 's/__init_array_end/_einit/g' \
         -e 's/__fini_array_start/_sfini/g' -e 's/__fini_array_end/_efini/g' >nuttx.ld
echo "__init_array_start = .; __init_array_end = .; __fini_array_start = .; __fini_array_end = .;" >>nuttx.ld
"cc" "-g" -fomit-frame-pointer -fprofile-arcs -ftest-coverage -fno-inline -fno-common -fvisibility=hidden -ffunction-sections -fdata-sections -Wall -Wstrict-prototypes -Wshadow -Wundef -Wno-attributes -Wno-unknown-pragmas -fno-pic -mcmodel=medium -isystem /github/workspace/sources/nuttx/include -D__NuttX__ -DNDEBUG -U_AIX -U_WIN32 -U__APPLE__ -U__FreeBSD__ -U__NetBSD__ -U__linux__ -U__sun__ -U__unix__ -U__ENVIRONMENT_MAC_OS_X_VERSION_MIN_REQUIRED__ -D__KERNEL__  -I "/github/workspace/sources/apps/include" -I /github/workspace/sources/nuttx/arch/sim/src -I /github/workspace/sources/nuttx/arch/sim/src/chip -I /github/workspace/sources/nuttx/sched -fvisibility=default -Wl,--gc-sections -Wl,-Ttext-segment=0x40000000 -Wl,-Map=/github/workspace/sources/nuttx/nuttx.map -Wl,-Map=/github/workspace/sources/nuttx/nuttx.map -no-pie -Wl,-z,now -Tnuttx.ld -o /github/workspace/sources/nuttx/nuttx  nuttx.rel sim_hostirq.o sim_hostmemory.o sim_hostmisc.o sim_hosttime.o sim_hostuart.o sim_hostfs.o sim_errno.o sim_hostsmp.o sim_ftdi_gpiochip.o  -lpthread -lrt -lm -lgcov -lz -lftdi1 -lusb-1.0
nm /github/workspace/sources/nuttx/nuttx | \
	grep -v '\(compiled\)\|\(\.o$\)\|\( [aUw] \)\|\(\.\.ng$\)\|\(LASH[RL]DI\)' | \
	sort > /github/workspace/sources/nuttx/System.map
make[1]: Leaving directory '/github/workspace/sources/nuttx/arch/sim/src'
if [ -w /tftpboot ] ; then \
	cp -f nuttx /tftpboot/nuttx.sim; \
fi
echo nuttx > nuttx.manifest
printf "%s\n" *.map >> nuttx.manifest

```

https://github.com/simbit18/nuttx_test_pr/actions/runs/27905280266/job/82572790810#logs