### PR TITLE
docs/boards: Fix missing information

### DIFF
--- a/Documentation/platforms/arm/rp2040/boards/seeed-xiao-rp2040/index.rst
+++ b/Documentation/platforms/arm/rp2040/boards/seeed-xiao-rp2040/index.rst
@@ -100,10 +100,21 @@ nsh
 
 Basic NuttShell configuration (console enabled in UART0, at 115200 bps).
 
-userled
--------
+userleds
+--------
 
 This is an nsh configuration with added support for user LEDs.
+
+gpio
+----
+
+Basic nsh configuration with GPIO driver support and the :doc:`gpio example
+</applications/examples/gpio/index>`.
+
+ws2812
+------
+
+Basic nsh configuration with WS2812 driver and example enabled.
 
 usbnsh
 ------

--- a/Documentation/platforms/xtensa/esp32s3/boards/esp32s3-xiao/index.rst
+++ b/Documentation/platforms/xtensa/esp32s3/boards/esp32s3-xiao/index.rst
@@ -82,7 +82,7 @@ Installation
   $ git clone https://github.com/apache/nuttx-apps.git apps
   $ cd nuttx
   $ make distclean
-  $ ./tools/configure.sh xiao-esp32s3:usbnsh
+  $ ./tools/configure.sh esp32s3-xiao:usbnsh
   $ make V=1
 
 2. Connect the Seeed Studio XIAO ESP32S3, and enter "Bootloader" mode,
@@ -98,6 +98,14 @@ Example command:
 
 Configurations
 ==============
+
+Configurations can be selected using
+
+.. code:: console
+
+   $ ./tools/configure.sh esp32s3-xiao:<config>
+
+where ``<config>`` is the name of one of the configurations listed below.
 
 usbnsh
 ------


### PR DESCRIPTION
## Summary

Adds documentation for missing configs on XIAO RP2040 board.

Corrects incorrect board ID in XIAO ESP32S3 board docs.

## Impact

Docs only.

## Testing

Local doc build.