### PR TITLE
arch/arm: remove duplicate .globl for up_saveusercontext

### DIFF
--- a/arch/arm/src/arm/arm_saveusercontext.S
+++ b/arch/arm/src/arm/arm_saveusercontext.S
@@ -53,7 +53,6 @@
  ****************************************************************************/
 
 	.globl	up_saveusercontext
-	.globl	up_saveusercontext
 	.type	up_saveusercontext, %function
 
 up_saveusercontext:

--- a/arch/arm/src/armv6-m/arm_saveusercontext.S
+++ b/arch/arm/src/armv6-m/arm_saveusercontext.S
@@ -53,7 +53,6 @@
  ****************************************************************************/
 
 	.globl	up_saveusercontext
-	.globl	up_saveusercontext
 	.type	up_saveusercontext, %function
 
 up_saveusercontext:

--- a/arch/arm/src/armv7-a/arm_saveusercontext.S
+++ b/arch/arm/src/armv7-a/arm_saveusercontext.S
@@ -53,7 +53,6 @@
  ****************************************************************************/
 
 	.globl	up_saveusercontext
-	.globl	up_saveusercontext
 	.type	up_saveusercontext, %function
 
 up_saveusercontext:

--- a/arch/arm/src/armv7-m/arm_saveusercontext.S
+++ b/arch/arm/src/armv7-m/arm_saveusercontext.S
@@ -57,7 +57,6 @@
  ****************************************************************************/
 
 	.globl	up_saveusercontext
-	.globl	up_saveusercontext
 #ifdef __ghs__
 	.type	up_saveusercontext, $function
 #else

--- a/arch/arm/src/armv7-r/arm_saveusercontext.S
+++ b/arch/arm/src/armv7-r/arm_saveusercontext.S
@@ -53,7 +53,6 @@
  ****************************************************************************/
 
 	.globl	up_saveusercontext
-	.globl	up_saveusercontext
 	.type	up_saveusercontext, %function
 
 up_saveusercontext:

--- a/arch/arm/src/armv8-m/arm_saveusercontext.S
+++ b/arch/arm/src/armv8-m/arm_saveusercontext.S
@@ -53,7 +53,6 @@
  ****************************************************************************/
 
 	.globl	up_saveusercontext
-	.globl	up_saveusercontext
 	.type	up_saveusercontext, %function
 
 up_saveusercontext:

--- a/arch/arm/src/armv8-r/arm_saveusercontext.S
+++ b/arch/arm/src/armv8-r/arm_saveusercontext.S
@@ -55,7 +55,6 @@
  ****************************************************************************/
 
 	.globl	up_saveusercontext
-	.globl	up_saveusercontext
 #ifdef __ghs__
 	.type	up_saveusercontext, $function
 #else


### PR DESCRIPTION
## Summary

Each `arm_saveusercontext.S` under `arch/arm/src/` declared the
`up_saveusercontext` symbol with `.globl` on two consecutive, identical lines.
The `.globl` directive is idempotent, so the second declaration is a no-op that
has no effect on the generated object — it is just dead text that diverges from
the single-declaration convention used by every other `.S` file in these
directories.

This PR removes the redundant `.globl up_saveusercontext` line from each of the
seven affected ARM sub-architectures (one commit per file):

- `arch/arm/src/arm/arm_saveusercontext.S`
- `arch/arm/src/armv6-m/arm_saveusercontext.S`
- `arch/arm/src/armv7-a/arm_saveusercontext.S`
- `arch/arm/src/armv7-m/arm_saveusercontext.S`
- `arch/arm/src/armv7-r/arm_saveusercontext.S`
- `arch/arm/src/armv8-m/arm_saveusercontext.S`
- `arch/arm/src/armv8-r/arm_saveusercontext.S`

## Impact

- **Users**: None. No API, behavior, or symbol-table change.
- **Build**: None. The emitted object is byte-for-byte identical because
  `.globl` is idempotent.
- **Hardware**: None.
- **Documentation**: None.
- **Security / Compatibility**: None.

This is a pure source-cleanup change with no functional effect.

## Testing

This is a no-op source cleanup: `.globl` is idempotent, so removing the
duplicate declaration cannot change the generated object — the symbol table for
`up_saveusercontext` is identical before and after.

Verified only that the affected sub-architectures still build cleanly
(`tools/configure.sh <board>:nsh` + `make -j22`)
