### PR TITLE
crypto: Support SHA2_224_HMAC

### DIFF
--- a/Documentation/components/crypto.rst
+++ b/Documentation/components/crypto.rst
@@ -62,6 +62,7 @@ Authentication and Hashing Algorithms
   - CRYPTO_SHA1_HMAC
 
 - SHA-2 HMAC:
+  - CRYPTO_SHA2_224_HMAC (224-bit)
   - CRYPTO_SHA2_256_HMAC (256-bit)
   - CRYPTO_SHA2_384_HMAC (384-bit)
   - CRYPTO_SHA2_512_HMAC (512-bit)

--- a/crypto/cryptodev.c
+++ b/crypto/cryptodev.c
@@ -250,6 +250,7 @@ static int cryptof_ioctl(FAR struct file *filep,
             case CRYPTO_MD5_HMAC:
             case CRYPTO_SHA1_HMAC:
             case CRYPTO_RIPEMD160_HMAC:
+            case CRYPTO_SHA2_224_HMAC:
             case CRYPTO_SHA2_256_HMAC:
             case CRYPTO_SHA2_384_HMAC:
             case CRYPTO_SHA2_512_HMAC:

--- a/crypto/cryptosoft.c
+++ b/crypto/cryptosoft.c
@@ -1153,6 +1153,7 @@ int swcr_authcompute(FAR struct cryptop *crp,
       case CRYPTO_MD5_HMAC:
       case CRYPTO_SHA1_HMAC:
       case CRYPTO_RIPEMD160_HMAC:
+      case CRYPTO_SHA2_224_HMAC:
       case CRYPTO_SHA2_256_HMAC:
       case CRYPTO_SHA2_384_HMAC:
       case CRYPTO_SHA2_512_HMAC:
@@ -1665,6 +1666,9 @@ int swcr_newsession(FAR uint32_t *sid, FAR struct cryptoini *cri)
           case CRYPTO_RIPEMD160_HMAC:
             axf = &auth_hash_hmac_ripemd_160_96;
             goto authcommon;
+          case CRYPTO_SHA2_224_HMAC:
+            axf = &auth_hash_hmac_sha2_224_114;
+            goto authcommon;
           case CRYPTO_SHA2_256_HMAC:
           case CRYPTO_PBKDF2_HMAC_SHA256:
             axf = &auth_hash_hmac_sha2_256_128;
@@ -1894,6 +1898,7 @@ int swcr_freesession(uint64_t tid)
           case CRYPTO_MD5_HMAC:
           case CRYPTO_SHA1_HMAC:
           case CRYPTO_RIPEMD160_HMAC:
+          case CRYPTO_SHA2_224_HMAC:
           case CRYPTO_SHA2_256_HMAC:
           case CRYPTO_SHA2_384_HMAC:
           case CRYPTO_SHA2_512_HMAC:
@@ -2044,6 +2049,7 @@ int swcr_process(struct cryptop *crp)
           case CRYPTO_MD5_HMAC:
           case CRYPTO_SHA1_HMAC:
           case CRYPTO_RIPEMD160_HMAC:
+          case CRYPTO_SHA2_224_HMAC:
           case CRYPTO_SHA2_256_HMAC:
           case CRYPTO_SHA2_384_HMAC:
           case CRYPTO_SHA2_512_HMAC:
@@ -2409,6 +2415,7 @@ void swcr_init(void)
   algs[CRYPTO_AES_GCM_16] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_AES_GMAC] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_NULL] = CRYPTO_ALG_FLAG_SUPPORTED;
+  algs[CRYPTO_SHA2_224_HMAC] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_SHA2_256_HMAC] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_SHA2_384_HMAC] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_SHA2_512_HMAC] = CRYPTO_ALG_FLAG_SUPPORTED;

--- a/crypto/xform.c
+++ b/crypto/xform.c
@@ -357,6 +357,15 @@ const struct auth_hash auth_hash_hmac_ripemd_160_96 =
   (void (*)(FAR uint8_t *, FAR void *)) rmd160final
 };
 
+const struct auth_hash auth_hash_hmac_sha2_224_114 =
+{
+  CRYPTO_SHA2_256_HMAC, "HMAC-SHA2-224",
+  HMAC_SHA2_224_BLOCK_LEN, 28, 14, sizeof(SHA2_CTX), HMAC_SHA2_224_BLOCK_LEN,
+  (void (*)(FAR void *)) sha224init, NULL, NULL,
+  sha224update_int,
+  (void (*)(FAR uint8_t *, FAR void *)) sha224final
+};
+
 const struct auth_hash auth_hash_hmac_sha2_256_128 =
 {
   CRYPTO_SHA2_256_HMAC, "HMAC-SHA2-256",

--- a/include/crypto/cryptodev.h
+++ b/include/crypto/cryptodev.h
@@ -73,6 +73,7 @@
 #define HMAC_MD5_BLOCK_LEN       64
 #define HMAC_SHA1_BLOCK_LEN      64
 #define HMAC_RIPEMD160_BLOCK_LEN 64
+#define HMAC_SHA2_224_BLOCK_LEN  64
 #define HMAC_SHA2_256_BLOCK_LEN  64
 #define HMAC_SHA2_384_BLOCK_LEN  128
 #define HMAC_SHA2_512_BLOCK_LEN  128
@@ -138,7 +139,8 @@
 #define CRYPTO_PBKDF2_HMAC_SHA1 38
 #define CRYPTO_PBKDF2_HMAC_SHA256 39
 #define CRYPTO_ESN              40 /* Support for Extended Sequence Numbers */
-#define CRYPTO_ALGORITHM_MAX    40 /* Keep updated */
+#define CRYPTO_SHA2_224_HMAC    41
+#define CRYPTO_ALGORITHM_MAX    41 /* Keep updated */
 
 /* Algorithm flags */
 

--- a/include/crypto/xform.h
+++ b/include/crypto/xform.h
@@ -118,6 +118,7 @@ extern const struct enc_xform enc_xform_null;
 extern const struct auth_hash auth_hash_hmac_md5_96;
 extern const struct auth_hash auth_hash_hmac_sha1_96;
 extern const struct auth_hash auth_hash_hmac_ripemd_160_96;
+extern const struct auth_hash auth_hash_hmac_sha2_224_114;
 extern const struct auth_hash auth_hash_hmac_sha2_256_128;
 extern const struct auth_hash auth_hash_hmac_sha2_384_192;
 extern const struct auth_hash auth_hash_hmac_sha2_512_256;


### PR DESCRIPTION
## Summary

Since already have support for SHA2-224, extend cryptodev/cryptosoft to support HMAC version of SHA2-224.

## Impact

- User experience: No adaptation required. This fix extends existing behavior.
- Build: No impact.
- Hardware: No impact.
- Documentation: Add mention of SHA2_224_HMAC crypto method.
- Security: No impact.
- Compatibility: Backward compatible - adds functionality.

## Testing

Build Host:

- OS: Ubuntu 24.04.4 LTS
- Compiler: arm-none-eabi-gcc 13.2.1

Target:

- Architecture: ARM (STM32H753ZI)
- Board: Nucleo-h753zi
- Configuration: nucleo-h753zi:crypto configuration followed by changing configuration:
-- Enable CRYPTO_SW_AES
-- Disable CRYPTO_CRYPTODEV_HARDWARE
-- Enable CRYPTO_CRYPTODEV_SOTWARE_CRYPTO
-- Enable TESTING_CRYPTO_HMAC

Runtime testing:
 
Modified version of nuttx-apps/testing/drivers/crypto/hmac.c to add SHA2_224_HMAC test results (generated by openssl) to run same HMAC testcase data through SHA2_224_HMAC crypto method (PR coming in nuttx-apps repository to submit these changes after this PR is merged).

From target console:

```
NuttShell (NSH) NuttX-13.0.0-RC0
nsh> uname -a
NuttX 13.0.0-RC0 7a4f270492-dirty Jul  3 2026 16:50:50 arm nucleo-h753zi
nsh> hmac
hmac md5 success
hmac md5 success
hmac md5 success
hmac md5 success
hmac md5 success
hmac sha1 success
hmac sha1 success
hmac sha1 success
hmac sha1 success
hmac sha1 success
hmac sha224 success
hmac sha224 success
hmac sha224 success
hmac sha224 success
hmac sha224 success
hmac sha256 success
hmac sha256 success
hmac sha256 success
hmac sha256 success
hmac sha256 success
nsh>
```
