### PR TITLE
{bp-19230} drivers/crypto/pnt: Minor Overflow in Secure Element Driver May Cause a DoS

### DIFF
--- a/drivers/crypto/pnt/pnt_se05x_api.c
+++ b/drivers/crypto/pnt/pnt_se05x_api.c
@@ -308,6 +308,12 @@ int pnt_se05x_create_signature(
 {
   create_signature_args->signature.buffer_content_size =
       create_signature_args->signature.buffer_size;
+
+  if (create_signature_args->algorithm >= SE05X_ALGORITHM_SIZE)
+    {
+      return -EINVAL;
+    }
+
   int result =
       Se05x_API_ECDSASign(
           &(se05x->pnt->session), create_signature_args->key_id,
@@ -327,6 +333,12 @@ int pnt_se05x_verify_signature(
     FAR struct se05x_signature_s *verify_signature_args)
 {
   SE05x_Result_t se05x_result;
+
+  if (verify_signature_args->algorithm >= SE05X_ALGORITHM_SIZE)
+    {
+      return -EINVAL;
+    }
+
   int result =
       Se05x_API_ECDSAVerify(
           &(se05x->pnt->session), verify_signature_args->key_id,


### PR DESCRIPTION
## Summary

Invalid data is passed to the NXP Plug & Trust Nano Package used by the NuttX secure element driver. If the NXP code is not handling the malformed data, a corruption can occur. Alternatively, if the attacker is able to point create_signature_args->algorithm in memory at an address that is not accessible, a crash can occur.

Applicable to:
* `signature_algorithm_mapping[create_signature_args->algorithm]`
* `signature_algorithm_mapping[verify_signature_args->algorithm]`

## Impact

RELEASE

## Testing

CI