### PR TITLE
doc/nxdoom: Improve the nxdoom doc to let user play it

### DIFF
--- a/Documentation/platforms/sim/sim/boards/sim/index.rst
+++ b/Documentation/platforms/sim/sim/boards/sim/index.rst
@@ -952,6 +952,19 @@ nxdoom
 Play :doc:`NXDoom </applications/games/nxdoom/index>` on the Simulator using X11
 keyboard input and graphics. Read the docs for NXDoom to see how to play.
 
+By default this NuttX board config mounts the current directory from the host where it was executed, making the files visible internally at /data directory.
+So you can copy the DOOM1.WAD (or other WAD file) to the current directory where
+you compiled NuttX and run Doom from there:
+
+.. code:: console
+
+   $ cp ~/Download/DOOM1.WAD .
+   $ ./nuttx
+   NuttShell (NSH) NuttX-13.0.0
+   nsh> ls -l /data/DOOM1.WAD
+   -rw-rw-r--     4196020 2026-07-03 12:32 /data/DOOM1.WAD
+   nsh> nxdoom -iwad /data/DOOM1.WAD
+
 .. warning::
 
    X11 keyboard codes are not perfectly translated to the NuttX codec currently,


### PR DESCRIPTION
## Summary

It is very easy to get NXDoom running on NuttX, but the instructions was omitting the needed steps to get it running on Simulator.

## Impact

Now all users will be able to test NXDoom on SIM

## Testing
```
nsh> ls -l /data/DOOM1.WAD
 -rw-rw-r--     4196020 2026-07-03 12:32 /data/DOOM1.WAD
nsh> nxdoom -iwad /data/DOOM1.WAD
                             NXDoom v0.0.0
z_init: Init zone memory allocation daemon. 
zone memory: Using native C allocator.
Using /data/ for configuration and saves
v_init: allocate screens.
m_load_defaults: Load system defaults.
saving config in /data/default.cfg
W_Init: Init WADfiles.
 adding /data/DOOM1.WAD
===========================================================================
                            DOOM Shareware
===========================================================================
 NXDoom is free software, covered by the GNU General Public
 License.  There is NO warranty; not even for MERCHANTABILITY or FITNESS
 FOR A PARTICULAR PURPOSE. You are welcome to change and distribute
 copies under certain conditions. See the source for more information.
===========================================================================
i_init: Setting up machine state.
m_init: Init miscellaneous info.
r_init: Init DOOM refresh daemon - [...................]
p_init: Init Playloop state.
d_check_net_game: Checking network game status.
startskill 2  deathmatch: 0  startmap: 1  startepisode: 1
player 1 of 1 (1 nodes)
Emulating the behavior of the 'Doom 1.9' executable.
hu_init: Setting up heads up display.
st_init: Init status bar.
```