### PR TITLE
arch/arm: fix DMA transfers with sizes smaller than 4 bytes.

### DIFF
--- a/arch/arm/src/common/stm32/stm32_sdio_m3m4_v1.c
+++ b/arch/arm/src/common/stm32/stm32_sdio_m3m4_v1.c
@@ -1087,7 +1087,7 @@ static void stm32_sendfifo(struct stm32_dev_s *priv)
            * padding with zero as necessary to extend to a full word.
            */
 
-          uint8_t *ptr = (uint8_t *)priv->remaining;
+          uint8_t *ptr = (uint8_t *)priv->buffer;
           int i;
 
           data.w = 0;

--- a/arch/arm/src/stm32f7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32f7/stm32_sdmmc.c
@@ -1313,7 +1313,7 @@ static void stm32_sendfifo(struct stm32_dev_s *priv)
            * padding with zero as necessary to extend to a full word.
            */
 
-          uint8_t *ptr = (uint8_t *)priv->remaining;
+          uint8_t *ptr = (uint8_t *)priv->buffer;
           int i;
 
           data.w = 0;

--- a/arch/arm/src/stm32h7/stm32_sdmmc.c
+++ b/arch/arm/src/stm32h7/stm32_sdmmc.c
@@ -1232,7 +1232,7 @@ static void stm32_sendfifo(struct stm32_dev_s *priv)
            * padding with zero as necessary to extend to a full word.
            */
 
-          uint8_t *ptr = (uint8_t *)priv->remaining;
+          uint8_t *ptr = (uint8_t *)priv->buffer;
           int i;
 
           data.w = 0;

--- a/arch/arm/src/stm32l4/stm32l4_sdmmc.c
+++ b/arch/arm/src/stm32l4/stm32l4_sdmmc.c
@@ -1177,7 +1177,7 @@ static void stm32_sendfifo(struct stm32_dev_s *priv)
            * padding with zero as necessary to extend to a full word.
            */
 
-          uint8_t *ptr = (uint8_t *)priv->remaining;
+          uint8_t *ptr = (uint8_t *)priv->buffer;
           int i;
 
           data.w = 0;


### PR DESCRIPTION
## Summary

All STM32 SDIO/SDMMC drivers are affected by this bug which comes from the original addition of interrupt handing to the base STM32 SDIO driver in 2009 (https://github.com/apache/nuttx/commit/373959f7dbce2233c56f0267a31deab67edd7aa4).

When the buffer to send has a size not multiple of 4 bytes, 4-byte words are sent correctly, but when the code reaches the section to send the remaining bytes (1, 2 or 3) it takes the *remaining byte count* as origin of the copy, instead of the *buffer* (as it should). The explicit cast (used to convert a uint32_t pointer to a uint8_t pointer) prevents the compiler warning/error to appear and hides the fact an integer (non-pointer) is used as a pointer.

## Impact

This has been around since 2009 and has not triggered, probably because most (all?) SDIO transfers are word-sized so that section of the code is not being used at all.

## Testing

The change has been tested on custom HW, using STM32H5, with STM32H7 SDMMC driver ported (it requires almost no changes to work on STM32H5). This has no effect (meaning: the driver still works after this change). I have not been able to find a use case triggering the bug, so I can not really test that this fixes it.