### PR TITLE
{bp-19197} syslog: avoid an infinite loop if one channel fails

### DIFF
--- a/drivers/syslog/syslog_write.c
+++ b/drivers/syslog/syslog_write.c
@@ -107,7 +107,7 @@ ssize_t syslog_write_foreach(FAR const char *buffer,
   syslog_write_t write;
   syslog_putc_t  putc;
   size_t nwritten = 0;
-  size_t nwritten_max = 0;
+  ssize_t nwritten_max = -EIO;
   ssize_t ret;
   int i;
 
@@ -153,7 +153,7 @@ ssize_t syslog_write_foreach(FAR const char *buffer,
 
                   if (ret < 0)
                     {
-                      return ret;
+                      continue;
                     }
 
                   nwritten = head + 1;
@@ -166,7 +166,7 @@ ssize_t syslog_write_foreach(FAR const char *buffer,
               ret = write(channel, buffer + nwritten, buflen - nwritten);
               if (ret < 0)
                 {
-                  return ret;
+                  continue;
                 }
               else
                 {

--- a/libs/libc/stream/lib_syslograwstream.c
+++ b/libs/libc/stream/lib_syslograwstream.c
@@ -123,7 +123,12 @@ static void syslograwstream_addchar(FAR struct lib_syslograwstream_s *stream,
 
       /* Yes.. then flush the buffer */
 
-      syslograwstream_flush(&stream->common);
+      int ret = syslograwstream_flush(&stream->common);
+      if (ret < 0)
+        {
+          stream->offset = 0;
+          stream->common.nput = 0;
+        }
     }
 }
 
@@ -136,7 +141,6 @@ syslograwstream_addstring(FAR struct lib_syslograwstream_s *stream,
                           FAR const char *buff, size_t len)
 {
   ssize_t ret = 0;
-
   do
     {
       size_t remain = CONFIG_SYSLOG_BUFSIZE - stream->offset;
@@ -155,7 +159,13 @@ syslograwstream_addstring(FAR struct lib_syslograwstream_s *stream,
 
           /* Yes.. then flush the buffer */
 
-          syslograwstream_flush(&stream->common);
+          int ret_flush = syslograwstream_flush(&stream->common);
+          if (ret_flush < 0)
+            {
+               stream->offset = 0;
+               stream->common.nput = 0;
+               break;
+            }
         }
     }
   while (ret < len);


### PR DESCRIPTION
## Summary

The current implementation exits syslog_write_foreach function if write to one channel fails, causing other channels not being written and returning negated errno. libc syslog functions then stay in an infinite loop, because error is returned and the same bytes are still passed to syslograwstream_flush and syslog_write_foreach.

The channel write may fail for many reasons - disconnected USB if CDC ACM syslog is enabled, lost networking if telnet syslog is enabled, error on NOR flash etc. This shouldn't lead to an ininite loop in the code though.

The solution ensures all channels in syslog_write_foreach are tried, therefore the user get the output to the working channels even if the first one is broken. It also updates syslograwstream_addchar and syslograwstream_addstring to skip the bytes if all channels fails. This ensures syslog call won't result in an infinite loop, but the user may lost the debugging output.

## Impact

RELEASE

## Testing

CI