### PR TITLE
{bp-19229} arch/riscv: Add CONFIG_ARCH_RV_ISA_ZICSR_ZIFENCEI for fence.i

### DIFF
--- a/arch/risc-v/include/barriers.h
+++ b/arch/risc-v/include/barriers.h
@@ -39,6 +39,10 @@
 
 /* UP_ISB() is used to synchronize the instruction and data streams */
 
-#define UP_ISB()       __asm__ __volatile__ ("fence.i" ::: "memory")
+#ifdef CONFIG_ARCH_RV_ISA_ZICSR_ZIFENCEI
+#  define UP_ISB()       __asm__ __volatile__ ("fence.i" ::: "memory")
+#else
+#  define UP_ISB()       
+#endif
 
 #endif /* __ARCH_RISCV_INCLUDE_BARRIERS_H */

--- a/arch/risc-v/src/common/riscv_fpu.S
+++ b/arch/risc-v/src/common/riscv_fpu.S
@@ -72,8 +72,9 @@ riscv_fpuconfig:
   csrs         CSR_STATUS, a0
 
   fscsr        zero
-
+#ifdef CONFIG_ARCH_RV_ISA_ZICSR_ZIFENCEI
   fence.i
+#endif
   ret
 
 /****************************************************************************

--- a/arch/risc-v/src/common/riscv_mmu.h
+++ b/arch/risc-v/src/common/riscv_mmu.h
@@ -224,7 +224,9 @@ static inline void mmu_write_satp(uintptr_t reg)
       "csrw satp, %0\n"
       "sfence.vma x0, x0\n"
       "fence rw, rw\n"
+#ifdef CONFIG_ARCH_RV_ISA_ZICSR_ZIFENCEI
       "fence.i\n"
+#endif
       :
       : "rK" (reg)
       : "memory"

--- a/arch/risc-v/src/common/riscv_vpu.S
+++ b/arch/risc-v/src/common/riscv_vpu.S
@@ -70,8 +70,9 @@
 riscv_vpuconfig:
   li           a0, MSTATUS_VS_INIT
   csrs         CSR_STATUS, a0
-
+#ifdef CONFIG_ARCH_RV_ISA_ZICSR_ZIFENCEI
   fence.i
+#endif
   ret
 
 /****************************************************************************

--- a/arch/risc-v/src/mpfs/mpfs_head.S
+++ b/arch/risc-v/src/mpfs/mpfs_head.S
@@ -172,7 +172,9 @@ __start:
   csrw CSR_MIE, a2     /* Set MSIE bit to receive IPI */
 
   /* flush the instruction cache */
+#ifdef CONFIG_ARCH_RV_ISA_ZICSR_ZIFENCEI
   fence.i
+#endif
 
 .wait_boot:
   wfi


### PR DESCRIPTION
## Summary

The fence.i instruction is only available when the Zifencei extension (CONFIG_ARCH_RV_ISA_ZICSR_ZIFENCEI) is supported by the hardware.

This commit adds a macro wrapper around fence.i usages to prevent compilation errors on toolchains or targets where the Zifencei extension is absent.

## Impact

RELEASE

## Testing

CI