### PR TITLE
{bp-19261} drivers/contactless/mfrc522: Contactless Driver Is Not Robust

### DIFF
--- a/drivers/contactless/mfrc522.c
+++ b/drivers/contactless/mfrc522.c
@@ -1221,6 +1221,14 @@ int mfrc522_mifare_read(FAR struct mfrc522_dev_s *dev,
   uint8_t validbits = 0;
   int     ret       = OK;
 
+  /* Validate expected tag size (only pages 0x0, ..., 0xf are valid. */
+
+  if (data->address > 15)
+    {
+      ret = -ERANGE;
+      goto errout;
+    }
+
   /* Read block from address */
 
   command[0] = PICC_CMD_MF_READ;

--- a/drivers/contactless/pn532.c
+++ b/drivers/contactless/pn532.c
@@ -637,6 +637,13 @@ uint32_t pn532_write_passive_data(FAR struct pn532_dev_s *dev,
   uint8_t resp[20];
   uint32_t res = -EIO;
 
+  /* Validate expected tag size (only pages 0x0, ..., 0xf are valid. */
+
+  if (address > 15)
+    {
+      return -ERANGE;
+    }
+
   pn532_frame_init(f, PN532_COMMAND_INDATAEXCHANGE);
   f->data[1] = 1;       /* max n cards at once */
   f->data[2] = 0xa2;    /* command WRITE */
@@ -676,6 +683,13 @@ uint32_t pn532_read_passive_data(FAR struct pn532_dev_s *dev,
   FAR struct pn532_frame *f = (FAR struct pn532_frame *) cmd_buffer;
   uint8_t resp[30];
   uint32_t res = -1;
+
+  /* Validate against expected tag size */
+
+  if (address > 15)
+    {
+      return -ERANGE;
+    }
 
   pn532_frame_init(f, PN532_COMMAND_INDATAEXCHANGE);
   f->data[1] = 1;       /* max n cards at once */


### PR DESCRIPTION
## Summary

An attacker can specify an arbitrary page address when reading MIFARE tags. Without validation, this could read beyond intended memory regions on the tag, potentially causing a crash.

The mfrc522_mifare_read() command is also not robust and does not check that the page address is valid. From section 7.6.5 of the *MIFARE Ultralight contactless single-ticket IC
(https://www.nxp.com/docs/en/data-sheet/MF0ICU1.pdf) document:

>> The READ command needs the page address as a parameter. Only addresses
00h to 0Fh are decoded.

Testing: Builds fine.

## Impact

RELEASE

## Testing

CI