### PR TITLE
{bp-19175} arch/arm/armv7-a: Fix L1 page table entry double-offset in addrenv create region

### DIFF
--- a/arch/arm/src/armv7-a/arm_addrenv_utils.c
+++ b/arch/arm/src/armv7-a/arm_addrenv_utils.c
@@ -107,8 +107,7 @@ int arm_addrenv_create_region(uintptr_t *l1table, unsigned int listlen,
 
       DEBUGASSERT(MM_ISALIGNED(paddr));
 
-      mmu_l1table_setentry(l1table, paddr, vaddr + i * SECTION_SIZE,
-                           MMU_L1_PGTABFLAGS);
+      mmu_l1table_setentry(l1table, paddr, vaddr, MMU_L1_PGTABFLAGS);
 
       /* Get the virtual address corresponding to the physical page address */
 


### PR DESCRIPTION
## Summary

In arm_addrenv_create_region(), the inner loop already advances vaddr by MM_PGSIZE for each mapped page, so after filling one L2 page table (i.e., ENTRIES_PER_L2TABLE pages), vaddr has naturally advanced to the start of the next 1MB section.  The old code additionally added i * SECTION_SIZE, causing the L1 entry for the second and subsequent sections to skip one section each iteration—leaving virtual address holes in the mapping.

Remove the redundant i * SECTION_SIZE offset so that the L1 entry tracks the vaddr already maintained by the inner loop, producing contiguous section mappings.

## Impact

RELEASE

## Testing

CI