### PR TITLE
mm,boards/arm/qemu: Fix KASAN user-space false positives, global region link error, and linker script section placement.

### DIFF
--- a/boards/arm/qemu/qemu-armv7a/scripts/dramboot.ld
+++ b/boards/arm/qemu/qemu-armv7a/scripts/dramboot.ld
@@ -34,21 +34,6 @@ MEMORY
 SECTIONS
 {
 
-  /* where the global variable out-of-bounds detection information located */
-
-#ifdef CONFIG_MM_KASAN_GLOBAL
-  .kasan.unused : {
-    *(.data..LASANLOC*)
-  }
-  .kasan.global : {
-    KEEP (*(.data..LASAN0))
-    KEEP (*(.data.rel.local..LASAN0))
-  }
-  .kasan.shadows : {
-    *(.kasan.shadows)
-  }
-#endif
-
   .text : {
       _stext = .;            /* Text section */
       __text_start = .;
@@ -92,6 +77,19 @@ SECTIONS
       . = ALIGN(4096);
       _erodata = .;
   } > ROM
+
+#ifdef CONFIG_MM_KASAN_GLOBAL
+  .kasan.shadows : {
+      KEEP(*(.kasan.shadows))
+  } > ROM
+  .kasan.unused : {
+    *(.data..LASANLOC*)
+  } > RAM
+  .kasan.global : {
+    KEEP (*(.data..LASAN0))
+    KEEP (*(.data.rel.local..LASAN0))
+  } > RAM
+#endif
 
   _eronly = LOADADDR(.data);
   .data : {                    /* Data */

--- a/cmake/nuttx_multiple_link.cmake
+++ b/cmake/nuttx_multiple_link.cmake
@@ -134,6 +134,19 @@ define_multiple_link_target(final_nuttx second_link final)
 
 # fixing timing dependencies
 add_dependencies(nuttx_post final_nuttx)
+
+# Strip .kasan.unused and .kasan.global sections from the final binary. These
+# sections are only needed during the intermediate link passes for
+# kasan_global.py to extract global variable descriptors. At runtime they sit at
+# the start of RAM (0x40000000) and conflict with QEMU's DTB placement.
+if(CONFIG_MM_KASAN_GLOBAL)
+  add_custom_command(
+    TARGET final_nuttx
+    POST_BUILD
+    COMMAND ${CMAKE_OBJCOPY} -R .kasan.unused -R .kasan.global final_nuttx
+    COMMENT "Stripping .kasan.unused and .kasan.global sections")
+endif()
+
 # finally use final_nuttx to overwrite the already generated nuttx
 add_custom_command(
   TARGET final_nuttx

--- a/mm/kasan/hook.c
+++ b/mm/kasan/hook.c
@@ -31,7 +31,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#ifdef CONFIG_MM_KASAN_GLOBAL
+#if defined(CONFIG_MM_KASAN_GLOBAL) && defined(__KERNEL__)
 #  include "global.c"
 #else
 #  define kasan_global_is_poisoned(addr, size) false

--- a/mm/umm_heap/umm_initialize.c
+++ b/mm/umm_heap/umm_initialize.c
@@ -92,6 +92,7 @@ void umm_initialize(FAR void *heap_start, size_t heap_size)
   config.start = heap_start;
   config.size  = heap_size;
 #ifdef CONFIG_BUILD_KERNEL
+  config.nokasan = true;
   USR_HEAP = mm_initialize_pool(&config, NULL);
 #else
   config.name = "Umem";


### PR DESCRIPTION
## Summary

  * When CONFIG_MM_KASAN and CONFIG_BUILD_KERNEL are both enabled on
    qemu-armv7a:knsh, there are three issues preventing correct build
    and runtime: (1) user-space heap false positive KASAN reports,
    (2) app link failure due to undefined g_global_region symbol,
    (3) linker script misplaces KASAN sections causing boot failure.
  * This series fixes all three issues to make KASAN work correctly
    in kernel mode on QEMU ARMv7-A.

## Impact

  * Is new feature added? NO
  * Impact on user? NO
  * Impact on build? YES — CMake post-build now strips .kasan.unused
    and .kasan.global sections when CONFIG_MM_KASAN_GLOBAL is enabled.
  * Impact on hardware? YES — affects boards using qemu-armv7a with
    KASAN enabled in kernel build.
  * Impact on documentation? NO
  * Impact on security? NO
  * Impact on compatibility? NO

## Testing

- Build Host: Linux x86_64, GCC
- Target: qemu-armv7a:knsh (QEMU virt, Cortex-A7)

Setup config:

```
diff --git a/boards/arm/qemu/qemu-armv7a/configs/knsh/defconfig b/boards/arm/qemu/qemu-armv7a/configs/knsh/defconfig
index 18b086834c..1e2a1c3f96 100644
--- a/boards/arm/qemu/qemu-armv7a/configs/knsh/defconfig
+++ b/boards/arm/qemu/qemu-armv7a/configs/knsh/defconfig
@@ -91,3 +91,6 @@ CONFIG_UART1_PL011=y
 CONFIG_UART1_SERIAL_CONSOLE=y
 CONFIG_UART_PL011=y
 CONFIG_USEC_PER_TICK=1000
+CONFIG_MM_KASAN=y
+CONFIG_MM_KASAN_INSTRUMENT_ALL=y
+CONFIG_MM_KASAN_GLOBAL=y
```

Build:

```
cmake -B build -DBOARD_CONFIG=qemu-armv7a:knsh -GNinja && cmake --build build
```

Run:

```
qemu-system-arm -semihosting -M virt -m 128 -nographic -kernel ./build/nuttx
```

  Testing logs before change:

- Without commit 1 (mm/umm_heap), ls /proc triggers "detect kasan error".
- Without commit 2 (mm/kasan), app link fails with undefined g_global_region.
- Without commit 3 (boards/arm/qemu), QEMU fails to boot (LOAD segment conflict).  Log of booting failure is below

```
qemu-system-arm: Some ROM regions are overlapping
These ROM regions might have been loaded by direct user request or by default.
They could be BIOS/firmware images, a guest kernel, initrd or some other file loaded into guest memory.
Check whether you intended to load all this guest code, and whether it has been built to load to the correct addresses.

The following two regions overlap (in the cpu-memory-0 address space):
  ./build/nuttx ELF program header segment 1 (addresses 0x0000000000000000 - 0x0000000000030000)
  dtb (addresses 0x0000000000000000 - 0x0000000000100000)

The following two regions overlap (in the cpu-memory-0 address space):
  dtb (addresses 0x0000000000000000 - 0x0000000000100000)
  ./build/nuttx ELF program header segment 2 (addresses 0x0000000000030000 - 0x0000000000034420)
```