### PR TITLE
drivers/usbdev: rndis: Reject truncated responses

### DIFF
--- a/drivers/usbdev/rndis.c
+++ b/drivers/usbdev/rndis.c
@@ -2615,7 +2615,16 @@ static int usbclass_setup(FAR struct usbdevclass_driver_s *driver,
                       (struct rndis_response_header *)priv->response_queue;
                     ret = priv->response_queue_words * sizeof(uint32_t);
                     if (ret > len)
-                      ret = hdr->msglen;
+                      {
+                        if (hdr->msglen > len)
+                          {
+                            ret = -EMSGSIZE;
+                            break;
+                          }
+
+                        ret = hdr->msglen;
+                      }
+
                     memcpy(ctrlreq->buf, hdr, ret);
                     ctrlreq->priv = priv;
                   }


### PR DESCRIPTION
## Summary
- reject RNDIS encapsulated response reads when host wLength cannot hold the first queued response
- keep the response queue intact instead of copying and consuming a partial response

## Rationale
The handler already falls back from the whole response queue to the first queued message when wLength is smaller than the queue. If that first message is also larger than wLength, copying hdr->msglen bytes can exceed the requested control transfer and the completion path would later account only for the truncated transfer length. Returning EMSGSIZE before memcpy avoids both cases.

## Testing
- git diff --check
- git show --check --stat --oneline HEAD
- not run: local C compiler is not installed on this Windows host