### PR TITLE
ci/testing: Update MemBrowse targets and cuncurrency condition

### DIFF
--- a/.github/membrowse-targets.json
+++ b/.github/membrowse-targets.json
@@ -3,7 +3,7 @@
     "target_name": "stm32-nucleo-f103rb",
     "board_config": "nucleo-f103rb:nsh",
     "elf": "nuttx",
-    "ld": "boards/arm/stm32/nucleo-f103rb/scripts/ld.script",
+    "ld": "boards/arm/stm32f1/nucleo-f103rb/scripts/ld.script",
     "map_file": "nuttx.map",
     "linker_vars": "",
     "config_overrides": ""

--- a/.github/workflows/membrowse-report.yml
+++ b/.github/workflows/membrowse-report.yml
@@ -10,8 +10,13 @@ on:
 permissions:
   contents: read
 
+# Per-PR group so superseded PR pushes cancel; per-SHA on push so master
+# commits never share a group. A shared refs/heads/master group lets a burst
+# of pushes evict each other while pending (GitHub keeps only one pending run
+# per group), leaving a commit with no report and breaking the MemBrowse
+# parent chain for every commit that bases on it.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION

## Summary

Update the linker script path in membrowse-targets.json and the concurrency condition,
 to prevent breaking the commit chain

## Impact

Fixing MemBrowse reporting

## Testing

Tested on a fork repo