### PR TITLE
{bp-19324} drivers: pci: Fix EPC MSI IRQ map validation

### DIFF
--- a/drivers/pci/pci_epc.c
+++ b/drivers/pci/pci_epc.c
@@ -324,7 +324,8 @@ int pci_epc_map_msi_irq(FAR struct pci_epc_ctrl_s *epc, uint8_t funcno,
 {
   int ret;
 
-  if (epc == NULL && epc->ops->map_msi_irq == NULL)
+  if (epc == NULL || funcno >= epc->max_functions ||
+      epc->ops->map_msi_irq == NULL)
     {
       return -EINVAL;
     }


### PR DESCRIPTION
## Summary

pci_epc_map_msi_irq() used && when checking the EPC pointer and map_msi_irq callback. If epc is NULL, the right-hand side dereferences it; if the callback is NULL on a valid EPC, the guard does not reject it before the call.

Match the surrounding EPC wrappers by rejecting a NULL EPC, an out-of-range function number, or a missing map_msi_irq callback before taking the lock and invoking the operation.

Generated-by: OpenAI Codex

## Impact

RELEASE

## Testing

CI