### PR TITLE
drivers: pci: fix EPF debug assertions

### DIFF
--- a/drivers/pci/pci_epf.c
+++ b/drivers/pci/pci_epf.c
@@ -298,7 +298,7 @@ int pci_epf_device_register(FAR struct pci_epf_device_s *epf)
   FAR struct pci_epc_ctrl_s *epc;
   int ret;
 
-  DEBUGASSERT(epf != NULL || epf->name != NULL);
+  DEBUGASSERT(epf != NULL && epf->name != NULL);
 
   ret = nxmutex_lock(&g_pci_epf_lock);
   if (ret < 0)
@@ -499,7 +499,7 @@ int pci_epf_unregister_driver(FAR struct pci_epf_driver_s *drv)
   FAR struct pci_epf_device_s *epf;
   int ret;
 
-  DEBUGASSERT(drv != NULL || drv->remove != NULL);
+  DEBUGASSERT(drv != NULL && drv->remove != NULL);
 
   ret = nxmutex_lock(&g_pci_epf_lock);
   if (ret < 0)


### PR DESCRIPTION
## Summary
- fix two PCI EPF `DEBUGASSERT()` precondition checks
- require both the object pointer and the required member/callback to be non-NULL

## Why
`pci_epf_device_register()` asserted `epf != NULL || epf->name != NULL`, and `pci_epf_unregister_driver()` asserted `drv != NULL || drv->remove != NULL`. With `||`, a NULL object still evaluates the right-hand side and can dereference NULL in debug builds, while a non-NULL object with a missing required member passes the assertion.

## Testing
- `git diff --check origin/master...HEAD`
- `git show --stat --check --format=fuller HEAD`
- Not run: local NuttX build, because this Windows workstation does not have the required C build toolchain installed.