### PR TITLE
drivers: leds: Fix LP503X bank mode LED bounds

### DIFF
--- a/drivers/leds/lp503x.c
+++ b/drivers/leds/lp503x.c
@@ -829,6 +829,12 @@ static int lp503x_ioctl(struct file *filep, int cmd,
         break;
 
       case PWMIOC_ENABLE_LED_BANK_MODE: /* led(0..11), mode required */
+        if (lp503x_ioctl_args->lednum > MAX_RGB_LEDS)
+          {
+            ret = -EINVAL;
+            break;
+          }
+
         ledinfo("INFO: setting LED %d mode to %" PRIx32 "\n",
                 lp503x_ioctl_args->lednum,
                 lp503x_ioctl_args->param);


### PR DESCRIPTION
## Summary
- validate LP503X bank-mode LED indexes before writing the led_mode array
- return -EINVAL for out-of-range RGB LED indexes

## Testing
- git diff --check origin/master..HEAD

checkpatch.sh could not complete in this Windows environment because tools/nxstyle and make were unavailable.