### PR TITLE
{bp-19180} ci/test: Remove FTDI from CI to avoid failure

### DIFF
--- a/tools/ci/testlist/sim-02.dat
+++ b/tools/ci/testlist/sim-02.dat
@@ -1,6 +1,9 @@
 /sim/*/*/*/c[j-z]*
 /sim/*/*/*/[d-n]*
 
+# FTDI lib doesn't work on CI
+-sim:ft2232h_gpio
+
 # cURL error 60 SSL certificate expired
 -sim:cxxtest
 


### PR DESCRIPTION
## Summary

Even after installing the ftdi library on CI it doesn't work to compile the sim:ft2232h_gpio, so remove it from CI test.

## Impact

RELEASE

## Testing

CI