### PR TITLE
{bp-19329} libc/stream: Check lowout bounds before access

### DIFF
--- a/libs/libc/stream/lib_lowoutstream.c
+++ b/libs/libc/stream/lib_lowoutstream.c
@@ -86,7 +86,7 @@ static ssize_t lowoutstream_puts(FAR struct lib_outstream_s *self,
   size_t idx          = 0;
   DEBUGASSERT(self);
 
-  while (str[idx] != 0 && idx < len)
+  while (idx < len && str[idx] != 0)
     {
       lowoutstream_putc(self, str[idx]);
       idx++;


### PR DESCRIPTION
## Summary

Check the provided length before reading the current lowoutstream byte. This avoids reading past zero-length or fully consumed buffers before the loop condition stops.

Generated-by: OpenAI Codex

## Impact

RELEASE

## Testing

CI