### PR TITLE
{bp-19247} boards/stm32l0538-disco: Remove DD command to release more space

### DIFF
--- a/boards/arm/stm32l0/stm32l0538-disco/configs/nsh/defconfig
+++ b/boards/arm/stm32l0/stm32l0538-disco/configs/nsh/defconfig
@@ -5,7 +5,7 @@
 # You can then do "make savedefconfig" to generate a new defconfig file that includes your
 # modifications.
 #
-# CONFIG_SYSTEM_DD_STATS is not set
+# CONFIG_SYSTEM_DD is not set
 CONFIG_ARCH="arm"
 CONFIG_ARCH_BOARD="stm32l0538-disco"
 CONFIG_ARCH_BOARD_STM32L0538_DISCO=y


### PR DESCRIPTION
## Summary

Currently stm32l0538-disco is using all its space on NuttX mainline After some investigation I noticed that DD is using more than 1500 bytes. After disabling it the board returned to compile.

## Impact

RELEASE

## Testing

CI