### PR TITLE
!include/fcntl.h: align open flags with Linux values

### DIFF
--- a/arch/arm/src/common/arm_hostfs.c
+++ b/arch/arm/src/common/arm_hostfs.c
@@ -78,7 +78,7 @@ static ssize_t host_flen(long fd)
 
 static int host_flags_to_mode(int flags)
 {
-  static const int modemasks = O_RDONLY | O_WRONLY | O_TEXT | O_RDWR |
+  static const int modemasks = O_ACCMODE | O_TEXT |
                                O_CREAT | O_TRUNC | O_APPEND;
   static const int modeflags[] =
   {

--- a/arch/arm/src/cxd56xx/cxd56_hostif.c
+++ b/arch/arm/src/cxd56xx/cxd56_hostif.c
@@ -209,20 +209,19 @@ static int hif_open(struct file *filep)
 
   /* Check parameters */
 
-  if ((filep->f_oflags & O_WRONLY) != 0 &&
-      (filep->f_oflags & O_RDONLY) != 0)
+  if ((filep->f_oflags & O_ACCMODE) == O_RDWR)
     {
       return -EACCES;
     }
 
-  if ((filep->f_oflags & O_RDONLY) &&
-      ((priv->flags & HOSTIF_BUFF_ATTR_READ) == 0))
+  if ((filep->f_oflags & O_ACCMODE) != O_WRONLY &&
+      (priv->flags & HOSTIF_BUFF_ATTR_READ) == 0)
     {
       return -EINVAL;
     }
 
-  if ((filep->f_oflags & O_WRONLY) &&
-      ((priv->flags & HOSTIF_BUFF_ATTR_READ) != 0))
+  if ((filep->f_oflags & O_ACCMODE) != O_RDONLY &&
+      (priv->flags & HOSTIF_BUFF_ATTR_READ) != 0)
     {
       return -EINVAL;
     }
@@ -292,7 +291,7 @@ static ssize_t hif_read(struct file *filep, char *buffer, size_t len)
 
   DEBUGASSERT(buffer);
 
-  if ((filep->f_oflags & O_RDONLY) == 0)
+  if ((filep->f_oflags & O_ACCMODE) == O_WRONLY)
     {
       return -EACCES;
     }
@@ -323,7 +322,7 @@ static ssize_t hif_write(struct file *filep,
 
   DEBUGASSERT(buffer);
 
-  if ((filep->f_oflags & O_WRONLY) == 0)
+  if ((filep->f_oflags & O_ACCMODE) == O_RDONLY)
     {
       return -EACCES;
     }

--- a/arch/arm/src/cxd56xx/cxd56_powermgr_procfs.c
+++ b/arch/arm/src/cxd56xx/cxd56_powermgr_procfs.c
@@ -488,7 +488,7 @@ static int cxd56_powermgr_procfs_open(struct file *filep,
    * REVISIT:  Write-able proc files could be quite useful.
    */
 
-  if (((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0))
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       pmerr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/arch/arm/src/cxd56xx/cxd56_usbdev.c
+++ b/arch/arm/src/cxd56xx/cxd56_usbdev.c
@@ -3388,7 +3388,7 @@ static int cxd56_usbdev_open(struct file *filep, const char *relpath,
    * REVISIT:  Write-able proc files could be quite useful.
    */
 
-  if (((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0))
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       uerr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/arch/arm/src/s32k1xx/s32k1xx_resetcause_procfs.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_resetcause_procfs.c
@@ -128,7 +128,7 @@ static int s32k1xx_resetcause_procfs_open(struct file *filep,
    * REVISIT:  Write-able proc files could be quite useful.
    */
 
-  if ((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0)
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/arch/arm64/src/common/arm64_fpu.c
+++ b/arch/arm64/src/common/arm64_fpu.c
@@ -166,7 +166,7 @@ static int arm64_fpu_procfs_open(struct file *filep, const char *relpath,
    * REVISIT:  Write-able proc files could be quite useful.
    */
 
-  if (((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0))
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       uerr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/arch/arm64/src/common/arm64_hostfs.c
+++ b/arch/arm64/src/common/arm64_hostfs.c
@@ -78,7 +78,7 @@ static ssize_t host_flen(long fd)
 
 static int host_flags_to_mode(int flags)
 {
-  static const int modemasks = O_RDONLY | O_WRONLY | O_TEXT | O_RDWR |
+  static const int modemasks = O_ACCMODE | O_TEXT |
                                O_CREAT | O_TRUNC | O_APPEND;
   static const int modeflags[] =
   {

--- a/arch/risc-v/src/common/riscv_hostfs.c
+++ b/arch/risc-v/src/common/riscv_hostfs.c
@@ -78,7 +78,7 @@ static ssize_t host_flen(long fd)
 
 static int host_flags_to_mode(int flags)
 {
-  static const int modemasks = O_RDONLY | O_WRONLY | O_TEXT | O_RDWR |
+  static const int modemasks = O_ACCMODE | O_TEXT |
                                O_CREAT | O_TRUNC | O_APPEND;
   static const int modeflags[] =
   {

--- a/arch/sim/src/sim/posix/sim_hostfs.c
+++ b/arch/sim/src/sim/posix/sim_hostfs.c
@@ -134,17 +134,19 @@ int host_open(const char *pathname, int flags, int mode)
 
   /* Perform flag mapping */
 
-  if ((flags & NUTTX_O_RDWR) == NUTTX_O_RDWR)
+  switch (flags & NUTTX_O_ACCMODE)
     {
-      mapflags = O_RDWR;
-    }
-  else if (flags & NUTTX_O_RDONLY)
-    {
-      mapflags = O_RDONLY;
-    }
-  else if (flags & NUTTX_O_WRONLY)
-    {
-      mapflags = O_WRONLY;
+      case NUTTX_O_RDONLY:
+        mapflags = O_RDONLY;
+        break;
+
+      case NUTTX_O_WRONLY:
+        mapflags = O_WRONLY;
+        break;
+
+      case NUTTX_O_RDWR:
+        mapflags = O_RDWR;
+        break;
     }
 
   if (flags & NUTTX_O_APPEND)

--- a/arch/sim/src/sim/win/sim_hostfs.c
+++ b/arch/sim/src/sim/win/sim_hostfs.c
@@ -89,17 +89,19 @@ int host_open(const char *pathname, int flags, int mode)
 
   /* Perform flag mapping */
 
-  if ((flags & NUTTX_O_RDWR) == NUTTX_O_RDWR)
+  switch (flags & NUTTX_O_ACCMODE)
     {
-      mapflags = O_RDWR;
-    }
-  else if (flags & NUTTX_O_RDONLY)
-    {
-      mapflags = O_RDONLY;
-    }
-  else if (flags & NUTTX_O_WRONLY)
-    {
-      mapflags = O_WRONLY;
+      case NUTTX_O_RDONLY:
+        mapflags = O_RDONLY;
+        break;
+
+      case NUTTX_O_WRONLY:
+        mapflags = O_WRONLY;
+        break;
+
+      case NUTTX_O_RDWR:
+        mapflags = O_RDWR;
+        break;
     }
 
   if (flags & NUTTX_O_APPEND)

--- a/arch/x86_64/src/common/x86_64_acpi_procfs.c
+++ b/arch/x86_64/src/common/x86_64_acpi_procfs.c
@@ -144,7 +144,7 @@ static int acpi_open(struct file *filep, const char *relpath,
    * is not permitted.
    */
 
-  if ((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0)
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/boards/arm/s32k1xx/rddrone-bms772/src/s32k1xx_nrstcheck_procfs.c
+++ b/boards/arm/s32k1xx/rddrone-bms772/src/s32k1xx_nrstcheck_procfs.c
@@ -134,7 +134,7 @@ static int s32k1xx_nrstcheck_procfs_open(struct file *filep,
    * REVISIT:  Write-able proc files could be quite useful.
    */
 
-  if ((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0)
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/drivers/bch/bchlib_setup.c
+++ b/drivers/bch/bchlib_setup.c
@@ -59,7 +59,7 @@ int bchlib_setup(FAR const char *blkdev, int oflags, FAR void **handle)
 {
   FAR struct bchlib_s *bch;
   struct geometry geo;
-  bool readonly = (oflags & O_WRONLY) == 0;
+  bool readonly = (oflags & O_ACCMODE) == O_RDONLY;
   int ret;
 
   DEBUGASSERT(blkdev);

--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -276,7 +276,7 @@ static int can_open(FAR struct file *filep)
 
           reader = init_can_reader(filep);
 
-          if ((filep->f_oflags & O_RDONLY) != 0)
+          if ((filep->f_oflags & O_ACCMODE) != O_WRONLY)
             {
               list_add_head(&dev->cd_readers,
                             (FAR struct list_node *)reader);

--- a/drivers/clk/clk.c
+++ b/drivers/clk/clk.c
@@ -141,7 +141,7 @@ static int clk_procfs_open(FAR struct file *filep, FAR const char *relpath,
 {
   FAR struct procfs_file_s *priv;
 
-  if ((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0)
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       return -EACCES;
     }

--- a/drivers/mmcsd/mmcsd_procfs.c
+++ b/drivers/mmcsd/mmcsd_procfs.c
@@ -180,7 +180,7 @@ static int mmcsd_open(FAR struct file *filep, FAR const char *relpath,
    * is not permitted.
    */
 
-  if ((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0)
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       finfo("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/drivers/mtd/mtd_partition.c
+++ b/drivers/mtd/mtd_partition.c
@@ -564,7 +564,7 @@ static int part_procfs_open(FAR struct file *filep, FAR const char *relpath,
    * REVISIT:  Write-able proc files could be quite useful.
    */
 
-  if ((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0)
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/drivers/pipes/pipe_common.c
+++ b/drivers/pipes/pipe_common.c
@@ -169,7 +169,7 @@ int pipecommon_open(FAR struct file *filep)
    * instance.
    */
 
-  if ((filep->f_oflags & O_WRONLY) != 0)
+  if ((filep->f_oflags & O_ACCMODE) != O_RDONLY)
     {
       dev->d_nwriters++;
 
@@ -184,10 +184,10 @@ int pipecommon_open(FAR struct file *filep)
         }
     }
 
-  while ((filep->f_oflags & O_NONBLOCK) == 0 &&     /* Blocking */
-         (filep->f_oflags & O_RDWR) == O_WRONLY &&  /* Write-only */
-         dev->d_nreaders < 1 &&                     /* No readers on the pipe */
-         circbuf_is_empty(&dev->d_buffer))          /* Buffer is empty */
+  while ((filep->f_oflags & O_NONBLOCK) == 0 &&       /* Blocking */
+         (filep->f_oflags & O_ACCMODE) == O_WRONLY && /* Write-only */
+         dev->d_nreaders < 1 &&                       /* No readers on the pipe */
+         circbuf_is_empty(&dev->d_buffer))            /* Buffer is empty */
     {
       /* If opened for write-only, then wait for at least one reader
        * on the pipe.
@@ -233,7 +233,7 @@ int pipecommon_open(FAR struct file *filep)
    * instance.
    */
 
-  if ((filep->f_oflags & O_RDONLY) != 0)
+  if ((filep->f_oflags & O_ACCMODE) != O_WRONLY)
     {
       dev->d_nreaders++;
 
@@ -248,10 +248,10 @@ int pipecommon_open(FAR struct file *filep)
         }
     }
 
-  while ((filep->f_oflags & O_NONBLOCK) == 0 &&     /* Blocking */
-         (filep->f_oflags & O_RDWR) == O_RDONLY &&  /* Read-only */
-         dev->d_nwriters < 1 &&                     /* No writers on the pipe */
-         circbuf_is_empty(&dev->d_buffer))          /* Buffer is empty */
+  while ((filep->f_oflags & O_NONBLOCK) == 0 &&       /* Blocking */
+         (filep->f_oflags & O_ACCMODE) == O_RDONLY && /* Read-only */
+         dev->d_nwriters < 1 &&                       /* No writers on the pipe */
+         circbuf_is_empty(&dev->d_buffer))            /* Buffer is empty */
     {
       /* If opened for read-only, then wait for either at least one writer
        * on the pipe.
@@ -337,7 +337,7 @@ int pipecommon_close(FAR struct file *filep)
        * writers on the pipe instance.
        */
 
-      if ((filep->f_oflags & O_WRONLY) != 0)
+      if ((filep->f_oflags & O_ACCMODE) != O_RDONLY)
         {
           /* If there are no longer any writers on the pipe, then notify all
            * of the waiting readers that they must return end-of-file.
@@ -357,7 +357,7 @@ int pipecommon_close(FAR struct file *filep)
        * instance.
        */
 
-      if ((filep->f_oflags & O_RDONLY) != 0)
+      if ((filep->f_oflags & O_ACCMODE) != O_WRONLY)
         {
           if (--dev->d_nreaders <= 0)
             {
@@ -718,15 +718,16 @@ int pipecommon_poll(FAR struct file *filep, FAR struct pollfd *fds,
        */
 
       eventset = 0;
-      if ((filep->f_oflags & O_WRONLY) &&
-          nbytes < (dev->d_bufsize - dev->d_polloutthrd))
+      if ((filep->f_oflags & O_ACCMODE) != O_RDONLY &&
+          nbytes < dev->d_bufsize - dev->d_polloutthrd)
         {
           eventset |= POLLOUT;
         }
 
       /* Notify the POLLIN event if buffer used exceeds poll threshold */
 
-      if ((filep->f_oflags & O_RDONLY) && (nbytes > dev->d_pollinthrd))
+      if ((filep->f_oflags & O_ACCMODE) != O_WRONLY &&
+          nbytes > dev->d_pollinthrd)
         {
           eventset |= POLLIN;
         }

--- a/drivers/power/pm/pm_procfs.c
+++ b/drivers/power/pm/pm_procfs.c
@@ -200,7 +200,7 @@ static int pm_open(FAR struct file *filep, FAR const char *relpath,
    * is not permitted.
    */
 
-  if ((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0)
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -728,7 +728,7 @@ static int sensor_open(FAR struct file *filep)
    * allowing for direct I/O operations.
    */
 
-  if (filep->f_oflags & O_RDONLY)
+  if ((filep->f_oflags & O_ACCMODE) != O_WRONLY)
     {
       if (upper->state.nsubscribers == 0 && lower->ops->activate)
         {
@@ -743,7 +743,7 @@ static int sensor_open(FAR struct file *filep)
       upper->state.nsubscribers++;
     }
 
-  if (filep->f_oflags & O_WRONLY)
+  if ((filep->f_oflags & O_ACCMODE) != O_RDONLY)
     {
       user->role |= SENSOR_ROLE_WR;
       upper->state.nadvertisers++;
@@ -820,7 +820,7 @@ static int sensor_close(FAR struct file *filep)
    * allowing for direct I/O operations.
    */
 
-  if (filep->f_oflags & O_RDONLY)
+  if ((filep->f_oflags & O_ACCMODE) != O_WRONLY)
     {
       upper->state.nsubscribers--;
       if (upper->state.nsubscribers == 0 && lower->ops->activate)
@@ -829,7 +829,7 @@ static int sensor_close(FAR struct file *filep)
         }
     }
 
-  if (filep->f_oflags & O_WRONLY)
+  if ((filep->f_oflags & O_ACCMODE) != O_RDONLY)
     {
       upper->state.nadvertisers--;
     }

--- a/drivers/sensors/sensor_rpmsg.c
+++ b/drivers/sensors/sensor_rpmsg.c
@@ -680,7 +680,7 @@ static int sensor_rpmsg_open(FAR struct sensor_lowerhalf_s *lower,
     }
 
   sensor_rpmsg_lock(dev);
-  if (filep->f_oflags & O_WRONLY)
+  if ((filep->f_oflags & O_ACCMODE) != O_RDONLY)
     {
       if (dev->nadvertisers++ == 0)
         {
@@ -688,7 +688,7 @@ static int sensor_rpmsg_open(FAR struct sensor_lowerhalf_s *lower,
         }
     }
 
-  if (filep->f_oflags & O_RDONLY)
+  if ((filep->f_oflags & O_ACCMODE) != O_WRONLY)
     {
       if (dev->nsubscribers++ == 0)
         {
@@ -722,7 +722,7 @@ static int sensor_rpmsg_close(FAR struct sensor_lowerhalf_s *lower,
     }
 
   sensor_rpmsg_lock(dev);
-  if (filep->f_oflags & O_WRONLY)
+  if ((filep->f_oflags & O_ACCMODE) != O_RDONLY)
     {
       if (dev->nadvertisers == 1)
         {
@@ -737,7 +737,7 @@ static int sensor_rpmsg_close(FAR struct sensor_lowerhalf_s *lower,
       dev->nadvertisers--;
     }
 
-  if (filep->f_oflags & O_RDONLY)
+  if ((filep->f_oflags & O_ACCMODE) != O_WRONLY)
     {
       if (dev->nsubscribers == 1)
         {

--- a/fs/aio/aio_write.c
+++ b/fs/aio/aio_write.c
@@ -280,7 +280,7 @@ int aio_write(FAR struct aiocb *aiocbp)
    */
 
   flags = fcntl(aiocbp->aio_fildes, F_GETFL);
-  if ((flags & O_WRONLY) == 0)
+  if ((flags & O_ACCMODE) == O_RDONLY)
     {
       aiocbp->aio_result = -EBADF;
       return OK;

--- a/fs/binfs/fs_binfs.c
+++ b/fs/binfs/fs_binfs.c
@@ -158,7 +158,7 @@ static int binfs_open(FAR struct file *filep, FAR const char *relpath,
    * access is not permitted.
    */
 
-  if ((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0)
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/fs/cromfs/fs_cromfs.c
+++ b/fs/cromfs/fs_cromfs.c
@@ -761,7 +761,7 @@ static int cromfs_open(FAR struct file *filep, FAR const char *relpath,
    * access is not permitted.
    */
 
-  if ((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0)
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/fs/fat/fs_fat32.c
+++ b/fs/fat/fs_fat32.c
@@ -253,7 +253,7 @@ static int fat_open(FAR struct file *filep, FAR const char *relpath,
       /* Check if the caller has sufficient privileges to open the file */
 
       readonly = ((DIR_GETATTRIBUTES(direntry) & FATATTR_READONLY) != 0);
-      if (((oflags & O_WRONLY) != 0) && readonly)
+      if ((oflags & O_ACCMODE) != O_RDONLY && readonly)
         {
           ret = -EACCES;
           goto errout_with_lock;
@@ -379,7 +379,7 @@ static int fat_open(FAR struct file *filep, FAR const char *relpath,
    * the file.
    */
 
-  if ((oflags & (O_APPEND | O_WRONLY)) == (O_APPEND | O_WRONLY))
+  if ((oflags & O_APPEND) && (oflags & O_ACCMODE) != O_RDONLY)
     {
       off_t offset = fat_seek(filep, ff->ff_size, SEEK_SET);
       if (offset < 0)
@@ -802,7 +802,7 @@ static ssize_t fat_read(FAR struct file *filep, FAR char *buffer,
 
   /* Check if the file was opened with read access */
 
-  if ((ff->ff_oflags & O_RDONLY) == 0)
+  if ((ff->ff_oflags & O_ACCMODE) == O_WRONLY)
     {
       ret = -EACCES;
       goto errout_with_lock;
@@ -1020,7 +1020,7 @@ static ssize_t fat_write(FAR struct file *filep, FAR const char *buffer,
 
   /* Check if the file was opened for write access */
 
-  if ((ff->ff_oflags & O_WRONLY) == 0)
+  if ((ff->ff_oflags & O_ACCMODE) == O_RDONLY)
     {
       ret = -EACCES;
       goto errout_with_lock;
@@ -2289,7 +2289,7 @@ static int fat_truncate(FAR struct file *filep, off_t length)
 
   /* Check if the file was opened for write access */
 
-  if ((ff->ff_oflags & O_WRONLY) == 0)
+  if ((ff->ff_oflags & O_ACCMODE) == O_RDONLY)
     {
       ret = -EACCES;
       goto errout_with_lock;

--- a/fs/hostfs/hostfs.c
+++ b/fs/hostfs/hostfs.c
@@ -304,7 +304,7 @@ static int hostfs_open(FAR struct file *filep, FAR const char *relpath,
    * file.
    */
 
-  if ((oflags & (O_APPEND | O_WRONLY)) == (O_APPEND | O_WRONLY))
+  if ((oflags & O_APPEND) && (oflags & O_ACCMODE) != O_RDONLY)
     {
       ret = host_lseek(hf->fd, 0, 0, SEEK_END);
       if (ret >= 0)
@@ -516,7 +516,7 @@ static ssize_t hostfs_write(FAR struct file *filep, const char *buffer,
    * write flags.
    */
 
-  if ((hf->oflags & O_WRONLY) == 0)
+  if ((hf->oflags & O_ACCMODE) == O_RDONLY)
     {
       ret = -EACCES;
       goto errout_with_lock;

--- a/fs/inode/fs_inode.c
+++ b/fs/inode/fs_inode.c
@@ -111,19 +111,20 @@ int fs_checkmode(uid_t owner, gid_t group, mode_t mode, int amode)
 
 int fs_open_amode(int oflags)
 {
-  int amode = 0;
-
-  if ((oflags & O_RDONLY) != 0)
+  switch (oflags & O_ACCMODE)
     {
-      amode |= R_OK;
-    }
+      case O_RDONLY:
+        return R_OK;
 
-  if ((oflags & O_WRONLY) != 0)
-    {
-      amode |= W_OK;
-    }
+      case O_WRONLY:
+        return W_OK;
 
-  return amode;
+      case O_RDWR:
+        return R_OK | W_OK;
+
+      default:
+        return 0;
+    }
 }
 
 /****************************************************************************
@@ -285,9 +286,9 @@ int inode_checkopenperm(FAR struct inode *inode, int oflags)
       return -ENXIO;
     }
 
-  if (((oflags & O_RDONLY) != 0 &&
+  if (((oflags & O_ACCMODE) != O_WRONLY &&
        !ops->readv && !ops->read && !ops->ioctl) ||
-      ((oflags & O_WRONLY) != 0 &&
+      ((oflags & O_ACCMODE) != O_RDONLY &&
        !ops->writev && !ops->write && !ops->ioctl))
     {
       return -EACCES;

--- a/fs/littlefs/lfs_vfs.c
+++ b/fs/littlefs/lfs_vfs.c
@@ -287,14 +287,19 @@ static int littlefs_convert_oflags(int oflags)
 {
   int ret = 0;
 
-  if ((oflags & O_RDONLY) != 0)
+  switch (oflags & O_ACCMODE)
     {
-      ret |= LFS_O_RDONLY;
-    }
+      case O_RDONLY:
+        ret |= LFS_O_RDONLY;
+        break;
 
-  if ((oflags & O_WRONLY) != 0)
-    {
-      ret |= LFS_O_WRONLY;
+      case O_WRONLY:
+        ret |= LFS_O_WRONLY;
+        break;
+
+      case O_RDWR:
+        ret |= LFS_O_RDWR;
+        break;
     }
 
   if ((oflags & O_CREAT) != 0)

--- a/fs/mmap/fs_mmap.c
+++ b/fs/mmap/fs_mmap.c
@@ -138,7 +138,7 @@ static int file_mmap_(FAR struct file *filep, FAR void *start,
     }
 
   if ((flags & MAP_SHARED) &&
-      (filep->f_oflags & O_WRONLY) == 0 && prot == PROT_WRITE)
+      (filep->f_oflags & O_WRONLY) == 0 && (prot & PROT_WRITE))
     {
       ferr("ERROR: Unsupported options for read-only file descriptor,"
            "prot=%x flags=%04x\n", prot, flags);

--- a/fs/mmap/fs_mmap.c
+++ b/fs/mmap/fs_mmap.c
@@ -137,15 +137,15 @@ static int file_mmap_(FAR struct file *filep, FAR void *start,
       return -EBADF;
     }
 
-  if ((flags & MAP_SHARED) &&
-      (filep->f_oflags & O_WRONLY) == 0 && (prot & PROT_WRITE))
+  if ((flags & MAP_SHARED) && (prot & PROT_WRITE) &&
+      (filep->f_oflags & O_ACCMODE) == O_RDONLY)
     {
       ferr("ERROR: Unsupported options for read-only file descriptor,"
            "prot=%x flags=%04x\n", prot, flags);
       return -EACCES;
     }
 
-  if ((filep->f_oflags & O_RDONLY) == 0)
+  if ((filep->f_oflags & O_ACCMODE) == O_WRONLY)
     {
       ferr("ERROR: File descriptor does not have read permission\n");
       return -EACCES;

--- a/fs/mount/fs_procfs_mount.c
+++ b/fs/mount/fs_procfs_mount.c
@@ -377,7 +377,7 @@ static int mount_open(FAR struct file *filep, FAR const char *relpath,
    * REVISIT:  Write-able proc files could be quite useful.
    */
 
-  if ((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0)
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/fs/nfs/nfs_vfsops.c
+++ b/fs/nfs/nfs_vfsops.c
@@ -581,7 +581,7 @@ static int nfs_fileopen(FAR struct nfsmount *nmp, FAR struct nfsnode *np,
 
   /* Check if the caller has sufficient privileges to open the file */
 
-  if ((oflags & O_WRONLY) != 0)
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       /* Check if anyone has privileges to write to the file -- owner,
        * group, or other (we are probably "other" and may still not be
@@ -737,7 +737,7 @@ static int nfs_open(FAR struct file *filep, FAR const char *relpath,
    * the file.
    */
 
-  if ((oflags & (O_APPEND | O_WRONLY)) == (O_APPEND | O_WRONLY))
+  if ((oflags & O_APPEND) && (oflags & O_ACCMODE) != O_RDONLY)
     {
       filep->f_pos = (off_t)np->n_size;
     }

--- a/fs/nxffs/nxffs_open.c
+++ b/fs/nxffs/nxffs_open.c
@@ -706,7 +706,7 @@ static inline int nxffs_rdopen(FAR struct nxffs_volume_s *volume,
        * Limitation:  Files cannot be open both for reading and writing.
        */
 
-      if ((ofile->oflags & O_WRONLY) != 0)
+      if ((ofile->oflags & O_ACCMODE) != O_RDONLY)
         {
           ferr("ERROR: File is open for writing\n");
           ret = -ENOSYS;
@@ -1013,9 +1013,8 @@ int nxffs_open(FAR struct file *filep, FAR const char *relpath,
    * extension is supported.
    */
 
-  switch (oflags & (O_WRONLY | O_RDONLY))
+  switch (oflags & O_ACCMODE)
     {
-      case 0:
       default:
         ferr("ERROR: One of O_WRONLY/O_RDONLY must be provided\n");
         return -EINVAL;
@@ -1028,7 +1027,7 @@ int nxffs_open(FAR struct file *filep, FAR const char *relpath,
         ret = nxffs_rdopen(volume, relpath, &ofile);
         break;
 
-      case O_WRONLY | O_RDONLY:
+      case O_RDWR:
         ferr("ERROR: O_RDWR is not supported\n");
         return -ENOSYS;
     }
@@ -1156,7 +1155,7 @@ int nxffs_close(FAR struct file *filep)
 
       /* Handle special finalization of the write operation. */
 
-      if ((ofile->oflags & O_WRONLY) != 0)
+      if ((ofile->oflags & O_ACCMODE) != O_RDONLY)
         {
           ret = nxffs_wrclose(volume, (FAR struct nxffs_wrfile_s *)ofile);
         }

--- a/fs/nxffs/nxffs_read.c
+++ b/fs/nxffs/nxffs_read.c
@@ -168,7 +168,7 @@ ssize_t nxffs_read(FAR struct file *filep, FAR char *buffer, size_t buflen)
 
   /* Check if the file was opened with read access */
 
-  if ((ofile->oflags & O_RDONLY) == 0)
+  if ((ofile->oflags & O_ACCMODE) == O_WRONLY)
     {
       ferr("ERROR: File not open for read access\n");
       ret = -EACCES;

--- a/fs/nxffs/nxffs_truncate.c
+++ b/fs/nxffs/nxffs_truncate.c
@@ -83,7 +83,7 @@ int nxffs_truncate(FAR struct file *filep, off_t length)
 
   /* Check if the file was opened with write access */
 
-  if ((wrfile->ofile.oflags & O_WRONLY) == 0)
+  if ((wrfile->ofile.oflags & O_ACCMODE) == O_RDONLY)
     {
       ferr("ERROR: File not open for write access\n");
       ret = -EACCES;

--- a/fs/nxffs/nxffs_write.c
+++ b/fs/nxffs/nxffs_write.c
@@ -545,7 +545,7 @@ ssize_t nxffs_write(FAR struct file *filep, FAR const char *buffer,
 
   /* Check if the file was opened with write access */
 
-  if ((wrfile->ofile.oflags & O_WRONLY) == 0)
+  if ((wrfile->ofile.oflags & O_ACCMODE) == O_RDONLY)
     {
       ferr("ERROR: File not open for write access\n");
       ret = -EACCES;

--- a/fs/procfs/fs_procfscpuload.c
+++ b/fs/procfs/fs_procfscpuload.c
@@ -138,7 +138,7 @@ static int cpuload_open(FAR struct file *filep, FAR const char *relpath,
    * REVISIT:  Write-able proc files could be quite useful.
    */
 
-  if ((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0)
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/fs/procfs/fs_procfscritmon.c
+++ b/fs/procfs/fs_procfscritmon.c
@@ -137,7 +137,7 @@ static int critmon_open(FAR struct file *filep, FAR const char *relpath,
    * REVISIT:  Write-able proc files could be quite useful.
    */
 
-  if ((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0)
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/fs/procfs/fs_procfsfdt.c
+++ b/fs/procfs/fs_procfsfdt.c
@@ -119,7 +119,7 @@ static int fdt_open(FAR struct file *filep, FAR const char *relpath,
    * REVISIT:  Write-able proc files could be quite useful.
    */
 
-  if ((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0)
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/fs/procfs/fs_procfsiobinfo.c
+++ b/fs/procfs/fs_procfsiobinfo.c
@@ -132,7 +132,7 @@ static int iobinfo_open(FAR struct file *filep, FAR const char *relpath,
    * REVISIT:  Write-able proc files could be quite useful.
    */
 
-  if ((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0)
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/fs/procfs/fs_procfstcbinfo.c
+++ b/fs/procfs/fs_procfstcbinfo.c
@@ -137,7 +137,7 @@ static int tcbinfo_open(FAR struct file *filep, FAR const char *relpath,
    * REVISIT:  Write-able proc files could be quite useful.
    */
 
-  if ((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0)
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/fs/procfs/fs_procfsuptime.c
+++ b/fs/procfs/fs_procfsuptime.c
@@ -138,7 +138,7 @@ static int uptime_open(FAR struct file *filep, FAR const char *relpath,
    * REVISIT:  Write-able proc files could be quite useful.
    */
 
-  if ((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0)
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/fs/procfs/fs_procfsversion.c
+++ b/fs/procfs/fs_procfsversion.c
@@ -138,7 +138,7 @@ static int version_open(FAR struct file *filep, FAR const char *relpath,
    * REVISIT:  Write-able proc files could be quite useful.
    */
 
-  if ((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0)
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/fs/procfs/fs_skeleton.c
+++ b/fs/procfs/fs_skeleton.c
@@ -168,8 +168,8 @@ static int skel_open(FAR struct file *filep, FAR const char *relpath,
    * can not be permitted.
    */
 
-  if (((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0) &&
-      (skel_procfsoperations.write == NULL))
+  if ((oflags & O_ACCMODE) != O_RDONLY &&
+      skel_procfsoperations.write == NULL)
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/fs/romfs/fs_romfs.c
+++ b/fs/romfs/fs_romfs.c
@@ -202,7 +202,7 @@ static int romfs_open(FAR struct file *filep, FAR const char *relpath,
    * access is not permitted.
    */
 
-  if ((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0)
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       ret = -EACCES;

--- a/fs/rpmsgfs/rpmsgfs.c
+++ b/fs/rpmsgfs/rpmsgfs.c
@@ -341,7 +341,7 @@ static int rpmsgfs_open(FAR struct file *filep, FAR const char *relpath,
    * file.
    */
 
-  if ((oflags & (O_APPEND | O_WRONLY)) == (O_APPEND | O_WRONLY))
+  if ((oflags & O_APPEND) && (oflags & O_ACCMODE) != O_RDONLY)
     {
       ret = rpmsgfs_client_lseek(fs->handle, hf->fd, 0, SEEK_END);
       if (ret >= 0)
@@ -553,7 +553,7 @@ static ssize_t rpmsgfs_write(FAR struct file *filep, const char *buffer,
    * write flags.
    */
 
-  if ((hf->oflags & O_WRONLY) == 0)
+  if ((hf->oflags & O_ACCMODE) == O_RDONLY)
     {
       ret = -EACCES;
       goto errout_with_lock;

--- a/fs/shm/shm_open.c
+++ b/fs/shm/shm_open.c
@@ -113,8 +113,8 @@ static int file_shm_open(FAR struct file *shm, FAR const char *name,
         }
 
 #ifdef CONFIG_PSEUDOFS_ATTRIBUTES
-      if (((oflags & O_WRONLY) && !(inode->i_mode & S_IWUSR)) ||
-          ((oflags & O_RDONLY) && !(inode->i_mode & S_IRUSR))
+      if (((oflags & O_ACCMODE) != O_RDONLY && !(inode->i_mode & S_IWUSR)) ||
+          ((oflags & O_ACCMODE) != O_WRONLY && !(inode->i_mode & S_IRUSR)))
         {
           ret = -EACCES;
           inode_release(inode);

--- a/fs/shm/shm_open.c
+++ b/fs/shm/shm_open.c
@@ -29,6 +29,7 @@
 #include <stdio.h>
 #include <fcntl.h>
 #include <errno.h>
+#include <sys/stat.h>
 
 #include "inode/inode.h"
 #include "vfs/vfs.h"
@@ -110,6 +111,16 @@ static int file_shm_open(FAR struct file *shm, FAR const char *name,
           inode_release(inode);
           goto errout_with_sem;
         }
+
+#ifdef CONFIG_PSEUDOFS_ATTRIBUTES
+      if (((oflags & O_WRONLY) && !(inode->i_mode & S_IWUSR)) ||
+          ((oflags & O_RDONLY) && !(inode->i_mode & S_IRUSR))
+        {
+          ret = -EACCES;
+          inode_release(inode);
+          goto errout_with_sem;
+        }
+#endif
 
       /* If the shared memory object already exists, truncate it to
        * zero bytes.

--- a/fs/smartfs/smartfs_procfs.c
+++ b/fs/smartfs/smartfs_procfs.c
@@ -351,8 +351,8 @@ static int smartfs_open(FAR struct file *filep, FAR const char *relpath,
    * REVISIT:  Write-able proc files could be quite useful.
    */
 
-  if (((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0) &&
-      (g_smartfs_procfs_operations.write == NULL))
+  if ((oflags & O_ACCMODE) != O_RDONLY &&
+      g_smartfs_procfs_operations.write == NULL)
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/fs/smartfs/smartfs_smart.c
+++ b/fs/smartfs/smartfs_smart.c
@@ -693,7 +693,7 @@ static ssize_t smartfs_write(FAR struct file *filep, FAR const char *buffer,
    * write flags.
    */
 
-  if ((sf->oflags & O_WRONLY) == 0)
+  if ((sf->oflags & O_ACCMODE) == O_RDONLY)
     {
       ret = -EACCES;
       goto errout_with_lock;
@@ -1223,7 +1223,7 @@ static int smartfs_truncate(FAR struct file *filep, off_t length)
    * write flags.
    */
 
-  if ((sf->oflags & O_WRONLY) == 0)
+  if ((sf->oflags & O_ACCMODE) == O_RDONLY)
     {
       ret = -EACCES;
       goto errout_with_lock;

--- a/fs/spiffs/src/spiffs_vfs.c
+++ b/fs/spiffs/src/spiffs_vfs.c
@@ -433,7 +433,7 @@ static int spiffs_open(FAR struct file *filep, FAR const char *relpath,
    */
 
   offset = 0;
-  if ((oflags & (O_APPEND | O_WRONLY)) == (O_APPEND | O_WRONLY))
+  if ((oflags & O_APPEND) && (oflags & O_ACCMODE) != O_RDONLY)
     {
       offset = fobj->size == SPIFFS_UNDEFINED_LEN ? 0 : fobj->size;
     }
@@ -629,7 +629,7 @@ static ssize_t spiffs_write(FAR struct file *filep, FAR const char *buffer,
 
   /* Verify that the file was opened with write access */
 
-  if ((fobj->oflags & O_WRONLY) == 0)
+  if ((fobj->oflags & O_ACCMODE) == O_RDONLY)
     {
       ret = -EACCES;
       goto errout_with_lock;

--- a/fs/spiffs/src/spiffs_volume.c
+++ b/fs/spiffs/src/spiffs_volume.c
@@ -371,7 +371,7 @@ ssize_t spiffs_fobj_read(FAR struct spiffs_s *fs,
 
   /* Make sure that read access is supported */
 
-  if ((fobj->oflags & O_RDONLY) == 0)
+  if ((fobj->oflags & O_ACCMODE) == O_WRONLY)
     {
       return -EACCES;
     }

--- a/fs/tmpfs/fs_tmpfs.c
+++ b/fs/tmpfs/fs_tmpfs.c
@@ -1679,7 +1679,7 @@ static int tmpfs_open(FAR struct file *filep, FAR const char *relpath,
    */
 
   offset = 0;
-  if ((oflags & (O_APPEND | O_WRONLY)) == (O_APPEND | O_WRONLY))
+  if ((oflags & O_APPEND) && (oflags & O_ACCMODE) != O_RDONLY)
     {
       offset = tfo->tfo_size;
     }

--- a/fs/vfs/fs_inotify.c
+++ b/fs/vfs/fs_inotify.c
@@ -1349,7 +1349,7 @@ void notify_open(FAR const char *path, int oflags)
 
 void notify_close(FAR const char *path, int oflags)
 {
-  if (oflags & O_WRONLY)
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       notify_queue_path_event(path, IN_CLOSE_WRITE);
     }

--- a/fs/vfs/fs_open.c
+++ b/fs/vfs/fs_open.c
@@ -220,7 +220,7 @@ static int file_vopen(FAR struct file *filep, FAR const char *path,
   FS_PROFILE_STOP(start_time, g_fs_profile.total_open_time,
                   g_fs_profile.opens);
 
-  if (ret == -EISDIR && ((oflags & O_WRONLY) == 0))
+  if (ret == -EISDIR && (oflags & O_ACCMODE) == O_RDONLY)
     {
       ret = dir_allocate(filep, desc.relpath);
     }

--- a/fs/vfs/fs_read.c
+++ b/fs/vfs/fs_read.c
@@ -192,7 +192,7 @@ ssize_t file_readv(FAR struct file *filep,
 
   /* Was this file opened for read access? */
 
-  if ((filep->f_oflags & O_RDONLY) == 0)
+  if ((filep->f_oflags & O_ACCMODE) == O_WRONLY)
     {
       /* No.. File is not read-able */
 

--- a/fs/vfs/fs_truncate.c
+++ b/fs/vfs/fs_truncate.c
@@ -57,7 +57,7 @@ int file_truncate(FAR struct file *filep, off_t length)
 
   /* Was this file opened for write access? */
 
-  if ((filep->f_oflags & O_WRONLY) == 0)
+  if ((filep->f_oflags & O_ACCMODE) == O_RDONLY)
     {
       fwarn("WARNING: Cannot truncate a file opened read-only\n");
       return -EINVAL;

--- a/fs/vfs/fs_write.c
+++ b/fs/vfs/fs_write.c
@@ -153,7 +153,7 @@ ssize_t file_writev(FAR struct file *filep,
 
   /* Was this file opened for write access? */
 
-  if ((filep->f_oflags & O_WRONLY) == 0)
+  if ((filep->f_oflags & O_ACCMODE) == O_RDONLY)
     {
       return -EACCES;
     }

--- a/graphics/nxterm/nxterm_driver.c
+++ b/graphics/nxterm/nxterm_driver.c
@@ -122,7 +122,7 @@ static int nxterm_open(FAR struct file *filep)
   /* Verify that the driver is opened for write-only access */
 
 #ifndef CONFIG_NXTERM_NXKBDIN
-  if ((filep->f_oflags & O_RDONLY) != 0)
+  if ((filep->f_oflags & O_ACCMODE) != O_WRONLY)
     {
       gerr("ERROR: Attempted open with read access\n");
       return -EACCES;

--- a/include/fcntl.h
+++ b/include/fcntl.h
@@ -36,53 +36,56 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* open flag settings for open() (and related APIs) */
+/* Open flag settings for open() (and related APIs) */
 
-#define O_RDONLY     (1 << 0)        /* Open for read access (only) */
-#define O_WRONLY     (1 << 1)        /* Open for write access (only) */
-#define O_RDWR       (3 << 0)        /* Open for both read & write access */
-#define O_CREAT      (1 << 2)        /* Create file/sem/mq object */
-#define O_EXCL       (1 << 3)        /* Name must not exist when opened  */
-#define O_APPEND     (1 << 4)        /* Keep contents, append to end */
-#define O_TRUNC      (1 << 5)        /* Delete contents */
-#define O_NONBLOCK   (1 << 6)        /* Don't wait for data */
-#define O_NDELAY     O_NONBLOCK      /* Synonym for O_NONBLOCK */
-#define O_SYNC       (1 << 7)        /* Synchronize output on write */
-#define O_DSYNC      O_SYNC          /* Equivalent to OSYNC in NuttX */
-#define O_TEXT       (1 << 8)        /* Open the file in text (translated) mode. */
-#define O_DIRECT     (1 << 9)        /* Avoid caching, write directly to hardware */
-#define O_CLOEXEC    (1 << 10)       /* Close on execute */
-#define O_DIRECTORY  (1 << 11)       /* Must be a directory */
-#define O_NOFOLLOW   (1 << 12)       /* Don't follow links */
-#define O_LARGEFILE  (1 << 13)       /* Large File */
-#define O_RESERVE14  (1 << 14)       /* reserved and used by mount flag : MS_NOSUID in mount.h */
-#define O_RESERVE15  (1 << 15)       /* reserved and used by mount flag : MS_NODEV in mount.h */
-#define O_RESERVE16  (1 << 16)       /* reserved and used by mount flag : MS_DIRSYNC in mount.h */
-#define O_RESERVE17  (1 << 17)       /* reserved and used by mount flag : MS_REMOUNT in mount.h */
-#define O_NOATIME    (1 << 18)       /* Don't update the file last access time */
-#define O_RESERVE19  (1 << 19)       /* reserved and used by mount flag : MS_MANDLOCK in mount.h */
-#define O_RESERVE20  (1 << 20)       /* reserved and used by mount flag : MS_NOEXEC in mount.h */
+/* The access mode flags (O_RDONLY/O_WRONLY/O_RDWR) use the same values
+ * as Linux (0/1/2) so that the FUSE wire protocol and other cross-
+ * platform interfaces work without conversion.  The remaining flags
+ * are also aligned with Linux where possible.
+ */
 
-/* Unsupported, but required open flags */
+#define O_RDONLY     (0U << 0)       /* Open for read access (only) */
+#define O_WRONLY     (1U << 0)       /* Open for write access (only) */
+#define O_RDWR       (2U << 0)       /* Open for both read & write access */
+#define O_ACCMODE    (3U << 0)       /* Mask for access mode */
+#define O_TEXT       (1U << 5)       /* Open the file in text (translated) mode. */
+#define O_CREAT      (1U << 6)       /* Create file/sem/mq object */
+#define O_EXCL       (1U << 7)       /* Name must not exist when opened  */
+#define O_NOCTTY     (1U << 8)       /* Don't assign a controlling terminal */
+#define O_TRUNC      (1U << 9)       /* Delete contents */
+#define O_APPEND     (1U << 10)      /* Keep contents, append to end */
+#define O_NONBLOCK   (1U << 11)      /* Don't wait for data */
+#define O_DSYNC      (1U << 12)      /* Synchronize data on write */
+#define O_ASYNC      (1U << 13)      /* Enable signal-driven I/O */
+#define O_DIRECT     (1U << 14)      /* Avoid caching, write directly to hardware */
+#define O_LARGEFILE  (1U << 15)      /* Large File */
+#define O_DIRECTORY  (1U << 16)      /* Must be a directory */
+#define O_NOFOLLOW   (1U << 17)      /* Don't follow links */
+#define O_NOATIME    (1U << 18)      /* Don't update the file last access time */
+#define O_CLOEXEC    (1U << 19)      /* Close on execute */
+#define __O_SYNC     (1U << 20)      /* Synchronize file (data+metadata) */
+#define O_PATH       (1U << 21)      /* Obtain a path-only fd (no I/O) */
+#define __O_TMPFILE  (1U << 22)      /* Create an unnamed temporary file */
 
-#define O_RSYNC     O_SYNC          /* Synchronize input on read */
-#define O_ACCMODE   O_RDWR          /* Mask for access mode */
-#define O_NOCTTY    0               /* Required by POSIX */
-#define O_BINARY    0               /* Open the file in binary (untranslated) mode. */
+#define O_NDELAY     O_NONBLOCK                  /* Synonym for O_NONBLOCK */
+#define O_SYNC       (__O_SYNC | O_DSYNC)        /* Synchronize output on write */
+#define O_RSYNC      O_SYNC                      /* Synchronize input on read */
+#define O_TMPFILE    (__O_TMPFILE | O_DIRECTORY) /* Create a temporary file */
+#define O_BINARY     0                           /* Open the file in binary mode */
 
 /* This is the highest bit number used in the open flags bitset.  Bits above
  * this bit number may be used within NuttX for other, internal purposes.
  */
 
-#define _O_MAXBIT   8
+#define _O_MAXBIT   22
 
 /* Synonyms historically used as F_SETFL flags (BSD). */
 
-#define FNDELAY     O_NONBLOCK        /* Don't wait for data */
-#define FNONBLOCK   O_NONBLOCK        /* Don't wait for data */
-#define FAPPEND     O_APPEND          /* Keep contents, append to end */
-#define FSYNC       O_SYNC            /* Synchronize output on write */
-#define FASYNC      0                 /* No counterpart in NuttX */
+#define FNDELAY     O_NONBLOCK       /* Don't wait for data */
+#define FNONBLOCK   O_NONBLOCK       /* Don't wait for data */
+#define FAPPEND     O_APPEND         /* Keep contents, append to end */
+#define FSYNC       O_SYNC           /* Synchronize output on write */
+#define FASYNC      O_ASYNC          /* No counterpart in NuttX */
 
 /* FFCNTL is all the bits that may be set via fcntl. */
 

--- a/include/nuttx/fs/hostfs.h
+++ b/include/nuttx/fs/hostfs.h
@@ -76,20 +76,34 @@
 
 /* These must exactly match the definitions from include/fcntl.h: */
 
-#define NUTTX_O_RDONLY          (1 << 0)  /* Open for read access (only) */
-#define NUTTX_O_WRONLY          (1 << 1)  /* Open for write access (only) */
-#define NUTTX_O_CREAT           (1 << 2)  /* Create file/sem/mq object */
-#define NUTTX_O_EXCL            (1 << 3)  /* Name must not exist when opened  */
-#define NUTTX_O_APPEND          (1 << 4)  /* Keep contents, append to end */
-#define NUTTX_O_TRUNC           (1 << 5)  /* Delete contents */
-#define NUTTX_O_NONBLOCK        (1 << 6)  /* Don't wait for data */
-#define NUTTX_O_SYNC            (1 << 7)  /* Synchronize output on write */
-#define NUTTX_O_TEXT            (1 << 8)  /* Open the file in text (translated) mode. */
-#define NUTTX_O_DIRECT          (1 << 9)  /* Avoid caching, write directly to hardware */
-#define NUTTX_O_CLOEXEC         (1 << 10) /* Close on execute */
-#define NUTTX_O_DIRECTORY       (1 << 11) /* Must be a directory */
+#define NUTTX_O_RDONLY          (0 << 0)       /* Open for read access (only) */
+#define NUTTX_O_WRONLY          (1 << 0)       /* Open for write access (only) */
+#define NUTTX_O_RDWR            (2 << 0)       /* Open for both read & write access */
+#define NUTTX_O_ACCMODE         (3 << 0)       /* Mask for access mode */
+#define NUTTX_O_TEXT            (1 << 5)       /* Open the file in text (translated) mode. */
+#define NUTTX_O_CREAT           (1 << 6)       /* Create file/sem/mq object */
+#define NUTTX_O_EXCL            (1 << 7)       /* Name must not exist when opened  */
+#define NUTTX_O_NOCTTY          (1 << 8)       /* Don't assign a controlling terminal */
+#define NUTTX_O_TRUNC           (1 << 9)       /* Delete contents */
+#define NUTTX_O_APPEND          (1 << 10)      /* Keep contents, append to end */
+#define NUTTX_O_NONBLOCK        (1 << 11)      /* Don't wait for data */
+#define NUTTX_O_DSYNC           (1 << 12)      /* Synchronize data on write */
+#define NUTTX_O_ASYNC           (1 << 13)      /* Enable signal-driven I/O */
+#define NUTTX_O_DIRECT          (1 << 14)      /* Avoid caching, write directly to hardware */
+#define NUTTX_O_LARGEFILE       (1 << 15)      /* Large File */
+#define NUTTX_O_DIRECTORY       (1 << 16)      /* Must be a directory */
+#define NUTTX_O_NOFOLLOW        (1 << 17)      /* Don't follow links */
+#define NUTTX_O_NOATIME         (1 << 18)      /* Don't update the file last access time */
+#define NUTTX_O_CLOEXEC         (1 << 19)      /* Close on execute */
+#define NUTTX___O_SYNC          (1 << 20)      /* Synchronize file (data+metadata) */
+#define NUTTX_O_PATH            (1 << 21)      /* Obtain a path-only fd (no I/O) */
+#define NUTTX___O_TMPFILE       (1 << 22)      /* Create an unnamed temporary file */
 
-#define NUTTX_O_RDWR            (NUTTX_O_RDONLY | NUTTX_O_WRONLY)
+#define NUTTX_O_NDELAY          NUTTX_O_NONBLOCK                        /* Synonym for O_NONBLOCK */
+#define NUTTX_O_SYNC            (NUTTX___O_SYNC | NUTTX_O_DSYNC)        /* Synchronize output on write */
+#define NUTTX_O_RSYNC           NUTTX_O_SYNC                            /* Synchronize input on read */
+#define NUTTX_O_TMPFILE         (NUTTX___O_TMPFILE | NUTTX_O_DIRECTORY) /* Create a temporary file */
+#define NUTTX_O_BINARY          0                                       /* Open the file in binary mode */
 
 /* Should match definition in include/nuttx/fs/fs.h */
 

--- a/include/sys/mount.h
+++ b/include/sys/mount.h
@@ -40,16 +40,16 @@
 
 /* Mount flags */
 
-#define MS_RDONLY       O_RDONLY    /* Mount file system read-only */
-#define MS_SYNCHRONOUS  O_SYNC      /* Writes are synced at once */
-#define MS_NOSYMFOLLOW  O_NOFOLLOW  /* Do not follow symlinks */
-#define MS_NOATIME      O_NOATIME   /* Do not update access times. */
-#define MS_NOSUID       O_RESERVE14 /* Ignore suid and sgid bits */
-#define MS_NODEV        O_RESERVE15 /* Disallow access to device special files */
-#define MS_DIRSYNC      O_RESERVE16 /* Directory modifications are synchronous */
-#define MS_REMOUNT      O_RESERVE17 /* Alter flags of a mounted FS */
-#define MS_MANDLOCK     O_RESERVE19 /* Allow mandatory locks on an FS */
-#define MS_NOEXEC       O_RESERVE20 /* Disallow program execution */
+#define MS_RDONLY       0x0001 /* Mount file system read-only */
+#define MS_NOSUID       0x0002 /* Ignore suid and sgid bits */
+#define MS_NODEV        0x0004 /* Disallow access to device special files */
+#define MS_NOEXEC       0x0008 /* Disallow program execution */
+#define MS_SYNCHRONOUS  0x0010 /* Writes are synced at once */
+#define MS_REMOUNT      0x0020 /* Alter flags of a mounted FS */
+#define MS_MANDLOCK     0x0040 /* Allow mandatory locks on an FS */
+#define MS_DIRSYNC      0x0080 /* Directory modifications are synchronous */
+#define MS_NOSYMFOLLOW  0x0100 /* Do not follow symlinks */
+#define MS_NOATIME      0x0400 /* Do not update access times. */
 
 /* Un-mount flags
  *

--- a/libs/libc/stdio/lib_fclose.c
+++ b/libs/libc/stdio/lib_fclose.c
@@ -102,7 +102,7 @@ int fclose(FAR FILE *stream)
 
       /* If the stream was opened for writing, then flush the stream */
 
-      if ((stream->fs_oflags & O_WRONLY) != 0)
+      if ((stream->fs_oflags & O_ACCMODE) != O_RDONLY)
         {
           ret = lib_fflush(stream);
           errcode = get_errno();

--- a/libs/libc/stdio/lib_fmemopen.c
+++ b/libs/libc/stdio/lib_fmemopen.c
@@ -195,7 +195,7 @@ FAR FILE *fmemopen(FAR void *buf, size_t size, FAR const char *mode)
        * include a '+'.
        */
 
-      if ((oflags & O_RDWR) != O_RDWR)
+      if ((oflags & O_ACCMODE) != O_RDWR)
         {
           lib_free(fmemopen_cookie);
           set_errno(EINVAL);
@@ -245,7 +245,7 @@ FAR FILE *fmemopen(FAR void *buf, size_t size, FAR const char *mode)
    * by the size argument.
    */
 
-  if ((oflags & O_RDWR) == O_RDONLY)
+  if ((oflags & O_ACCMODE) == O_RDONLY)
     {
       fmemopen_cookie->end = size;
     }

--- a/libs/libc/stdio/lib_libfflush.c
+++ b/libs/libc/stdio/lib_libfflush.c
@@ -66,7 +66,7 @@ ssize_t lib_fflush_unlocked(FAR FILE *stream)
 
   /* Return EBADF if the file is not opened for writing */
 
-  if ((stream->fs_oflags & O_WRONLY) == 0)
+  if ((stream->fs_oflags & O_ACCMODE) == O_RDONLY)
     {
       return -EBADF;
     }

--- a/libs/libc/stdio/lib_libflushall.c
+++ b/libs/libc/stdio/lib_libflushall.c
@@ -76,7 +76,7 @@ int lib_flushall_unlocked(FAR struct streamlist *list)
            * the pending write data in the stream.
            */
 
-          if ((stream->fs_oflags & O_WRONLY) != 0)
+          if ((stream->fs_oflags & O_ACCMODE) != O_RDONLY)
             {
               /* Flush the writable FILE */
 
@@ -129,7 +129,7 @@ int lib_flushall(FAR struct streamlist *list)
            * the pending write data in the stream.
            */
 
-          if ((stream->fs_oflags & O_WRONLY) != 0)
+          if ((stream->fs_oflags & O_ACCMODE) != O_RDONLY)
             {
               /* Flush the writable FILE */
 

--- a/libs/libc/stdio/lib_libfread_unlocked.c
+++ b/libs/libc/stdio/lib_libfread_unlocked.c
@@ -64,7 +64,7 @@ ssize_t lib_fread_unlocked(FAR void *ptr, size_t count, FAR FILE *stream)
       _NX_SETERRNO(EBADF);
       return ERROR;
     }
-  else if ((stream->fs_oflags & O_RDONLY) == 0)
+  else if ((stream->fs_oflags & O_ACCMODE) == O_WRONLY)
     {
       stream->fs_flags |= __FS_FLAG_ERROR;
       _NX_SETERRNO(EBADF);

--- a/libs/libc/stdio/lib_libfwrite.c
+++ b/libs/libc/stdio/lib_libfwrite.c
@@ -64,7 +64,7 @@ ssize_t lib_fwrite_unlocked(FAR const void *ptr, size_t count,
 
   /* Check if write access is permitted */
 
-  if ((stream->fs_oflags & O_WRONLY) == 0)
+  if ((stream->fs_oflags & O_ACCMODE) == O_RDONLY)
     {
       set_errno(EBADF);
       goto errout;

--- a/libs/libc/stdio/lib_ungetc.c
+++ b/libs/libc/stdio/lib_ungetc.c
@@ -54,7 +54,7 @@ int ungetc(int c, FAR FILE *stream)
 
   /* Stream must be open for read access */
 
-  if ((stream->fs_oflags & O_RDONLY) == 0)
+  if ((stream->fs_oflags & O_ACCMODE) == O_WRONLY)
     {
       return EOF;
     }

--- a/libs/libc/stdio/lib_ungetwc.c
+++ b/libs/libc/stdio/lib_ungetwc.c
@@ -64,7 +64,7 @@ wint_t ungetwc_unlocked(wint_t wc, FAR FILE *f)
 
   /* Stream must be open for read access */
 
-  if ((f->fs_oflags & O_RDONLY) == 0)
+  if ((f->fs_oflags & O_ACCMODE) == O_WRONLY)
     {
       return WEOF;
     }

--- a/libs/libc/stdio/lib_wrflush_unlocked.c
+++ b/libs/libc/stdio/lib_wrflush_unlocked.c
@@ -70,7 +70,7 @@ int lib_wrflush_unlocked(FAR FILE *stream)
    * that case.
    */
 
-  if ((stream->fs_oflags & O_WRONLY) == 0)
+  if ((stream->fs_oflags & O_ACCMODE) == O_RDONLY)
     {
       /* Report that the success was successful if we attempt to flush a
        * read-only stream.

--- a/net/procfs/net_procfs.c
+++ b/net/procfs/net_procfs.c
@@ -204,8 +204,8 @@ static int netprocfs_open(FAR struct file *filep, FAR const char *relpath,
    * REVISIT:  Write-able proc files could be quite useful.
    */
 
-  if (((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0) &&
-      (g_net_operations.write == NULL))
+  if ((oflags & O_ACCMODE) != O_RDONLY &&
+      g_net_operations.write == NULL)
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/net/procfs/net_procfs_route.c
+++ b/net/procfs/net_procfs_route.c
@@ -445,7 +445,7 @@ static int route_open(FAR struct file *filep, FAR const char *relpath,
    * REVISIT:  Write-able proc files could be quite useful.
    */
 
-  if ((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0)
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/sched/irq/irq_procfs.c
+++ b/sched/irq/irq_procfs.c
@@ -274,7 +274,7 @@ static int irq_open(FAR struct file *filep, FAR const char *relpath,
    * is not permitted.
    */
 
-  if ((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0)
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/sched/module/mod_procfs.c
+++ b/sched/module/mod_procfs.c
@@ -171,7 +171,7 @@ static int modprocfs_open(FAR struct file *filep, FAR const char *relpath,
    * REVISIT:  Write-able proc files could be quite useful.
    */
 
-  if (((oflags & O_WRONLY) != 0 || (oflags & O_RDONLY) == 0))
+  if ((oflags & O_ACCMODE) != O_RDONLY)
     {
       ferr("ERROR: Only O_RDONLY supported\n");
       return -EACCES;

--- a/sched/mqueue/mq_receive.c
+++ b/sched/mqueue/mq_receive.c
@@ -90,7 +90,7 @@ static int nxmq_verify_receive(FAR struct file *mq,
       return -EINVAL;
     }
 
-  if ((mq->f_oflags & O_RDONLY) == 0)
+  if ((mq->f_oflags & O_ACCMODE) == O_WRONLY)
     {
       return -EBADF;
     }

--- a/sched/mqueue/mq_send.c
+++ b/sched/mqueue/mq_send.c
@@ -91,7 +91,7 @@ static int nxmq_verify_send(FAR FAR struct file *mq, FAR const char *msg,
       return -EINVAL;
     }
 
-  if ((mq->f_oflags & O_WRONLY) == 0)
+  if ((mq->f_oflags & O_ACCMODE) == O_RDONLY)
     {
       return -EBADF;
     }


### PR DESCRIPTION
## Summary

Align the NuttX `open(2)` flag constants (`O_RDONLY`/`O_WRONLY`/`O_RDWR`) with the Linux asm-generic values (`0`/`1`/`2` instead of `1`/`2`/`3`) so that the FUSE wire protocol and other cross-platform interfaces work without conversion.

*   Realign the access-mode flags and the remaining open flags (`O_CREAT`, `O_EXCL`, `O_APPEND`, `O_TRUNC`, `O_NONBLOCK`, `O_SYNC`, `O_DSYNC`, `O_DIRECT`, `O_DIRECTORY`, `O_NOFOLLOW`, `O_NOATIME`, `O_CLOEXEC`, `O_PATH`, `O_TMPFILE`, etc.) with the Linux `asm-generic` values.
*   Update all code that used `(flags & O_RDONLY)` as a bitmask check (which is always `0` now that `O_RDONLY == 0`) to use `(flags & O_ACCMODE)` comparisons instead, across `fs/`, `drivers/`, `libs/`, `arch/`, `sched/`, `net/`, and `graphics/`.
*   Update the `NUTTX_O_*` constants in `include/nuttx/fs/hostfs.h` to match, and fix the sim hostfs open-flag mapping.

### Access-mode flag values across major operating systems

| Constant    | NuttX (before) | NuttX (after) | Linux | glibc | FreeBSD | macOS |
|-------------|---------------|---------------|-------|-------|---------|-------|
| `O_RDONLY`  | `1`           | `0`           | `0`   | `0`   | `0`     | `0`   |
| `O_WRONLY`  | `2`           | `1`           | `1`   | `1`   | `1`     | `1`   |
| `O_RDWR`    | `3`           | `2`           | `2`   | `2`   | `2`     | `2`   |
| `O_ACCMODE` | `3`           | `3`           | `3`   | `3`   | `3`     | `3`   |

Before this change NuttX was the only major OS using `1`/`2`/`3` for the access-mode flags; every other platform (Linux, glibc, FreeBSD, macOS) uses the `0`/`1`/`2` convention. After this change NuttX matches the de-facto standard, so interfaces that pass open flags directly across the kernel/userspace or host/guest boundary (e.g. FUSE) work without conversion.

## Impact

*   **Compatibility:** The new flag values match Linux, so FUSE and other wire protocols that pass open flags directly no longer need translation. This is the primary motivation.
*   **Behavior:** Existing code that performed `(flags & O_RDONLY)` would silently break (`O_RDONLY` is now `0`), so every such site has been audited and converted to `(flags & O_ACCMODE)`.
*   **No new APIs:** No public API signatures change; only the numeric values of existing `#define`s change.
*   **Build:** No build-system changes required.

## Testing

Tested on the `sim:nsh` target (Linux x86_64 host, gcc).

**Boot log:**

```
NuttShell (NSH) NuttX-10.4.0
nsh> uname -a
NuttX 10.4.0 6bb526f459a Jun 29 2026 23:37:06 sim sim
nsh> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK
 STACK COMMAND
    0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0069584 Idle_Task
    1     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067456 sim_loop_wq
    2     0     0 224 FIFO     Kthread   - Waiting  Semaphore 0000000000000000 0067472 hpwork
    4     4     0 100 FIFO     Task      - Running            0000000000000000 0067496 nsh_main
nsh> mount
  /bin type binfs
  /data type hostfs
  /etc type romfs
  /proc type procfs
nsh> cat /proc/version
NuttX version 10.4.0 6bb526f459a Jun 29 2026 23:37:06 sim:nsh
```

**OSTest:** ran `ostest` from the NSH prompt — all tests passed with no failures or panics. Final summary:

```
waitpid_last: PASS: PID 10 waitpid failed with ECHILD.  That may be
waitpid_last: PASS: PID 13 waitpid failed with ECHILD.  That may be
waitpid_last: PASS: PID 19 waitpid failed with ECHILD.  That may be
waitpid_last: PASS: PID 25 waitpid failed with ECHILD.  That may be
```
