### PR TITLE
{bp-19061} Assert size optimizations

### DIFF
--- a/Documentation/debugging/disabling_stackdumpdebug.rst
+++ b/Documentation/debugging/disabling_stackdumpdebug.rst
@@ -13,3 +13,37 @@ the board configuration:
 .. code-block:: c
 
     CONFIG_ARCH_STACKDUMP=n
+
+Reducing the Crash Dump Verbosity
+=================================
+
+In addition to ``CONFIG_ARCH_STACKDUMP``, which controls whether the
+architecture-specific stack dump is produced at all, two finer-grained
+options are available to tune how verbose the assertion / crash output
+from ``sched/misc/assert.c`` is. Disabling them is useful to reduce
+flash usage on small targets and to keep the crash log short.
+
+Both options default to ``y`` unless ``CONFIG_DEFAULT_SMALL`` is
+selected, in which case they default to ``n``.
+
+CONFIG_SCHED_DUMP_TASKS
+-----------------------
+
+Controls whether the per-task information table (task list with PID,
+priority, scheduling policy, stack usage, state, etc.) is printed as
+part of the crash dump.
+
+.. code-block:: c
+
+    CONFIG_SCHED_DUMP_TASKS=n   /* Omit the task table from the crash dump */
+
+CONFIG_SCHED_DUMP_STACK
+-----------------------
+
+Controls whether the contents of each stack (IRQ / kernel / user) are
+dumped as hex words. When disabled, only the base address and size of
+each stack are printed; the stack memory itself is not dumped.
+
+.. code-block:: c
+
+    CONFIG_SCHED_DUMP_STACK=n   /* Omit the hex stack contents from the dump */

--- a/Kconfig
+++ b/Kconfig
@@ -733,6 +733,28 @@ config DEBUG_ALERT
 	bool
 	default n
 
+config SCHED_DUMP_TASKS
+	bool "Include dumping the task info table in assert/crash output"
+	default !DEFAULT_SMALL
+	depends on DEBUG_ALERT
+	---help---
+		Selects whether the per-task table is printed as part of the
+		crash dump.
+
+		Defaults to y unless DEFAULT_SMALL is selected.
+
+config SCHED_DUMP_STACK
+	bool "Include stack content in assert/crash output"
+	default !DEFAULT_SMALL
+	depends on DEBUG_ALERT && ARCH_STACKDUMP
+	---help---
+		When enabled, the crash dump prints the contents of each stack
+		(IRQ / kernel / user) as hex words.
+
+		When disabled, only base and size are printed out for each stack.
+
+		Defaults to y unless DEFAULT_SMALL is selected.
+
 config DEBUG_FEATURES
 	bool "Enable Debug Features"
 	default n

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -118,7 +118,7 @@ static spinlock_t g_assert_lock = SP_UNLOCKED;
 static uintptr_t g_last_regs[CONFIG_SMP_NCPUS][XCPTCONTEXT_REGS]
                  aligned_data(XCPTCONTEXT_ALIGN);
 
-#ifdef CONFIG_DEBUG_ALERT
+#ifdef CONFIG_SCHED_DUMP_TASKS
 static FAR const char * const g_policy[4] =
 {
   "FIFO", "RR", "SPORADIC"
@@ -173,6 +173,7 @@ static void sp_out_of_range(uintptr_t sp)
   _alert("ERROR: Stack pointer %" PRIxPTR " is not within the stack\n", sp);
 }
 
+#ifdef CONFIG_SCHED_DUMP_STACK
 /****************************************************************************
  * Name: stack_dump
  ****************************************************************************/
@@ -192,6 +193,7 @@ static void stack_dump(uintptr_t sp, uintptr_t stack_top)
              DUMP_PTR(ptr, 5), DUMP_PTR(ptr , 6), DUMP_PTR(ptr, 7));
     }
 }
+#endif
 
 /****************************************************************************
  * Name: dump_stackinfo
@@ -200,14 +202,14 @@ static void stack_dump(uintptr_t sp, uintptr_t stack_top)
 static void dump_stackinfo(FAR const char *tag, uintptr_t sp,
                            uintptr_t base, size_t size, size_t used)
 {
-  uintptr_t top = base + size;
-
   _alert("%s Stack:\n", tag);
   _alert("  base: %p\n", (FAR void *)base);
   _alert("  size: %08zu\n", size);
 
+#ifdef CONFIG_SCHED_DUMP_STACK
   if (sp != 0)
     {
+      uintptr_t top = base + size;
       _alert("    sp: %p\n", (FAR void *)sp);
 
       /* Get more information */
@@ -237,6 +239,7 @@ static void dump_stackinfo(FAR const char *tag, uintptr_t sp,
 
       stack_dump(base, base + size);
     }
+#endif
 }
 
 /****************************************************************************
@@ -346,10 +349,9 @@ static void dump_stacks(FAR struct tcb_s *rtcb, uintptr_t sp)
                      );
     }
 }
-
 #endif
 
-#ifdef CONFIG_DEBUG_ALERT
+#ifdef CONFIG_SCHED_DUMP_TASKS
 /****************************************************************************
  * Name: dump_task
  ****************************************************************************/
@@ -481,6 +483,7 @@ static void dump_fdlist(FAR struct tcb_s *tcb, FAR void *arg)
 
 static void dump_tasks(void)
 {
+#ifdef CONFIG_SCHED_DUMP_TASKS
 #if CONFIG_ARCH_INTERRUPTSTACK > 0
   int cpu;
 #endif
@@ -551,9 +554,8 @@ static void dump_tasks(void)
     }
 #endif
 
-#ifdef CONFIG_DEBUG_ALERT
   nxsched_foreach(dump_task, NULL);
-#endif
+#endif /* CONFIG_SCHED_DUMP_TASKS */
 
 #ifdef CONFIG_SCHED_BACKTRACE
   nxsched_foreach(dump_backtrace, NULL);

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -168,6 +168,11 @@ static int assert_tracecallback(FAR struct usbtrace_s *trace, FAR void *arg)
 
 #ifdef CONFIG_ARCH_STACKDUMP
 
+static void sp_out_of_range(uintptr_t sp)
+{
+  _alert("ERROR: Stack pointer %" PRIxPTR " is not within the stack\n", sp);
+}
+
 /****************************************************************************
  * Name: stack_dump
  ****************************************************************************/
@@ -285,8 +290,7 @@ static void dump_stacks(FAR struct tcb_s *rtcb, uintptr_t sp)
   else
     {
       force = true;
-      _alert("ERROR: Stack pointer %" PRIxPTR "is not within the stack\n",
-             sp);
+      sp_out_of_range(sp);
     }
 
 #if CONFIG_ARCH_INTERRUPTSTACK > 0
@@ -309,8 +313,7 @@ static void dump_stacks(FAR struct tcb_s *rtcb, uintptr_t sp)
                     up_getusrsp((FAR void *)running_regs()) : 0;
       if (tcbstack_sp < tcbstack_base || tcbstack_sp >= tcbstack_top)
         {
-          _alert("ERROR: Stack pointer %" PRIxPTR " is not within the"
-                 " stack\n", tcbstack_sp);
+          sp_out_of_range(tcbstack_sp);
 
           tcbstack_sp = 0;
           force = true;
@@ -436,7 +439,7 @@ static void dump_task(FAR struct tcb_s *tcb, FAR void *arg)
          , tcb->stack_base_ptr
          , tcb->adj_stack_size
 #ifdef CONFIG_STACK_COLORATION
-         , up_check_tcbstack(tcb, tcb->adj_stack_size)
+         , stack_used
          , stack_filled / 10, stack_filled % 10
          , (stack_filled >= 10 * 80 ? '!' : ' ')
 #endif


### PR DESCRIPTION
## Summary

Here is one proposal, how we could save a bit of flash on small systems.

First commit (not too significant one) doesn't change functionality, just cleans up a tiny amount of flash (64 bytes on 32-bit arm) by removing a duplicate string and an extra function call. The duplicate string was not cleaned up by linker because the string was only almost the same, the other one had one extra space.

The second one adds two new CONFIG flags giving more granularity to configure what to dump at crash:

CONFIG_SCHED_DUMP_STACK : Output stack dump at crash, consumes ~1kB flash ( If disabled, it still dumps the current stack, irq stack and kernel stack base and size )
CONFIG_SCHED_DUMP_TASKS : Output tasks dump at crash, consumes ~0.5kB flash

By removing these two, 1.6kB can be saved in flash size.

Both flags are defined !CONFIG_DEFAULT_SMALL, so with normal configurations the functionality is unchanged.

## Impact

RELEASE

## Testing

CI