### PR TITLE
boards: tiva: Fix CC13xx red LED selection

### DIFF
--- a/boards/arm/tiva/launchxl-cc1310/src/cc1310_userleds.c
+++ b/boards/arm/tiva/launchxl-cc1310/src/cc1310_userleds.c
@@ -62,7 +62,7 @@ void board_userled(int led, bool ledon)
     {
       pinconfig = &g_gpio_gled;
     }
-  else if (led = BOARD_RLED)
+  else if (led == BOARD_RLED)
     {
       pinconfig = &g_gpio_rled;
     }

--- a/boards/arm/tiva/launchxl-cc1312r1/src/cc1312_userleds.c
+++ b/boards/arm/tiva/launchxl-cc1312r1/src/cc1312_userleds.c
@@ -62,7 +62,7 @@ void board_userled(int led, bool ledon)
     {
       pinconfig = &g_gpio_gled;
     }
-  else if (led = BOARD_RLED)
+  else if (led == BOARD_RLED)
     {
       pinconfig = &g_gpio_rled;
     }


### PR DESCRIPTION
## Summary
- compare led against BOARD_RLED in the CC1310 user LED handler
- make the same fix in the CC1312R1 user LED handler

## Rationale
BOARD_RLED is 1, so else if (led = BOARD_RLED) always selects the red LED for every non-green LED id. Use comparison so invalid LED ids continue to take the existing eturn path.

## Testing
- git diff --check
- git show --stat --check --format=fuller HEAD
- git ls-files --eol -- boards\\arm\\tiva\\launchxl-cc1310\\src\\cc1310_userleds.c boards\\arm\\tiva\\launchxl-cc1312r1\\src\\cc1312_userleds.c