### PR TITLE
{bp-19112} arch/arm/gd32f4: fix missing CTL selector bits in up_disableusartint.

### DIFF
--- a/arch/arm/src/gd32f4/gd32f4xx_serial.c
+++ b/arch/arm/src/gd32f4/gd32f4xx_serial.c
@@ -1142,25 +1142,47 @@ static void up_disableusartint(struct up_dev_s *priv, uint32_t *ie)
     {
       uint32_t ctl;
 
+      ctl_ie = 0;
+
       /* Save interrupt in CTL0 register */
 
       ctl = up_serialin(priv, GD32_USART_CTL0_OFFSET);
-      ctl_ie = ((ctl & USART_CTL0_USED_INTS) >> USART_CFG_CTL0_INT_SHIFT);
+      if (ctl & USART_CTL0_USED_INTS)
+        {
+          ctl_ie |= ((ctl & USART_CTL0_USED_INTS) >>
+                       USART_CFG_CTL0_INT_SHIFT);
+          ctl_ie |= (USART_CFG_CTL0_INT << USART_CFG_SHIFT);
+        }
 
       /* Save interrupt in CTL1 register */
 
       ctl = up_serialin(priv, GD32_USART_CTL1_OFFSET);
-      ctl_ie |= ((ctl & USART_CTL1_USED_INTS) >> USART_CFG_CTL1_INT_SHIFT);
+      if (ctl & USART_CTL1_USED_INTS)
+        {
+          ctl_ie |= ((ctl & USART_CTL1_USED_INTS) >>
+                       USART_CFG_CTL1_INT_SHIFT);
+          ctl_ie |= (USART_CFG_CTL1_INT << USART_CFG_SHIFT);
+        }
 
       /* Save interrupt in CTL2 register */
 
       ctl = up_serialin(priv, GD32_USART_CTL2_OFFSET);
-      ctl_ie |= ((ctl & USART_CTL2_USED_INTS) << USART_CFG_CTL2_INT_SHIFT);
+      if (ctl & USART_CTL2_USED_INTS)
+        {
+          ctl_ie |= ((ctl & USART_CTL2_USED_INTS) <<
+                       USART_CFG_CTL2_INT_SHIFT);
+          ctl_ie |= (USART_CFG_CTL2_INT << USART_CFG_SHIFT);
+        }
 
       /* Save interrupt in CTL3 register */
 
       ctl = up_serialin(priv, GD32_USART_CTL3_OFFSET);
-      ctl_ie |= ((ctl & USART_CTL3_USED_INTS) << USART_CFG_CTL3_INT_SHIFT);
+      if (ctl & USART_CTL3_USED_INTS)
+        {
+          ctl_ie |= ((ctl & USART_CTL3_USED_INTS) <<
+                       USART_CFG_CTL3_INT_SHIFT);
+          ctl_ie |= (USART_CFG_CTL3_INT << USART_CFG_SHIFT);
+        }
 
       *ie = ctl_ie;
     }

--- a/arch/arm/src/gd32f4/gd32f4xx_serial.c
+++ b/arch/arm/src/gd32f4/gd32f4xx_serial.c
@@ -2763,7 +2763,7 @@ void arm_earlyserialinit(void)
 
   for (i = 0; i < GD32_NUSART; i++)
     {
-      if (g_uart_devs[i]->priv)
+      if (g_uart_devs[i] && g_uart_devs[i]->priv)
         {
           up_disableusartint(g_uart_devs[i]->priv, 0);
         }

--- a/arch/arm/src/gd32f4/gd32f4xx_serial.c
+++ b/arch/arm/src/gd32f4/gd32f4xx_serial.c
@@ -2763,7 +2763,7 @@ void arm_earlyserialinit(void)
 
   for (i = 0; i < GD32_NUSART; i++)
     {
-      if (g_uart_devs[i] && g_uart_devs[i]->priv)
+      if (g_uart_devs[i]->priv)
         {
           up_disableusartint(g_uart_devs[i]->priv, 0);
         }


### PR DESCRIPTION
## Summary

Fix a bug in up_disableusartint() where USART interrupt state is saved without CTL selector bits (bits 24-27), causing up_restoreusartint() to never restore interrupt enables.

NOTE
included a wrongly rebased patch https://github.com/apache/nuttx/pull/19040

## Impact

RELEASE

## Testing

CI