### PR TITLE
{bp-19171} drivers/eeprom/i2c_xx24xx: Integer Overflow in I2C EEPROM ee24xx_seek()

### DIFF
--- a/drivers/eeprom/i2c_xx24xx.c
+++ b/drivers/eeprom/i2c_xx24xx.c
@@ -570,20 +570,35 @@ static off_t ee24xx_seek(FAR struct file *filep, off_t offset, int whence)
       return ret;
     }
 
-  /* Determine the new, requested file position */
+  /* Determine the new, requested file position
+   * For EEPROM sparse files are not allowed.
+   * "offset" can be negative, "newpos" must be between 0 and eedev->size
+   */
 
   switch (whence)
     {
     case SEEK_CUR:
       newpos = filep->f_pos + offset;
+      if (newpos < 0 || newpos > eedev->size)
+        {
+          return -EINVAL;
+        }
       break;
 
     case SEEK_SET:
       newpos = offset;
+      if (newpos < 0 || newpos > eedev->size)
+        {
+          return -EINVAL;
+        }
       break;
 
     case SEEK_END:
       newpos = eedev->size + offset;
+      if (newpos < 0 || newpos > eedev->size)
+        {
+          return -EINVAL;
+        }
       break;
 
     default:

--- a/drivers/eeprom/spi_xx25xx.c
+++ b/drivers/eeprom/spi_xx25xx.c
@@ -929,20 +929,35 @@ static off_t ee25xx_seek(FAR struct file *filep, off_t offset, int whence)
       return ret;
     }
 
-  /* Determine the new, requested file position */
+  /* Determine the new, requested file position
+   * For EEPROM sparse files are not allowed.
+   * "offset" can be negative, "newpos" must be between 0 and eedev->size
+   */
 
   switch (whence)
     {
     case SEEK_CUR:
       newpos = filep->f_pos + offset;
+      if (newpos < 0 || newpos > eedev->size)
+        {
+          return -EINVAL;
+        }
       break;
 
     case SEEK_SET:
       newpos = offset;
+      if (newpos < 0 || newpos > eedev->size)
+        {
+          return -EINVAL;
+        }
       break;
 
     case SEEK_END:
       newpos = eedev->size + offset;
+      if (newpos < 0 || newpos > eedev->size)
+        {
+          return -EINVAL;
+        }
       break;
 
     default:


### PR DESCRIPTION
## Summary
The function seek which allows the user to move the cursor to a particular offset in order to read and write from EEPROM storage does not validate the offset is valid. Later, this can cause an out-of-bounds reads or writes. Note that newpos may store a large value, larger than the size of the EEPROM.

Similar change in the SPI driver.

Tested locally, builds fine.

## Impact

RELEASE

## Testing

CI