### PR TITLE
{bp-19198} mm,qemu: Fix KASAN user-space false positives, global region link error, and linker script section placement

### DIFF
--- a/boards/arm/qemu/qemu-armv7a/scripts/dramboot.ld
+++ b/boards/arm/qemu/qemu-armv7a/scripts/dramboot.ld
@@ -34,21 +34,6 @@ MEMORY
 SECTIONS
 {
 
-  /* where the global variable out-of-bounds detection information located */
-
-#ifdef CONFIG_MM_KASAN_GLOBAL
-  .kasan.unused : {
-    *(.data..LASANLOC*)
-  }
-  .kasan.global : {
-    KEEP (*(.data..LASAN0))
-    KEEP (*(.data.rel.local..LASAN0))
-  }
-  .kasan.shadows : {
-    *(.kasan.shadows)
-  }
-#endif
-
   .text : {
       _stext = .;            /* Text section */
       __text_start = .;
@@ -92,6 +77,19 @@ SECTIONS
       . = ALIGN(4096);
       _erodata = .;
   } > ROM
+
+#ifdef CONFIG_MM_KASAN_GLOBAL
+  .kasan.shadows : {
+      KEEP(*(.kasan.shadows))
+  } > ROM
+  .kasan.unused : {
+    *(.data..LASANLOC*)
+  } > RAM
+  .kasan.global : {
+    KEEP (*(.data..LASAN0))
+    KEEP (*(.data.rel.local..LASAN0))
+  } > RAM
+#endif
 
   _eronly = LOADADDR(.data);
   .data : {                    /* Data */

--- a/cmake/nuttx_multiple_link.cmake
+++ b/cmake/nuttx_multiple_link.cmake
@@ -134,6 +134,19 @@ define_multiple_link_target(final_nuttx second_link final)
 
 # fixing timing dependencies
 add_dependencies(nuttx_post final_nuttx)
+
+# Strip .kasan.unused and .kasan.global sections from the final binary. These
+# sections are only needed during the intermediate link passes for
+# kasan_global.py to extract global variable descriptors. At runtime they sit at
+# the start of RAM (0x40000000) and conflict with QEMU's DTB placement.
+if(CONFIG_MM_KASAN_GLOBAL)
+  add_custom_command(
+    TARGET final_nuttx
+    POST_BUILD
+    COMMAND ${CMAKE_OBJCOPY} -R .kasan.unused -R .kasan.global final_nuttx
+    COMMENT "Stripping .kasan.unused and .kasan.global sections")
+endif()
+
 # finally use final_nuttx to overwrite the already generated nuttx
 add_custom_command(
   TARGET final_nuttx

--- a/mm/kasan/hook.c
+++ b/mm/kasan/hook.c
@@ -31,7 +31,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#ifdef CONFIG_MM_KASAN_GLOBAL
+#if defined(CONFIG_MM_KASAN_GLOBAL) && defined(__KERNEL__)
 #  include "global.c"
 #else
 #  define kasan_global_is_poisoned(addr, size) false

--- a/mm/umm_heap/umm_initialize.c
+++ b/mm/umm_heap/umm_initialize.c
@@ -92,6 +92,7 @@ void umm_initialize(FAR void *heap_start, size_t heap_size)
   config.start = heap_start;
   config.size  = heap_size;
 #ifdef CONFIG_BUILD_KERNEL
+  config.nokasan = true;
   USR_HEAP = mm_initialize_pool(&config, NULL);
 #else
   config.name = "Umem";


### PR DESCRIPTION
## Summary

When CONFIG_MM_KASAN and CONFIG_BUILD_KERNEL are both enabled on
qemu-armv7a:knsh, there are three issues preventing correct build
and runtime: (1) user-space heap false positive KASAN reports,
(2) app link failure due to undefined g_global_region symbol,
(3) linker script misplaces KASAN sections causing boot failure.
This series fixes all three issues to make KASAN work correctly
in kernel mode on QEMU ARMv7-A.

## Impact

RELEASE

## Testing

CI