### PR TITLE
drivers: 1wire: Fix DS2XXX device type bounds

### DIFF
--- a/drivers/1wire/1wire_ds2xxx.c
+++ b/drivers/1wire/1wire_ds2xxx.c
@@ -793,7 +793,7 @@ int ds2xxx_initialize(FAR struct onewire_dev_s *dev,
 {
   FAR struct ds2xxx_dev_s *priv;
 
-  if (devtype < 0 || devtype > EEPROM_DS_COUNT)
+  if (devtype < 0 || devtype >= EEPROM_DS_COUNT)
     {
       return -EINVAL;
     }


### PR DESCRIPTION
## Summary
- reject EEPROM_DS_COUNT as an invalid DS2XXX device type
- keep the guard at ds2xxx_initialize(), before the value is stored and used for geometry table indexing

## Testing
- git diff --check