### PR TITLE
Documentation: rework Realtek RTL8721Dx and RTL8720F chip/board pages

### DIFF
--- a/Documentation/platforms/arm/rtl8720f/boards/rtl8720f_evb/index.rst
+++ b/Documentation/platforms/arm/rtl8720f/boards/rtl8720f_evb/index.rst
@@ -9,36 +9,28 @@ RTL8720F EVB
    Add a photo of the RTL8720F EVB board here as ``rtl8720f_evb.png`` in this
    directory, referenced with a ``.. figure::`` directive.
 
-The RTL8720F EVB is a Realtek RTL8720F (dual-core Wi-Fi Host Controller)
-evaluation board. NuttX runs on the KM4TZ (Cortex-M33, secure world)
-application core as the Wi-Fi host; the KM4NS network processor runs the
-prebuilt vendor Wi-Fi firmware. See the
-:doc:`RTL8720F chip documentation <../../index>` for the SoC architecture,
-memory map and vendor-SDK dependency.
+The RTL8720F EVB is a Realtek RTL8720F evaluation board built around the
+RTL8720FBF (QFN40, 4 MB NOR flash). NuttX runs on the KM4TZ application core —
+an Arm Cortex-M55-compatible core running at up to 320 MHz. See the
+:doc:`RTL8720F chip documentation <../../index>` for the full SoC
+specifications and the vendor-SDK dependency.
 
 Features
 ========
 
-* RTL8720F dual-core Wi-Fi Host Controller (KM4TZ Cortex-M33 secure host +
-  KM4NS NP)
-* 2.4 GHz Wi-Fi (station and SoftAP)
-* SPI NOR flash (shared with the NP, XIP)
+* RTL8720FBF: Arm Cortex-M55-compatible KM4TZ core up to 320 MHz, 512 KB SRAM,
+  4 MB NOR flash
+* Wi-Fi 6 (802.11 b/g/n/ax), 2.4 GHz station and SoftAP
+* SPI NOR flash (XIP)
 * LOG-UART console
 
 Supported in this NuttX port:
 
-* NSH shell over the LOG-UART console (NuttX owns LOG-UART RX directly; the NP
-  shell is disabled)
+* NSH shell over the LOG-UART console
 * littlefs persistent storage mounted at ``/data`` (a dedicated SPI NOR flash
   partition), backing the Wi-Fi key-value store
 * Wi-Fi station and SoftAP through the ``wapi`` tool
 * DHCP client (STA) and DHCP server (SoftAP)
-
-.. note::
-
-   The Wi-Fi MAC/PHY is driven by the prebuilt vendor firmware on the KM4NS
-   network processor. NuttX is the Wi-Fi host and exchanges frames with the NP
-   over the on-chip IPC transport; see the chip documentation.
 
 Buttons and LEDs
 ================
@@ -91,8 +83,9 @@ Realtek ``arm-none-eabi`` toolchain must be on ``PATH``; see the
    $ ./tools/configure.sh rtl8720f_evb:nsh
    $ make
 
-This produces ``nuttx/app.bin`` (the NuttX KM4TZ image2), ``boot.bin`` and the
-NP (KM4NS) image in the build directory.
+This produces the two flashable images in the build directory: ``app.bin``
+(the NuttX application image, which also bundles the prebuilt Wi-Fi firmware)
+and ``boot.bin`` (the bootloader).
 
 After a successful build, flash via one of these methods:
 
@@ -126,6 +119,6 @@ License Exceptions
 This board depends on Realtek vendor code that is not part of NuttX and is
 subject to its own license:
 
-* The prebuilt KM4NS (NP) Wi-Fi firmware image and the Realtek ``ameba-rtos``
+* The prebuilt Wi-Fi / Bluetooth firmware image and the Realtek ``ameba-rtos``
   SDK libraries/headers linked into the image. See the SDK's own license; the
   SDK is auto-fetched and is not redistributed in the NuttX tree.

--- a/Documentation/platforms/arm/rtl8720f/index.rst
+++ b/Documentation/platforms/arm/rtl8720f/index.rst
@@ -2,55 +2,70 @@
 Realtek RTL8720F
 ================
 
-The Realtek RTL8720F is a dual-core Wi-Fi Host Controller (WHC) SoC, similar in
-scheme to the :doc:`RTL8721Dx <../rtl8721dx/index>`:
+The Realtek RTL8720F is a low-power multi-protocol wireless SoC from the
+Realtek Ameba IoT family, combining 2.4 GHz Wi-Fi 6, Bluetooth LE and Thread
+(IEEE 802.15.4) connectivity, and 2.4 GHz Wi-Fi radar sensing.
 
-- **KM4TZ** — an ARM Cortex-M33 (ARMv8-M.main, with FPU) application/host core
-  running in the TrustZone secure world. NuttX runs here.
-- **KM4NS** — the non-secure network-processor (NP) core that owns the Wi-Fi
-  MAC/PHY and runs a prebuilt vendor firmware image.
+NuttX runs on the **KM4TZ application core** — an Arm Cortex-M55-compatible
+core (Real-M300, Armv8.1-M) running at up to **320 MHz**, with a
+single-precision FPU, DSP extensions and Arm TrustZone-M.
 
-NuttX is the Wi-Fi *host*: it talks to the NP over the on-chip IPC transport
-(WHC) while the NP drives the radio. The IC-agnostic glue (os_wrapper backend,
-netdev, key-value store, flash MTD, WHC Wi-Fi glue) is shared from
-``arch/arm/src/common/ameba`` with the other Ameba WHC parts; only the
-register-level drivers are IC-specific.
-
-Memory Map
+Highlights
 ==========
 
-============ ============= ======
-Block Name   Start Address Length
-============ ============= ======
-SRAM         0x20000000    512K
-============ ============= ======
+- **CPU:** Arm Cortex-M55-compatible application core, up to 320 MHz, with
+  FPU + DSP instructions, TrustZone-M and instruction/data caches.
+- **Memory:** 512 KB on-chip SRAM; external QSPI NOR flash (up to 104 MHz)
+  and/or DDR PSRAM (up to 200 MHz), depending on the part number.
+- **Wireless:** Wi-Fi 6 (802.11 b/g/n/ax), 2.4 GHz, up to 114.7 Mbps,
+  WPA/WPA2/WPA3; Bluetooth LE 5.x; Thread (IEEE 802.15.4); and 2.4 GHz Wi-Fi
+  radar sensing (CSI/RSSI).
+- **Peripherals:** UART, SPI, I2C, I2S, SDIO, PWM, ADC, IR, GDMA, RTC and
+  watchdogs (count varies by package); some I/O groups support 5 V levels.
+- **Security:** Secure Boot, TrustZone-M, AES/SHA and ECDSA/RSA crypto
+  engines, Flash decryption, OTP, and a true random number generator.
+- **Package:** QFN40.
 
-The KM4TZ runs in the secure world, so the SRAM is also visible through the
-secure alias at ``0x30000000``. The KM4TZ image2 RAM window is a slice of that
-SRAM; the flash is a SPI NOR shared with the NP.
+Memory
+======
+
+============ ============= =======
+Block        Start Address Length
+============ ============= =======
+SRAM         0x2000_0000   512 KB
+============ ============= =======
+
+The on-chip SRAM holds the system heap and application. The flash is an SPI
+NOR accessed through the SDK XIP path. The exact flash / PSRAM size depends on
+the part number — for example the RTL8720FBF has 4 MB of NOR flash and no
+PSRAM.
 
 Vendor SDK Dependency
 =====================
 
 The build depends on Realtek's open ``ameba-rtos`` SDK, which is **not** part
-of the NuttX tree. The first build auto-fetches the pinned revision (a shallow
-``git clone`` of ``https://gitee.com/ameba-aiot/ameba-rtos.git``) into
-``arch/arm/src/common/ameba/ameba-rtos`` (git-ignored) and applies the
-out-of-SDK build patch under ``arch/arm/src/common/ameba/patches``. To use a
-local checkout instead of auto-fetching, export ``AMEBA_SDK`` to its path.
+of the NuttX tree. It provides the Wi-Fi / Bluetooth firmware and the
+low-level chip libraries. The first build auto-fetches the pinned revision (a
+shallow ``git clone`` of ``https://github.com/Ameba-AIoT/ameba-rtos.git``) into
+``arch/arm/src/common/ameba/ameba-rtos`` (git-ignored) and builds against it
+unmodified. To use a local checkout instead of auto-fetching, export
+``AMEBA_SDK`` to its path.
+
+Toolchain
+=========
 
 A matching Realtek ARM toolchain (``arm-none-eabi`` from the Realtek asdk
-release) is required; NuttX links its own libc/libm and reuses the SDK's
-``app_start()`` as the image2 entry point.
+release) is required and is fetched automatically by the board build. NuttX
+links its own libc / libm and reuses the SDK's ``app_start()`` as the image
+entry point.
 
 Supported Features
 ==================
 
-- NSH over the LOG-UART console (NuttX owns LOG-UART RX directly; the NP shell
-  is disabled)
-- littlefs persistent storage at ``/data`` on the SPI NOR
-- Wi-Fi STA (scan / connect) and SoftAP via the ``wapi`` tool
-- Networking over the WHC netdev (NuttX TCP/IP stack), DHCP client and server
+- NSH over the LOG-UART console
+- littlefs persistent storage at ``/data`` on the SPI NOR flash
+- Wi-Fi station (scan / connect) and SoftAP via the ``wapi`` tool
+- Networking on NuttX's own TCP/IP stack, with DHCP client and DHCP server
 
 Boards
 ======

--- a/Documentation/platforms/arm/rtl8721dx/boards/pke8721daf/index.rst
+++ b/Documentation/platforms/arm/rtl8721dx/boards/pke8721daf/index.rst
@@ -11,18 +11,19 @@ PKE8721DAF
 
    The PKE8721DAF development board.
 
-The PKE8721DAF is a Realtek RTL8721Dx (dual-core Wi-Fi Host Controller)
-development board. NuttX runs on the KM4 (Cortex-M33) application core as the
-Wi-Fi host; the KM0 network processor runs the prebuilt vendor Wi-Fi firmware.
-See the :doc:`RTL8721Dx chip documentation <../../index>` for the SoC
-architecture, memory map and vendor-SDK dependency.
+The PKE8721DAF is a Realtek RTL8721Dx development board built around the
+RTL8721DAF (QFN48, 4 MB NOR flash). NuttX runs on the KM4 application core —
+an Arm Cortex-M55-compatible core running at up to 345 MHz. See the
+:doc:`RTL8721Dx chip documentation <../../index>` for the full SoC
+specifications and the vendor-SDK dependency.
 
 Features
 ========
 
-* RTL8721Dx dual-core Wi-Fi Host Controller (KM4 Cortex-M33 host + KM0 NP)
-* 2.4 GHz Wi-Fi (station and SoftAP)
-* SPI NOR flash (shared with the NP, XIP)
+* RTL8721DAF: Arm Cortex-M55-compatible KM4 core up to 345 MHz, 512 KB SRAM,
+  4 MB NOR flash
+* Wi-Fi 4 dual-band (2.4 / 5 GHz) station and SoftAP
+* SPI NOR flash (XIP)
 * LOG-UART console
 
 Supported in this NuttX port:
@@ -32,12 +33,6 @@ Supported in this NuttX port:
   partition), backing the Wi-Fi key-value store
 * Wi-Fi station and SoftAP through the ``wapi`` tool
 * DHCP client (STA) and DHCP server (SoftAP)
-
-.. note::
-
-   The Wi-Fi MAC/PHY is driven by the prebuilt vendor firmware on the KM0
-   network processor. NuttX is the Wi-Fi host and exchanges frames with the NP
-   over the on-chip IPC transport; see the chip documentation.
 
 Buttons and LEDs
 ================
@@ -90,8 +85,9 @@ Realtek ``arm-none-eabi`` toolchain must be on ``PATH``; see the
    $ ./tools/configure.sh pke8721daf:nsh
    $ make
 
-This produces ``nuttx/app.bin`` (the NuttX KM4 image2), ``boot.bin`` and the
-NP (KM0) image in the build directory.
+This produces the two flashable images in the build directory: ``app.bin``
+(the NuttX application image, which also bundles the prebuilt Wi-Fi firmware)
+and ``boot.bin`` (the bootloader).
 
 After a successful build, flash via one of these methods:
 
@@ -125,6 +121,6 @@ License Exceptions
 This board depends on Realtek vendor code that is not part of NuttX and is
 subject to its own license:
 
-* The prebuilt KM0 (NP) Wi-Fi firmware image and the Realtek ``ameba-rtos``
+* The prebuilt Wi-Fi / Bluetooth firmware image and the Realtek ``ameba-rtos``
   SDK libraries/headers linked into the image. See the SDK's own license; the
   SDK is auto-fetched and is not redistributed in the NuttX tree.

--- a/Documentation/platforms/arm/rtl8721dx/index.rst
+++ b/Documentation/platforms/arm/rtl8721dx/index.rst
@@ -2,54 +2,72 @@
 Realtek RTL8721Dx
 =================
 
-The Realtek RTL8721Dx is a dual-core Wi-Fi Host Controller (WHC) SoC:
+The Realtek RTL8721Dx is a low-power dual-band Wi-Fi and Bluetooth LE SoC from
+the Realtek Ameba IoT family, targeting smart-home control, wireless audio,
+battery-powered cameras, smart locks and other IoT products.
 
-- **KM4** — an ARM Cortex-M33 (ARMv8-M.main, with FPU) application/host core.
-  NuttX runs here.
-- **KM0** — the network-processor (NP) core that owns the Wi-Fi MAC/PHY and
-  runs a prebuilt vendor firmware image.
+NuttX runs on the **KM4 application core** — an Arm Cortex-M55-compatible core
+(Real-M300, Armv8.1-M) running at up to **345 MHz**, with a single-precision
+FPU, DSP extensions and Arm TrustZone-M.
 
-NuttX is the Wi-Fi *host*: it talks to the NP over the on-chip IPC transport
-(WHC, ``WHC_HOST`` + ``WHC_INTF_IPC``) while the NP drives the radio. The
-IC-agnostic glue (os_wrapper backend, netdev, key-value store, flash MTD, WHC
-Wi-Fi glue) is shared from ``arch/arm/src/common/ameba`` with the other Ameba
-WHC parts; only the register-level drivers are IC-specific.
-
-Memory Map
+Highlights
 ==========
 
-============ ============= ======
-Block Name   Start Address Length
-============ ============= ======
-SRAM (KM4)   0x20020000    288K
-============ ============= ======
+- **CPU:** Arm Cortex-M55-compatible application core, up to 345 MHz, with
+  FPU + DSP instructions, TrustZone-M, and 16 KB I-Cache + 16 KB D-Cache.
+- **Memory:** 512 KB on-chip SRAM; external QSPI NOR flash (up to 104 MHz)
+  and/or DDR PSRAM (up to 200 MHz), depending on the part number.
+- **Wireless:** Wi-Fi 4 (802.11 a/b/g/n), dual-band 2.4 GHz / 5 GHz, 1T1R, up
+  to 150 Mbps, WPA/WPA2/WPA3; Bluetooth LE 5.0.
+- **Peripherals:** UART x4, I2C x2, SPI x2, QSPI/OSPI, I2S x2, DMIC x2,
+  PWM x8, ADC + cap-touch, USB 2.0 full-speed device, SDIO device, IR, RTC,
+  independent/system watchdogs, GDMA, and up to 64 GPIO (count varies by
+  package).
+- **Security:** Secure Boot, TrustZone-M, AES/SHA hardware crypto engine, OTP,
+  and a true random number generator (PSA Level 2).
+- **Packages:** QFN48, QFN68 and BGA100.
 
-The KM4 image2 RAM window is a slice of the on-chip SRAM; the flash is a SPI
-NOR accessed via the SDK XIP path and shared with the NP.
+Memory
+======
+
+============ ============= =======
+Block        Start Address Length
+============ ============= =======
+SRAM         0x2000_0000   512 KB
+============ ============= =======
+
+The on-chip SRAM holds the system heap and application. The flash is an SPI
+NOR accessed through the SDK XIP path. The exact flash / PSRAM size depends on
+the part number — for example the RTL8721DAF has 4 MB of NOR flash and no
+PSRAM.
 
 Vendor SDK Dependency
 =====================
 
 The build depends on Realtek's open ``ameba-rtos`` SDK, which is **not** part
-of the NuttX tree. The first build auto-fetches the pinned revision (a shallow
-``git clone`` of ``https://gitee.com/ameba-aiot/ameba-rtos.git``) into
-``arch/arm/src/common/ameba/ameba-rtos`` (git-ignored) and applies the
-out-of-SDK build patch under ``arch/arm/src/common/ameba/patches``. To use a
-local checkout instead of auto-fetching, export ``AMEBA_SDK`` to its path.
+of the NuttX tree. It provides the Wi-Fi / Bluetooth firmware and the
+low-level chip libraries. The first build auto-fetches the pinned revision (a
+shallow ``git clone`` of ``https://github.com/Ameba-AIoT/ameba-rtos.git``) into
+``arch/arm/src/common/ameba/ameba-rtos`` (git-ignored) and builds against it
+unmodified. To use a local checkout instead of auto-fetching, export
+``AMEBA_SDK`` to its path.
+
+Toolchain
+=========
 
 A matching Realtek ARM toolchain (``arm-none-eabi`` from the Realtek asdk
-release) is required; NuttX links its own libc/libm and reuses the SDK's
-``app_start()`` as the image2 entry point.
+release) is required and is fetched automatically by the board build. NuttX
+links its own libc / libm and reuses the SDK's ``app_start()`` as the image
+entry point.
 
 Supported Features
 ==================
 
 - NSH over the LOG-UART console
-- littlefs persistent storage at ``/data`` on the SPI NOR (a dedicated flash
+- littlefs persistent storage at ``/data`` on the SPI NOR flash (a dedicated
   partition), backing the Wi-Fi key-value store
-- Wi-Fi STA (scan / connect) and SoftAP via the ``wapi`` tool
-- Networking (lwIP-free: NuttX's own TCP/IP stack over the WHC netdev),
-  DHCP client and DHCP server
+- Wi-Fi station (scan / connect) and SoftAP via the ``wapi`` tool
+- Networking on NuttX's own TCP/IP stack, with DHCP client and DHCP server
 
 Boards
 ======


### PR DESCRIPTION
## Summary
  Rewrite the RTL8721Dx / PKE8721DAF and RTL8720F / RTL8720F-EVB documentation
  pages against the official Realtek product specifications, from an
  application-developer point of view:
  
  - Describe the application core NuttX runs on — an Arm Cortex-M55-compatible
    core, up to 345 MHz on RTL8721Dx (KM4) and 320 MHz on RTL8720F (KM4TZ) — and
    the on-chip memory, instead of the internal multi-core / IPC arrangement that
    is not relevant to application developers.
  - Fix the RTL8721Dx SRAM size: 512 KB (was incorrectly documented as 288 KB).
  - Add per-part memory, wireless, peripheral and security highlights
    (RTL8721Dx: Wi-Fi 4 dual-band + BLE 5.0; RTL8720F: Wi-Fi 6 2.4 GHz + BLE +
    Thread; RTL8721DAF / RTL8720FBF: 4 MB NOR flash, 512 KB SRAM).
  - Correct the SDK source URL (github.com/Ameba-AIoT/ameba-rtos) and drop stale
    claims (out-of-SDK patch, "BLE not yet").

  ## Impact
  
  Documentation only — no code, build, or functional change. Touches
  `Documentation/platforms/arm/rtl8721dx/` and `.../rtl8720f/` pages.
  
  ## Testing
  
  Proofread the reStructuredText against the official Realtek specifications and
  verified the pages render (Sphinx doc build) with correct formatting and
  cross-references. No source paths are affected.