### PR TITLE
fs/vfs: link() fails with ENOSYS instead of aliasing symlink

### DIFF
--- a/fs/vfs/CMakeLists.txt
+++ b/fs/vfs/CMakeLists.txt
@@ -51,7 +51,8 @@ set(SRCS
     fs_dir.c
     fs_fsync.c
     fs_syncfs.c
-    fs_truncate.c)
+    fs_truncate.c
+    fs_link.c)
 
 # File notify support
 
@@ -66,7 +67,7 @@ if(NOT "${CONFIG_FS_LOCK_BUCKET_SIZE}" STREQUAL "0")
 endif()
 
 if(NOT "${CONFIG_PSEUDOFS_SOFTLINKS}" STREQUAL "0")
-  list(APPEND SRCS fs_link.c fs_symlink.c fs_readlink.c)
+  list(APPEND SRCS fs_symlink.c fs_readlink.c)
 endif()
 
 # Pseudofile support

--- a/fs/vfs/Make.defs
+++ b/fs/vfs/Make.defs
@@ -27,7 +27,7 @@ CSRCS += fs_epoll.c fs_fchstat.c fs_fstat.c fs_fstatfs.c fs_ioctl.c fs_lseek.c
 CSRCS += fs_mkdir.c fs_open.c fs_poll.c fs_pread.c fs_pwrite.c fs_read.c
 CSRCS += fs_rename.c fs_rmdir.c fs_select.c fs_sendfile.c fs_stat.c
 CSRCS += fs_statfs.c fs_uio.c fs_unlink.c fs_write.c fs_dir.c fs_fsync.c
-CSRCS += fs_syncfs.c fs_truncate.c
+CSRCS += fs_syncfs.c fs_truncate.c fs_link.c
 
 ifeq ($(CONFIG_FS_NOTIFY),y)
 CSRCS += fs_inotify.c
@@ -38,7 +38,7 @@ CSRCS += fs_lock.c
 endif
 
 ifneq ($(CONFIG_PSEUDOFS_SOFTLINKS),0)
-CSRCS += fs_link.c fs_symlink.c fs_readlink.c
+CSRCS += fs_symlink.c fs_readlink.c
 endif
 
 # Pseudofile support

--- a/fs/vfs/fs_link.c
+++ b/fs/vfs/fs_link.c
@@ -26,13 +26,9 @@
 
 #include <nuttx/config.h>
 
+#include <sys/types.h>
 #include <unistd.h>
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#ifdef CONFIG_PSEUDOFS_SOFTLINKS
+#include <errno.h>
 
 /****************************************************************************
  * Public Functions
@@ -42,10 +38,8 @@
  * Name: link
  *
  * Description:
- *  The link function provides a wrapper to symlink. Solely to provide
- *  compatibility to posix compatibility layer.
- *
- *  See symlink for details on limitations.
+ *   Create a hard link.  The NuttX VFS does not support hard links, so this
+ *   always fails with ENOSYS rather than silently creating a symbolic link.
  *
  * Input Parameters:
  *   path1 - Points to a pathname naming an existing file.
@@ -53,14 +47,15 @@
  *           created.
  *
  * Returned Value:
- *   On success, zero (OK) is returned.  Otherwise, -1 (ERROR) is returned
- *   the errno variable is set appropriately.
+ *   -1 (ERROR) is always returned with the errno set to ENOSYS.
  *
  ****************************************************************************/
 
 int link(FAR const char *path1, FAR const char *path2)
 {
-  return symlink(path1, path2);
-}
+  (void)path1;
+  (void)path2;
 
-#endif /* CONFIG_PSEUDOFS_SOFTLINKS */
+  set_errno(ENOSYS);
+  return ERROR;
+}

--- a/syscall/syscall.csv
+++ b/syscall/syscall.csv
@@ -59,7 +59,7 @@
 "kill","signal.h","","int","pid_t","int"
 "lchmod","sys/stat.h","","int","FAR const char *","mode_t"
 "lchown","unistd.h","","int","FAR const char *","uid_t","gid_t"
-"link","unistd.h","defined(CONFIG_PSEUDOFS_SOFTLINKS)","int","FAR const char *","FAR const char *"
+"link","unistd.h","","int","FAR const char *","FAR const char *"
 "listen","sys/socket.h","defined(CONFIG_NET)","int","int","int"
 "lseek","unistd.h","","off_t","int","off_t","int"
 "lstat","sys/stat.h","","int","FAR const char *","FAR struct stat *"


### PR DESCRIPTION
## Summary

The NuttX VFS has no hard-link support, yet `link()` was implemented as a thin
alias of `symlink()`:

```c
#ifdef CONFIG_PSEUDOFS_SOFTLINKS
int link(FAR const char *path1, FAR const char *path2)
{
  return symlink(path1, path2);
}
#endif
```

This is wrong in two independent ways, and fixing it correctly is *why the
change is not a one-liner*.

**1. Incorrect POSIX semantics.** `link()` is defined to create a *hard* link.
Silently creating a *symbolic* link instead is surprising and breaks callers
that rely on the distinction. In particular, the common portability pattern of
probing for hard-link support — call `link()` and check for failure — was told
the operation *succeeded*, having quietly created a symlink it never asked for.
The correct answer for a filesystem with no hard links is `-1` / `ENOSYS`.

**2. The hard-link API was gated behind an unrelated feature.** Returning
`ENOSYS` from the function body alone fixes nothing, because the whole of
`fs_link.c` was compiled only under `CONFIG_PSEUDOFS_SOFTLINKS`. When soft links
are disabled, `link()` did not exist at all — so editing its body changes
nothing for those configurations; `link()` simply remains an undefined symbol.
Hard links and soft links are independent concepts, so gating `link()` (hard
link) on `CONFIG_PSEUDOFS_SOFTLINKS` (soft links) is a category error. Making
`link()` report `ENOSYS` *regardless of soft-link configuration* therefore
requires decoupling it from that option.

That decoupling is a single logical change, but NuttX expresses the same build
condition in four parallel places, so the same `CONFIG_PSEUDOFS_SOFTLINKS`
guard had to be removed from each:

| File | Role |
| --- | --- |
| `fs/vfs/fs_link.c` | the `#ifdef` wrapping the function itself |
| `fs/vfs/Make.defs` | Make build |
| `fs/vfs/CMakeLists.txt` | CMake build |
| `syscall/syscall.csv` | syscall stub generation |

These are four copies of one condition, not four independent changes; leaving
the guard in any of them would make the tree inconsistent (e.g. compiled but
absent from the syscall table, or present in CMake but not in Make).

`fs_symlink.c` and `fs_readlink.c` remain under `CONFIG_PSEUDOFS_SOFTLINKS`, as
they should — soft-link support is untouched (see Impact).

**This was already a latent inconsistency, not just a cosmetic issue.**
`libs/libc/unistd/lib_linkat.c` is built *unconditionally* and is implemented on
top of `link()`:

```c
ret = link(oldfullpath, newfullpath);   /* lib_linkat.c */
```

So the tree already assumed `link()` is always available — directly
contradicting the `CONFIG_PSEUDOFS_SOFTLINKS` guard. Without soft links,
`linkat()` referenced a `link()` that was never built. After this change
`fs_link.c` is always compiled, `link()` always returns `-1`/`ENOSYS`, and
`linkat()` has a consistent, always-present backend.

```c
int link(FAR const char *path1, FAR const char *path2)
{
  (void)path1;
  (void)path2;

  set_errno(ENOSYS);
  return ERROR;
}
```

## Impact

**Soft-link support (`CONFIG_PSEUDOFS_SOFTLINKS`) is fully preserved.** This
change does not touch soft links: `symlink()`/`readlink()` remain gated by the
option and behave exactly as before. The two features are orthogonal —
`CONFIG_PSEUDOFS_SOFTLINKS` provides *symbolic* links via `symlink()`, while
`link()` is the *hard*-link API. Enabling soft links should not, and now does
not, change the behavior of the hard-link API. The only difference for a
`CONFIG_PSEUDOFS_SOFTLINKS=y` build is that `link()` no longer silently creates
a symlink:

| Call | `SOFTLINKS=y`, before | `SOFTLINKS=y`, after |
| --- | --- | --- |
| `symlink()` | creates a symlink | creates a symlink (unchanged) |
| `readlink()` | reads a symlink | reads a symlink (unchanged) |
| `link()` | silently created a *symlink* | `-1` / `ENOSYS` |

A caller that wants a symbolic link must use `symlink()` (the correct API,
already available when the option is enabled); a caller of `link()` wants a
*hard* link, which NuttX supports in no configuration, so `ENOSYS` is the
correct result with or without soft links. No in-tree caller relied on the old
aliasing.

Other effects:

- **Configurations without soft links:** `link()` now exists and returns
  `ENOSYS` instead of being an undefined reference, and `linkat()` behaves
  consistently in every configuration.
- **Build:** `fs_link.c` is now always compiled — a tiny `ENOSYS` stub, no new
  dependencies and no Kconfig changes. No size impact beyond a few bytes.
- **API / docs:** `link()` is still declared in `<unistd.h>`; only its runtime
  behavior changes, and it is now standards-compliant for a filesystem without
  hard-link support.
- **Rejected alternative:** simply enabling `CONFIG_PSEUDOFS_SOFTLINKS` in a
  board defconfig would pull in the entire symlink/readlink machinery just to
  make a hard-link call report "unsupported", keeps the incorrect coupling, and
  hides a VFS-wide issue behind a per-board workaround instead of fixing it in
  the place the behavior actually lives.

## Testing

Host: <Ubuntu 24.04 x86_64>
Board: esp32c3-devkit, configuration without `CONFIG_PSEUDOFS_SOFTLINKS`

Built and exercised on the esp32c3-devkit: `link()` returns `-1` with
`errno == ENOSYS`, and `linkat()` resolves consistently in a build with soft
links disabled.
