### PR TITLE
1wire: Move onewire_valid_rom to 1wire_crc.h

### DIFF
--- a/drivers/1wire/1wire.c
+++ b/drivers/1wire/1wire.c
@@ -35,6 +35,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/1wire/1wire_master.h>
 #include <nuttx/1wire/1wire.h>
+#include <nuttx/1wire/1wire_crc.h>
 
 #include "1wire_internal.h"
 

--- a/drivers/1wire/1wire_internal.h
+++ b/drivers/1wire/1wire_internal.h
@@ -66,10 +66,6 @@ struct onewire_slave_s
  * Public Function Prototypes
  ****************************************************************************/
 
-/* Additional CRC helpers from 1wire_crc.c */
-
-bool onewire_valid_rom(uint64_t rom);
-
 /* Rest are from 1wire.c */
 
 int onewire_addslave(FAR struct onewire_master_s *master,

--- a/include/nuttx/1wire/1wire_crc.h
+++ b/include/nuttx/1wire/1wire_crc.h
@@ -83,6 +83,22 @@ uint16_t onewire_crc16(FAR const uint8_t *input, uint16_t len,
                        uint16_t initial_crc);
 
 /****************************************************************************
+ * Name: onewire_valid_rom
+ *
+ * Description:
+ *   Check CRC-8 of received input
+ *
+ * Input Parameters:
+ *   rom   - 64-bit rom code
+ *
+ * Returned Value:
+ *   true if CRC-8 of rom matches
+ *
+ ****************************************************************************/
+
+bool onewire_valid_rom(uint64_t rom);
+
+/****************************************************************************
  * Name: onewire_check_crc16
  *
  * Description:


### PR DESCRIPTION
To let developers use all procedures implemented in the corresponding .c file when 1wire_crc.h is included.

## Summary

When `nuttx/1wire/1wire_crc.h` is included, all the procedures implemented in the `drivers/1wire/1wire_crc.c` all available except `onewire_valid_rom`.

## Impact

`onewire_valid_rom` will be available after `#include <nuttx/1wire/1wire_crc.h>`.

## Testing

I have compiled the NuttX with the custom implementation of 1wire protocol that uses `onewire_valid_rom` and sucessfuly used it.

I have **not** tested this on a board where 1wire is used. Could anyone, please, do it? It looks `onewire_valid_rom` is used only in `drivers/1wire/1wire.c` and

```
@@ -35,6 +35,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/1wire/1wire_master.h>
 #include <nuttx/1wire/1wire.h>
+#include <nuttx/1wire/1wire_crc.h>
 
 #include "1wire_internal.h"
```

is a part of this PR, but better save than sorry. Thanks!