### PR TITLE
{bp-19316} drivers: 1wire: Fix DS2XXX device type bounds

### DIFF
--- a/drivers/1wire/1wire_ds2xxx.c
+++ b/drivers/1wire/1wire_ds2xxx.c
@@ -793,7 +793,7 @@ int ds2xxx_initialize(FAR struct onewire_dev_s *dev,
 {
   FAR struct ds2xxx_dev_s *priv;
 
-  if (devtype < 0 || devtype > EEPROM_DS_COUNT)
+  if (devtype < 0 || devtype >= EEPROM_DS_COUNT)
     {
       return -EINVAL;
     }


### PR DESCRIPTION
## Summary

EEPROM_DS_COUNT is the number of supported DS2XXX device types and is used as the size of the EEPROM geometry tables. Reject it before storing the device type for later table indexing.

Generated-by: OpenAI Codex

## Impact

RELEASE

## Testing

CI