### PR TITLE
tools: kconfig2html: Handle blank input lines

### DIFF
--- a/tools/kconfig2html.c
+++ b/tools/kconfig2html.c
@@ -702,6 +702,8 @@ static char *read_line(FILE *stream)
           g_line[len] = '\0';
         }
 
+      /* A blank line has no continuation marker to inspect. */
+
       if (len == 0)
         {
           g_lnptr = g_line;

--- a/tools/kconfig2html.c
+++ b/tools/kconfig2html.c
@@ -702,6 +702,12 @@ static char *read_line(FILE *stream)
           g_line[len] = '\0';
         }
 
+      if (len == 0)
+        {
+          g_lnptr = g_line;
+          return g_line;
+        }
+
       /* Does this continue on the next line?  Note that this check
        * could erroneoulsy combine two lines if a comment line ends with
        * a line continuation... Don't do that!


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

`read_line()` removes a trailing newline and then checks `g_line[len - 1]` for a line-continuation backslash. A blank input line leaves `len` at zero, so the continuation check would read before `g_line`.

Return the empty line to the caller before checking for a continuation. `kconfig_line()` already skips empty lines, so parser behavior for non-empty Kconfig entries stays unchanged.

## Impact

No configuration syntax, generated output, or hardware behavior changes. Blank Kconfig lines are now handled safely instead of reaching the continuation-marker access with an empty buffer.

## Testing

- Host: Windows 11; compiled `tools/kconfig2html.c` with GCC 16.1.0 (winlibs).
- Created a minimal Kconfig fixture containing blank lines, then ran the compiled `kconfig2html`; it exited successfully and generated a 4,177-byte HTML file.
- `git diff --check` passed.
- A full-tree run was also attempted. It stops at the existing `Unrecognized garbage after default value` parser limitation, outside the changed `read_line()` blank-line path; no hardware testing applies to this host tool change.