### PR TITLE
libc/stream: Check lowout bounds before access

### DIFF
--- a/libs/libc/stream/lib_lowoutstream.c
+++ b/libs/libc/stream/lib_lowoutstream.c
@@ -86,7 +86,7 @@ static ssize_t lowoutstream_puts(FAR struct lib_outstream_s *self,
   size_t idx          = 0;
   DEBUGASSERT(self);
 
-  while (str[idx] != 0 && idx < len)
+  while (idx < len && str[idx] != 0)
     {
       lowoutstream_putc(self, str[idx]);
       idx++;


### PR DESCRIPTION
## Summary\n- check the output length before reading the current byte in lowoutstream_puts()\n- avoid reading str[0] for zero-length writes or str[len] after the buffer is consumed\n\n## Verification\n- git diff --check HEAD^ HEAD -- libs/libc/stream/lib_lowoutstream.c\n- git show --stat --check --format=fuller HEAD\n- git ls-files --eol -- libs/libc/stream/lib_lowoutstream.c