### PR TITLE
arch/lpc214x: Fix LPC214x to work again

### DIFF
--- a/arch/arm/include/lpc214x/irq.h
+++ b/arch/arm/include/lpc214x/irq.h
@@ -103,10 +103,8 @@ extern "C"
 #define EXTERN extern
 #endif
 
-#ifndef CONFIG_VECTORED_INTERRUPTS
 void up_attach_vector(int irq, int vector, vic_vector_t handler);
 void up_detach_vector(int vector);
-#endif
 
 #undef EXTERN
 #ifdef __cplusplus

--- a/arch/arm/src/lpc214x/chip.h
+++ b/arch/arm/src/lpc214x/chip.h
@@ -288,8 +288,12 @@
 #define LPC214X_VIC_SOFTINTCLEAR_OFFSET 0x1c   /* W: Software Interrupt Clear Register */
 #define LPC214X_VIC_PROTECTION_OFFSET   0x20   /* Protection Enable Register */
 
+#define LPC214X_VIC_PRIORITY_MASK_OFFSET 0x024  /* Priority Mask Register */
+
 #define LPC214X_VIC_VECTADDR_OFFSET     0x30   /* RW: Vector Address Register */
 #define LPC214X_VIC_DEFVECTADDR_OFFSET  0x34   /* RW: Default Vector Address Register */
+
+#define LPC214X_VIC_ADDRESS_OFFSET      0xF00  /* RW: Vector Address Register */
 
 #define LPC214X_VIC_VECTADDR0_OFFSET    0x100  /* RW: Vector Address 0 Register */
 #define LPC214X_VIC_VECTADDR1_OFFSET    0x104  /* RW: Vector Address 1 Register */

--- a/arch/arm/src/lpc214x/lpc214x_decodeirq.c
+++ b/arch/arm/src/lpc214x/lpc214x_decodeirq.c
@@ -41,15 +41,6 @@
  * Private Data
  ****************************************************************************/
 
-/* This array maps 4 bits into the bit number of the lowest bit that it set */
-
-#ifndef CONFIG_SUPPRESS_INTERRUPTS
-static uint8_t g_nibblemap[16] =
-{
-  0, 0, 1, 0, 2, 0, 1, 0, 3, 0, 1, 0, 2, 0, 1, 0
-};
-#endif
-
 /****************************************************************************
  * Public Functions
  ****************************************************************************/
@@ -78,42 +69,22 @@ static uint8_t g_nibblemap[16] =
  *
  ****************************************************************************/
 
-#ifndef CONFIG_VECTORED_INTERRUPTS
 uint32_t *arm_decodeirq(uint32_t *regs)
-#else
-static uint32_t *lpc214x_decodeirq(uint32_t *regs)
-#endif
 {
-  struct tcb_s *tcb = this_task();
-
 #ifdef CONFIG_SUPPRESS_INTERRUPTS
-  tcb->xcp.regs = regs;
-  up_set_interrupt_context(true);
   err("ERROR: Unexpected IRQ\n");
   PANIC();
-  return NULL;
 #else
 
-  /* Decode the interrupt. We have to do this by search for the lowest
-   * numbered non-zero bit in the interrupt status register.
-   */
+  /* Check which IRQ fires */
 
-  uint32_t pending = vic_getreg(LPC214X_VIC_IRQSTATUS_OFFSET) & 0x007fffff;
-  unsigned int nibble;
-  unsigned int irq_base;
-  unsigned int irq = NR_IRQS;
+  uint32_t irqbits = vic_getreg(LPC214X_VIC_IRQSTATUS_OFFSET) & 0xffffffff;
+  unsigned int irq;
 
-  /* Search in groups of four bits.  For 22 sources, this is at most six
-   * times through the loop.
-   */
-
-  for (nibble = pending & 0x0f, irq_base = 0;
-       pending && irq_base < NR_IRQS;
-       pending >>= 4, nibble = pending & 0x0f, irq_base += 4)
+  for (irq = 0; irq < NR_IRQS; irq++)
     {
-      if (nibble)
+      if (irqbits & (uint32_t) (1 << irq))
         {
-          irq = irq_base + g_nibblemap[nibble];
           break;
         }
     }
@@ -122,34 +93,11 @@ static uint32_t *lpc214x_decodeirq(uint32_t *regs)
 
   if (irq < NR_IRQS)
     {
-      uint32_t *saveregs;
-      bool savestate;
-
-      savestate = up_interrupt_context();
-      saveregs = tcb->xcp.regs;
-      up_set_interrupt_context(true);
-      tcb->xcp.regs = regs;
-
       /* Deliver the IRQ */
 
-      irq_dispatch(irq, regs);
-
-      /* Restore the previous value of saveregs. */
-
-      up_set_interrupt_context(savestate);
-      tcb->xcp.regs = saveregs;
+      regs = arm_doirq(irq, regs);
     }
-
-  return NULL;  /* Return not used in this architecture */
 #endif
-}
 
-#ifdef CONFIG_VECTORED_INTERRUPTS
-uint32_t *arm_decodeirq(uint32_t *regs)
-{
-  vic_vector_t vector =
-               (vic_vector_t)vic_getreg(LPC214X_VIC_VECTADDR_OFFSET);
-  vector(regs);
-  return NULL;  /* Return not used in this architecture */
+  return regs;
 }
-#endif

--- a/arch/arm/src/lpc214x/lpc214x_irq.c
+++ b/arch/arm/src/lpc214x/lpc214x_irq.c
@@ -131,6 +131,59 @@ void up_enable_irq(int irq)
 }
 
 /****************************************************************************
+ * Name: arm_ack_irq
+ *
+ * Description:
+ *   Acknowledge the interrupt
+ *
+ ****************************************************************************/
+
+void arm_ack_irq(int irq)
+{
+  uint32_t reg32;
+
+  if ((unsigned)irq < NR_IRQS)
+    {
+      /* Mask the IRQ by clearing the associated bit in Software Priority
+       * Mask register
+       */
+
+      reg32 = vic_getreg(LPC214X_VIC_PRIORITY_MASK_OFFSET);
+      reg32 &= ~(1 << irq);
+      vic_putreg(reg32, LPC214X_VIC_PRIORITY_MASK_OFFSET);
+    }
+
+  /* Clear interrupt */
+
+  vic_putreg((1 << irq), LPC214X_VIC_SOFTINTCLEAR_OFFSET);
+  vic_putreg(0, LPC214X_VIC_ADDRESS_OFFSET);    /* dummy write to clear VICADDRESS */
+}
+
+/****************************************************************************
+ * Name: up_prioritize_irq
+ *
+ * Description:
+ *   set interrupt priority
+ * MOD
+ ****************************************************************************/
+
+#ifdef CONFIG_ARCH_IRQPRIO
+int up_prioritize_irq(int irq, int priority)
+{
+  /* The default priority on reset is 16 */
+
+  if (irq < NR_IRQS && priority > 0 && priority < 16)
+    {
+      int offset = irq << 2;
+      vic_putreg(priority, LPC214X_VIC_VECTPRIORITY0_OFFSET + offset);
+      return OK;
+    }
+
+  return -EINVAL;
+}
+#endif
+
+/****************************************************************************
  * Name: up_attach_vector
  *
  * Description:
@@ -138,7 +191,6 @@ void up_enable_irq(int irq)
  *
  ****************************************************************************/
 
-#ifndef CONFIG_VECTORED_INTERRUPTS
 void up_attach_vector(int irq, int vector, vic_vector_t handler)
 {
   /* Verify that the IRQ number and vector number are within range */
@@ -163,7 +215,6 @@ void up_attach_vector(int irq, int vector, vic_vector_t handler)
       leave_critical_section(flags);
     }
 }
-#endif
 
 /****************************************************************************
  * Name: up_detach_vector
@@ -173,7 +224,6 @@ void up_attach_vector(int irq, int vector, vic_vector_t handler)
  *
  ****************************************************************************/
 
-#ifndef CONFIG_VECTORED_INTERRUPTS
 void up_detach_vector(int vector)
 {
   /* Verify that the vector number is within range */
@@ -186,4 +236,3 @@ void up_detach_vector(int vector)
       vic_putreg(0, LPC214X_VIC_VECTCNTL0_OFFSET + offset);
     }
 }
-#endif

--- a/arch/arm/src/lpc214x/lpc214x_timerisr.c
+++ b/arch/arm/src/lpc214x/lpc214x_timerisr.c
@@ -70,11 +70,7 @@
  *
  ****************************************************************************/
 
-#ifdef CONFIG_VECTORED_INTERRUPTS
 static int lpc214x_timerisr(uint32_t *regs)
-#else
-static int lpc214x_timerisr(int irq, uint32_t *regs, void *arg)
-#endif
 {
   /* Process timer interrupt */
 
@@ -86,9 +82,8 @@ static int lpc214x_timerisr(int irq, uint32_t *regs, void *arg)
 
   /* Reset the VIC as well */
 
-#ifdef CONFIG_VECTORED_INTERRUPTS
   vic_putreg(0, LPC214X_VIC_VECTADDR_OFFSET);
-#endif
+
   return 0;
 }
 
@@ -139,12 +134,8 @@ void up_timer_initialize(void)
 
   /* Attach the timer interrupt vector */
 
-#ifdef CONFIG_VECTORED_INTERRUPTS
   up_attach_vector(LPC214X_IRQ_SYSTIMER, LPC214X_SYSTIMER_VEC,
                    (vic_vector_t)lpc214x_timerisr);
-#else
-  irq_attach(LPC214X_IRQ_SYSTIMER, (xcpt_t)lpc214x_timerisr, NULL);
-#endif
 
   /* And enable the timer interrupt */
 


### PR DESCRIPTION
## Summary

This fix is based on the same fix for LPC2378, however it wasn't tested on real hardware because I don't have a LPC214x board.

## Impact

LPC214x will work again.

## Testing

Only tested on LPC2378 board.