### PR TITLE
tools: escape Python string backslashes

### DIFF
--- a/tools/ide_exporter.py
+++ b/tools/ide_exporter.py
@@ -474,7 +474,7 @@ class IARProject(IdeProject):
         IAR sample including nodes
             <option>
               <name>CCIncludePath2</name>
-              <state>$PROJ_DIR$\nuttx\include\</state>
+              <state>$PROJ_DIR$\\nuttx\\include\\</state>
             </option>
         Args:
             sources: list of SourceInfo

--- a/tools/licensing/apachize.py
+++ b/tools/licensing/apachize.py
@@ -34,7 +34,7 @@ def apachize(path, header):
 
     with open(path) as f:
         s = f.read()
-        s = re.sub("(?i)/\*\*\*.+?(?:Copyright).+?\*\*\*+/", header, s, 1, re.DOTALL)
+        s = re.sub(r"(?i)/\*\*\*.+?(?:Copyright).+?\*\*\*+/", header, s, 1, re.DOTALL)
         print(s)
 
 

--- a/tools/licensing/check.py
+++ b/tools/licensing/check.py
@@ -51,7 +51,7 @@ def commit_attributions(c):
 
 
 def get_headers(s):
-    return re.findall("(?i)/\*\*\*.+?(?:Copyright).+?\*\*\*+/", s, re.DOTALL)
+    return re.findall(r"(?i)/\*\*\*.+?(?:Copyright).+?\*\*\*+/", s, re.DOTALL)
 
 
 def get_file(blob):
@@ -131,7 +131,7 @@ def author_has_cla(author):
 
 def header_copyrights(header):
     results = re.findall(
-        " \* *[Cc]opyright:?(?: ?.[Cc].)? *(?:[12][0-9]{3}[,-]? ?)* *(.+)", header
+        r" \* *[Cc]opyright:?(?: ?.[Cc].)? *(?:[12][0-9]{3}[,-]? ?)* *(.+)", header
     )
     return [re.sub("(. )?[Aa]ll rights reserved.?", "", result) for result in results]
 
@@ -139,7 +139,7 @@ def header_copyrights(header):
 def report_cla(author):
     cla = author_has_cla(author)
     if cla:
-        (apacheid, name) = cla
+        apacheid, name = cla
         print(colored("✓", "green"), end=" ")
     else:
         apacheid = None


### PR DESCRIPTION
## Summary
- use raw regex strings in the licensing helpers to avoid Python invalid escape warnings
- escape the backslashes in the IAR project docstring path example

## Verification
- Python compile warning scan for the changed files reports `TOTAL 0` for each file
- AST comparison against `origin/master` reports `AST_EQUAL True` for the two licensing helpers
- executable AST comparison with docstrings stripped reports `AST_EQUAL_NO_DOCS True` for all three changed files
- `git diff --check`
- `git ls-files --eol tools/licensing/apachize.py tools/licensing/check.py tools/ide_exporter.py`

I also checked for open duplicate PRs/issues mentioning `invalid escape`, `SyntaxWarning`, `tools/licensing`, `apachize.py`, and `ide_exporter.py`, and found no matches.

I did not run the full NuttX build/test suite locally because this Windows environment does not have CMake or a C compiler installed.