### PR TITLE
arch/arm/stm32h5/adc: disable CONT for timer-triggered circular DMA

### DIFF
--- a/arch/arm/src/stm32h5/stm32_adc.c
+++ b/arch/arm/src/stm32h5/stm32_adc.c
@@ -1445,7 +1445,18 @@ static int adc_setup(struct adc_dev_s *dev)
         {
           setbits |= ADC_CFGR_OVRMOD; /* overwrite on overrun */
           setbits |= ADC_CFGR_DMACFG;
+#  ifdef ADC_HAVE_TIMER
+          if (priv->tbase != 0)
+            {
+              clrbits |= ADC_CFGR_CONT;
+            }
+          else
+            {
+              setbits |= ADC_CFGR_CONT;
+            }
+#  else
           setbits |= ADC_CFGR_CONT;
+#  endif
         }
       else
         {


### PR DESCRIPTION
## Summary

Clear `ADC_CFGR_CONT` when circular DMA is used together with an external timer trigger on STM32H5.

When ADC_CFGR_CONT is set, the first timer event starts a conversion sequence and the ADC then continues converting without waiting for additional triggers. As a result, sampling is no longer synchronized to the timer.

This change clears ADC_CFGR_CONT for timer-triggered circular DMA while preserving continuous conversion mode for non timer-triggered circular DMA operation.

## Impact

Fixes timer-triggered circular DMA sampling on STM32H5 by keeping ADC conversions synchronized to the configured timer.

## Testing

Tested on STM32 Nucleo-H563ZI with ADC1 configured for circular DMA and timer-triggered sampling at 100 Hz.

Board code patch used for this test  [nucleo-h563zi-timer-dma-driven-test.patch](https://github.com/user-attachments/files/29304237/nucleo-h563zi-timer-dma-driven-test.patch)


Build configuration:

```sh
cmake -B build -DBOARD_CONFIG=nucleo-h563zi:adc -GNinja
cmake --build build
```

Readings were taken from NSH using the patch ADC frequency test task.

### Without this change (Expected 100/s)

```text
ADC frequency: samples=1884/s
ADC frequency: samples=1881/s
ADC frequency: samples=1884/s
ADC frequency: samples=1882/s
ADC frequency: samples=1862/s
```

### With this change (Expected 100/s)

```text
ADC frequency: samples=100/s
ADC frequency: samples=100/s
ADC frequency: samples=100/s
ADC frequency: samples=100/s
ADC frequency: samples=100/s
```