### PR TITLE
fs/vfs: provide link fallback without softlinks

### DIFF
--- a/fs/vfs/CMakeLists.txt
+++ b/fs/vfs/CMakeLists.txt
@@ -51,7 +51,8 @@ set(SRCS
     fs_dir.c
     fs_fsync.c
     fs_syncfs.c
-    fs_truncate.c)
+    fs_truncate.c
+    fs_link.c)
 
 # File notify support
 
@@ -66,7 +67,7 @@ if(NOT "${CONFIG_FS_LOCK_BUCKET_SIZE}" STREQUAL "0")
 endif()
 
 if(NOT "${CONFIG_PSEUDOFS_SOFTLINKS}" STREQUAL "0")
-  list(APPEND SRCS fs_link.c fs_symlink.c fs_readlink.c)
+  list(APPEND SRCS fs_symlink.c fs_readlink.c)
 endif()
 
 # Pseudofile support

--- a/fs/vfs/Make.defs
+++ b/fs/vfs/Make.defs
@@ -27,7 +27,7 @@ CSRCS += fs_epoll.c fs_fchstat.c fs_fstat.c fs_fstatfs.c fs_ioctl.c fs_lseek.c
 CSRCS += fs_mkdir.c fs_open.c fs_poll.c fs_pread.c fs_pwrite.c fs_read.c
 CSRCS += fs_rename.c fs_rmdir.c fs_select.c fs_sendfile.c fs_stat.c
 CSRCS += fs_statfs.c fs_uio.c fs_unlink.c fs_write.c fs_dir.c fs_fsync.c
-CSRCS += fs_syncfs.c fs_truncate.c
+CSRCS += fs_syncfs.c fs_truncate.c fs_link.c
 
 ifeq ($(CONFIG_FS_NOTIFY),y)
 CSRCS += fs_inotify.c
@@ -38,7 +38,7 @@ CSRCS += fs_lock.c
 endif
 
 ifneq ($(CONFIG_PSEUDOFS_SOFTLINKS),0)
-CSRCS += fs_link.c fs_symlink.c fs_readlink.c
+CSRCS += fs_symlink.c fs_readlink.c
 endif
 
 # Pseudofile support

--- a/fs/vfs/fs_link.c
+++ b/fs/vfs/fs_link.c
@@ -26,13 +26,8 @@
 
 #include <nuttx/config.h>
 
+#include <errno.h>
 #include <unistd.h>
-
-/****************************************************************************
- * Pre-processor Definitions
- ****************************************************************************/
-
-#ifdef CONFIG_PSEUDOFS_SOFTLINKS
 
 /****************************************************************************
  * Public Functions
@@ -42,10 +37,8 @@
  * Name: link
  *
  * Description:
- *  The link function provides a wrapper to symlink. Solely to provide
- *  compatibility to posix compatibility layer.
- *
- *  See symlink for details on limitations.
+ *  The link function provides a wrapper to symlink when pseudo filesystem
+ *  softlinks are enabled. Otherwise, hard links are unsupported.
  *
  * Input Parameters:
  *   path1 - Points to a pathname naming an existing file.
@@ -60,7 +53,13 @@
 
 int link(FAR const char *path1, FAR const char *path2)
 {
+#ifdef CONFIG_PSEUDOFS_SOFTLINKS
   return symlink(path1, path2);
-}
+#else
+  (void)path1;
+  (void)path2;
 
-#endif /* CONFIG_PSEUDOFS_SOFTLINKS */
+  set_errno(ENOSYS);
+  return ERROR;
+#endif
+}


### PR DESCRIPTION
## Summary

Fix the VFS link() build coverage when `CONFIG_PSEUDOFS_SOFTLINKS` is disabled.
link() is declared unconditionally in unistd.h, but fs_link.c was only built when pseudo filesystem softlinks were enabled.
This change builds fs_link.c unconditionally and keeps only fs_symlink.c and fs_readlink.c behind `CONFIG_PSEUDOFS_SOFTLINKS`. When softlinks are enabled, link() keeps the existing behavior of delegating to symlink(). When softlinks are disabled, link() returns -1 with errno set to ENOSYS.

## Impact

Applications can safely reference link() regardless of CONFIG_PSEUDOFS_SOFTLINKS.
