### PR TITLE
Documentation: fill in pass1 directory description in organization.rst

### DIFF
--- a/Documentation/quickstart/organization.rst
+++ b/Documentation/quickstart/organization.rst
@@ -193,7 +193,15 @@ For details see :doc:`/components/openamp`.
 ``nuttx/pass1``
 ===============
 
-TODO
+This directory provides support for the two-pass build
+(``CONFIG_BUILD_2PASS=y``). In a two-pass build, the application logic
+is built during pass 1 and the operating system kernel during pass 2.
+Applications may generate and install source files into this directory
+during pass 1; those files are then compiled and linked into the kernel
+address space during pass 2.
+
+The primary use of this mechanism is to generate kernel symbol tables
+required for loadable kernel module support.
 
 ``nuttx/sched``
 ===============


### PR DESCRIPTION
## Summary

Replace the `TODO` placeholder in `Documentation/quickstart/organization.rst` for the `nuttx/pass1` directory with a description of the two-pass build mechanism.

## Impact

Documentation only — no functional changes.

## Testing

Verified against source code:
- `Kconfig` (`BUILD_2PASS`, `PASS1_TARGET`, `PASS1_BUILDIR`, `PASS1_OBJECT`) 
- `pass1/README.txt` and `pass1/Makefile`
- `tools/Unix.mk` (pass1 build invocation at line 554)
- `tools/FlatLibs.mk` / `tools/ProtectedLibs.mk` (`NUTTXLIBS += libpass1`)
- `Documentation/ReleaseNotes/NuttX-7.26` (kernel symbol table generation)
- `apps/examples/module/` (loadable kernel module example)