### PR TITLE
arch: fall back to the kernel heap when there is no separate text heap

### DIFF
--- a/arch/sim/src/sim/sim_sectionheap.c
+++ b/arch/sim/src/sim/sim_sectionheap.c
@@ -33,7 +33,9 @@
  * Private Data
  ****************************************************************************/
 
+#ifdef CONFIG_ARCH_USE_TEXT_HEAP
 static struct mm_heap_s *g_textheap;
+#endif
 static struct mm_heap_s *g_dataheap;
 
 /****************************************************************************
@@ -48,6 +50,7 @@ static struct mm_heap_s *g_dataheap;
  *
  ****************************************************************************/
 
+#ifdef CONFIG_ARCH_USE_TEXT_HEAP
 #ifdef CONFIG_ARCH_USE_SEPARATED_SECTION
 void *up_textheap_memalign(const char *sectname, size_t align, size_t size)
 #else
@@ -92,6 +95,7 @@ bool up_textheap_heapmember(void *p)
 {
   return g_textheap != NULL && mm_heapmember(g_textheap, p);
 }
+#endif /* CONFIG_ARCH_USE_TEXT_HEAP */
 
 /****************************************************************************
  * Name: up_dataheap_memalign

--- a/include/nuttx/arch.h
+++ b/include/nuttx/arch.h
@@ -847,6 +847,11 @@ void up_extraheaps_init(void);
  * Description:
  *   Allocate memory for text with the specified alignment and sectname.
  *
+ *   If the architecture does not provide a separate text heap
+ *   (CONFIG_ARCH_USE_TEXT_HEAP is not set), the text heap API falls back
+ *   to the normal kernel heap: on flat-memory architectures the kernel
+ *   heap is executable, so no separate allocator is needed.
+ *
  ****************************************************************************/
 
 #if defined(CONFIG_ARCH_USE_TEXT_HEAP)
@@ -855,6 +860,12 @@ FAR void *up_textheap_memalign(FAR const char *sectname,
                                size_t align, size_t size);
 #  else
 FAR void *up_textheap_memalign(size_t align, size_t size);
+#  endif
+#else
+#  if defined(CONFIG_ARCH_USE_SEPARATED_SECTION)
+#    define up_textheap_memalign(s,a,z) kmm_memalign(a,z)
+#  else
+#    define up_textheap_memalign(a,z) kmm_memalign(a,z)
 #  endif
 #endif
 
@@ -868,6 +879,8 @@ FAR void *up_textheap_memalign(size_t align, size_t size);
 
 #if defined(CONFIG_ARCH_USE_TEXT_HEAP)
 void up_textheap_free(FAR void *p);
+#else
+#  define up_textheap_free(p) kmm_free(p)
 #endif
 
 /****************************************************************************
@@ -880,6 +893,8 @@ void up_textheap_free(FAR void *p);
 
 #if defined(CONFIG_ARCH_USE_TEXT_HEAP)
 bool up_textheap_heapmember(FAR void *p);
+#else
+#  define up_textheap_heapmember(p) kmm_heapmember(p)
 #endif
 
 /****************************************************************************
@@ -900,12 +915,11 @@ bool up_textheap_heapmember(FAR void *p);
  *
  ****************************************************************************/
 
-#if defined(CONFIG_ARCH_USE_TEXT_HEAP)
-#if defined(CONFIG_ARCH_HAVE_TEXT_HEAP_SEPARATE_DATA_ADDRESS)
+#if defined(CONFIG_ARCH_USE_TEXT_HEAP) && \
+    defined(CONFIG_ARCH_HAVE_TEXT_HEAP_SEPARATE_DATA_ADDRESS)
 FAR void *up_textheap_data_address(FAR void *p);
 #else
 #define up_textheap_data_address(p) ((FAR void *)p)
-#endif
 #endif
 
 /****************************************************************************
@@ -918,12 +932,11 @@ FAR void *up_textheap_data_address(FAR void *p);
  *
  ****************************************************************************/
 
-#if defined(CONFIG_ARCH_USE_TEXT_HEAP)
-#if defined(CONFIG_ARCH_HAVE_TEXT_HEAP_SEPARATE_DATA_ADDRESS)
+#if defined(CONFIG_ARCH_USE_TEXT_HEAP) && \
+    defined(CONFIG_ARCH_HAVE_TEXT_HEAP_SEPARATE_DATA_ADDRESS)
 void up_textheap_data_sync(void);
 #else
 #define up_textheap_data_sync() do {} while (0)
-#endif
 #endif
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Reworked per review: instead of adding a per-arch text-heap stub for rp23xx, the text heap API now falls back to the normal kernel heap at the common layer, as suggested by @xiaoxiang781216.

- `include/nuttx/arch.h`: when `CONFIG_ARCH_USE_TEXT_HEAP` is not set, `up_textheap_memalign()`/`up_textheap_free()`/`up_textheap_heapmember()` redirect to `kmm_memalign()`/`kmm_free()`/`kmm_heapmember()`, and the `up_textheap_data_address()`/`up_textheap_data_sync()` identity fallbacks become available unconditionally. On flat-memory architectures the kernel heap is executable, so code written against the portable text-heap API works on every such port (rp23xx included) with no per-arch boilerplate.
- `arch/sim/src/sim/sim_sectionheap.c`: gate the sim text-heap implementation on `CONFIG_ARCH_USE_TEXT_HEAP` — it was compiled unconditionally (harmless before, but it would collide with the fallback macros), and every other implementation is already gated this way in its Make.defs/CMakeLists.
- The rp23xx `up_textheap_*` stub from the previous revision is dropped entirely.

Existing common consumers (`libs/libc/elf`) are unchanged — they already carry their own `lib_memalign()` fallbacks when `CONFIG_ARCH_USE_TEXT_HEAP` is unset.

## Impact

Direct callers of the text-heap API now build and work on flat-memory ports without the architecture claiming `ARCH_HAVE_TEXT_HEAP`. No change in behavior where `CONFIG_ARCH_USE_TEXT_HEAP` is enabled.

## Testing

- `sim:nsh` builds clean both **with and without** `CONFIG_ARCH_USE_TEXT_HEAP` (both sides of the new gating).
- `raspberrypi-pico-2:nsh` builds clean.
- A test translation unit calling `up_textheap_memalign()`, `up_textheap_heapmember()`, `up_textheap_data_address()`, `up_textheap_data_sync()` and `up_textheap_free()` through the fallback macros compiles clean for Cortex-M33 (arm-none-eabi-gcc, `-Wall -Werror`).
- The previous revision of this PR (kmm-backed allocator) was exercised on a Raspberry Pi Pico 2 W by loading and running a Thumb code image allocated from the text heap; the fallback maps to the same kmm calls.
- `checkpatch.sh` clean.

---
*Disclosure: this change was developed with an AI agent (Claude Code, Anthropic) and human-reviewed before submission.*
