### PR TITLE
{bp-19325} drivers: pci: Fix EPF debug assertions

### DIFF
--- a/drivers/pci/pci_epf.c
+++ b/drivers/pci/pci_epf.c
@@ -298,7 +298,7 @@ int pci_epf_device_register(FAR struct pci_epf_device_s *epf)
   FAR struct pci_epc_ctrl_s *epc;
   int ret;
 
-  DEBUGASSERT(epf != NULL || epf->name != NULL);
+  DEBUGASSERT(epf != NULL && epf->name != NULL);
 
   ret = nxmutex_lock(&g_pci_epf_lock);
   if (ret < 0)
@@ -499,7 +499,7 @@ int pci_epf_unregister_driver(FAR struct pci_epf_driver_s *drv)
   FAR struct pci_epf_device_s *epf;
   int ret;
 
-  DEBUGASSERT(drv != NULL || drv->remove != NULL);
+  DEBUGASSERT(drv != NULL && drv->remove != NULL);
 
   ret = nxmutex_lock(&g_pci_epf_lock);
   if (ret < 0)


### PR DESCRIPTION
## Summary

pci_epf_device_register() and pci_epf_unregister_driver() used || in DEBUGASSERT expressions that validate a pointer and a required field or callback. If the pointer is NULL, the right-hand side dereferences it; if the pointer is valid but the required member is NULL, the assertion passes.

Require both conditions in each assertion so the debug checks match the preconditions used later in the functions.

Generated-by: OpenAI Codex

## Impact

RELEASE

## Testing

CI