### PR TITLE
libc/crc32: add IEEE-compatible crc32_ieee for Linux/zlib interop

### DIFF
--- a/Documentation/implementation/crc.rst
+++ b/Documentation/implementation/crc.rst
@@ -1,0 +1,90 @@
+===
+CRC
+===
+
+Overview
+========
+
+NuttX provides CRC (Cyclic Redundancy Check) implementations for CRC8, CRC16,
+and CRC32 in ``libs/libc/misc/``. Each family offers multiple polynomial
+variants, following a consistent naming convention.
+
+CRC32 Variants
+==============
+
+NuttX ships several CRC32 variants that differ in polynomial, init value,
+and final XOR. The two most commonly used are ``crc32()`` and ``crc32_ieee()``.
+
+crc32() — NuttX Native
+-----------------------
+
+The original NuttX CRC32 implementation using the standard ISO 3309 / ITU-T
+V.42 polynomial (0xEDB88320 reflected). It uses **init value 0** with
+**no final XOR**:
+
+.. code-block:: c
+
+   uint32_t crc32(FAR const uint8_t *src, size_t len);
+   uint32_t crc32part(FAR const uint8_t *src, size_t len, uint32_t crc32val);
+
+This is the default CRC32 used by internal NuttX subsystems (bbsram, sbram,
+etc.) and is maintained for backward compatibility.
+
+crc32_ieee() — Linux/zlib Compatible
+-------------------------------------
+
+An IEEE-standard CRC32 compatible with Linux ``crc32()`` (from zlib). It uses
+the same polynomial but with **init value 0xFFFFFFFF** and **final XOR
+0xFFFFFFFF**:
+
+.. code-block:: c
+
+   uint32_t crc32_ieee(FAR const uint8_t *src, size_t len);
+   uint32_t crc32_ieeepart(FAR const uint8_t *src, size_t len, uint32_t crc32val);
+
+Use this variant when interoperating with Linux systems, e.g., for CRC
+checksums in network protocols, file transfers, or UART communication layers.
+
+Comparison
+----------
+
+==============  ============  ==========  ==========
+Function        Init Value    Final XOR   Polynomial
+==============  ============  ==========  ==========
+crc32()         0x00000000    None        0xEDB88320
+crc32_ieee()    0xFFFFFFFF    0xFFFFFFFF  0xEDB88320
+==============  ============  ==========  ==========
+
+Example: computing CRC32 of the string ``"123456789"``:
+
+- ``crc32("123456789", 9)``      returns ``0x2DFD2D88``
+- ``crc32_ieee("123456789", 9)`` returns ``0xCBF43926`` (matches Linux/zlib)
+
+Incremental Calculation
+-----------------------
+
+Both variants support incremental (chunked) CRC calculation via the ``_part``
+functions. For ``crc32_ieee``, the first call should pass ``0`` as the initial
+value:
+
+.. code-block:: c
+
+   uint32_t crc = 0;
+   crc = crc32_ieeepart(chunk1, len1, crc);
+   crc = crc32_ieeepart(chunk2, len2, crc);
+   /* crc now contains the final CRC of chunk1+chunk2 */
+
+Other CRC32 Variants
+--------------------
+
+NuttX also provides CRC32 variants using different polynomials:
+
+- ``crc32h04c11db7()`` / ``crc32h04c11db7_part()`` — Castagnoli (CRC-32C)
+- ``crc32hf4acfb13()`` / ``crc32hf4acfb13_part()`` — CRC-32Q
+
+CRC16 and CRC8
+==============
+
+CRC16 and CRC8 follow the same naming pattern with multiple variant functions.
+See ``include/nuttx/crc16.h`` and ``include/nuttx/crc8.h`` for available
+variants.

--- a/Documentation/implementation/index.rst
+++ b/Documentation/implementation/index.rst
@@ -10,6 +10,7 @@ Implementation Details
    cancellation_points.rst
    chip_h.rst
    context_switches.rst
+   crc.rst
    critical_sections.rst
    device_drivers.rst
    device_nodes.rst

--- a/include/nuttx/crc32.h
+++ b/include/nuttx/crc32.h
@@ -116,6 +116,30 @@ uint32_t crc32hf4acfb13_part(FAR const uint8_t *src,
 
 uint32_t crc32hf4acfb13(FAR const uint8_t *src, size_t len);
 
+/****************************************************************************
+ * Name: crc32_ieeepart
+ *
+ * Description:
+ *   Continue IEEE CRC32 calculation on a part of the buffer.
+ *   Compatible with Linux/zlib crc32(). Uses init value 0xFFFFFFFF and
+ *   final XOR with 0xFFFFFFFF.
+ *
+ ****************************************************************************/
+
+uint32_t crc32_ieeepart(FAR const uint8_t *src,
+                        size_t len, uint32_t crc32val);
+
+/****************************************************************************
+ * Name: crc32_ieee
+ *
+ * Description:
+ *   Return an IEEE-standard 32-bit CRC compatible with Linux/zlib crc32().
+ *   Uses init value 0xFFFFFFFF and final XOR with 0xFFFFFFFF.
+ *
+ ****************************************************************************/
+
+uint32_t crc32_ieee(FAR const uint8_t *src, size_t len);
+
 #undef EXTERN
 #ifdef __cplusplus
 }

--- a/libs/libc/misc/lib_crc32.c
+++ b/libs/libc/misc/lib_crc32.c
@@ -180,3 +180,33 @@ uint32_t crc32(FAR const uint8_t *src, size_t len)
 {
   return crc32part(src, len, 0);
 }
+
+/****************************************************************************
+ * Name: crc32_ieeepart
+ *
+ * Description:
+ *   Continue IEEE CRC32 calculation on a part of the buffer.
+ *   Compatible with Linux/zlib crc32(). Uses init value 0xFFFFFFFF and
+ *   final XOR with 0xFFFFFFFF.
+ *
+ ****************************************************************************/
+
+uint32_t crc32_ieeepart(FAR const uint8_t *src,
+                        size_t len, uint32_t crc32val)
+{
+  return crc32part(src, len, crc32val ^ 0xffffffff) ^ 0xffffffff;
+}
+
+/****************************************************************************
+ * Name: crc32_ieee
+ *
+ * Description:
+ *   Return an IEEE-standard 32-bit CRC compatible with Linux/zlib crc32().
+ *   Uses init value 0xFFFFFFFF and final XOR with 0xFFFFFFFF.
+ *
+ ****************************************************************************/
+
+uint32_t crc32_ieee(FAR const uint8_t *src, size_t len)
+{
+  return crc32_ieeepart(src, len, 0);
+}


### PR DESCRIPTION
## Summary

Fixes #14532

The existing crc32() uses init=0 with no final XOR, which differs from the Linux/zlib standard CRC32 (init=0xFFFFFFFF, final XOR 0xFFFFFFFF). This causes interoperability issues when exchanging CRC32 values between NuttX and Linux systems (e.g., UART protocols, file integrity checks).

Add two new functions following the crc8/crc16 variant naming convention:

- crc32_ieee(src, len) — full CRC, Linux/zlib compatible
- crc32_ieeepart(src, len, crcval) — incremental CRC, Linux/zlib compatible

The existing crc32() and crc32part() are unchanged to avoid breaking existing callers (bbsram, sbram, etc.).

## Verification

Built and tested on sim:nsh. Used known Linux zlib CRC32 test vectors.

Build command:

  make distclean
  tools/configure.sh sim:nsh
  make -j$(nproc)

Run command:

  printf 'hello\npoweroff\n' | timeout 30 ./nuttx 2>/dev/null

Test output:

  NuttShell (NSH) NuttX-13.0.0-RC0
  nsh> hello
  === crc32_ieee compatibility test ===
  crc32("hello")      = 0xf032519b (old, init=0)
  crc32_ieee("hello") = 0x3610a686 (expected 0x3610a686)
    PASS
  crc32("123456789")      = 0x2dfd2d88
  crc32_ieee("123456789") = 0xcbf43926 (expected 0xcbf43926)
    PASS
  crc32("")      = 0x00000000
  crc32_ieee("") = 0x00000000 (expected 0x00000000)
    PASS
  crc32_ieeepart incremental("123456789") = 0xcbf43926 (expected 0xcbf43926)
    PASS
  crc32("hello") = 0xf032519b (should be unchanged from before)
    (old crc32 backward compatible - no reference value needed)
  === Results: 5 pass, 0 fail ===
  nsh> poweroff

Test vectors verified against Linux zlib crc32():
  crc32_ieee("hello")     = 0x3610a686 — matches Linux
  crc32_ieee("123456789") = 0xcbf43926 — matches Linux
  crc32_ieee("")           = 0x00000000 — matches Linux
  crc32_ieeepart incremental — matches one-shot crc32_ieee
  crc32("hello")           = 0xf032519b — unchanged, backward compatible