### PR TITLE
arch/riscv: Add CONFIG_ARCH_RV_ISA_ZICSR_ZIFENCEI for fence.i

### DIFF
--- a/arch/risc-v/include/barriers.h
+++ b/arch/risc-v/include/barriers.h
@@ -39,6 +39,10 @@
 
 /* UP_ISB() is used to synchronize the instruction and data streams */
 
-#define UP_ISB()       __asm__ __volatile__ ("fence.i" ::: "memory")
+#ifdef CONFIG_ARCH_RV_ISA_ZICSR_ZIFENCEI
+#  define UP_ISB()       __asm__ __volatile__ ("fence.i" ::: "memory")
+#else
+#  define UP_ISB()       
+#endif
 
 #endif /* __ARCH_RISCV_INCLUDE_BARRIERS_H */

--- a/arch/risc-v/src/common/riscv_fpu.S
+++ b/arch/risc-v/src/common/riscv_fpu.S
@@ -72,8 +72,9 @@ riscv_fpuconfig:
   csrs         CSR_STATUS, a0
 
   fscsr        zero
-
+#ifdef CONFIG_ARCH_RV_ISA_ZICSR_ZIFENCEI
   fence.i
+#endif
   ret
 
 /****************************************************************************

--- a/arch/risc-v/src/common/riscv_mmu.h
+++ b/arch/risc-v/src/common/riscv_mmu.h
@@ -224,7 +224,9 @@ static inline void mmu_write_satp(uintptr_t reg)
       "csrw satp, %0\n"
       "sfence.vma x0, x0\n"
       "fence rw, rw\n"
+#ifdef CONFIG_ARCH_RV_ISA_ZICSR_ZIFENCEI
       "fence.i\n"
+#endif
       :
       : "rK" (reg)
       : "memory"

--- a/arch/risc-v/src/common/riscv_vpu.S
+++ b/arch/risc-v/src/common/riscv_vpu.S
@@ -70,8 +70,9 @@
 riscv_vpuconfig:
   li           a0, MSTATUS_VS_INIT
   csrs         CSR_STATUS, a0
-
+#ifdef CONFIG_ARCH_RV_ISA_ZICSR_ZIFENCEI
   fence.i
+#endif
   ret
 
 /****************************************************************************

--- a/arch/risc-v/src/mpfs/mpfs_head.S
+++ b/arch/risc-v/src/mpfs/mpfs_head.S
@@ -172,7 +172,9 @@ __start:
   csrw CSR_MIE, a2     /* Set MSIE bit to receive IPI */
 
   /* flush the instruction cache */
+#ifdef CONFIG_ARCH_RV_ISA_ZICSR_ZIFENCEI
   fence.i
+#endif
 
 .wait_boot:
   wfi


### PR DESCRIPTION
## Summary

The fence.i instruction is only available when the Zifencei extension (CONFIG_ARCH_RV_ISA_ZICSR_ZIFENCEI) 
is supported by the hardware.

This commit adds a macro wrapper around fence.i usages to prevent compilation errors 
on toolchains or targets where the Zifencei extension is absent.

## Impact

Fix compilation errors on toolchains or targets where the Zifencei extension is absent

## Testing

'''
ostest passed on rv-virt:nsh

NuttShell (NSH)
nsh> 
nsh> 
nsh> uname -a
NuttX 0.0.0 5e1b10971d-dirty Jun 27 2026 22:53:48 risc-v rv-virt
nsh> 
nsh> ostest 
stdio_test: write fd=1
stdio_test: Standard I/O Check: printf
stdio_test: write fd=2
stdio_test: Standard I/O Check: fprintf to stderr
ostest_main: putenv(Variable1=BadValue3)
ostest_main: setenv(Variable1, GoodValue1, TRUE)
ostest_main: setenv(Variable2, BadValue1, FALSE)
ostest_main: setenv(Variable2, GoodValue2, TRUE)
ostest_main: setenv(Variable3, GoodValue3, FALSE)
ostest_main: setenv(Variable3, BadValue2, FALSE)
show_variable: Variable=Variable1 has value=GoodValue1
show_variable: Variable=Variable2 has value=GoodValue2
show_variable: Variable=Variable3 has value=GoodValue3
ostest_main: Started user_main at PID=4

user_main: Begin argument test
user_main: Started with argc=5
user_main: argv[0]="ostest"
user_main: argv[1]="Arg1"
user_main: argv[2]="Arg2"
user_main: argv[3]="Arg3"
user_main: argv[4]="Arg4"

...

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fcd580  1fcd580
ordblks         3        3
mxordblk  1fc6fe0  1fc6fe0
uordblks     4330     4330
fordblks  1fc9250  1fc9250

user_main: vfork() test
vfork_test: Child 79 ran successfully

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fcd580  1fcd580
ordblks         2        3
mxordblk  1fc92a0  1fc6fe0
uordblks     42c0     4330
fordblks  1fc92c0  1fc9250
user_main: Exiting
ostest_main: Exiting with status 0
nsh>

'''

