### PR TITLE
tools: pass TOPDIR in SDIR_template and MAKE_template

### DIFF
--- a/tools/Config.mk
+++ b/tools/Config.mk
@@ -718,13 +718,13 @@ endif
 # Invoke make
 
 define MAKE_template
-	+$(Q) $(MAKE) -C $(1) $(2) APPDIR="$(APPDIR)"
+	+$(Q) $(MAKE) -C $(1) $(2) APPDIR="$(APPDIR)" TOPDIR="$(TOPDIR)"
 
 endef
 
 define SDIR_template
 $(1)_$(2):
-	+$(Q) $(MAKE) -C $(1) $(2) APPDIR="$(APPDIR)"
+	+$(Q) $(MAKE) -C $(1) $(2) APPDIR="$(APPDIR)" TOPDIR="$(TOPDIR)"
 
 endef
 


### PR DESCRIPTION
## Summary

`SDIR_template` and `MAKE_template` in `tools/Config.mk` did not pass `TOPDIR` to recursive makes.  When a sub-make needed to include `$(TOPDIR)/Make.defs` (e.g. to define `SDIR_template` for further recursion into nested subdirectories), `TOPDIR` was missing and the include silently failed via `-include`.

## Changes

Pass `TOPDIR` in both templates so recursive makes have full access to the build system configuration.

## Motivation

Companion PR for apache/nuttx-apps#3585 which fixes distclean for partial builds.  Without TOPDIR being passed, the distclean targets defined inline in Directory.mk cannot recurse into sub-subdirectories.

Signed-off-by: hanzhijian <hanzhijian@zepp.com>