### PR TITLE
libs: netdb: Advance stream buffers by transfer count

### DIFF
--- a/libs/libc/netdb/lib_dnsquery.c
+++ b/libs/libc/netdb/lib_dnsquery.c
@@ -140,7 +140,7 @@ static ssize_t stream_send(int fd, FAR const void *buf, size_t len)
           break;
         }
 
-      buf = (FAR const uint8_t *)buf + len;
+      buf = (FAR const uint8_t *)buf + ret;
       len -= ret;
       total += ret;
     }
@@ -186,7 +186,7 @@ static ssize_t stream_recv(int fd, FAR void *buf, size_t len)
           break;
         }
 
-      buf = (FAR uint8_t *)buf + len;
+      buf = (FAR uint8_t *)buf + ret;
       len -= ret;
       total += ret;
     }


### PR DESCRIPTION
## Summary
- advance DNS stream send buffers by the actual send() return count
- advance DNS stream receive buffers by the actual recv() return count

## Rationale
send() and recv() may complete partially on stream sockets. Advancing by the original remaining length skips bytes after a short transfer, which can corrupt DNS-over-stream payload handling.

## Testing
- git diff --check HEAD~1..HEAD
- git show --stat --check --format=fuller HEAD
- git ls-files --eol -- libs\libc\netdb\lib_dnsquery.c