### PR TITLE
include/fcntl.h: remove O_RDOK/O_WROK aliases

### DIFF
--- a/drivers/bch/bchlib_setup.c
+++ b/drivers/bch/bchlib_setup.c
@@ -59,7 +59,7 @@ int bchlib_setup(FAR const char *blkdev, int oflags, FAR void **handle)
 {
   FAR struct bchlib_s *bch;
   struct geometry geo;
-  bool readonly = (oflags & O_WROK) == 0;
+  bool readonly = (oflags & O_WRONLY) == 0;
   int ret;
 
   DEBUGASSERT(blkdev);

--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -269,14 +269,14 @@ static int can_open(FAR struct file *filep)
           dev->cd_crefs++;
 
           /* Per-file context (msgalign, optional ioctl FIFO).  Always
-           * allocated: write-only needs msgalign / CANIOC_* without O_RDOK.
-           * Receive path and poll() only use readers that are also queued
-           * on cd_readers (see below).
+           * allocated: write-only path needs msgalign / CANIOC_* even
+           * without O_RDONLY.  Receive path and poll() only use readers
+           * that are also queued on cd_readers (see below).
            */
 
           reader = init_can_reader(filep);
 
-          if ((filep->f_oflags & O_RDOK) != 0)
+          if ((filep->f_oflags & O_RDONLY) != 0)
             {
               list_add_head(&dev->cd_readers,
                             (FAR struct list_node *)reader);

--- a/drivers/misc/optee.c
+++ b/drivers/misc/optee.c
@@ -937,7 +937,7 @@ optee_ioctl_shm_alloc(FAR struct optee_priv_data *priv,
     }
 
   ret = file_allocate_from_inode(&g_optee_shm_inode,
-                                 O_CLOEXEC | O_RDOK, 0, shm, 0);
+                                 O_CLOEXEC | O_RDONLY, 0, shm, 0);
 
   if (ret < 0)
     {

--- a/drivers/mtd/filemtd.c
+++ b/drivers/mtd/filemtd.c
@@ -813,7 +813,7 @@ FAR struct mtd_dev_s *filemtd_initialize(FAR const char *path, off_t offset,
 
   /* Set the file open mode. */
 
-  mode = O_RDOK | O_WROK | O_CLOEXEC;
+  mode = O_RDONLY | O_WRONLY | O_CLOEXEC;
 
   /* Try to open the file.  NOTE that block devices will use a character
    * driver proxy.

--- a/drivers/pipes/pipe_common.c
+++ b/drivers/pipes/pipe_common.c
@@ -169,7 +169,7 @@ int pipecommon_open(FAR struct file *filep)
    * instance.
    */
 
-  if ((filep->f_oflags & O_WROK) != 0)
+  if ((filep->f_oflags & O_WRONLY) != 0)
     {
       dev->d_nwriters++;
 
@@ -233,7 +233,7 @@ int pipecommon_open(FAR struct file *filep)
    * instance.
    */
 
-  if ((filep->f_oflags & O_RDOK) != 0)
+  if ((filep->f_oflags & O_RDONLY) != 0)
     {
       dev->d_nreaders++;
 
@@ -337,7 +337,7 @@ int pipecommon_close(FAR struct file *filep)
        * writers on the pipe instance.
        */
 
-      if ((filep->f_oflags & O_WROK) != 0)
+      if ((filep->f_oflags & O_WRONLY) != 0)
         {
           /* If there are no longer any writers on the pipe, then notify all
            * of the waiting readers that they must return end-of-file.
@@ -357,7 +357,7 @@ int pipecommon_close(FAR struct file *filep)
        * instance.
        */
 
-      if ((filep->f_oflags & O_RDOK) != 0)
+      if ((filep->f_oflags & O_RDONLY) != 0)
         {
           if (--dev->d_nreaders <= 0)
             {
@@ -718,7 +718,7 @@ int pipecommon_poll(FAR struct file *filep, FAR struct pollfd *fds,
        */
 
       eventset = 0;
-      if ((filep->f_oflags & O_WROK) &&
+      if ((filep->f_oflags & O_WRONLY) &&
           nbytes < (dev->d_bufsize - dev->d_polloutthrd))
         {
           eventset |= POLLOUT;
@@ -726,7 +726,7 @@ int pipecommon_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
       /* Notify the POLLIN event if buffer used exceeds poll threshold */
 
-      if ((filep->f_oflags & O_RDOK) && (nbytes > dev->d_pollinthrd))
+      if ((filep->f_oflags & O_RDONLY) && (nbytes > dev->d_pollinthrd))
         {
           eventset |= POLLIN;
         }

--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -728,7 +728,7 @@ static int sensor_open(FAR struct file *filep)
    * allowing for direct I/O operations.
    */
 
-  if (filep->f_oflags & O_RDOK)
+  if (filep->f_oflags & O_RDONLY)
     {
       if (upper->state.nsubscribers == 0 && lower->ops->activate)
         {
@@ -743,7 +743,7 @@ static int sensor_open(FAR struct file *filep)
       upper->state.nsubscribers++;
     }
 
-  if (filep->f_oflags & O_WROK)
+  if (filep->f_oflags & O_WRONLY)
     {
       user->role |= SENSOR_ROLE_WR;
       upper->state.nadvertisers++;
@@ -820,7 +820,7 @@ static int sensor_close(FAR struct file *filep)
    * allowing for direct I/O operations.
    */
 
-  if (filep->f_oflags & O_RDOK)
+  if (filep->f_oflags & O_RDONLY)
     {
       upper->state.nsubscribers--;
       if (upper->state.nsubscribers == 0 && lower->ops->activate)
@@ -829,7 +829,7 @@ static int sensor_close(FAR struct file *filep)
         }
     }
 
-  if (filep->f_oflags & O_WROK)
+  if (filep->f_oflags & O_WRONLY)
     {
       upper->state.nadvertisers--;
     }

--- a/drivers/sensors/sensor_rpmsg.c
+++ b/drivers/sensors/sensor_rpmsg.c
@@ -617,7 +617,7 @@ sensor_rpmsg_alloc_stub(FAR struct sensor_rpmsg_dev_s *dev,
   stub->ept = ept;
   stub->cookie = cookie;
   ret = file_open(&stub->file, dev->path,
-                  O_RDOK | O_NONBLOCK | O_CLOEXEC | SENSOR_REMOTE);
+                  O_RDONLY | O_NONBLOCK | O_CLOEXEC | SENSOR_REMOTE);
   if (ret < 0)
     {
       kmm_free(stub);
@@ -680,7 +680,7 @@ static int sensor_rpmsg_open(FAR struct sensor_lowerhalf_s *lower,
     }
 
   sensor_rpmsg_lock(dev);
-  if (filep->f_oflags & O_WROK)
+  if (filep->f_oflags & O_WRONLY)
     {
       if (dev->nadvertisers++ == 0)
         {
@@ -688,7 +688,7 @@ static int sensor_rpmsg_open(FAR struct sensor_lowerhalf_s *lower,
         }
     }
 
-  if (filep->f_oflags & O_RDOK)
+  if (filep->f_oflags & O_RDONLY)
     {
       if (dev->nsubscribers++ == 0)
         {
@@ -722,7 +722,7 @@ static int sensor_rpmsg_close(FAR struct sensor_lowerhalf_s *lower,
     }
 
   sensor_rpmsg_lock(dev);
-  if (filep->f_oflags & O_WROK)
+  if (filep->f_oflags & O_WRONLY)
     {
       if (dev->nadvertisers == 1)
         {
@@ -737,7 +737,7 @@ static int sensor_rpmsg_close(FAR struct sensor_lowerhalf_s *lower,
       dev->nadvertisers--;
     }
 
-  if (filep->f_oflags & O_RDOK)
+  if (filep->f_oflags & O_RDONLY)
     {
       if (dev->nsubscribers == 1)
         {

--- a/fs/fat/fs_fat32.c
+++ b/fs/fat/fs_fat32.c
@@ -802,7 +802,7 @@ static ssize_t fat_read(FAR struct file *filep, FAR char *buffer,
 
   /* Check if the file was opened with read access */
 
-  if ((ff->ff_oflags & O_RDOK) == 0)
+  if ((ff->ff_oflags & O_RDONLY) == 0)
     {
       ret = -EACCES;
       goto errout_with_lock;
@@ -1020,7 +1020,7 @@ static ssize_t fat_write(FAR struct file *filep, FAR const char *buffer,
 
   /* Check if the file was opened for write access */
 
-  if ((ff->ff_oflags & O_WROK) == 0)
+  if ((ff->ff_oflags & O_WRONLY) == 0)
     {
       ret = -EACCES;
       goto errout_with_lock;
@@ -2289,7 +2289,7 @@ static int fat_truncate(FAR struct file *filep, off_t length)
 
   /* Check if the file was opened for write access */
 
-  if ((ff->ff_oflags & O_WROK) == 0)
+  if ((ff->ff_oflags & O_WRONLY) == 0)
     {
       ret = -EACCES;
       goto errout_with_lock;

--- a/fs/hostfs/hostfs.c
+++ b/fs/hostfs/hostfs.c
@@ -516,7 +516,7 @@ static ssize_t hostfs_write(FAR struct file *filep, const char *buffer,
    * write flags.
    */
 
-  if ((hf->oflags & O_WROK) == 0)
+  if ((hf->oflags & O_WRONLY) == 0)
     {
       ret = -EACCES;
       goto errout_with_lock;

--- a/fs/inode/fs_inode.c
+++ b/fs/inode/fs_inode.c
@@ -113,12 +113,12 @@ int fs_open_amode(int oflags)
 {
   int amode = 0;
 
-  if ((oflags & O_RDOK) != 0)
+  if ((oflags & O_RDONLY) != 0)
     {
       amode |= R_OK;
     }
 
-  if ((oflags & O_WROK) != 0)
+  if ((oflags & O_WRONLY) != 0)
     {
       amode |= W_OK;
     }
@@ -285,9 +285,9 @@ int inode_checkopenperm(FAR struct inode *inode, int oflags)
       return -ENXIO;
     }
 
-  if (((oflags & O_RDOK) != 0 &&
+  if (((oflags & O_RDONLY) != 0 &&
        !ops->readv && !ops->read && !ops->ioctl) ||
-      ((oflags & O_WROK) != 0 &&
+      ((oflags & O_WRONLY) != 0 &&
        !ops->writev && !ops->write && !ops->ioctl))
     {
       return -EACCES;

--- a/fs/mmap/fs_mmap.c
+++ b/fs/mmap/fs_mmap.c
@@ -138,14 +138,14 @@ static int file_mmap_(FAR struct file *filep, FAR void *start,
     }
 
   if ((flags & MAP_SHARED) &&
-      (filep->f_oflags & O_WROK) == 0 && prot == PROT_WRITE)
+      (filep->f_oflags & O_WRONLY) == 0 && prot == PROT_WRITE)
     {
       ferr("ERROR: Unsupported options for read-only file descriptor,"
            "prot=%x flags=%04x\n", prot, flags);
       return -EACCES;
     }
 
-  if ((filep->f_oflags & O_RDOK) == 0)
+  if ((filep->f_oflags & O_RDONLY) == 0)
     {
       ferr("ERROR: File descriptor does not have read permission\n");
       return -EACCES;

--- a/fs/nxffs/nxffs_open.c
+++ b/fs/nxffs/nxffs_open.c
@@ -706,7 +706,7 @@ static inline int nxffs_rdopen(FAR struct nxffs_volume_s *volume,
        * Limitation:  Files cannot be open both for reading and writing.
        */
 
-      if ((ofile->oflags & O_WROK) != 0)
+      if ((ofile->oflags & O_WRONLY) != 0)
         {
           ferr("ERROR: File is open for writing\n");
           ret = -ENOSYS;
@@ -740,7 +740,7 @@ static inline int nxffs_rdopen(FAR struct nxffs_volume_s *volume,
       /* Initialize the open file state structure */
 
       ofile->crefs  = 1;
-      ofile->oflags = O_RDOK;
+      ofile->oflags = O_RDONLY;
 
       /* Find the file on this volume associated with this file name */
 
@@ -1013,22 +1013,22 @@ int nxffs_open(FAR struct file *filep, FAR const char *relpath,
    * extension is supported.
    */
 
-  switch (oflags & (O_WROK | O_RDOK))
+  switch (oflags & (O_WRONLY | O_RDONLY))
     {
       case 0:
       default:
         ferr("ERROR: One of O_WRONLY/O_RDONLY must be provided\n");
         return -EINVAL;
 
-      case O_WROK:
+      case O_WRONLY:
         ret = nxffs_wropen(volume, relpath, oflags, &ofile);
         break;
 
-      case O_RDOK:
+      case O_RDONLY:
         ret = nxffs_rdopen(volume, relpath, &ofile);
         break;
 
-      case O_WROK | O_RDOK:
+      case O_WRONLY | O_RDONLY:
         ferr("ERROR: O_RDWR is not supported\n");
         return -ENOSYS;
     }
@@ -1156,7 +1156,7 @@ int nxffs_close(FAR struct file *filep)
 
       /* Handle special finalization of the write operation. */
 
-      if ((ofile->oflags & O_WROK) != 0)
+      if ((ofile->oflags & O_WRONLY) != 0)
         {
           ret = nxffs_wrclose(volume, (FAR struct nxffs_wrfile_s *)ofile);
         }

--- a/fs/nxffs/nxffs_read.c
+++ b/fs/nxffs/nxffs_read.c
@@ -168,7 +168,7 @@ ssize_t nxffs_read(FAR struct file *filep, FAR char *buffer, size_t buflen)
 
   /* Check if the file was opened with read access */
 
-  if ((ofile->oflags & O_RDOK) == 0)
+  if ((ofile->oflags & O_RDONLY) == 0)
     {
       ferr("ERROR: File not open for read access\n");
       ret = -EACCES;

--- a/fs/nxffs/nxffs_truncate.c
+++ b/fs/nxffs/nxffs_truncate.c
@@ -83,7 +83,7 @@ int nxffs_truncate(FAR struct file *filep, off_t length)
 
   /* Check if the file was opened with write access */
 
-  if ((wrfile->ofile.oflags & O_WROK) == 0)
+  if ((wrfile->ofile.oflags & O_WRONLY) == 0)
     {
       ferr("ERROR: File not open for write access\n");
       ret = -EACCES;

--- a/fs/nxffs/nxffs_write.c
+++ b/fs/nxffs/nxffs_write.c
@@ -545,7 +545,7 @@ ssize_t nxffs_write(FAR struct file *filep, FAR const char *buffer,
 
   /* Check if the file was opened with write access */
 
-  if ((wrfile->ofile.oflags & O_WROK) == 0)
+  if ((wrfile->ofile.oflags & O_WRONLY) == 0)
     {
       ferr("ERROR: File not open for write access\n");
       ret = -EACCES;

--- a/fs/rpmsgfs/rpmsgfs.c
+++ b/fs/rpmsgfs/rpmsgfs.c
@@ -553,7 +553,7 @@ static ssize_t rpmsgfs_write(FAR struct file *filep, const char *buffer,
    * write flags.
    */
 
-  if ((hf->oflags & O_WROK) == 0)
+  if ((hf->oflags & O_WRONLY) == 0)
     {
       ret = -EACCES;
       goto errout_with_lock;

--- a/fs/smartfs/smartfs_smart.c
+++ b/fs/smartfs/smartfs_smart.c
@@ -285,7 +285,7 @@ static int smartfs_open(FAR struct file *filep, FAR const char *relpath,
        * is writeable. O_TRUNC without write access is ignored.
        */
 
-      if ((oflags & (O_TRUNC | O_WROK)) == (O_TRUNC | O_WROK))
+      if ((oflags & (O_TRUNC | O_WRONLY)) == (O_TRUNC | O_WRONLY))
         {
           /* Truncate the file as part of the open */
 
@@ -693,7 +693,7 @@ static ssize_t smartfs_write(FAR struct file *filep, FAR const char *buffer,
    * write flags.
    */
 
-  if ((sf->oflags & O_WROK) == 0)
+  if ((sf->oflags & O_WRONLY) == 0)
     {
       ret = -EACCES;
       goto errout_with_lock;
@@ -1223,7 +1223,7 @@ static int smartfs_truncate(FAR struct file *filep, off_t length)
    * write flags.
    */
 
-  if ((sf->oflags & O_WROK) == 0)
+  if ((sf->oflags & O_WRONLY) == 0)
     {
       ret = -EACCES;
       goto errout_with_lock;

--- a/fs/spiffs/src/spiffs_vfs.c
+++ b/fs/spiffs/src/spiffs_vfs.c
@@ -433,7 +433,7 @@ static int spiffs_open(FAR struct file *filep, FAR const char *relpath,
    */
 
   offset = 0;
-  if ((oflags & (O_APPEND | O_WROK)) == (O_APPEND | O_WROK))
+  if ((oflags & (O_APPEND | O_WRONLY)) == (O_APPEND | O_WRONLY))
     {
       offset = fobj->size == SPIFFS_UNDEFINED_LEN ? 0 : fobj->size;
     }
@@ -629,7 +629,7 @@ static ssize_t spiffs_write(FAR struct file *filep, FAR const char *buffer,
 
   /* Verify that the file was opened with write access */
 
-  if ((fobj->oflags & O_WROK) == 0)
+  if ((fobj->oflags & O_WRONLY) == 0)
     {
       ret = -EACCES;
       goto errout_with_lock;

--- a/fs/vfs/fs_inotify.c
+++ b/fs/vfs/fs_inotify.c
@@ -1255,7 +1255,7 @@ int inotify_init1(int flags)
       goto exit_set_errno;
     }
 
-  ret = file_allocate_from_inode(&g_inotify_inode, O_RDOK | flags,
+  ret = file_allocate_from_inode(&g_inotify_inode, O_RDONLY | flags,
                                  0, dev, 0);
   if (ret < 0)
     {
@@ -1349,7 +1349,7 @@ void notify_open(FAR const char *path, int oflags)
 
 void notify_close(FAR const char *path, int oflags)
 {
-  if (oflags & O_WROK)
+  if (oflags & O_WRONLY)
     {
       notify_queue_path_event(path, IN_CLOSE_WRITE);
     }

--- a/fs/vfs/fs_open.c
+++ b/fs/vfs/fs_open.c
@@ -155,7 +155,7 @@ static int file_vopen(FAR struct file *filep, FAR const char *path,
 
 #ifdef CONFIG_BCH_DEVICE_READONLY
       oflags &= ~O_RDWR;
-      oflags |= O_RDOK;
+      oflags |= O_RDONLY;
 #endif
 
       ret = block_proxy(filep, path, oflags);

--- a/fs/vfs/fs_read.c
+++ b/fs/vfs/fs_read.c
@@ -192,7 +192,7 @@ ssize_t file_readv(FAR struct file *filep,
 
   /* Was this file opened for read access? */
 
-  if ((filep->f_oflags & O_RDOK) == 0)
+  if ((filep->f_oflags & O_RDONLY) == 0)
     {
       /* No.. File is not read-able */
 

--- a/fs/vfs/fs_signalfd.c
+++ b/fs/vfs/fs_signalfd.c
@@ -352,7 +352,7 @@ int signalfd(int fd, FAR const sigset_t *mask, int flags)
 
       nxmutex_init(&dev->mutex);
 
-      fd = file_allocate_from_inode(&g_signalfd_inode, O_RDOK | flags,
+      fd = file_allocate_from_inode(&g_signalfd_inode, O_RDONLY | flags,
                                     0, dev, 0);
       if (fd < 0)
         {

--- a/fs/vfs/fs_truncate.c
+++ b/fs/vfs/fs_truncate.c
@@ -57,7 +57,7 @@ int file_truncate(FAR struct file *filep, off_t length)
 
   /* Was this file opened for write access? */
 
-  if ((filep->f_oflags & O_WROK) == 0)
+  if ((filep->f_oflags & O_WRONLY) == 0)
     {
       fwarn("WARNING: Cannot truncate a file opened read-only\n");
       return -EINVAL;

--- a/fs/vfs/fs_write.c
+++ b/fs/vfs/fs_write.c
@@ -153,7 +153,7 @@ ssize_t file_writev(FAR struct file *filep,
 
   /* Was this file opened for write access? */
 
-  if ((filep->f_oflags & O_WROK) == 0)
+  if ((filep->f_oflags & O_WRONLY) == 0)
     {
       return -EACCES;
     }

--- a/graphics/nxterm/nxterm_driver.c
+++ b/graphics/nxterm/nxterm_driver.c
@@ -122,7 +122,7 @@ static int nxterm_open(FAR struct file *filep)
   /* Verify that the driver is opened for write-only access */
 
 #ifndef CONFIG_NXTERM_NXKBDIN
-  if ((filep->f_oflags & O_RDOK) != 0)
+  if ((filep->f_oflags & O_RDONLY) != 0)
     {
       gerr("ERROR: Attempted open with read access\n");
       return -EACCES;

--- a/include/fcntl.h
+++ b/include/fcntl.h
@@ -39,10 +39,8 @@
 /* open flag settings for open() (and related APIs) */
 
 #define O_RDONLY     (1 << 0)        /* Open for read access (only) */
-#define O_RDOK       O_RDONLY        /* Read access is permitted (non-standard) */
 #define O_WRONLY     (1 << 1)        /* Open for write access (only) */
-#define O_WROK       O_WRONLY        /* Write access is permitted (non-standard) */
-#define O_RDWR       (O_RDOK|O_WROK) /* Open for both read & write access */
+#define O_RDWR       (3 << 0)        /* Open for both read & write access */
 #define O_CREAT      (1 << 2)        /* Create file/sem/mq object */
 #define O_EXCL       (1 << 3)        /* Name must not exist when opened  */
 #define O_APPEND     (1 << 4)        /* Keep contents, append to end */

--- a/libs/libc/stdio/lib_fclose.c
+++ b/libs/libc/stdio/lib_fclose.c
@@ -102,7 +102,7 @@ int fclose(FAR FILE *stream)
 
       /* If the stream was opened for writing, then flush the stream */
 
-      if ((stream->fs_oflags & O_WROK) != 0)
+      if ((stream->fs_oflags & O_WRONLY) != 0)
         {
           ret = lib_fflush(stream);
           errcode = get_errno();

--- a/libs/libc/stdio/lib_fmemopen.c
+++ b/libs/libc/stdio/lib_fmemopen.c
@@ -245,7 +245,7 @@ FAR FILE *fmemopen(FAR void *buf, size_t size, FAR const char *mode)
    * by the size argument.
    */
 
-  if ((oflags & O_RDWR) == O_RDOK)
+  if ((oflags & O_RDWR) == O_RDONLY)
     {
       fmemopen_cookie->end = size;
     }

--- a/libs/libc/stdio/lib_fopen.c
+++ b/libs/libc/stdio/lib_fopen.c
@@ -229,7 +229,7 @@ int lib_mode2oflags(FAR const char *mode)
               {
                 /* Open for read access */
 
-                oflags = O_RDOK | O_TEXT;
+                oflags = O_RDONLY | O_TEXT;
                 state  = MODE_R;
               }
             else
@@ -245,7 +245,7 @@ int lib_mode2oflags(FAR const char *mode)
               {
                 /* Open for write access, truncating any existing file */
 
-                oflags = O_WROK | O_CREAT | O_TRUNC | O_TEXT;
+                oflags = O_WRONLY | O_CREAT | O_TRUNC | O_TEXT;
                 state  = MODE_W;
               }
             else
@@ -261,7 +261,7 @@ int lib_mode2oflags(FAR const char *mode)
               {
                 /* Write to the end of the file */
 
-                oflags = O_WROK | O_CREAT | O_APPEND | O_TEXT;
+                oflags = O_WRONLY | O_CREAT | O_APPEND | O_TEXT;
                 state  = MODE_A;
               }
             else

--- a/libs/libc/stdio/lib_libfflush.c
+++ b/libs/libc/stdio/lib_libfflush.c
@@ -66,7 +66,7 @@ ssize_t lib_fflush_unlocked(FAR FILE *stream)
 
   /* Return EBADF if the file is not opened for writing */
 
-  if ((stream->fs_oflags & O_WROK) == 0)
+  if ((stream->fs_oflags & O_WRONLY) == 0)
     {
       return -EBADF;
     }

--- a/libs/libc/stdio/lib_libflushall.c
+++ b/libs/libc/stdio/lib_libflushall.c
@@ -76,7 +76,7 @@ int lib_flushall_unlocked(FAR struct streamlist *list)
            * the pending write data in the stream.
            */
 
-          if ((stream->fs_oflags & O_WROK) != 0)
+          if ((stream->fs_oflags & O_WRONLY) != 0)
             {
               /* Flush the writable FILE */
 
@@ -129,7 +129,7 @@ int lib_flushall(FAR struct streamlist *list)
            * the pending write data in the stream.
            */
 
-          if ((stream->fs_oflags & O_WROK) != 0)
+          if ((stream->fs_oflags & O_WRONLY) != 0)
             {
               /* Flush the writable FILE */
 

--- a/libs/libc/stdio/lib_libfread_unlocked.c
+++ b/libs/libc/stdio/lib_libfread_unlocked.c
@@ -64,7 +64,7 @@ ssize_t lib_fread_unlocked(FAR void *ptr, size_t count, FAR FILE *stream)
       _NX_SETERRNO(EBADF);
       return ERROR;
     }
-  else if ((stream->fs_oflags & O_RDOK) == 0)
+  else if ((stream->fs_oflags & O_RDONLY) == 0)
     {
       stream->fs_flags |= __FS_FLAG_ERROR;
       _NX_SETERRNO(EBADF);

--- a/libs/libc/stdio/lib_libfwrite.c
+++ b/libs/libc/stdio/lib_libfwrite.c
@@ -64,7 +64,7 @@ ssize_t lib_fwrite_unlocked(FAR const void *ptr, size_t count,
 
   /* Check if write access is permitted */
 
-  if ((stream->fs_oflags & O_WROK) == 0)
+  if ((stream->fs_oflags & O_WRONLY) == 0)
     {
       set_errno(EBADF);
       goto errout;

--- a/libs/libc/stdio/lib_ungetc.c
+++ b/libs/libc/stdio/lib_ungetc.c
@@ -54,7 +54,7 @@ int ungetc(int c, FAR FILE *stream)
 
   /* Stream must be open for read access */
 
-  if ((stream->fs_oflags & O_RDOK) == 0)
+  if ((stream->fs_oflags & O_RDONLY) == 0)
     {
       return EOF;
     }

--- a/libs/libc/stdio/lib_ungetwc.c
+++ b/libs/libc/stdio/lib_ungetwc.c
@@ -64,7 +64,7 @@ wint_t ungetwc_unlocked(wint_t wc, FAR FILE *f)
 
   /* Stream must be open for read access */
 
-  if ((f->fs_oflags & O_RDOK) == 0)
+  if ((f->fs_oflags & O_RDONLY) == 0)
     {
       return WEOF;
     }

--- a/libs/libc/stdio/lib_wrflush_unlocked.c
+++ b/libs/libc/stdio/lib_wrflush_unlocked.c
@@ -70,7 +70,7 @@ int lib_wrflush_unlocked(FAR FILE *stream)
    * that case.
    */
 
-  if ((stream->fs_oflags & O_WROK) == 0)
+  if ((stream->fs_oflags & O_WRONLY) == 0)
     {
       /* Report that the success was successful if we attempt to flush a
        * read-only stream.

--- a/sched/mqueue/mq_receive.c
+++ b/sched/mqueue/mq_receive.c
@@ -90,7 +90,7 @@ static int nxmq_verify_receive(FAR struct file *mq,
       return -EINVAL;
     }
 
-  if ((mq->f_oflags & O_RDOK) == 0)
+  if ((mq->f_oflags & O_RDONLY) == 0)
     {
       return -EBADF;
     }

--- a/sched/mqueue/mq_send.c
+++ b/sched/mqueue/mq_send.c
@@ -91,7 +91,7 @@ static int nxmq_verify_send(FAR FAR struct file *mq, FAR const char *msg,
       return -EINVAL;
     }
 
-  if ((mq->f_oflags & O_WROK) == 0)
+  if ((mq->f_oflags & O_WRONLY) == 0)
     {
       return -EBADF;
     }

--- a/sched/tls/task_initinfo.c
+++ b/sched/tls/task_initinfo.c
@@ -83,7 +83,7 @@ static void task_init_stream(FAR struct streamlist *list)
        */
 
       stream[i].fs_cookie   = (FAR void *)(intptr_t)i;
-      stream[i].fs_oflags   = i ? O_WROK : O_RDONLY;
+      stream[i].fs_oflags   = i ? O_WRONLY : O_RDONLY;
 
       /* Assign custom callbacks to NULL. */
 


### PR DESCRIPTION
## Summary

`O_RDOK` and `O_WROK` are non-standard aliases for `O_RDONLY` and `O_WRONLY` respectively. Having two names for the same flag creates confusion, especially when aligning the flag values with Linux. This PR removes the aliases from `include/fcntl.h` and replaces all in-tree uses with the standard `O_RDONLY`/`O_WRONLY`.

## Impact

No functional change. `O_RDOK` was defined as `O_RDONLY` and `O_WROK` as `O_WRONLY`, so the replacement is a pure text substitution that preserves existing behavior while using the standard POSIX flag names.

A companion change for the apps repository (replacing the remaining `O_RDOK` usages there) is submitted separately as apache/nuttx-apps#3566.

## Testing

- `tools/checkpatch.sh -c -u -m -g` (commit mode, same as CI) passes with no errors.
- `git grep 'O_RDOK\|O_WROK'` confirms no remaining references in the tree.
- Builds cleanly on affected configs.

## Note

need merge https://github.com/apache/nuttx-apps/pull/3566 first