### PR TITLE
stm32f746g-disco: Fix USERLED support

### DIFF
--- a/boards/arm/stm32f7/stm32f746g-disco/src/stm32_bringup.c
+++ b/boards/arm/stm32f7/stm32f746g-disco/src/stm32_bringup.c
@@ -42,6 +42,10 @@
 #  include <nuttx/video/fb.h>
 #endif
 
+#if defined(CONFIG_USERLED_LOWER) && !defined(CONFIG_ARCH_LEDS)
+#  include <nuttx/leds/userled.h>
+#endif
+
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -147,6 +151,14 @@ int stm32_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: stm32_wm8994_initialize failed: %d\n", ret);
+    }
+#endif
+
+#if defined(CONFIG_USERLED_LOWER) && !defined(CONFIG_ARCH_LEDS)
+  ret = userled_lower_initialize("/dev/led0");
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);
     }
 #endif
 

--- a/boards/arm/stm32f7/stm32f746g-disco/src/stm32_userleds.c
+++ b/boards/arm/stm32f7/stm32f746g-disco/src/stm32_userleds.c
@@ -25,6 +25,7 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <arch/board/board.h>
 
 #include <stdbool.h>
 #include <nuttx/debug.h>
@@ -67,9 +68,9 @@ uint32_t board_userled_initialize(void)
 
 void board_userled(int led, bool ledon)
 {
-  if (led == BOARD_STATUS_LED)
+  if (led == BOARD_LED1)
     {
-      stm32_gpiowrite(GPIO_LD1, !ledon);
+      stm32_gpiowrite(GPIO_LD1, ledon);
     }
 }
 
@@ -86,7 +87,7 @@ void board_userled(int led, bool ledon)
 
 void board_userled_all(uint32_t ledset)
 {
-  stm32_gpiowrite(GPIO_LD1, (ledset & BOARD_STATUS_LED_BIT) != 0);
+  stm32_gpiowrite(GPIO_LD1, (ledset & BOARD_LED1_BIT) != 0);
 }
 
 #endif /* !CONFIG_ARCH_LEDS */


### PR DESCRIPTION
## Summary

To make `USERLED` driver working on the stm32f746g-disco board, the following changes were made:

1. Provide correct pin name `BOARD_LED1` and associated bit mask `BOARD_LED1_BIT`
2. Use non-negated `ledon`
3. Add initialization into bringup code.

## Impact

`USERLED` driver can be used on the stm32f746g-disco board.

## Testing

Tested on stm32f746g-disco board.