### PR TITLE
tools: rp2040: Drop uninitialized name length check

### DIFF
--- a/tools/rp2040/make_flash_fs.c
+++ b/tools/rp2040/make_flash_fs.c
@@ -237,12 +237,6 @@ int scan_dir(int in_sector)
   struct stat    stat;
   int            name_len;
 
-  if (name_len > max_name_len)
-    {
-      fprintf(stderr, "directory name to big. skipped. (%s)\n", path);
-      return -1;
-    }
-
   input_dir = opendir(path);
 
   if (input_dir == NULL)


### PR DESCRIPTION
## Summary
- remove the stale pre-`opendir()` `name_len` check in `scan_dir()`
- keep directory entry name validation in the loop where `a_dirent->d_name` is available

## Why
`scan_dir()` checked `name_len` before assigning it. That means the tool can branch on an uninitialized local variable before opening the directory. The actual filesystem entry names are already measured and checked after `readdir()` returns each regular file or directory.

## Testing
- `git diff --check origin/master..HEAD`
- `git show --check --stat --oneline HEAD`
- local compile/checkpatch not run: this Windows environment has no usable `gcc`/`clang`/`make` or WSL/bash shell