### PR TITLE
tools: avoid returning from finally blocks

### DIFF
--- a/tools/ci/testrun/utils/common.py
+++ b/tools/ci/testrun/utils/common.py
@@ -284,7 +284,8 @@ class connectNuttx(object):
 
             if self.method != "minicom":
                 time.sleep(0.5)
-            return ret
+
+        return ret
 
     def switch_to_original_core(self):
         if self.target == "target":

--- a/tools/pynuttx/nxgdb/net.py
+++ b/tools/pynuttx/nxgdb/net.py
@@ -310,8 +310,7 @@ class NetCheck(gdb.Command):
             result = max(result, NetCheckResult.FAILED)
             message.append("[FAILED] Failed to check IOB: %s" % e)
 
-        finally:
-            return result, message
+        return result, message
 
     def invoke(self, args, from_tty):
         if utils.get_symbol_value("CONFIG_MM_IOB"):


### PR DESCRIPTION
## Summary
- Move two Python returns out of finally blocks.
- Keep normal return values unchanged while avoiding suppression of unexpected exceptions.

## Testing
- python -We compile check for tools/ci/testrun/utils/common.py and tools/pynuttx/nxgdb/net.py
- git show --check --stat --oneline HEAD