### PR TITLE
stm32h5/adc: Enable ADC1.OR.OP0 for INP0 and INN1.

### DIFF
--- a/arch/arm/src/stm32h5/stm32_adc.c
+++ b/arch/arm/src/stm32h5/stm32_adc.c
@@ -203,6 +203,7 @@ static uint32_t adc_sqrbits(struct stm32_dev_s *priv, int first,
                             int last, int offset);
 static int  adc_set_ch(struct adc_dev_s *dev, uint8_t ch);
 static bool adc_internal(struct stm32_dev_s * priv, uint32_t *adc_ccr);
+static void adc_enable_optreg(struct stm32_dev_s * priv);
 static void adc_startconv(struct stm32_dev_s *priv, bool enable);
 #ifdef ADC_HAVE_WDG1
 static void adc_wdog1_enable(struct stm32_dev_s *priv);
@@ -1481,6 +1482,8 @@ static int adc_setup(struct adc_dev_s *dev)
 
   adc_set_ch(dev, 0);
 
+  adc_enable_optreg(priv);
+
   /* ADC CCR configuration */
 
   clrbits = ADC_CCR_PRESC_MASK | ADC_CCR_VREFEN |
@@ -1645,6 +1648,41 @@ static bool adc_internal(struct stm32_dev_s * priv, uint32_t *adc_ccr)
     }
 
   return internal;
+}
+
+/****************************************************************************
+ * Name: adc_enable_optreg
+ *
+ * Description:
+ *   Connects ADC1_INP0/ADC1_INN1 to the ADC mux if necessary.
+ *
+ * Input Parameters:
+ *   priv - A reference to the ADC block status
+ *
+ ****************************************************************************/
+
+static void adc_enable_optreg(struct stm32_dev_s * priv)
+{
+  int i;
+
+  /* ADC1.OR.OP0 (RM0481 26.6.23)
+   * Enables the GPIO switch connecting ADC1_INP0/ADC1_INN1 to the ADC mux.
+   * This bit must be set when channel ADC1_INP0 or ADCx_INN1 is selected.
+   */
+
+  if (priv->intf == 1)
+    {
+      for (i = 0; i < priv->cchannels; i++)
+        {
+          uint8_t ch = priv->chanlist[i];
+
+          if (ch == 0 || (ch == 1 && (priv->difsel & ADC_DIFSEL_CH(1))))
+            {
+              adc_putreg(priv, STM32_ADC_OR_OFFSET, ADC_OR_OP0);
+              return;
+            }
+        }
+    }
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Enable `ADC1.OR.OP0` on STM32H5 when ADC1 channel 0 is selected, or when channel 1 is used in differential mode.

On STM32H5, `ADC1.OR.OP0` enables the GPIO switch that connects PA0 to the ADC mux for `ADC1_INP0` and `ADC1_INN1`. Without this bit set, PA0 remains disconnected and ADC conversions return invalid values.

Additional details are available in the [Reference manual](https://www.st.com/resource/en/reference_manual/rm0481-stm32h52333xx-stm32h56263xx-and-stm32h573xx-armbased-32bit-mcus-stmicroelectronics.pdf) section `26.6.23 ADC option register (ADC_OR)`

## Impact

Fixes ADC1 conversions for:

* `ADC1_INP0` on PA0
* `ADC1_INN1` on PA0 when channel 1 is configured in differential mode

## Testing

Tested on STM32 Nucleo-H563ZI with:

```sh
cmake -B build -DBOARD_CONFIG=nucleo-h563zi:adc -GNinja
```

Readings were taken from NSH using the `adc` command.

### ADC1_INP0 on PA0

Board configuration used for this test is available in [nucleo-h563zi-adc1-inp0-test.patch](https://github.com/user-attachments/files/29233746/nucleo-h563zi-adc1-inp0-test.patch).

With this change:

```text
INP0 = 3.3V: 4095
INP0 = GND:  0
```

Without this change:

```text
INP0 = 3.3V: 124~1137
INP0 = GND:  119~1135
```

### ADC1_INP1 / ADC1_INN1 differential mode

Board configuration used for this test is available in [nucleo-h563zi-adc1-inn1-test.patch](https://github.com/user-attachments/files/29233740/nucleo-h563zi-adc1-inn1-test.patch).

With this change:

```text
IN1P = 3.3V, IN1N = GND:  4095
IN1P = 3.3V, IN1N = 3.3V: 2047
IN1P = GND,  IN1N = GND:  2000
IN1P = GND,  IN1N = 3.3V: 0
```

Without this change:

```text
IN1P = 3.3V, IN1N = GND:  2862~3791
IN1P = 3.3V, IN1N = 3.3V: 3743~4095
IN1P = GND,  IN1N = GND:  2092~2882
IN1P = GND,  IN1N = 3.3V: 2109~2880
```

