### PR TITLE
{bp-19242} Long double macros

### DIFF
--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -621,6 +621,12 @@
 
 #  endif
 
+/* Use compiler definition to define long double mantisa digits */
+
+#  ifdef CONFIG_HAVE_LONG_DOUBLE
+#    define LDBL_MANT_DIG __LDBL_MANT_DIG__
+#  endif
+
 /* Indicate that a local variable is not used */
 
 #  ifndef UNUSED
@@ -1200,6 +1206,10 @@
 /* Memory barrier. */
 
 #  define memory_barrier()
+
+/* long double is suppose to be same as double on MSVC. */
+
+#  define LDBL_MANT_DIG 53
 
 /* TASKING (Infineon AURIX C/C++)-specific definitions **********************/
 

--- a/include/nuttx/lib/float.h
+++ b/include/nuttx/lib/float.h
@@ -64,7 +64,7 @@
 
 #ifndef LDBL_MANT_DIG  /* May be defined in a toolchain header */
 #  ifdef CONFIG_HAVE_LONG_DOUBLE
-#    define LDBL_MANT_DIG DBL_MANT_DIG /* FIX ME */
+#    error "LDBL_MANT_DIG has to be defined in compiler.h"
 #  else
 #    define LDBL_MANT_DIG DBL_MANT_DIG
 #  endif
@@ -96,8 +96,16 @@
 #endif
 
 #ifndef LDBL_DIG  /* May be defined in a toolchain header */
-# ifdef CONFIG_HAVE_LONG_DOUBLE
-#    define LDBL_DIG DBL_DIG  /* FIX ME */
+#  ifdef CONFIG_HAVE_LONG_DOUBLE
+#    if LDBL_MANT_DIG == 53  /* IEEE binary64 */
+#      define LDBL_DIG DBL_DIG
+#    elif LDBL_MANT_DIG == 64  /* x87 80-bit */
+#      define LDBL_DIG 18
+#    elif LDBL_MANT_DIG == 113  /* IEEE binary128 */
+#      define LDBL_DIG 33
+#    else
+#      error "Unknown long double format"
+#    endif
 #  else
 #    define LDBL_DIG DBL_DIG
 #  endif
@@ -121,7 +129,15 @@
 
 #ifndef LDBL_MIN_EXP  /* May be defined in a toolchain header */
 #  ifdef CONFIG_HAVE_LONG_DOUBLE
-#    define LDBL_MIN_EXP DBL_MIN_EXP /* FIX ME */
+#    if LDBL_MANT_DIG == 53  /* IEEE binary64 */
+#      define LDBL_MIN_EXP DBL_MIN_EXP
+#    elif LDBL_MANT_DIG == 64  /* x87 80-bit */
+#      define LDBL_MIN_EXP (-16381)
+#    elif LDBL_MANT_DIG == 113  /* IEEE binary128 */
+#      define LDBL_MIN_EXP (-16381)
+#    else
+#      error "Unknown long double format"
+#    endif
 #  else
 #    define LDBL_MIN_EXP DBL_MIN_EXP
 #  endif
@@ -145,7 +161,15 @@
 
 #ifndef LDBL_MIN_10_EXP  /* May be defined in a toolchain header */
 #  ifdef CONFIG_HAVE_LONG_DOUBLE
-#    define LDBL_MIN_10_EXP DBL_MIN_10_EXP  /* FIX ME */
+#    if LDBL_MANT_DIG == 53  /* IEEE binary64 */
+#      define LDBL_MIN_10_EXP DBL_MIN_10_EXP
+#    elif LDBL_MANT_DIG == 64  /* x87 80-bit */
+#      define LDBL_MIN_10_EXP (-4931)
+#    elif LDBL_MANT_DIG == 113  /* IEEE binary128 */
+#      define LDBL_MIN_10_EXP (-4931)
+#    else
+#      error "Unknown long double format"
+#    endif
 #  else
 #    define LDBL_MIN_10_EXP DBL_MIN_10_EXP
 #  endif
@@ -169,7 +193,15 @@
 
 #ifndef LDBL_MAX_EXP  /* May be defined in a toolchain header */
 #  ifdef CONFIG_HAVE_LONG_DOUBLE
-#    define LDBL_MAX_EXP DBL_MAX_EXP /* FIX ME */
+#    if LDBL_MANT_DIG == 53  /* IEEE binary64 */
+#      define LDBL_MAX_EXP DBL_MAX_EXP
+#    elif LDBL_MANT_DIG == 64  /* x87 80-bit */
+#      define LDBL_MAX_EXP 16384
+#    elif LDBL_MANT_DIG == 113  /* IEEE binary128 */
+#      define LDBL_MAX_EXP 16384
+#    else
+#      error "Unknown long double format"
+#    endif
 #  else
 #    define LDBL_MAX_EXP DBL_MAX_EXP
 #  endif
@@ -193,7 +225,15 @@
 
 #ifndef LDBL_MAX_10_EXP      /* May be defined in toolchain header */
 #  ifdef CONFIG_HAVE_LONG_DOUBLE
-#    define LDBL_MAX_10_EXP DBL_MAX_10_EXP  /* FIX ME */
+#    if LDBL_MANT_DIG == 53  /* IEEE binary64 */
+#      define LDBL_MAX_10_EXP DBL_MAX_10_EXP
+#    elif LDBL_MANT_DIG == 64  /* x87 80-bit */
+#      define LDBL_MAX_10_EXP 4932
+#    elif LDBL_MANT_DIG == 113  /* IEEE binary128 */
+#      define LDBL_MAX_10_EXP 4932
+#    else
+#      error "Unknown long double format"
+#    endif
 #  else
 #    define LDBL_MAX_10_EXP DBL_MAX_10_EXP
 #  endif
@@ -215,7 +255,15 @@
 
 #ifndef LDBL_MAX                   /* May be defined in toolchain header */
 #  ifdef CONFIG_HAVE_LONG_DOUBLE
-#    define LDBL_MAX DBL_MAX       /* FIX ME */
+#    if LDBL_MANT_DIG == 53  /* IEEE binary64 */
+#      define LDBL_MAX DBL_MAX
+#    elif LDBL_MANT_DIG == 64  /* x87 80-bit */
+#      define LDBL_MAX 1.18973149535723176502126385303097021e+4932L
+#    elif LDBL_MANT_DIG == 113  /* IEEE binary128 */
+#      define LDBL_MAX 1.18973149535723176508575932662800702e+4932L
+#    else
+#      error "Unknown long double format"
+#    endif
 #  else
 #    define LDBL_MAX DBL_MAX
 #  endif
@@ -239,7 +287,15 @@
 
 #ifndef LDBL_EPSILON                 /* May be defined in toolchain header */
 #  ifdef CONFIG_HAVE_LONG_DOUBLE
-#    define LDBL_EPSILON DBL_EPSILON /* FIX ME */
+#    if LDBL_MANT_DIG == 53  /* IEEE binary64 */
+#      define LDBL_EPSILON DBL_EPSILON
+#    elif LDBL_MANT_DIG == 64  /* x87 80-bit */
+#      define LDBL_EPSILON 1.08420217248550443400745280086994171e-19L
+#    elif LDBL_MANT_DIG == 113  /* IEEE binary128 */
+#      define LDBL_EPSILON 1.92592994438723585305597794258492732e-34L
+#    else
+#      error "Unknown long double format"
+#    endif
 #  else
 #    define LDBL_EPSILON DBL_EPSILON
 #  endif
@@ -261,7 +317,15 @@
 
 #ifndef LDBL_MIN                    /* May be defined in toolchain header */
 #  ifdef CONFIG_HAVE_LONG_DOUBLE
-#    define LDBL_MIN DBL_MIN        /* FIX ME */
+#    if LDBL_MANT_DIG == 53  /* IEEE binary64 */
+#      define LDBL_MIN DBL_MIN
+#    elif LDBL_MANT_DIG == 64  /* x87 80-bit */
+#      define LDBL_MIN 3.36210314311209350626267781732175260e-4932L
+#    elif LDBL_MANT_DIG == 113  /* IEEE binary128 */
+#      define LDBL_MIN 3.36210314311209350626267781732175260e-4932L
+#    else
+#      error "Unknown long double format"
+#    endif
 #  else
 #    define LDBL_MIN DBL_MIN
 #  endif

--- a/libs/libc/Makefile
+++ b/libs/libc/Makefile
@@ -73,6 +73,8 @@ include wctype/Make.defs
 include wqueue/Make.defs
 include fdt/Make.defs
 
+CSRCS += limits_check.c
+
 # Use double delim to fix windows native build and give an error:
 # makefile:132: *** target mode do not include“%”. stop.
 #

--- a/libs/libc/limits_check.c
+++ b/libs/libc/limits_check.c
@@ -1,0 +1,195 @@
+/****************************************************************************
+ * libs/libc/limits_check.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/* NuttX prefers defining limits per architecture directly as constants
+ * instead of using compiler provided definitions. That is to support
+ * compilers that do not provide such definitions. On the other hand in case
+ * compiler provides these definitions we should not deviate from them. This
+ * file thus contains only checks of NuttX's defined limits against compiler
+ * definitions if available.
+ */
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <assert.h>
+
+#include <limits.h>
+#include <float.h>
+
+/****************************************************************************
+ * Pre-processor Prototypes
+ ****************************************************************************/
+
+#ifdef static_assert
+#  define static_assert_equal(COMPILER_DEF, DEF) \
+  static_assert(COMPILER_DEF == DEF, "Compiler definition mismatch for " #DEF)
+#else
+#  define DEFINITION_ASSERT(COMPILER_DEF, DEF)
+#endif
+
+#ifdef __CHAR_BIT__
+static_assert_equal(__CHAR_BIT__, CHAR_BIT);
+#endif
+
+#ifdef __SCHAR_MAX__
+static_assert_equal(__SCHAR_MAX__, SCHAR_MAX);
+#endif
+
+#ifdef __SHRT_MAX__
+static_assert_equal(__SHRT_MAX__, SHRT_MAX);
+#endif
+
+#ifdef __LONG_MAX__
+static_assert_equal(__LONG_MAX__, LONG_MAX);
+#endif
+
+#ifdef __LONG_LONG_MAX__
+static_assert_equal(__LONG_LONG_MAX__, LLONG_MAX);
+#endif
+
+#ifdef __UINTPTR_MAX__
+static_assert_equal(__UINTPTR_MAX__, UPTR_MAX);
+#endif
+
+#ifdef __WCHAR_MAX__
+static_assert_equal(__WCHAR_MAX__, WCHAR_MAX);
+#endif
+
+#ifdef __FLT_MANT_DIG__
+static_assert_equal(__FLT_MANT_DIG__, FLT_MANT_DIG);
+#endif
+
+#ifdef __DBL_MANT_DIG__
+static_assert_equal(__DBL_MANT_DIG__, DBL_MANT_DIG);
+#endif
+
+#ifdef __LDBL_MANT_DIG__
+static_assert_equal(__LDBL_MANT_DIG__, LDBL_MANT_DIG);
+#endif
+
+#ifdef __FLT_DIG__
+static_assert_equal(__FLT_DIG__, FLT_DIG);
+#endif
+
+#ifdef __DBL_DIG__
+static_assert_equal(__DBL_DIG__, DBL_DIG);
+#endif
+
+#ifdef __LDBL_DIG__
+static_assert_equal(__LDBL_DIG__, LDBL_DIG);
+#endif
+
+#ifdef __FLT_MIN_EXP__
+static_assert_equal(__FLT_MIN_EXP__, FLT_MIN_EXP);
+#endif
+
+#ifdef __DBL_MIN_EXP__
+static_assert_equal(__DBL_MIN_EXP__, DBL_MIN_EXP);
+#endif
+
+#ifdef __LDBL_MIN_EXP__
+static_assert_equal(__LDBL_MIN_EXP__, LDBL_MIN_EXP);
+#endif
+
+#ifdef __FLT_MIN_10_EXP__
+static_assert_equal(__FLT_MIN_10_EXP__, FLT_MIN_10_EXP);
+#endif
+
+#ifdef __DBL_MIN_10_EXP__
+static_assert_equal(__DBL_MIN_10_EXP__, DBL_MIN_10_EXP);
+#endif
+
+#ifdef __LDBL_MIN_10_EXP__
+static_assert_equal(__LDBL_MIN_10_EXP__, LDBL_MIN_10_EXP);
+#endif
+
+#ifdef __FLT_MAX_EXP__
+static_assert_equal(__FLT_MAX_EXP__, FLT_MAX_EXP);
+#endif
+
+#ifdef __DBL_MAX_EXP__
+static_assert_equal(__DBL_MAX_EXP__, DBL_MAX_EXP);
+#endif
+
+#ifdef __LDBL_MAX_EXP__
+static_assert_equal(__LDBL_MAX_EXP__, LDBL_MAX_EXP);
+#endif
+
+#ifdef __FLT_MAX_10_EXP__
+static_assert_equal(__FLT_MAX_10_EXP__, FLT_MAX_10_EXP);
+#endif
+
+#ifdef __DBL_MAX_10_EXP__
+static_assert_equal(__DBL_MAX_10_EXP__, DBL_MAX_10_EXP);
+#endif
+
+#ifdef __LDBL_MAX_10_EXP__
+static_assert_equal(__LDBL_MAX_10_EXP__, LDBL_MAX_10_EXP);
+#endif
+
+#ifdef __FLT_MAX__
+static_assert_equal(__FLT_MAX__, FLT_MAX);
+#endif
+
+#ifdef __DBL_MAX__
+static_assert_equal(__DBL_MAX__, DBL_MAX);
+#endif
+
+#ifdef __LDBL_MAX__
+static_assert_equal(__LDBL_MAX__, LDBL_MAX);
+#endif
+
+#ifdef __FLT_EPSILON__
+static_assert_equal(__FLT_EPSILON__, FLT_EPSILON);
+#endif
+
+#ifdef __DBL_EPSILON__
+static_assert_equal(__DBL_EPSILON__, DBL_EPSILON);
+#endif
+
+#ifdef __LDBL_EPSILON__
+static_assert_equal(__LDBL_EPSILON__, LDBL_EPSILON);
+#endif
+
+#ifdef __FLT_MIN__
+static_assert_equal(__FLT_MIN__, FLT_MIN);
+#endif
+
+#ifdef __DBL_MIN__
+static_assert_equal(__DBL_MIN__, DBL_MIN);
+#endif
+
+#ifdef __LDBL_MIN__
+static_assert_equal(__LDBL_MIN__, LDBL_MIN);
+#endif
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/

--- a/libs/libm/libm/lib_truncl.c
+++ b/libs/libm/libm/lib_truncl.c
@@ -35,6 +35,7 @@
 #include <nuttx/config.h>
 #include <nuttx/compiler.h>
 
+#include <assert.h>
 #include <stdint.h>
 #include <float.h>
 #include <math.h>
@@ -44,9 +45,18 @@
  ****************************************************************************/
 
 #ifdef CONFIG_HAVE_LONG_DOUBLE
-static const long double toint = 1 / LDBL_EPSILON;
+#if LDBL_MANT_DIG == DBL_MANT_DIG
 
-/* FIXME This will only work if long double is 64 bit and little endian */
+/* Cover case when double is the same as long double (64 bit ieee754). */
+
+long double truncl(long double x)
+{
+  return trunc(x);
+}
+
+#elif LDBL_MANT_DIG == 64
+
+static const long double toint = 1 / LDBL_EPSILON;
 
 union ldshape
 {
@@ -100,4 +110,13 @@ long double truncl(long double x)
   x += y;
   return s ? -x : x;
 }
+
+#else
+
+long double truncl(long double x)
+{
+  PANIC();  /* FIX ME */
+}
+
+#endif
 #endif


### PR DESCRIPTION
## Summary

This fixes the issue discovered with a new versions of GCC:

  libm/lib_truncl.c: In function 'truncl':
  libm/lib_truncl.c:68:14: error: 'u.i.se' is used uninitialized [-Werror=uninitialized]
     68 |   int e = u.i.se & 0x7fff;
        |           ~~~^~~
  libm/lib_truncl.c:63:17: note: 'u' declared here
     63 |   union ldshape u =
        |                 ^
  libm/lib_truncl.c:69:14: error: 'u.i.se' is used uninitialized [-Werror=uninitialized]
     69 |   int s = u.i.se >> 15;
        |           ~~~^~~
  libm/lib_truncl.c:63:17: note: 'u' declared here
     63 |   union ldshape u =
        |                 ^
  libm/lib_truncl.c:63:17: error: 'u.i.se' is used uninitialized [-Werror=uninitialized]

This was originally submitted in #18480, but that failed to approach the missing long double definitions.

## Impact

RELEASE

## Testing

CI