### PR TITLE
{bp-19323} drivers/usbdev: rndis: Reject truncated responses

### DIFF
--- a/drivers/usbdev/rndis.c
+++ b/drivers/usbdev/rndis.c
@@ -2615,7 +2615,16 @@ static int usbclass_setup(FAR struct usbdevclass_driver_s *driver,
                       (struct rndis_response_header *)priv->response_queue;
                     ret = priv->response_queue_words * sizeof(uint32_t);
                     if (ret > len)
-                      ret = hdr->msglen;
+                      {
+                        if (hdr->msglen > len)
+                          {
+                            ret = -EMSGSIZE;
+                            break;
+                          }
+
+                        ret = hdr->msglen;
+                      }
+
                     memcpy(ctrlreq->buf, hdr, ret);
                     ctrlreq->priv = priv;
                   }


### PR DESCRIPTION
## Summary

When several RNDIS responses are queued, the control request handler sends one complete response if the host wLength is smaller than the whole queue. If the first queued response is also larger than wLength, copying hdr->msglen bytes would overrun the requested transfer and the completion path would consume a partial message.

Return EMSGSIZE before copying in that case so the queued response remains intact for a retry with a large enough wLength.

## Impact

RELEASE

## Testing

CI