### PR TITLE
{bp-19146} mm/gran: reject pools with too many granules

### DIFF
--- a/mm/mm_gran/mm_graninit.c
+++ b/mm/mm_gran/mm_graninit.c
@@ -124,6 +124,14 @@ GRAN_HANDLE gran_initialize(FAR void *heapstart, size_t heapsize,
   alignedsize  = (heapend - alignedstart) & ~mask;
   ngranules    = alignedsize >> log2gran;
 
+  /* Reject oversized pools. */
+
+  DEBUGASSERT(ngranules > 0 && ngranules <= UINT16_MAX);
+  if (ngranules == 0 || ngranules > UINT16_MAX)
+    {
+      return NULL;
+    }
+
   /* Allocate the information structure with a granule table of the
    * correct size.
    */


### PR DESCRIPTION
## Summary

struct gran_s and struct graninfo_s store granule counts in uint16_t. Reject pools whose computed granule count exceeds UINT16_MAX, instead of truncating the count and creating an invalid handle.

## Impact

RELEASE

## Testing

CI