### PR TITLE
arch/arm/ameba: fix per-IC asdk toolchain selection and fwlib archive hygiene

### DIFF
--- a/arch/arm/src/common/ameba/toolchain.mk
+++ b/arch/arm/src/common/ameba/toolchain.mk
@@ -24,9 +24,21 @@
 
 AMEBA_TOOLCHAIN_DIR ?= $(HOME)/rtk-toolchain
 
+# The asdk version is declared PER SoC-project (component/soc/<soc>/project/
+# CMakeLists.txt: "set(v_ASDK_VER ...)"), which OVERRIDES the top-level
+# cmake/global_define.cmake default.  RTL8720F pins 12.3.1 there while the
+# amebadplus default (and its own project) is 10.3.1 -- so read the per-SoC
+# file FIRST (AMEBA_SOC_NAME is set by the chip Make.defs before this include)
+# and fall back to the global default only when the SoC has no project file.
+# Getting this wrong links the NuttX image2 with the wrong ld and trips the
+# SDK's ROM-overlay ASSERT ("__romlib_bss_end__ is changed") on 8720F.
+AMEBA_ASDK_VER_SRC := $(wildcard \
+  $(AMEBA_SDK)/component/soc/$(AMEBA_SOC_NAME)/project/CMakeLists.txt) \
+  $(AMEBA_SDK)/cmake/global_define.cmake
+
 AMEBA_ASDK_VER := $(strip $(shell sed -n \
   's/.*v_ASDK_VER[ \t][ \t]*\([0-9.][0-9.]*\).*/\1/p' \
-  $(AMEBA_SDK)/cmake/global_define.cmake 2>/dev/null))
+  $(firstword $(AMEBA_ASDK_VER_SRC)) 2>/dev/null))
 
 ifneq ($(AMEBA_ASDK_VER),)
   AMEBA_ASDK_BUILD := $(strip $(shell sed -n \

--- a/arch/arm/src/common/ameba/tools/ameba_fetch_toolchain.sh
+++ b/arch/arm/src/common/ameba/tools/ameba_fetch_toolchain.sh
@@ -24,6 +24,7 @@ set -e
 
 SDK="$1"
 TOOLCHAIN_DIR="${2:-$HOME/rtk-toolchain}"
+SOC="$3"
 
 if [ -z "$SDK" ] || [ ! -f "$SDK/cmake/global_define.cmake" ]; then
   echo "ameba_fetch_toolchain.sh: bad SDK dir '$SDK'" >&2
@@ -31,9 +32,18 @@ if [ -z "$SDK" ] || [ ! -f "$SDK/cmake/global_define.cmake" ]; then
 fi
 
 # --- Read the pinned version from the SDK (the single source of truth) ------
+# The version is declared per SoC-project (component/soc/<soc>/project/
+# CMakeLists.txt) which OVERRIDES the top-level global_define.cmake default
+# (e.g. RTL8720F pins 12.3.1 vs the amebadplus 10.3.1 default).  Prefer the
+# per-SoC file when a SoC name is given, so a bare machine fetches the exact
+# toolchain the NuttX image2 link will use.
 
-VER=$(sed -n 's/.*v_ASDK_VER[ \t][ \t]*\([0-9.][0-9.]*\).*/\1/p' \
-      "$SDK/cmake/global_define.cmake")
+VER_SRC="$SDK/cmake/global_define.cmake"
+if [ -n "$SOC" ] && [ -f "$SDK/component/soc/$SOC/project/CMakeLists.txt" ]; then
+  VER_SRC="$SDK/component/soc/$SOC/project/CMakeLists.txt"
+fi
+
+VER=$(sed -n 's/.*v_ASDK_VER[ \t][ \t]*\([0-9.][0-9.]*\).*/\1/p' "$VER_SRC")
 TC_CMAKE="$SDK/cmake/toolchain/ameba-toolchain-asdk-$VER.cmake"
 if [ -z "$VER" ] || [ ! -f "$TC_CMAKE" ]; then
   echo "ameba_fetch_toolchain.sh: cannot resolve ASDK version from SDK" >&2
@@ -51,7 +61,19 @@ fi
 
 # Archive name + candidate URLs, read from the SDK toolchain cmake.  The cmake
 # offers an Aliyun (default) and a GitHub (USE_SECOND_SOURCE) mirror; try both.
-NAME="$MAJOR-linux-newlib-build-$BUILD-x86_64_with_small_reent.tar.bz2"
+#
+# The archive name differs per toolchain version (e.g. asdk-10.3.1 has a
+# "_with_small_reent" suffix, asdk-12.3.1 does not), so read the Linux
+# TOOLCHAINNAME template from the cmake and expand its ${ToolChainVer*} vars
+# instead of hardcoding the suffix -- hardcoding it 404s on 12.3.1.
+NAME=$(grep -E 'set\(TOOLCHAINNAME .*linux-newlib.*\.tar\.bz2' "$TC_CMAKE" \
+       | head -1 | sed -E 's/.*set\(TOOLCHAINNAME[ \t]+(.+)\).*/\1/')
+NAME=$(printf '%s' "$NAME" \
+       | sed -e "s/\${ToolChainVerMajor}/$MAJOR/g" -e "s/\${ToolChainVerMinor}/$BUILD/g")
+if [ -z "$NAME" ]; then
+  echo "ameba_fetch_toolchain.sh: cannot resolve toolchain archive name from $TC_CMAKE" >&2
+  exit 1
+fi
 URLS=$(sed -n 's/.*set(TOOLCHAINURL[ \t][ \t]*\(http[^ )]*\).*/\1/p' "$TC_CMAKE")
 if [ -z "$URLS" ]; then
   echo "ameba_fetch_toolchain.sh: no TOOLCHAINURL found in $TC_CMAKE" >&2

--- a/arch/arm/src/rtl8720f/ameba_board.mk
+++ b/arch/arm/src/rtl8720f/ameba_board.mk
@@ -245,14 +245,14 @@ AMEBA_NP_POSTBUILD = $(AMEBA_BUILD_NP_SH) $(AMEBA_SDK) $(AMEBA_PY_SOC) \
 define PREBUILD
 	$(Q) test -n "$(AMEBA_SDK)" || \
 	  { echo "ERROR: AMEBA_SDK is not set. Export it to your ameba-rtos checkout."; exit 1; }
-	$(Q) $(AMEBA_FETCH_TOOLCHAIN) $(AMEBA_SDK) $(AMEBA_TOOLCHAIN_DIR)
+	$(Q) $(AMEBA_FETCH_TOOLCHAIN) $(AMEBA_SDK) $(AMEBA_TOOLCHAIN_DIR) $(AMEBA_SOC_NAME)
 	$(Q) $(AMEBA_SETUP_ENV) $(AMEBA_SDK) $(AMEBA_TOOLCHAIN_DIR)
 	$(Q) $(AMEBA_GEN_AUTOCONF) $(AMEBA_SDK) $(AMEBA_PY_SOC) $(AMEBA_AP_PROJECT) \
 	     $(AMEBA_AUTOCONF)
 	$(Q) $(AMEBA_NP_PREBUILD)
 	$(Q) echo "GEN: libameba_fwlib.a (fwlib from SDK source)"
 	$(Q) mkdir -p $(AMEBA_PREBUILT_LIBS)$(DELIM)fwlib_obj
-	$(Q) rebuild_fwlib=0; \
+	$(Q) rebuild_fwlib=0; fwlib_objs=""; \
 	     for src in $(AMEBA_FWLIB_SRCS); do \
 	       obj=$(AMEBA_PREBUILT_LIBS)/fwlib_obj/`basename $$src .c`.o; \
 	       if [ "$$src" -nt "$$obj" ] 2>/dev/null || [ ! -f "$$obj" ]; then \
@@ -260,14 +260,16 @@ define PREBUILD
 	           $(AMEBA_FWLIB_INC) -c $$src -o $$obj || exit 1; \
 	         rebuild_fwlib=1; \
 	       fi; \
+	       fwlib_objs="$$fwlib_objs $$obj"; \
 	     done; \
 	     if [ "$$rebuild_fwlib" = "1" ] || [ ! -f "$(AMEBA_FWLIB_A)" ]; then \
-	       $(CROSSDEV)ar crs $(AMEBA_FWLIB_A) $(AMEBA_PREBUILT_LIBS)/fwlib_obj/*.o; \
+	       rm -f $(AMEBA_FWLIB_A); \
+	       $(CROSSDEV)ar crs $(AMEBA_FWLIB_A) $$fwlib_objs; \
 	     fi
 	$(Q) if [ "$(CONFIG_RTL8720F_WIFI)" = "y" ]; then \
 	       echo "GEN: libameba_wifi.a (WHC host glue from SDK source + NuttX shim)"; \
 	       mkdir -p $(AMEBA_PREBUILT_LIBS)$(DELIM)wifi_obj; \
-	       rebuild_wifi=0; \
+	       rebuild_wifi=0; wifi_objs=""; \
 	       for src in $(AMEBA_WIFI_SRCS); do \
 	         obj=$(AMEBA_PREBUILT_LIBS)/wifi_obj/`basename $$src .c`.o; \
 	         if [ "$$src" -nt "$$obj" ] 2>/dev/null || [ ! -f "$$obj" ]; then \
@@ -275,9 +277,11 @@ define PREBUILD
 	             $(AMEBA_WIFI_INC) -c $$src -o $$obj || exit 1; \
 	           rebuild_wifi=1; \
 	         fi; \
+	         wifi_objs="$$wifi_objs $$obj"; \
 	       done; \
 	       if [ "$$rebuild_wifi" = "1" ] || [ ! -f "$(AMEBA_WIFI_A)" ]; then \
-	         $(CROSSDEV)ar crs $(AMEBA_WIFI_A) $(AMEBA_PREBUILT_LIBS)/wifi_obj/*.o; \
+	         rm -f $(AMEBA_WIFI_A); \
+	         $(CROSSDEV)ar crs $(AMEBA_WIFI_A) $$wifi_objs; \
 	       fi; \
 	     fi
 	$(Q) echo "GEN: ld.script.gen (Ameba KM4 image2)"

--- a/arch/arm/src/rtl8721dx/ameba_board.mk
+++ b/arch/arm/src/rtl8721dx/ameba_board.mk
@@ -246,14 +246,14 @@ AMEBA_NP_POSTBUILD = $(AMEBA_BUILD_NP_SH) $(AMEBA_SDK) $(AMEBA_PY_SOC) \
 define PREBUILD
 	$(Q) test -n "$(AMEBA_SDK)" || \
 	  { echo "ERROR: AMEBA_SDK is not set. Export it to your ameba-rtos checkout."; exit 1; }
-	$(Q) $(AMEBA_FETCH_TOOLCHAIN) $(AMEBA_SDK) $(AMEBA_TOOLCHAIN_DIR)
+	$(Q) $(AMEBA_FETCH_TOOLCHAIN) $(AMEBA_SDK) $(AMEBA_TOOLCHAIN_DIR) $(AMEBA_SOC_NAME)
 	$(Q) $(AMEBA_SETUP_ENV) $(AMEBA_SDK) $(AMEBA_TOOLCHAIN_DIR)
 	$(Q) $(AMEBA_GEN_AUTOCONF) $(AMEBA_SDK) $(AMEBA_PY_SOC) $(AMEBA_AP_PROJECT) \
 	     $(AMEBA_AUTOCONF)
 	$(Q) $(AMEBA_NP_PREBUILD)
 	$(Q) echo "GEN: libameba_fwlib.a (fwlib from SDK source)"
 	$(Q) mkdir -p $(AMEBA_PREBUILT_LIBS)$(DELIM)fwlib_obj
-	$(Q) rebuild_fwlib=0; \
+	$(Q) rebuild_fwlib=0; fwlib_objs=""; \
 	     for src in $(AMEBA_FWLIB_SRCS); do \
 	       obj=$(AMEBA_PREBUILT_LIBS)/fwlib_obj/`basename $$src .c`.o; \
 	       if [ "$$src" -nt "$$obj" ] 2>/dev/null || [ ! -f "$$obj" ]; then \
@@ -261,14 +261,16 @@ define PREBUILD
 	           $(AMEBA_FWLIB_INC) -c $$src -o $$obj || exit 1; \
 	         rebuild_fwlib=1; \
 	       fi; \
+	       fwlib_objs="$$fwlib_objs $$obj"; \
 	     done; \
 	     if [ "$$rebuild_fwlib" = "1" ] || [ ! -f "$(AMEBA_FWLIB_A)" ]; then \
-	       $(CROSSDEV)ar crs $(AMEBA_FWLIB_A) $(AMEBA_PREBUILT_LIBS)/fwlib_obj/*.o; \
+	       rm -f $(AMEBA_FWLIB_A); \
+	       $(CROSSDEV)ar crs $(AMEBA_FWLIB_A) $$fwlib_objs; \
 	     fi
 	$(Q) if [ "$(CONFIG_RTL8721DX_WIFI)" = "y" ]; then \
 	       echo "GEN: libameba_wifi.a (WHC host glue from SDK source + NuttX shim)"; \
 	       mkdir -p $(AMEBA_PREBUILT_LIBS)$(DELIM)wifi_obj; \
-	       rebuild_wifi=0; \
+	       rebuild_wifi=0; wifi_objs=""; \
 	       for src in $(AMEBA_WIFI_SRCS); do \
 	         obj=$(AMEBA_PREBUILT_LIBS)/wifi_obj/`basename $$src .c`.o; \
 	         if [ "$$src" -nt "$$obj" ] 2>/dev/null || [ ! -f "$$obj" ]; then \
@@ -276,9 +278,11 @@ define PREBUILD
 	             $(AMEBA_WIFI_INC) -c $$src -o $$obj || exit 1; \
 	           rebuild_wifi=1; \
 	         fi; \
+	         wifi_objs="$$wifi_objs $$obj"; \
 	       done; \
 	       if [ "$$rebuild_wifi" = "1" ] || [ ! -f "$(AMEBA_WIFI_A)" ]; then \
-	         $(CROSSDEV)ar crs $(AMEBA_WIFI_A) $(AMEBA_PREBUILT_LIBS)/wifi_obj/*.o; \
+	         rm -f $(AMEBA_WIFI_A); \
+	         $(CROSSDEV)ar crs $(AMEBA_WIFI_A) $$wifi_objs; \
 	       fi; \
 	     fi
 	$(Q) echo "GEN: ld.script.gen (Ameba AP km4 image2)"


### PR DESCRIPTION
## Summary

Two independent Ameba build-system fixes:

* **Per-IC asdk toolchain selection.** The asdk (arm-none-eabi) toolchain
  version is declared per SoC-project (`component/soc/<soc>/project/CMakeLists.txt:
  v_ASDK_VER`), overriding the top-level `cmake/global_define.cmake` default. The
  RTL8720F project declares 12.3.1 while the amebadplus (RTL8721Dx) subtree
  default is 10.3.1, but `toolchain.mk` / `ameba_fetch_toolchain.sh` only read the
  top-level default, so RTL8720F was built with the wrong toolchain (10.3.1
  instead of its declared 12.3.1). Now the per-SoC CMakeLists is read first (via
  `AMEBA_SOC_NAME`), falling back to the global default.

* **fwlib/wifi archive hygiene.** `libameba_fwlib.a` / `libameba_wifi.a` were
  archived with a `fwlib_obj/*.o` wildcard, but `distclean` does not clean the
  gitignored prebuilt object dir. On an incremental build after the source list
  changed, a stale object (e.g. `log.o`, whose `.bss` is ROM-resident) was
  silently re-archived and dragged into the link, tripping the SDK ROM-overlay
  assert (`__romlib_bss_end__ is changed`). A clean build is unaffected. Now only
  the explicit object list from `AMEBA_FWLIB_SRCS` / `AMEBA_WIFI_SRCS` is
  archived, and the archive is removed before rebuilding so it never accumulates.

## Impact

* Is new feature added / existing changed? NO (build-system fixes only).
* Impact on user? NO.
* Impact on build? YES — RTL8720F now uses its declared 12.3.1 toolchain, and
  incremental builds no longer trip the ROM-overlay assert from a stale object.
  RTL8721Dx is unaffected (10.3.1, now selected explicitly per-SoC).
* Impact on hardware? NO logic change; affects the arch/arm/ameba build only.
* Impact on documentation? NO.
* Impact on security? NO.
* Impact on compatibility? NO (self-contained to arch/arm/ameba).

## Testing

Build Host: Ubuntu (WSL2), x86_64; Realtek asdk arm-none-eabi-gcc auto-fetched by
the board build.
Targets: `pke8721daf:nsh` (RTL8721Dx), `rtl8720f_evb:nsh` (RTL8720F).

Before change — incremental RTL8720F build with a stale prebuilt object:

```
LD: nuttx
arm-none-eabi-ld: __romlib_bss_end__ is changed. Common bss of rom_lib and
rom_tz may be modified illegally.
make[1]: *** [Makefile:230: nuttx] Error 1
```

After change — both boards build clean; RTL8720F now selects asdk-12.3.1:

```
# rtl8720f_evb:nsh   -> asdk-12.3.1-4600
PACK: wrote {app.bin, boot.bin, km4ns_image2_all.bin}
# pke8721daf:nsh     -> asdk-10.3.1-4602
PACK: wrote {app.bin, boot.bin, km0_image2_all.bin}
```

Both images boot to NSH on hardware (boot/iperf logs in the WiFi PR).

## PR verification Self-Check

* [x] This PR introduces only one functional change (Ameba build-system).
* [x] I have updated all required description fields above.
* [x] My PR adheres to Contributing Guidelines (commit title/message, coding standard).
* [ ] My PR is still work in progress (not ready for review).
