### PR TITLE
{bp-19317} drivers: leds: Fix LP503X bank mode LED bounds

### DIFF
--- a/drivers/leds/lp503x.c
+++ b/drivers/leds/lp503x.c
@@ -829,6 +829,12 @@ static int lp503x_ioctl(struct file *filep, int cmd,
         break;
 
       case PWMIOC_ENABLE_LED_BANK_MODE: /* led(0..11), mode required */
+        if (lp503x_ioctl_args->lednum > MAX_RGB_LEDS)
+          {
+            ret = -EINVAL;
+            break;
+          }
+
         ledinfo("INFO: setting LED %d mode to %" PRIx32 "\n",
                 lp503x_ioctl_args->lednum,
                 lp503x_ioctl_args->param);


### PR DESCRIPTION
## Summary

PWMIOC_ENABLE_LED_BANK_MODE uses the provided LED number to index the LP503X led_mode array. Reject values outside the RGB LED range before writing that array.

Generated-by: OpenAI Codex

## Impact

RELEASE

## Testing

CI