### PR TITLE
crypto/chachapoly: add chacha20 stream cipher API

### DIFF
--- a/crypto/chachapoly.c
+++ b/crypto/chachapoly.c
@@ -21,6 +21,7 @@
  * Included Files
  ****************************************************************************/
 
+#include <assert.h>
 #include <endian.h>
 #include <sys/param.h>
 
@@ -70,6 +71,39 @@ void chacha20_crypt(caddr_t key, FAR uint8_t *data)
 
   chacha_encrypt_bytes((FAR chacha_ctx *)ctx->block, data, data,
                        CHACHA20_BLOCK_LEN);
+}
+
+static_assert(sizeof(struct chacha20_stream_ctx) == sizeof(chacha_ctx),
+              "chacha20_stream_ctx must mirror the private chacha_ctx");
+
+void chacha20_stream_setkey(FAR struct chacha20_stream_ctx *ctx,
+                            FAR const uint8_t *key)
+{
+  chacha_keysetup((FAR chacha_ctx *)ctx, key, CHACHA20_KEYSIZE * 8);
+}
+
+void chacha20_stream_ivctr64(FAR struct chacha20_stream_ctx *ctx,
+                             FAR const uint8_t *iv, uint64_t counter)
+{
+  uint8_t ctr[8];
+
+  ctr[0] = counter;
+  ctr[1] = counter >> 8;
+  ctr[2] = counter >> 16;
+  ctr[3] = counter >> 24;
+  ctr[4] = counter >> 32;
+  ctr[5] = counter >> 40;
+  ctr[6] = counter >> 48;
+  ctr[7] = counter >> 56;
+
+  chacha_ivsetup((FAR chacha_ctx *)ctx, iv, ctr);
+}
+
+void chacha20_stream_crypt(FAR struct chacha20_stream_ctx *ctx,
+                           FAR const uint8_t *in, FAR uint8_t *out,
+                           size_t len)
+{
+  chacha_encrypt_bytes((FAR chacha_ctx *)ctx, in, out, len);
 }
 
 void chacha20_poly1305_init(FAR void *xctx)

--- a/include/crypto/chachapoly.h
+++ b/include/crypto/chachapoly.h
@@ -36,6 +36,24 @@ int chacha20_setkey(FAR void *, FAR uint8_t *, int);
 void chacha20_reinit(caddr_t, FAR uint8_t *);
 void chacha20_crypt(caddr_t, FAR uint8_t *);
 
+/* ChaCha20 keystream API with an 8-byte IV and an explicit 64-bit block
+ * counter, as used by the SSH chacha20-poly1305 construction.  The context
+ * layout mirrors the private chacha_ctx.
+ */
+
+struct chacha20_stream_ctx
+{
+  uint32_t input[16];
+};
+
+void chacha20_stream_setkey(FAR struct chacha20_stream_ctx *ctx,
+                            FAR const uint8_t *key);
+void chacha20_stream_ivctr64(FAR struct chacha20_stream_ctx *ctx,
+                             FAR const uint8_t *iv, uint64_t counter);
+void chacha20_stream_crypt(FAR struct chacha20_stream_ctx *ctx,
+                           FAR const uint8_t *in, FAR uint8_t *out,
+                           size_t len);
+
 #define POLY1305_KEYLEN 32
 #define POLY1305_TAGLEN 16
 #define POLY1305_BLOCK_LEN 16


### PR DESCRIPTION
## Summary

Expose a chacha20 keystream API with a 64-bit block counter on top of the existing private chacha implementation, so flat-build applications (e.g. an SSH server) can reuse the kernel cipher for chacha20-poly1305.

This is necessary in the next steps of Dropbear port where we will stop to use internal dropbear crypto em use NuttX Crypto.

## Impact

No relevant impact. Only existing implementations are being shared as an API.

## Testing

Build and OSTest
