### PR TITLE
sim: Make inherited stdio non-blocking

### DIFF
--- a/arch/sim/src/sim/posix/sim_hostfs.c
+++ b/arch/sim/src/sim/posix/sim_hostfs.c
@@ -125,6 +125,30 @@ static void host_stat_convert(struct stat *hostbuf, struct nuttx_stat_s *buf)
  ****************************************************************************/
 
 /****************************************************************************
+ * Name: host_stdio_nonblock
+ ****************************************************************************/
+
+void host_stdio_nonblock(void)
+{
+  const int fds[] =
+    {
+      STDOUT_FILENO,
+      STDERR_FILENO,
+    };
+  size_t i;
+
+  for (i = 0; i < sizeof(fds) / sizeof(fds[0]); i++)
+    {
+      int flags = fcntl(fds[i], F_GETFL, 0);
+
+      if (flags >= 0)
+        {
+          (void)fcntl(fds[i], F_SETFL, flags | O_NONBLOCK);
+        }
+    }
+}
+
+/****************************************************************************
  * Name: host_open
  ****************************************************************************/
 

--- a/arch/sim/src/sim/sim_head.c
+++ b/arch/sim/src/sim/sim_head.c
@@ -170,6 +170,10 @@ int main(int argc, char **argv, char **envp)
   g_argc = argc;
   g_argv = argv;
 
+#ifndef CONFIG_WINDOWS_NATIVE
+  host_stdio_nonblock();
+#endif
+
   /* Parse simulator-specific options before handing control to NuttX.
    * --sim-rt-ratio=<percent>  Set simulated-to-real time ratio in percent
    *   (default 100).  Values > 100 speed up simulated time; < 100 slow down.

--- a/arch/sim/src/sim/sim_internal.h
+++ b/arch/sim/src/sim/sim_internal.h
@@ -225,6 +225,9 @@ pid_t host_posix_spawn(const char *path,
                        char *const argv[], char *const envp[]);
 int   host_waitpid(pid_t pid);
 int   host_kill(pid_t pid, int sig);
+#ifndef CONFIG_WINDOWS_NATIVE
+void  host_stdio_nonblock(void);
+#endif
 
 /* sim_hostmemory.c *********************************************************/
 


### PR DESCRIPTION
The simulator inherits stdout and stderr from its parent process. These descriptors may refer to a terminal or pipe, where writes can block if the consumer stops keeping up.

Set stdout and stderr to O_NONBLOCK during early simulator startup so diagnostic output cannot stall the simulated system. Ignore failures because some descriptors may not support F_GETFL or F_SETFL.