### PR TITLE
drivers: pci: fix EPC MSI IRQ map validation

### DIFF
--- a/drivers/pci/pci_epc.c
+++ b/drivers/pci/pci_epc.c
@@ -324,7 +324,8 @@ int pci_epc_map_msi_irq(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno,
 {
   int ret;
 
-  if (epc == NULL && epc->ops->map_msi_irq == NULL)
+  if (epc == NULL || funcno >= epc->max_functions ||
+      epc->ops->map_msi_irq == NULL)
     {
       return -EINVAL;
     }


### PR DESCRIPTION
## Summary
- fix the guard in `pci_epc_map_msi_irq()` to reject a NULL EPC or missing `map_msi_irq` callback
- reject out-of-range endpoint function numbers before invoking the controller op

## Why
`pci_epc_map_msi_irq()` currently uses `&&` between the EPC NULL check and the callback check. That dereferences `epc` when it is NULL, and it lets a valid EPC with no `map_msi_irq` callback pass through to a NULL function call.

The surrounding EPC wrappers also validate `funcno` before dispatching to controller operations, so this helper now follows the same input-validation pattern.

## Testing
- `git diff --check origin/master...HEAD`
- `git show --stat --check --format=fuller HEAD`
- Not run: local NuttX build, because this Windows workstation does not have the required C build toolchain installed.