### PR TITLE
{bp-19307} drivers/audio/i2s: Fix unsigned integers in function signatures

### DIFF
--- a/arch/arm/src/common/stm32/stm32_i2s_m3m4_v1.c
+++ b/arch/arm/src/common/stm32/stm32_i2s_m3m4_v1.c
@@ -407,14 +407,14 @@ static void     i2s_txdma_callback(DMA_HANDLE handle, uint8_t result,
 
 static int      i2s_checkwidth(struct stm32_i2s_s *priv, int bits);
 
-static uint32_t stm32_i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate);
-static uint32_t stm32_i2s_rxdatawidth(struct i2s_dev_s *dev, int bits);
+static int32_t  stm32_i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate);
+static int32_t  stm32_i2s_rxdatawidth(struct i2s_dev_s *dev, int bits);
 static int      stm32_i2s_receive(struct i2s_dev_s *dev,
                                   struct ap_buffer_s *apb,
                                   i2s_callback_t callback,
                                   void *arg, uint32_t timeout);
-static uint32_t stm32_i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate);
-static uint32_t stm32_i2s_txdatawidth(struct i2s_dev_s *dev, int bits);
+static int32_t  stm32_i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate);
+static int32_t  stm32_i2s_txdatawidth(struct i2s_dev_s *dev, int bits);
 static int      stm32_i2s_send(struct i2s_dev_s *dev,
                                struct ap_buffer_s *apb,
                                i2s_callback_t callback, void *arg,
@@ -1723,7 +1723,7 @@ static int i2s_checkwidth(struct stm32_i2s_s *priv, int bits)
  *
  ****************************************************************************/
 
-static uint32_t stm32_i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
+static int32_t stm32_i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
 {
 #if defined(I2S_HAVE_RX) && defined(I2S_HAVE_MCK)
   struct stm32_i2s_s *priv = (struct stm32_i2s_s *)dev;
@@ -1759,7 +1759,7 @@ static uint32_t stm32_i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
  *
  ****************************************************************************/
 
-static uint32_t stm32_i2s_rxdatawidth(struct i2s_dev_s *dev, int bits)
+static int32_t stm32_i2s_rxdatawidth(struct i2s_dev_s *dev, int bits)
 {
 #ifdef I2S_HAVE_RX
   struct stm32_i2s_s *priv = (struct stm32_i2s_s *)dev;
@@ -1928,7 +1928,7 @@ static int stm32_i2s_roundf(float num)
  *
  ****************************************************************************/
 
-static uint32_t stm32_i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
+static int32_t stm32_i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
 {
 #if defined(I2S_HAVE_TX) && defined(I2S_HAVE_MCK)
   struct stm32_i2s_s *priv = (struct stm32_i2s_s *)dev;
@@ -1965,7 +1965,7 @@ static uint32_t stm32_i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
  *
  ****************************************************************************/
 
-static uint32_t stm32_i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
+static int32_t stm32_i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
 {
 #ifdef I2S_HAVE_TX
   struct stm32_i2s_s *priv = (struct stm32_i2s_s *)dev;

--- a/arch/arm/src/lc823450/lc823450_i2s.c
+++ b/arch/arm/src/lc823450/lc823450_i2s.c
@@ -186,17 +186,17 @@ static uint32_t _i2s_tx_th_bytes;
  * Private Function Prototypes
  ****************************************************************************/
 
-static uint32_t lc823450_i2s_rxsamplerate(struct i2s_dev_s *dev,
+static int32_t  lc823450_i2s_rxsamplerate(struct i2s_dev_s *dev,
                                           uint32_t rate);
-static uint32_t lc823450_i2s_rxdatawidth(struct i2s_dev_s *dev, int bits);
+static int32_t  lc823450_i2s_rxdatawidth(struct i2s_dev_s *dev, int bits);
 static int      lc823450_i2s_receive(struct i2s_dev_s *dev,
                                      struct ap_buffer_s *apb,
                                      i2s_callback_t callback, void *arg,
                                      uint32_t timeout);
 
-static uint32_t lc823450_i2s_txsamplerate(struct i2s_dev_s *dev,
+static int32_t  lc823450_i2s_txsamplerate(struct i2s_dev_s *dev,
                                           uint32_t rate);
-static uint32_t lc823450_i2s_txdatawidth(struct i2s_dev_s *dev, int bits);
+static int32_t  lc823450_i2s_txdatawidth(struct i2s_dev_s *dev, int bits);
 static int      lc823450_i2s_send(struct i2s_dev_s *dev,
                                   struct ap_buffer_s *apb,
                                   i2s_callback_t callback, void *arg,
@@ -312,7 +312,7 @@ static void _setup_audio_pll(uint32_t freq)
  * Name: lc823450_i2s_rxsamplerate
  ****************************************************************************/
 
-static uint32_t lc823450_i2s_rxsamplerate(struct i2s_dev_s *dev,
+static int32_t lc823450_i2s_rxsamplerate(struct i2s_dev_s *dev,
                                           uint32_t rate)
 {
   /* Change ASRC FSO rate */
@@ -340,7 +340,7 @@ static uint32_t lc823450_i2s_rxsamplerate(struct i2s_dev_s *dev,
  * Name: lc823450_i2s_rxdatawidth
  ****************************************************************************/
 
-static uint32_t lc823450_i2s_rxdatawidth(struct i2s_dev_s *dev, int bits)
+static int32_t lc823450_i2s_rxdatawidth(struct i2s_dev_s *dev, int bits)
 {
   return 0;
 }
@@ -573,7 +573,7 @@ static void _i2s_txdma_callback(DMA_HANDLE hdma, void *arg, int result)
  * Name: lc823450_i2s_txsamplerate
  ****************************************************************************/
 
-static uint32_t lc823450_i2s_txsamplerate(struct i2s_dev_s *dev,
+static int32_t lc823450_i2s_txsamplerate(struct i2s_dev_s *dev,
                                           uint32_t rate)
 {
   /* Change SSRC FSI rate */
@@ -601,7 +601,7 @@ static uint32_t lc823450_i2s_txsamplerate(struct i2s_dev_s *dev,
  * Name: lc823450_i2s_txdatawidth
  ****************************************************************************/
 
-static uint32_t lc823450_i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
+static int32_t lc823450_i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
 {
   return 0;
 }

--- a/arch/arm/src/rp2040/rp2040_i2s.c
+++ b/arch/arm/src/rp2040/rp2040_i2s.c
@@ -194,9 +194,9 @@ static int      i2s_checkwidth(struct rp2040_i2s_s *priv, int bits);
 
 static int      rp2040_i2s_txchannels(struct i2s_dev_s *dev,
                                       uint8_t channels);
-static uint32_t rp2040_i2s_txsamplerate(struct i2s_dev_s *dev,
+static int32_t  rp2040_i2s_txsamplerate(struct i2s_dev_s *dev,
                                         uint32_t rate);
-static uint32_t rp2040_i2s_txdatawidth(struct i2s_dev_s *dev, int bits);
+static int32_t  rp2040_i2s_txdatawidth(struct i2s_dev_s *dev, int bits);
 static int      rp2040_i2s_send(struct i2s_dev_s *dev,
                                 struct ap_buffer_s *apb,
                                 i2s_callback_t callback, void *arg,
@@ -749,7 +749,7 @@ static int rp2040_i2s_txchannels(struct i2s_dev_s *dev, uint8_t channels)
  *
  ****************************************************************************/
 
-static uint32_t rp2040_i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
+static int32_t rp2040_i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
 {
   struct rp2040_i2s_s *priv = (struct rp2040_i2s_s *)dev;
 
@@ -780,7 +780,7 @@ static uint32_t rp2040_i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
  *
  ****************************************************************************/
 
-static uint32_t rp2040_i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
+static int32_t rp2040_i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
 {
   struct rp2040_i2s_s *priv = (struct rp2040_i2s_s *)dev;
   int ret;

--- a/arch/arm/src/rp23xx/rp23xx_i2s.c
+++ b/arch/arm/src/rp23xx/rp23xx_i2s.c
@@ -194,9 +194,9 @@ static int      i2s_checkwidth(struct rp23xx_i2s_s *priv, int bits);
 
 static int      rp23xx_i2s_txchannels(struct i2s_dev_s *dev,
                                       uint8_t channels);
-static uint32_t rp23xx_i2s_txsamplerate(struct i2s_dev_s *dev,
+static int32_t  rp23xx_i2s_txsamplerate(struct i2s_dev_s *dev,
                                         uint32_t rate);
-static uint32_t rp23xx_i2s_txdatawidth(struct i2s_dev_s *dev, int bits);
+static int32_t  rp23xx_i2s_txdatawidth(struct i2s_dev_s *dev, int bits);
 static int      rp23xx_i2s_send(struct i2s_dev_s *dev,
                                 struct ap_buffer_s *apb,
                                 i2s_callback_t callback, void *arg,
@@ -749,7 +749,7 @@ static int rp23xx_i2s_txchannels(struct i2s_dev_s *dev, uint8_t channels)
  *
  ****************************************************************************/
 
-static uint32_t rp23xx_i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
+static int32_t rp23xx_i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
 {
   struct rp23xx_i2s_s *priv = (struct rp23xx_i2s_s *)dev;
 
@@ -780,7 +780,7 @@ static uint32_t rp23xx_i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
  *
  ****************************************************************************/
 
-static uint32_t rp23xx_i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
+static int32_t rp23xx_i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
 {
   struct rp23xx_i2s_s *priv = (struct rp23xx_i2s_s *)dev;
   int ret;

--- a/arch/arm/src/sama5/sam_ssc.c
+++ b/arch/arm/src/sama5/sam_ssc.c
@@ -590,12 +590,12 @@ static void     ssc_txdma_callback(DMA_HANDLE handle, void *arg, int result);
 
 static int      ssc_checkwidth(struct sam_ssc_s *priv, int bits);
 
-static uint32_t ssc_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate);
-static uint32_t ssc_rxdatawidth(struct i2s_dev_s *dev, int bits);
+static int32_t  ssc_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate);
+static int32_t  ssc_rxdatawidth(struct i2s_dev_s *dev, int bits);
 static int      ssc_receive(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
                   i2s_callback_t callback, void *arg, uint32_t timeout);
-static uint32_t ssc_txsamplerate(struct i2s_dev_s *dev, uint32_t rate);
-static uint32_t ssc_txdatawidth(struct i2s_dev_s *dev, int bits);
+static int32_t  ssc_txsamplerate(struct i2s_dev_s *dev, uint32_t rate);
+static int32_t  ssc_txdatawidth(struct i2s_dev_s *dev, int bits);
 static int      ssc_send(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
                   i2s_callback_t callback, void *arg,
                   uint32_t timeout);
@@ -2012,7 +2012,7 @@ static int ssc_checkwidth(struct sam_ssc_s *priv, int bits)
  *
  ****************************************************************************/
 
-static uint32_t ssc_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
+static int32_t ssc_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
 {
 #if defined(SSC_HAVE_RX) && defined(SSC_HAVE_MCK2)
   struct sam_ssc_s *priv = (struct sam_ssc_s *)dev;
@@ -2048,7 +2048,7 @@ static uint32_t ssc_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
  *
  ****************************************************************************/
 
-static uint32_t ssc_rxdatawidth(struct i2s_dev_s *dev, int bits)
+static int32_t ssc_rxdatawidth(struct i2s_dev_s *dev, int bits)
 {
 #ifdef SSC_HAVE_RX
   struct sam_ssc_s *priv = (struct sam_ssc_s *)dev;
@@ -2229,7 +2229,7 @@ errout_with_buf:
  *
  ****************************************************************************/
 
-static uint32_t ssc_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
+static int32_t ssc_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
 {
 #if defined(SSC_HAVE_TX) && defined(SSC_HAVE_MCK2)
   struct sam_ssc_s *priv = (struct sam_ssc_s *)dev;
@@ -2265,7 +2265,7 @@ static uint32_t ssc_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
  *
  ****************************************************************************/
 
-static uint32_t ssc_txdatawidth(struct i2s_dev_s *dev, int bits)
+static int32_t ssc_txdatawidth(struct i2s_dev_s *dev, int bits)
 {
 #ifdef SSC_HAVE_TX
   struct sam_ssc_s *priv = (struct sam_ssc_s *)dev;

--- a/arch/arm/src/samv7/sam_ssc.c
+++ b/arch/arm/src/samv7/sam_ssc.c
@@ -564,12 +564,12 @@ static void     ssc_txdma_callback(DMA_HANDLE handle, void *arg, int result);
 
 static int      ssc_checkwidth(struct sam_ssc_s *priv, int bits);
 
-static uint32_t ssc_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate);
-static uint32_t ssc_rxdatawidth(struct i2s_dev_s *dev, int bits);
+static int32_t  ssc_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate);
+static int32_t  ssc_rxdatawidth(struct i2s_dev_s *dev, int bits);
 static int      ssc_receive(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
                   i2s_callback_t callback, void *arg, uint32_t timeout);
-static uint32_t ssc_txsamplerate(struct i2s_dev_s *dev, uint32_t rate);
-static uint32_t ssc_txdatawidth(struct i2s_dev_s *dev, int bits);
+static int32_t  ssc_txsamplerate(struct i2s_dev_s *dev, uint32_t rate);
+static int32_t  ssc_txdatawidth(struct i2s_dev_s *dev, int bits);
 static int      ssc_send(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
                   i2s_callback_t callback, void *arg,
                   uint32_t timeout);
@@ -1992,7 +1992,7 @@ static int ssc_checkwidth(struct sam_ssc_s *priv, int bits)
  *
  ****************************************************************************/
 
-static uint32_t ssc_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
+static int32_t ssc_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
 {
 #if defined(SSC_HAVE_RX) && defined(SSC_HAVE_MCK2)
   struct sam_ssc_s *priv = (struct sam_ssc_s *)dev;
@@ -2028,7 +2028,7 @@ static uint32_t ssc_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
  *
  ****************************************************************************/
 
-static uint32_t ssc_rxdatawidth(struct i2s_dev_s *dev, int bits)
+static int32_t ssc_rxdatawidth(struct i2s_dev_s *dev, int bits)
 {
 #ifdef SSC_HAVE_RX
   struct sam_ssc_s *priv = (struct sam_ssc_s *)dev;
@@ -2212,7 +2212,7 @@ errout_with_buf:
  *
  ****************************************************************************/
 
-static uint32_t ssc_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
+static int32_t ssc_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
 {
 #if defined(SSC_HAVE_TX) && defined(SSC_HAVE_MCK2)
   struct sam_ssc_s *priv = (struct sam_ssc_s *)dev;
@@ -2248,7 +2248,7 @@ static uint32_t ssc_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
  *
  ****************************************************************************/
 
-static uint32_t ssc_txdatawidth(struct i2s_dev_s *dev, int bits)
+static int32_t ssc_txdatawidth(struct i2s_dev_s *dev, int bits)
 {
 #ifdef SSC_HAVE_TX
   struct sam_ssc_s *priv = (struct sam_ssc_s *)dev;
@@ -2730,7 +2730,7 @@ static int ssc_tx_configure(struct sam_ssc_s *priv)
  *
  ****************************************************************************/
 
-static uint32_t ssc_mck2divider(struct sam_ssc_s *priv)
+static int32_t ssc_mck2divider(struct sam_ssc_s *priv)
 {
 #ifdef SSC_HAVE_MCK2
   uint32_t bitrate;

--- a/arch/arm/src/stm32f7/stm32_i2s.c
+++ b/arch/arm/src/stm32f7/stm32_i2s.c
@@ -447,14 +447,14 @@ static void     i2s_txdma_callback(DMA_HANDLE handle, uint8_t result,
 
 static int      i2s_checkwidth(struct stm32_i2s_s *priv, int bits);
 
-static uint32_t stm32_i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate);
-static uint32_t stm32_i2s_rxdatawidth(struct i2s_dev_s *dev, int bits);
+static int32_t  stm32_i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate);
+static int32_t  stm32_i2s_rxdatawidth(struct i2s_dev_s *dev, int bits);
 static int      stm32_i2s_receive(struct i2s_dev_s *dev,
                                   struct ap_buffer_s *apb,
                                   i2s_callback_t callback,
                                   void *arg, uint32_t timeout);
-static uint32_t stm32_i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate);
-static uint32_t stm32_i2s_txdatawidth(struct i2s_dev_s *dev, int bits);
+static int32_t  stm32_i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate);
+static int32_t  stm32_i2s_txdatawidth(struct i2s_dev_s *dev, int bits);
 static int      stm32_i2s_send(struct i2s_dev_s *dev,
                                struct ap_buffer_s *apb,
                                i2s_callback_t callback, void *arg,
@@ -1770,7 +1770,7 @@ static int i2s_checkwidth(struct stm32_i2s_s *priv, int bits)
  *
  ****************************************************************************/
 
-static uint32_t stm32_i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
+static int32_t stm32_i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
 {
 #if defined(I2S_HAVE_RX) && defined(I2S_HAVE_MCK)
   struct stm32_i2s_s *priv = (struct stm32_i2s_s *)dev;
@@ -1806,7 +1806,7 @@ static uint32_t stm32_i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
  *
  ****************************************************************************/
 
-static uint32_t stm32_i2s_rxdatawidth(struct i2s_dev_s *dev, int bits)
+static int32_t stm32_i2s_rxdatawidth(struct i2s_dev_s *dev, int bits)
 {
 #ifdef I2S_HAVE_RX
   struct stm32_i2s_s *priv = (struct stm32_i2s_s *)dev;
@@ -1975,7 +1975,7 @@ static int stm32_i2s_roundf(float num)
  *
  ****************************************************************************/
 
-static uint32_t stm32_i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
+static int32_t stm32_i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
 {
 #if defined(I2S_HAVE_TX) && defined(I2S_HAVE_MCK)
   struct stm32_i2s_s *priv = (struct stm32_i2s_s *)dev;
@@ -2012,7 +2012,7 @@ static uint32_t stm32_i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
  *
  ****************************************************************************/
 
-static uint32_t stm32_i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
+static int32_t stm32_i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
 {
 #ifdef I2S_HAVE_TX
   struct stm32_i2s_s *priv = (struct stm32_i2s_s *)dev;

--- a/arch/arm/src/stm32f7/stm32_sai.c
+++ b/arch/arm/src/stm32f7/stm32_sai.c
@@ -243,8 +243,8 @@ static void     sai_dma_callback(DMA_HANDLE handle, uint8_t isr, void *arg);
 
 /* I2S methods */
 
-static uint32_t sai_samplerate(struct i2s_dev_s *dev, uint32_t rate);
-static uint32_t sai_datawidth(struct i2s_dev_s *dev, int bits);
+static int32_t  sai_samplerate(struct i2s_dev_s *dev, uint32_t rate);
+static int32_t  sai_datawidth(struct i2s_dev_s *dev, int bits);
 static int      sai_receive(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
                   i2s_callback_t callback, void *arg, uint32_t timeout);
 static int      sai_send(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
@@ -1102,7 +1102,7 @@ static void sai_dma_callback(DMA_HANDLE handle, uint8_t isr, void *arg)
  *
  ****************************************************************************/
 
-static uint32_t sai_samplerate(struct i2s_dev_s *dev, uint32_t rate)
+static int32_t sai_samplerate(struct i2s_dev_s *dev, uint32_t rate)
 {
   struct stm32f7_sai_s *priv = (struct stm32f7_sai_s *)dev;
 
@@ -1143,7 +1143,7 @@ static uint32_t sai_samplerate(struct i2s_dev_s *dev, uint32_t rate)
  *
  ****************************************************************************/
 
-static uint32_t sai_datawidth(struct i2s_dev_s *dev, int bits)
+static int32_t sai_datawidth(struct i2s_dev_s *dev, int bits)
 {
   struct stm32f7_sai_s *priv = (struct stm32f7_sai_s *)dev;
   uint32_t setbits;

--- a/arch/arm/src/stm32l4/stm32l4_sai.c
+++ b/arch/arm/src/stm32l4/stm32l4_sai.c
@@ -198,8 +198,8 @@ static void     sai_dma_callback(DMA_HANDLE handle, uint8_t isr, void *arg);
 
 /* I2S methods */
 
-static uint32_t sai_samplerate(struct i2s_dev_s *dev, uint32_t rate);
-static uint32_t sai_datawidth(struct i2s_dev_s *dev, int bits);
+static int32_t  sai_samplerate(struct i2s_dev_s *dev, uint32_t rate);
+static int32_t  sai_datawidth(struct i2s_dev_s *dev, int bits);
 static int      sai_receive(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
                   i2s_callback_t callback, void *arg, uint32_t timeout);
 static int      sai_send(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
@@ -845,7 +845,7 @@ static void sai_dma_callback(DMA_HANDLE handle, uint8_t isr, void *arg)
  *
  ****************************************************************************/
 
-static uint32_t sai_samplerate(struct i2s_dev_s *dev, uint32_t rate)
+static int32_t sai_samplerate(struct i2s_dev_s *dev, uint32_t rate)
 {
   struct stm32_sai_s *priv = (struct stm32_sai_s *)dev;
 
@@ -875,7 +875,7 @@ static uint32_t sai_samplerate(struct i2s_dev_s *dev, uint32_t rate)
  *
  ****************************************************************************/
 
-static uint32_t sai_datawidth(struct i2s_dev_s *dev, int bits)
+static int32_t sai_datawidth(struct i2s_dev_s *dev, int bits)
 {
   struct stm32_sai_s *priv = (struct stm32_sai_s *)dev;
   uint32_t setbits;

--- a/arch/risc-v/src/common/espressif/esp_i2s.c
+++ b/arch/risc-v/src/common/espressif/esp_i2s.c
@@ -380,16 +380,16 @@ static uint32_t i2s_get_source_clk_freq(i2s_clock_src_t clk_src,
 static int32_t  i2s_check_mclkfrequency(struct esp_i2s_s *priv);
 static uint32_t i2s_set_datawidth(struct esp_i2s_s *priv);
 static int      i2s_set_clock(struct esp_i2s_s *priv);
-static uint32_t i2s_getmclkfrequency(struct i2s_dev_s *dev);
-static uint32_t i2s_setmclkfrequency(struct i2s_dev_s *dev,
+static int32_t  i2s_getmclkfrequency(struct i2s_dev_s *dev);
+static int32_t  i2s_setmclkfrequency(struct i2s_dev_s *dev,
                                      uint32_t frequency);
 static int      i2s_ioctl(struct i2s_dev_s *dev, int cmd, unsigned long arg);
 
 static void     i2s_tx_channel_start(struct esp_i2s_s *priv);
 static int      i2s_tx_channel_stop(struct esp_i2s_s *priv);
 static int      i2s_txchannels(struct i2s_dev_s *dev, uint8_t channels);
-static uint32_t i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate);
-static uint32_t i2s_txdatawidth(struct i2s_dev_s *dev, int bits);
+static int32_t  i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate);
+static int32_t  i2s_txdatawidth(struct i2s_dev_s *dev, int bits);
 static int      i2s_send(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
                          i2s_callback_t callback, void *arg,
                          uint32_t timeout);
@@ -404,8 +404,8 @@ static bool     i2s_rx_error(gdma_channel_handle_t dma_chan,
                              void *arg);
 
 static int      i2s_rxchannels(struct i2s_dev_s *dev, uint8_t channels);
-static uint32_t i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate);
-static uint32_t i2s_rxdatawidth(struct i2s_dev_s *dev, int bits);
+static int32_t  i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate);
+static int32_t  i2s_rxdatawidth(struct i2s_dev_s *dev, int bits);
 static int      i2s_receive(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
                             i2s_callback_t callback, void *arg,
                             uint32_t timeout);
@@ -2563,7 +2563,7 @@ static bool IRAM_ATTR i2s_rx_interrupt(gdma_channel_handle_t dma_chan,
  *
  ****************************************************************************/
 
-static uint32_t i2s_getmclkfrequency(struct i2s_dev_s *dev)
+static int32_t i2s_getmclkfrequency(struct i2s_dev_s *dev)
 {
   struct esp_i2s_s *priv = (struct esp_i2s_s *)dev;
 
@@ -2587,7 +2587,7 @@ static uint32_t i2s_getmclkfrequency(struct i2s_dev_s *dev)
  *
  ****************************************************************************/
 
-static uint32_t i2s_setmclkfrequency(struct i2s_dev_s *dev,
+static int32_t i2s_setmclkfrequency(struct i2s_dev_s *dev,
                                      uint32_t frequency)
 {
   struct esp_i2s_s *priv = (struct esp_i2s_s *)dev;
@@ -2747,7 +2747,7 @@ static int i2s_rxchannels(struct i2s_dev_s *dev, uint8_t channels)
  *
  ****************************************************************************/
 
-static uint32_t i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
+static int32_t i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
 {
   struct esp_i2s_s *priv = (struct esp_i2s_s *)dev;
 
@@ -2805,7 +2805,7 @@ static uint32_t i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
  *
  ****************************************************************************/
 
-static uint32_t i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
+static int32_t i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
 {
   struct esp_i2s_s *priv = (struct esp_i2s_s *)dev;
 
@@ -2864,7 +2864,7 @@ static uint32_t i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
  *
  ****************************************************************************/
 
-static uint32_t i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
+static int32_t i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
 {
   struct esp_i2s_s *priv = (struct esp_i2s_s *)dev;
 
@@ -2914,7 +2914,7 @@ static uint32_t i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
  *
  ****************************************************************************/
 
-static uint32_t i2s_rxdatawidth(struct i2s_dev_s *dev, int bits)
+static int32_t i2s_rxdatawidth(struct i2s_dev_s *dev, int bits)
 {
   struct esp_i2s_s *priv = (struct esp_i2s_s *)dev;
 

--- a/arch/risc-v/src/rp23xx-rv/rp23xx_i2s.c
+++ b/arch/risc-v/src/rp23xx-rv/rp23xx_i2s.c
@@ -194,9 +194,9 @@ static int      i2s_checkwidth(struct rp23xx_i2s_s *priv, int bits);
 
 static int      rp23xx_i2s_txchannels(struct i2s_dev_s *dev,
                                       uint8_t channels);
-static uint32_t rp23xx_i2s_txsamplerate(struct i2s_dev_s *dev,
-                                        uint32_t rate);
-static uint32_t rp23xx_i2s_txdatawidth(struct i2s_dev_s *dev, int bits);
+static int32_t  rp23xx_i2s_txsamplerate(struct i2s_dev_s *dev,
+                                         uint32_t rate);
+static int32_t  rp23xx_i2s_txdatawidth(struct i2s_dev_s *dev, int bits);
 static int      rp23xx_i2s_send(struct i2s_dev_s *dev,
                                 struct ap_buffer_s *apb,
                                 i2s_callback_t callback, void *arg,
@@ -749,7 +749,7 @@ static int rp23xx_i2s_txchannels(struct i2s_dev_s *dev, uint8_t channels)
  *
  ****************************************************************************/
 
-static uint32_t rp23xx_i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
+static int32_t rp23xx_i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
 {
   struct rp23xx_i2s_s *priv = (struct rp23xx_i2s_s *)dev;
 
@@ -780,7 +780,7 @@ static uint32_t rp23xx_i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
  *
  ****************************************************************************/
 
-static uint32_t rp23xx_i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
+static int32_t rp23xx_i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
 {
   struct rp23xx_i2s_s *priv = (struct rp23xx_i2s_s *)dev;
   int ret;

--- a/arch/xtensa/src/common/espressif/esp_i2s.c
+++ b/arch/xtensa/src/common/espressif/esp_i2s.c
@@ -498,8 +498,8 @@ static void           i2s_rx_schedule(struct esp_i2s_s *priv,
 static int32_t  i2s_check_mclkfrequency(struct esp_i2s_s *priv);
 static uint32_t i2s_set_datawidth(struct esp_i2s_s *priv);
 static void i2s_set_clock(struct esp_i2s_s *priv);
-static uint32_t i2s_getmclkfrequency(struct i2s_dev_s *dev);
-static uint32_t i2s_setmclkfrequency(struct i2s_dev_s *dev,
+static int32_t  i2s_getmclkfrequency(struct i2s_dev_s *dev);
+static int32_t  i2s_setmclkfrequency(struct i2s_dev_s *dev,
                                      uint32_t frequency);
 static int      i2s_ioctl(struct i2s_dev_s *dev, int cmd, unsigned long arg);
 
@@ -507,8 +507,8 @@ static int      i2s_ioctl(struct i2s_dev_s *dev, int cmd, unsigned long arg);
 static void     i2s_tx_channel_start(struct esp_i2s_s *priv);
 static void     i2s_tx_channel_stop(struct esp_i2s_s *priv);
 static int      i2s_txchannels(struct i2s_dev_s *dev, uint8_t channels);
-static uint32_t i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate);
-static uint32_t i2s_txdatawidth(struct i2s_dev_s *dev, int bits);
+static int32_t  i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate);
+static int32_t  i2s_txdatawidth(struct i2s_dev_s *dev, int bits);
 static int      i2s_send(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
                          i2s_callback_t callback, void *arg,
                          uint32_t timeout);
@@ -518,8 +518,8 @@ static int      i2s_send(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
 static void     i2s_rx_channel_start(struct esp_i2s_s *priv);
 static void     i2s_rx_channel_stop(struct esp_i2s_s *priv);
 static int      i2s_rxchannels(struct i2s_dev_s *dev, uint8_t channels);
-static uint32_t i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate);
-static uint32_t i2s_rxdatawidth(struct i2s_dev_s *dev, int bits);
+static int32_t  i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate);
+static int32_t  i2s_rxdatawidth(struct i2s_dev_s *dev, int bits);
 static int      i2s_receive(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
                             i2s_callback_t callback, void *arg,
                             uint32_t timeout);
@@ -2590,7 +2590,7 @@ static int i2s_interrupt(int irq, void *context, void *arg)
  *
  ****************************************************************************/
 
-static uint32_t i2s_getmclkfrequency(struct i2s_dev_s *dev)
+static int32_t i2s_getmclkfrequency(struct i2s_dev_s *dev)
 {
   struct esp_i2s_s *priv = (struct esp_i2s_s *)dev;
 
@@ -2614,7 +2614,7 @@ static uint32_t i2s_getmclkfrequency(struct i2s_dev_s *dev)
  *
  ****************************************************************************/
 
-static uint32_t i2s_setmclkfrequency(struct i2s_dev_s *dev,
+static int32_t i2s_setmclkfrequency(struct i2s_dev_s *dev,
                                      uint32_t frequency)
 {
   struct esp_i2s_s *priv = (struct esp_i2s_s *)dev;
@@ -2767,7 +2767,7 @@ static int i2s_rxchannels(struct i2s_dev_s *dev, uint8_t channels)
  ****************************************************************************/
 
 #ifdef I2S_HAVE_TX
-static uint32_t i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
+static int32_t i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
 {
   struct esp_i2s_s *priv = (struct esp_i2s_s *)dev;
 
@@ -2809,7 +2809,7 @@ static uint32_t i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
  ****************************************************************************/
 
 #ifdef I2S_HAVE_RX
-static uint32_t i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
+static int32_t i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
 {
   struct esp_i2s_s *priv = (struct esp_i2s_s *)dev;
 
@@ -2852,7 +2852,7 @@ static uint32_t i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
  ****************************************************************************/
 
 #ifdef I2S_HAVE_TX
-static uint32_t i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
+static int32_t i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
 {
   struct esp_i2s_s *priv = (struct esp_i2s_s *)dev;
 
@@ -2890,7 +2890,7 @@ static uint32_t i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
  ****************************************************************************/
 
 #ifdef I2S_HAVE_RX
-static uint32_t i2s_rxdatawidth(struct i2s_dev_s *dev, int bits)
+static int32_t i2s_rxdatawidth(struct i2s_dev_s *dev, int bits)
 {
   struct esp_i2s_s *priv = (struct esp_i2s_s *)dev;
 

--- a/arch/xtensa/src/esp32/esp32_i2s.c
+++ b/arch/xtensa/src/esp32/esp32_i2s.c
@@ -336,8 +336,8 @@ static void           i2s_rx_schedule(struct esp32_i2s_s *priv,
 
 static uint32_t i2s_set_datawidth(struct esp32_i2s_s *priv);
 static uint32_t i2s_set_clock(struct esp32_i2s_s *priv);
-static uint32_t i2s_getmclkfrequency(struct i2s_dev_s *dev);
-static uint32_t i2s_setmclkfrequency(struct i2s_dev_s *dev,
+static int32_t  i2s_getmclkfrequency(struct i2s_dev_s *dev);
+static int32_t  i2s_setmclkfrequency(struct i2s_dev_s *dev,
                                      uint32_t frequency);
 static int      i2s_ioctl(struct i2s_dev_s *dev, int cmd, unsigned long arg);
 
@@ -345,8 +345,8 @@ static int      i2s_ioctl(struct i2s_dev_s *dev, int cmd, unsigned long arg);
 static void     i2s_tx_channel_start(struct esp32_i2s_s *priv);
 static void     i2s_tx_channel_stop(struct esp32_i2s_s *priv);
 static int      i2s_txchannels(struct i2s_dev_s *dev, uint8_t channels);
-static uint32_t i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate);
-static uint32_t i2s_txdatawidth(struct i2s_dev_s *dev, int bits);
+static int32_t  i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate);
+static int32_t  i2s_txdatawidth(struct i2s_dev_s *dev, int bits);
 static int      i2s_send(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
                          i2s_callback_t callback, void *arg,
                          uint32_t timeout);
@@ -356,8 +356,8 @@ static int      i2s_send(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
 static void     i2s_rx_channel_start(struct esp32_i2s_s *priv);
 static void     i2s_rx_channel_stop(struct esp32_i2s_s *priv);
 static int      i2s_rxchannels(struct i2s_dev_s *dev, uint8_t channels);
-static uint32_t i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate);
-static uint32_t i2s_rxdatawidth(struct i2s_dev_s *dev, int bits);
+static int32_t  i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate);
+static int32_t  i2s_rxdatawidth(struct i2s_dev_s *dev, int bits);
 static void     i2s_cleanup_queues(struct esp32_i2s_s *priv);
 static int      i2s_receive(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
                             i2s_callback_t callback, void *arg,
@@ -2349,7 +2349,7 @@ static int i2s_interrupt(int irq, void *context, void *arg)
  *
  ****************************************************************************/
 
-static uint32_t i2s_getmclkfrequency(struct i2s_dev_s *dev)
+static int32_t i2s_getmclkfrequency(struct i2s_dev_s *dev)
 {
   struct esp32_i2s_s *priv = (struct esp32_i2s_s *)dev;
 
@@ -2373,7 +2373,7 @@ static uint32_t i2s_getmclkfrequency(struct i2s_dev_s *dev)
  *
  ****************************************************************************/
 
-static uint32_t i2s_setmclkfrequency(struct i2s_dev_s *dev,
+static int32_t i2s_setmclkfrequency(struct i2s_dev_s *dev,
                                      uint32_t frequency)
 {
   struct esp32_i2s_s *priv = (struct esp32_i2s_s *)dev;
@@ -2481,7 +2481,7 @@ static int i2s_rxchannels(struct i2s_dev_s *dev, uint8_t channels)
  ****************************************************************************/
 
 #ifdef I2S_HAVE_TX
-static uint32_t i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
+static int32_t i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
 {
   struct esp32_i2s_s *priv = (struct esp32_i2s_s *)dev;
 
@@ -2518,7 +2518,7 @@ static uint32_t i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
  ****************************************************************************/
 
 #ifdef I2S_HAVE_RX
-static uint32_t i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
+static int32_t i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
 {
   struct esp32_i2s_s *priv = (struct esp32_i2s_s *)dev;
 
@@ -2556,7 +2556,7 @@ static uint32_t i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
  ****************************************************************************/
 
 #ifdef I2S_HAVE_TX
-static uint32_t i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
+static int32_t i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
 {
   struct esp32_i2s_s *priv = (struct esp32_i2s_s *)dev;
 
@@ -2594,7 +2594,7 @@ static uint32_t i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
  ****************************************************************************/
 
 #ifdef I2S_HAVE_RX
-static uint32_t i2s_rxdatawidth(struct i2s_dev_s *dev, int bits)
+static int32_t i2s_rxdatawidth(struct i2s_dev_s *dev, int bits)
 {
   struct esp32_i2s_s *priv = (struct esp32_i2s_s *)dev;
 

--- a/arch/xtensa/src/esp32s2/esp32s2_i2s.c
+++ b/arch/xtensa/src/esp32s2/esp32s2_i2s.c
@@ -320,8 +320,8 @@ static void i2s_rx_schedule(struct esp32s2_i2s_s *priv,
 
 static uint32_t i2s_set_datawidth(struct esp32s2_i2s_s *priv);
 static uint32_t i2s_set_clock(struct esp32s2_i2s_s *priv);
-static uint32_t i2s_getmclkfrequency(struct i2s_dev_s *dev);
-static uint32_t i2s_setmclkfrequency(struct i2s_dev_s *dev,
+static int32_t  i2s_getmclkfrequency(struct i2s_dev_s *dev);
+static int32_t  i2s_setmclkfrequency(struct i2s_dev_s *dev,
                                      uint32_t frequency);
 static int      i2s_ioctl(struct i2s_dev_s *dev, int cmd, unsigned long arg);
 
@@ -329,8 +329,8 @@ static int      i2s_ioctl(struct i2s_dev_s *dev, int cmd, unsigned long arg);
 static void     i2s_tx_channel_start(struct esp32s2_i2s_s *priv);
 static void     i2s_tx_channel_stop(struct esp32s2_i2s_s *priv);
 static int      i2s_txchannels(struct i2s_dev_s *dev, uint8_t channels);
-static uint32_t i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate);
-static uint32_t i2s_txdatawidth(struct i2s_dev_s *dev, int bits);
+static int32_t  i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate);
+static int32_t  i2s_txdatawidth(struct i2s_dev_s *dev, int bits);
 static int      i2s_send(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
                          i2s_callback_t callback, void *arg,
                          uint32_t timeout);
@@ -340,8 +340,8 @@ static int      i2s_send(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
 static void     i2s_rx_channel_start(struct esp32s2_i2s_s *priv);
 static void     i2s_rx_channel_stop(struct esp32s2_i2s_s *priv);
 static int      i2s_rxchannels(struct i2s_dev_s *dev, uint8_t channels);
-static uint32_t i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate);
-static uint32_t i2s_rxdatawidth(struct i2s_dev_s *dev, int bits);
+static int32_t  i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate);
+static int32_t  i2s_rxdatawidth(struct i2s_dev_s *dev, int bits);
 static int      i2s_receive(struct i2s_dev_s *dev, struct ap_buffer_s *apb,
                             i2s_callback_t callback, void *arg,
                             uint32_t timeout);
@@ -2063,7 +2063,7 @@ static void i2s_interrupt(void *arg)
  *
  ****************************************************************************/
 
-static uint32_t i2s_getmclkfrequency(struct i2s_dev_s *dev)
+static int32_t i2s_getmclkfrequency(struct i2s_dev_s *dev)
 {
   struct esp32s2_i2s_s *priv = (struct esp32s2_i2s_s *)dev;
 
@@ -2087,7 +2087,7 @@ static uint32_t i2s_getmclkfrequency(struct i2s_dev_s *dev)
  *
  ****************************************************************************/
 
-static uint32_t i2s_setmclkfrequency(struct i2s_dev_s *dev,
+static int32_t i2s_setmclkfrequency(struct i2s_dev_s *dev,
                                      uint32_t frequency)
 {
   struct esp32s2_i2s_s *priv = (struct esp32s2_i2s_s *)dev;
@@ -2211,7 +2211,7 @@ static int i2s_rxchannels(struct i2s_dev_s *dev, uint8_t channels)
  ****************************************************************************/
 
 #ifdef I2S_HAVE_TX
-static uint32_t i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
+static int32_t i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
 {
   struct esp32s2_i2s_s *priv = (struct esp32s2_i2s_s *)dev;
 
@@ -2248,7 +2248,7 @@ static uint32_t i2s_txsamplerate(struct i2s_dev_s *dev, uint32_t rate)
  ****************************************************************************/
 
 #ifdef I2S_HAVE_RX
-static uint32_t i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
+static int32_t i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
 {
   struct esp32s2_i2s_s *priv = (struct esp32s2_i2s_s *)dev;
 
@@ -2286,7 +2286,7 @@ static uint32_t i2s_rxsamplerate(struct i2s_dev_s *dev, uint32_t rate)
  ****************************************************************************/
 
 #ifdef I2S_HAVE_TX
-static uint32_t i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
+static int32_t i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
 {
   struct esp32s2_i2s_s *priv = (struct esp32s2_i2s_s *)dev;
 
@@ -2324,7 +2324,7 @@ static uint32_t i2s_txdatawidth(struct i2s_dev_s *dev, int bits)
  ****************************************************************************/
 
 #ifdef I2S_HAVE_RX
-static uint32_t i2s_rxdatawidth(struct i2s_dev_s *dev, int bits)
+static int32_t i2s_rxdatawidth(struct i2s_dev_s *dev, int bits)
 {
   struct esp32s2_i2s_s *priv = (struct esp32s2_i2s_s *)dev;
 

--- a/include/nuttx/audio/i2s.h
+++ b/include/nuttx/audio/i2s.h
@@ -166,7 +166,7 @@
  *   channel - The I2S channel num
  *
  * Returned Value:
- *   Returns the number of RX channels
+ *   Returns the number of RX channels or negated errno on failure.
  *
  ****************************************************************************/
 
@@ -187,7 +187,7 @@
  *   rate - The I2S sample rate in samples (not bits) per second
  *
  * Returned Value:
- *   Returns the resulting bitrate
+ *   Returns the resulting bitrate or negated errno on failure.
  *
  ****************************************************************************/
 
@@ -206,7 +206,7 @@
  *   width - The I2S data with in bits.
  *
  * Returned Value:
- *   Returns the resulting bitrate
+ *   Returns the resulting bitrate or negated errno on failure.
  *
  ****************************************************************************/
 
@@ -258,7 +258,7 @@
  *   channel - The I2S channel num
  *
  * Returned Value:
- *   Returns the number of TX channels
+ *   Returns the number of TX channels or negated errno on failure.
  *
  ****************************************************************************/
 
@@ -279,7 +279,7 @@
  *   rate - The I2S sample rate in samples (not bits) per second
  *
  * Returned Value:
- *   Returns the resulting bitrate
+ *   Returns the resulting bitrate or negated errno on failure.
  *
  ****************************************************************************/
 
@@ -298,7 +298,7 @@
  *   width - The I2S data with in bits.
  *
  * Returned Value:
- *   Returns the resulting bitrate
+ *   Returns the resulting bitrate or negated errno on failure.
  *
  ****************************************************************************/
 
@@ -418,10 +418,10 @@ struct i2s_ops_s
 
   CODE int      (*i2s_rxchannels)(FAR struct i2s_dev_s *dev,
                                   uint8_t channels);
-  CODE uint32_t (*i2s_rxsamplerate)(FAR struct i2s_dev_s *dev,
+  CODE int32_t  (*i2s_rxsamplerate)(FAR struct i2s_dev_s *dev,
                                     uint32_t rate);
-  CODE uint32_t (*i2s_rxdatawidth)(FAR struct i2s_dev_s *dev,
-                                   int bits);
+  CODE int32_t  (*i2s_rxdatawidth)(FAR struct i2s_dev_s *dev,
+                                  int bits);
   CODE int      (*i2s_receive)(FAR struct i2s_dev_s *dev,
                                FAR struct ap_buffer_s *apb,
                                i2s_callback_t callback,
@@ -432,9 +432,9 @@ struct i2s_ops_s
 
   CODE int      (*i2s_txchannels)(FAR struct i2s_dev_s *dev,
                                   uint8_t channels);
-  CODE uint32_t (*i2s_txsamplerate)(FAR struct i2s_dev_s *dev,
+  CODE int32_t  (*i2s_txsamplerate)(FAR struct i2s_dev_s *dev,
                                     uint32_t rate);
-  CODE uint32_t (*i2s_txdatawidth)(FAR struct i2s_dev_s *dev,
+  CODE int32_t  (*i2s_txdatawidth)(FAR struct i2s_dev_s *dev,
                                    int bits);
   CODE int      (*i2s_send)(FAR struct i2s_dev_s *dev,
                             FAR struct ap_buffer_s *apb,
@@ -444,8 +444,8 @@ struct i2s_ops_s
 
   /* Master Clock methods */
 
-  CODE uint32_t (*i2s_getmclkfrequency)(FAR struct i2s_dev_s *dev);
-  CODE uint32_t (*i2s_setmclkfrequency)(FAR struct i2s_dev_s *dev,
+  CODE int32_t  (*i2s_getmclkfrequency)(FAR struct i2s_dev_s *dev);
+  CODE int32_t  (*i2s_setmclkfrequency)(FAR struct i2s_dev_s *dev,
                                         uint32_t frequency);
 
   /* Ioctl */


### PR DESCRIPTION
## Summary

All I2S driver operation functions say in their signature description that negative errno values are returned on failure. However, some of these same functions had `uint32_t` return types. This would result in incorrect comparison of the return value against signed error code values.

## Impact

RELEASE

## Testing

CI