### PR TITLE
Documentation/rexecd: document command-line options including -t

### DIFF
--- a/Documentation/applications/netutils/rexecd/index.rst
+++ b/Documentation/applications/netutils/rexecd/index.rst
@@ -1,3 +1,42 @@
 ==================================
 ``rexecd`` Remote Execution Server
 ==================================
+
+``rexecd`` is the daemon that serves remote execution requests from the
+``rexec`` client. For the IP families it listens on the rexec port
+(``REXECD_PORT``, 512); for ``AF_RPMSG`` it listens on a corresponding
+RPMsg socket name. It authenticates the request and runs the requested
+command, piping its output back to the client.
+
+By default ``rexecd`` spawns a detached worker thread per accepted
+connection so that multiple sessions can run concurrently.
+
+Usage
+=====
+
+.. code-block:: none
+
+   rexecd [-4|-6|-r] [-t]
+
+Options
+=======
+
+``-4``
+  Specify the address family as ``AF_INET`` (IPv4). This is the default.
+
+``-6``
+  Specify the address family as ``AF_INET6`` (IPv6).
+
+``-r``
+  Specify the address family as ``AF_RPMSG``. This serves the daemon over
+  an RPMsg link instead of TCP/IP, allowing a remote processor in an AMP
+  system to execute commands. See :doc:`/components/drivers/special/rpmsg/concepts`
+  for details on RPMsg.
+
+``-t``
+  Serve each connection inline in the main task instead of spawning a
+  per-connection worker thread. This avoids allocating the worker stack
+  (``CONFIG_NETUTILS_REXECD_STACKSIZE``) from the heap, which helps on
+  low-memory targets. With this option connections are served strictly
+  one at a time: a long-running or interactive command blocks the accept
+  loop until it finishes.


### PR DESCRIPTION
## Summary

The documentation page for the `rexecd` remote execution server
(`Documentation/applications/netutils/rexecd/index.rst`) previously
contained only a title and no content. This change fills it in with:

- A short description of the daemon: it serves remote execution
  requests from the `rexec` client, listens on the rexec port
  (`REXECD_PORT`, 512) for the IP families or on a corresponding RPMsg
  socket name for `AF_RPMSG`, authenticates the request, runs the
  command and pipes its output back to the client.
- A note that, by default, `rexecd` spawns a detached worker thread per
  accepted connection so multiple sessions can run concurrently.
- A `Usage` synopsis and an `Options` section documenting every
  command-line option: `-4` (AF_INET, default), `-6` (AF_INET6),
  `-r` (AF_RPMSG, with a `:doc:` cross-reference to the RPMsg core
  concepts page), and the `-t` threadless option, which serves each
  connection inline in the main task instead of spawning a
  per-connection worker thread.

The `-t` option is the recently added "threadless" mode: it avoids
allocating the worker stack (`CONFIG_NETUTILS_REXECD_STACKSIZE`) from
the heap, which helps on low-memory targets, at the cost of serving
connections strictly one at a time.

## Impact

- Documentation only. No source code, build process, hardware, security
  or compatibility impact.
- Adds user-facing documentation for the `rexecd` daemon and its
  command-line options, including the previously undocumented `-t`
  option.

## Testing

Pure documentation change, tested with `make html`.

- Host: Ubuntu 22.04, Python 3.10.12, Sphinx 8.1.3.
- Built the docs from `nuttx/Documentation` with `make html`.
- The `rexecd` page builds with no warnings or errors; the generated
  `_build/html/applications/netutils/rexecd/index.html` renders the
  description, usage, and all options correctly.
- The `:doc:` cross-reference to the RPMsg concepts page resolves to a
  valid link (`../../../components/drivers/special/rpmsg/concepts.html`,
  text "RPMsg Core Concepts"); no broken references.