### PR TITLE
{bp-19168} drivers/clk: use uintptr_t for register addresses to fix GCC15 warnings

### DIFF
--- a/drivers/clk/clk.h
+++ b/drivers/clk/clk.h
@@ -49,14 +49,14 @@
  * Inline Functions
  ****************************************************************************/
 
-static inline void clk_write(uint32_t reg, uint32_t value)
+static inline void clk_write(uintptr_t reg, uint32_t value)
 {
-  *((volatile uint32_t *)(uintptr_t)reg) = value;
+  *((volatile uint32_t *)reg) = value;
 }
 
-static inline uint32_t clk_read(uint32_t reg)
+static inline uint32_t clk_read(uintptr_t reg)
 {
-  return *((volatile uint32_t *)(uintptr_t)reg);
+  return *((volatile uint32_t *)reg);
 }
 
 static inline bool clk_is_best_rate_closest(uint32_t rate, uint32_t now,

--- a/drivers/clk/clk_divider.c
+++ b/drivers/clk/clk_divider.c
@@ -363,7 +363,7 @@ const struct clk_ops_s g_clk_divider_ops =
 
 FAR struct clk_s *clk_register_divider(FAR const char *name,
                                        FAR const char *parent_name,
-                                       uint8_t flags, uint32_t reg,
+                                       uint8_t flags, uintptr_t reg,
                                        uint8_t shift, uint8_t width,
                                        uint16_t clk_divider_flags)
 {

--- a/drivers/clk/clk_fractional_divider.c
+++ b/drivers/clk/clk_fractional_divider.c
@@ -159,7 +159,7 @@ const struct clk_ops_s g_clk_fractional_divider_ops =
 FAR struct clk_s *
 clk_register_fractional_divider(FAR const char *name,
                                 FAR const char *parent_name,
-                                uint8_t flags, uint32_t reg,
+                                uint8_t flags, uintptr_t reg,
                                 uint8_t mshift, uint8_t mwidth,
                                 uint8_t nshift, uint8_t nwidth,
                                 uint8_t clk_divider_flags)

--- a/drivers/clk/clk_gate.c
+++ b/drivers/clk/clk_gate.c
@@ -119,7 +119,7 @@ const struct clk_ops_s g_clk_gate_ops =
 
 FAR struct clk_s *clk_register_gate(FAR const char *name,
                                     FAR const char *parent_name,
-                                    uint8_t flags, uint32_t reg,
+                                    uint8_t flags, uintptr_t reg,
                                     uint8_t bit_idx,
                                     uint8_t clk_gate_flags)
 {

--- a/drivers/clk/clk_multiplier.c
+++ b/drivers/clk/clk_multiplier.c
@@ -227,7 +227,7 @@ const struct clk_ops_s g_clk_multiplier_ops =
 
 FAR struct clk_s *clk_register_multiplier(FAR const char *name,
                                           FAR const char *parent_name,
-                                          uint8_t flags, uint32_t reg,
+                                          uint8_t flags, uintptr_t reg,
                                           uint8_t shift,
                                           uint8_t width,
                                           uint8_t clk_multiplier_flags)

--- a/drivers/clk/clk_mux.c
+++ b/drivers/clk/clk_mux.c
@@ -177,7 +177,7 @@ const struct clk_ops_s g_clk_mux_ro_ops =
 FAR struct clk_s *clk_register_mux(FAR const char *name,
                                    FAR const char * const *parent_names,
                                    uint8_t num_parents,
-                                   uint8_t flags, uint32_t reg,
+                                   uint8_t flags, uintptr_t reg,
                                    uint8_t shift, uint8_t width,
                                    uint8_t clk_mux_flags)
 {

--- a/drivers/clk/clk_phase.c
+++ b/drivers/clk/clk_phase.c
@@ -92,7 +92,7 @@ const struct clk_ops_s g_clk_phase_ops =
 
 FAR struct clk_s *clk_register_phase(FAR const char *name,
                                      FAR const char *parent_name,
-                                     uint8_t flags, uint32_t reg,
+                                     uint8_t flags, uintptr_t reg,
                                      uint8_t shift, uint8_t width,
                                      uint8_t clk_phase_flags)
 {

--- a/include/nuttx/clk/clk_provider.h
+++ b/include/nuttx/clk/clk_provider.h
@@ -134,7 +134,7 @@ struct clk_ops_s
 
 struct clk_gate_s
 {
-  uint32_t            reg;
+  uintptr_t           reg;
   uint8_t             bit_idx;
   uint8_t             flags;
 };
@@ -153,7 +153,7 @@ struct clk_fixed_factor_s
 
 struct clk_divider_s
 {
-  uint32_t            reg;
+  uintptr_t           reg;
   uint8_t             shift;
   uint8_t             width;
   uint16_t            flags;
@@ -161,7 +161,7 @@ struct clk_divider_s
 
 struct clk_phase_s
 {
-  uint32_t            reg;
+  uintptr_t           reg;
   uint8_t             shift;
   uint8_t             width;
   uint8_t             flags;
@@ -169,7 +169,7 @@ struct clk_phase_s
 
 struct clk_fractional_divider_s
 {
-  uint32_t            reg;
+  uintptr_t           reg;
   uint8_t             mwidth;
   uint8_t             nwidth;
   uint8_t             mshift;
@@ -179,7 +179,7 @@ struct clk_fractional_divider_s
 
 struct clk_multiplier_s
 {
-  uint32_t            reg;
+  uintptr_t           reg;
   uint8_t             shift;
   uint8_t             width;
   uint8_t             flags;
@@ -187,7 +187,7 @@ struct clk_multiplier_s
 
 struct clk_mux_s
 {
-  uint32_t            reg;
+  uintptr_t           reg;
   uint8_t             width;
   uint8_t             shift;
   uint8_t             flags;
@@ -205,7 +205,7 @@ FAR struct clk_s *clk_register(FAR const char *name,
 
 FAR struct clk_s *clk_register_gate(FAR const char *name,
                                     FAR const char *parent_name,
-                                    uint8_t flags, uint32_t reg,
+                                    uint8_t flags, uintptr_t reg,
                                     uint8_t bit_idx,
                                     uint8_t clk_gate_flags);
 
@@ -221,34 +221,34 @@ FAR struct clk_s *clk_register_fixed_factor(FAR const char *name,
 
 FAR struct clk_s *clk_register_divider(FAR const char *name,
                                        FAR const char *parent_name,
-                                       uint8_t flags, uint32_t reg,
+                                       uint8_t flags, uintptr_t reg,
                                        uint8_t shift, uint8_t width,
                                        uint16_t clk_divider_flags);
 
 FAR struct clk_s *clk_register_phase(FAR const char *name,
                                      FAR const char *parent_name,
-                                     uint8_t flags, uint32_t reg,
+                                     uint8_t flags, uintptr_t reg,
                                      uint8_t shift, uint8_t width,
                                      uint8_t clk_phase_flags);
 
 FAR struct clk_s *
 clk_register_fractional_divider(FAR const char *name,
                                 FAR const char *parent_name,
-                                uint8_t flags, uint32_t reg,
+                                uint8_t flags, uintptr_t reg,
                                 uint8_t mshift, uint8_t mwidth,
                                 uint8_t nshift, uint8_t nwidth,
                                 uint8_t clk_divider_flags);
 
 FAR struct clk_s *clk_register_multiplier(FAR const char *name,
                                           FAR const char *parent_name,
-                                          uint8_t flags, uint32_t reg,
+                                          uint8_t flags, uintptr_t reg,
                                           uint8_t shift, uint8_t width,
                                           uint8_t clk_multiplier_flags);
 
 FAR struct clk_s *clk_register_mux(FAR const char *name,
                                    FAR const char * const *parent_names,
                                    uint8_t num_parents, uint8_t flags,
-                                   uint32_t reg, uint8_t shift,
+                                   uintptr_t reg, uint8_t shift,
                                    uint8_t width, uint8_t clk_mux_flags);
 
 #ifdef CONFIG_CLK_RPMSG


### PR DESCRIPTION
## Summary

Change the reg field type from uint32_t to uintptr_t in all clock provider structs and their clk_register_*() function prototypes. Update clk_write() / clk_read() inline helpers accordingly.

Fixes https://github.com/apache/nuttx/issues/16896 (sub-item: drivers/clk/clk.h int-to-pointer cast warning).

## Impact

RELEASE

## Testing

CI