### PR TITLE
arch: imx9: allow last CCM root index

### DIFF
--- a/arch/arm/src/imx9/imx9_ccm.c
+++ b/arch/arm/src/imx9/imx9_ccm.c
@@ -67,7 +67,7 @@ int imx9_ccm_configure_root_clock(int root, int mux, uint32_t div)
 {
   uint32_t value;
 
-  if (root >= CCM_CR_COUNT || div == 0 || div > 255 || mux >= ROOT_MUX_MAX)
+  if (root > CCM_CR_COUNT || div == 0 || div > 255 || mux >= ROOT_MUX_MAX)
     {
       return -EINVAL;
     }
@@ -103,7 +103,7 @@ int imx9_ccm_configure_root_clock(int root, int mux, uint32_t div)
 
 int imx9_ccm_root_clock_on(int root, bool enabled)
 {
-  if (root >= CCM_CR_COUNT)
+  if (root > CCM_CR_COUNT)
     {
       return -EINVAL;
     }

--- a/arch/arm64/src/imx9/imx9_ccm.c
+++ b/arch/arm64/src/imx9/imx9_ccm.c
@@ -270,7 +270,7 @@ int imx9_ccm_configure_root_clock(int root, int src, uint32_t div)
   uint32_t value;
   int i;
 
-  if (root >= CCM_CR_COUNT || div == 0 || div > 255)
+  if (root > CCM_CR_COUNT || div == 0 || div > 255)
     {
       return -EINVAL;
     }
@@ -321,7 +321,7 @@ int imx9_ccm_configure_root_clock(int root, int src, uint32_t div)
 
 int imx9_ccm_root_clock_on(int root, bool enabled)
 {
-  if (root >= CCM_CR_COUNT)
+  if (root > CCM_CR_COUNT)
     {
       return -EINVAL;
     }


### PR DESCRIPTION
## Summary
- allow i.MX9 non-SCMI CCM helpers to accept the last root index
- keep the fix in the register-level CCM boundary checks for arm and arm64

## Root cause
`CCM_CR_COUNT` is defined as 94 in the non-SCMI CCM headers, and `CCM_CR_PALCAMESCAN` is also 94. The `g_ccm_root_mux` tables contain 95 entries, so root 94 is a valid table/register index. The `root >= CCM_CR_COUNT` checks rejected that last valid root before reaching the CCM helpers.

## Testing
- `git diff --check HEAD~1 HEAD`
- `git show --stat --check --format=fuller HEAD`
- PowerShell consistency check: arm imx93, arm64 imx93, and arm64 imx95 CCM tables all report `CCM_CR_COUNT=94`, `CCM_CR_PALCAMESCAN=94`, `MuxEntries=95`

Not run locally:
- `tools/checkpatch.sh -f arch/arm/src/imx9/imx9_ccm.c arch/arm64/src/imx9/imx9_ccm.c` (local `bash` opens the Windows WSL install prompt)
- build tests (local `make`, `gcc`, `arm-none-eabi-gcc`, and `clang` are not installed)