### PR TITLE
boards/arm: Ameba produce nuttx.bin and derive flash offsets from the SDK layout

### DIFF
--- a/Documentation/platforms/arm/rtl8720f/boards/rtl8720f_evb/index.rst
+++ b/Documentation/platforms/arm/rtl8720f/boards/rtl8720f_evb/index.rst
@@ -83,9 +83,11 @@ Realtek ``arm-none-eabi`` toolchain must be on ``PATH``; see the
    $ ./tools/configure.sh rtl8720f_evb:nsh
    $ make
 
-This produces the two flashable images in the build directory: ``app.bin``
-(the NuttX application image, which also bundles the prebuilt Wi-Fi firmware)
-and ``boot.bin`` (the bootloader).
+This produces ``nuttx.bin`` in the top-level build directory: the NuttX
+application image, which also bundles the prebuilt Wi-Fi firmware.  The
+bootloader ``boot.bin`` is a prebuilt binary kept under the board's
+``prebuilt/`` directory; ``make flash`` writes both at the flash offsets
+taken from the generated flash layout, so no offsets are entered by hand.
 
 After a successful build, flash via one of these methods:
 
@@ -99,8 +101,8 @@ built-in ``make flash`` target:
 The baud rate defaults to 1500000; override with ``AMEBA_BAUD`` if needed.
 
 **GUI (Windows)** — use the Realtek AmebaImageTool (``AmebaImageTool.exe``
-under ``tools/ameba/ImageTool/`` in the SDK tree) to select ``boot.bin`` and
-``app.bin``.
+under ``tools/ameba/ImageTool/`` in the SDK tree) to select ``boot.bin`` (from
+the board's ``prebuilt/`` directory) and ``nuttx.bin``.
 
 See the `Realtek Ameba ImageTool guide
 <https://aiot.realmcu.com/en/latest/tools/image_tool/index.html>`_ for the

--- a/Documentation/platforms/arm/rtl8721dx/boards/pke8721daf/index.rst
+++ b/Documentation/platforms/arm/rtl8721dx/boards/pke8721daf/index.rst
@@ -85,9 +85,11 @@ Realtek ``arm-none-eabi`` toolchain must be on ``PATH``; see the
    $ ./tools/configure.sh pke8721daf:nsh
    $ make
 
-This produces the two flashable images in the build directory: ``app.bin``
-(the NuttX application image, which also bundles the prebuilt Wi-Fi firmware)
-and ``boot.bin`` (the bootloader).
+This produces ``nuttx.bin`` in the top-level build directory: the NuttX
+application image, which also bundles the prebuilt Wi-Fi firmware.  The
+bootloader ``boot.bin`` is a prebuilt binary kept under the board's
+``prebuilt/`` directory; ``make flash`` writes both at the flash offsets
+taken from the generated flash layout, so no offsets are entered by hand.
 
 After a successful build, flash via one of these methods:
 
@@ -101,8 +103,8 @@ built-in ``make flash`` target:
 The baud rate defaults to 1500000; override with ``AMEBA_BAUD`` if needed.
 
 **GUI (Windows)** — use the Realtek AmebaImageTool (``AmebaImageTool.exe``
-under ``tools/ameba/ImageTool/`` in the SDK tree) to select ``boot.bin`` and
-``app.bin``.
+under ``tools/ameba/ImageTool/`` in the SDK tree) to select ``boot.bin`` (from
+the board's ``prebuilt/`` directory) and ``nuttx.bin``.
 
 See the `Realtek Ameba ImageTool guide
 <https://aiot.realmcu.com/en/latest/tools/image_tool/index.html>`_ for the

--- a/arch/arm/src/rtl8720f/Make.defs
+++ b/arch/arm/src/rtl8720f/Make.defs
@@ -66,7 +66,7 @@ endif
 # own).  This folds the prototype scripts (nuttx-ameba-ext/link_img2.sh and
 # package_app.sh) into NuttX's native build: the linked `nuttx` ELF *is* the
 # AP (km4tz) image2 .axf, and POSTBUILD (board scripts/Make.defs) packages it
-# into a flashable app.bin.
+# into a flashable nuttx.bin.
 #
 # The vendor SDK (ameba-rtos) is treated as a referenced 3rd-party checkout:
 # its sources, ROM symbol files and linker scripts are referenced at build time

--- a/arch/arm/src/rtl8720f/ameba_board.mk
+++ b/arch/arm/src/rtl8720f/ameba_board.mk
@@ -319,7 +319,7 @@ NXFLATLDFLAGS2 = $(NXFLATLDFLAGS1) -T$(TOPDIR)$(DELIM)binfmt$(DELIM)libnxflat$(D
 LDNXFLATFLAGS = -e main -s 2048
 
 ############################################################################
-# POSTBUILD -- package the linked image2 into a flashable app.bin
+# POSTBUILD -- package the linked image2 into a flashable nuttx.bin
 #
 # Runs after `nuttx` (== the KM4 image2 .axf) is linked.  This folds the
 # prototype package_app.sh into NuttX's build:
@@ -328,7 +328,8 @@ LDNXFLATFLAGS = -e main -s 2048
 #   2. Run the SDK km4tz image2 postbuild.cmake (axf2bin) -> km4tz_image2_all.bin.
 #   3. Run the SDK project firmware_package postbuild.cmake combining the
 #      freshly built AP (km4tz) image2 with the freshly built NP (km4ns) image2
-#      -> app.bin, copied into $(TOPDIR).
+#      into the packed app image, copied into $(TOPDIR) as nuttx.bin.  boot.bin
+#      is a prebuilt bootloader and stays in prebuilt/ (flashed from there).
 #
 # The NP (km4ns) image2 is rebuilt from the pinned SDK source every build (by
 # AMEBA_NP_POSTBUILD, fed the AP disassembly), so the two cores never drift.
@@ -361,7 +362,7 @@ AMEBA_KM4_PROJ = $(AMEBA_SOC_PROJ)/project_km4tz
 AMEBA_PKGDIR = $(AMEBA_PREBUILT)$(DELIM)pkg
 
 define POSTBUILD
-	$(Q) echo "PACK: app.bin (Ameba AP km4tz image2 + NP km4ns image2)"
+	$(Q) echo "PACK: nuttx.bin (Ameba AP km4tz image2 + NP km4ns image2)"
 	$(Q) test -n "$(AMEBA_SDK)" || \
 	  { echo "ERROR: AMEBA_SDK is not set"; exit 1; }
 	$(Q) $(AMEBA_SETUP_ENV) $(AMEBA_SDK) $(AMEBA_TOOLCHAIN_DIR)
@@ -408,11 +409,10 @@ define POSTBUILD
 	  -Dc_IMAGE1_ALL_FILES= \
 	  -Dc_IMAGE2_ALL_FILES="$(AMEBA_PKGDIR)/km4ns_image2_all.bin;$(AMEBA_PKGDIR)/km4tz_image2_all.bin" \
 	  -Dc_IMAGE3_ALL_FILES= \
-	  -DFINAL_IMAGE_DIR=$(TOPDIR) \
+	  -DFINAL_IMAGE_DIR=$(AMEBA_PKGDIR) \
 	  -DANALYZE_MP_IMG=0 -DEXTERN_DIR=$(AMEBA_PKGDIR) \
 	  -P $(AMEBA_SOC_PROJ)/postbuild.cmake
-	$(Q) cp $(AMEBA_PREBUILT)$(DELIM)boot.bin $(TOPDIR)$(DELIM)boot.bin
-	$(Q) cp $(AMEBA_PREBUILT)$(DELIM)km4ns_image2_all.bin \
-	  $(TOPDIR)$(DELIM)km4ns_image2_all.bin
-	$(Q) echo "PACK: wrote $(TOPDIR)$(DELIM){app.bin,boot.bin,km4ns_image2_all.bin}"
+	$(Q) cp $(AMEBA_PKGDIR)$(DELIM)app.bin $(TOPDIR)$(DELIM)nuttx.bin
+	$(Q) echo "PACK: wrote $(TOPDIR)$(DELIM)nuttx.bin"
+	$(Q) echo "      Flash with: make flash AMEBA_PORT=/dev/ttyUSB0"
 endef

--- a/arch/arm/src/rtl8721dx/Make.defs
+++ b/arch/arm/src/rtl8721dx/Make.defs
@@ -60,7 +60,7 @@ endif
 # own).  This folds the prototype scripts (nuttx-ameba-ext/link_img2.sh and
 # package_app.sh) into NuttX's native build: the linked `nuttx` ELF *is* the
 # AP (km4) image2 .axf, and POSTBUILD (board scripts/Make.defs) packages it
-# into a flashable app.bin.
+# into a flashable nuttx.bin.
 #
 # The vendor SDK (ameba-rtos) is treated as a referenced 3rd-party checkout:
 # its sources, ROM symbol files and linker scripts are referenced at build time

--- a/arch/arm/src/rtl8721dx/ameba_board.mk
+++ b/arch/arm/src/rtl8721dx/ameba_board.mk
@@ -320,7 +320,7 @@ NXFLATLDFLAGS2 = $(NXFLATLDFLAGS1) -T$(TOPDIR)$(DELIM)binfmt$(DELIM)libnxflat$(D
 LDNXFLATFLAGS = -e main -s 2048
 
 ############################################################################
-# POSTBUILD -- package the linked image2 into a flashable app.bin
+# POSTBUILD -- package the linked image2 into a flashable nuttx.bin
 #
 # Runs after `nuttx` (== the KM4 image2 .axf) is linked.  This folds the
 # prototype package_app.sh into NuttX's build:
@@ -328,8 +328,9 @@ LDNXFLATFLAGS = -e main -s 2048
 #   1. Replicate the SDK image2 postbuild prologue (copy map/axf, nm/objdump).
 #   2. Run the SDK AP (km4) image2 postbuild.cmake (axf2bin) -> km4_image2_all.bin.
 #   3. Run the SDK project firmware_package postbuild.cmake combining the
-#      freshly built AP (km4) image2 with the freshly built NP (km0) image2 ->
-#      app.bin, copied into $(TOPDIR).
+#      freshly built AP (km4) image2 with the freshly built NP (km0) image2
+#      into the packed app image, copied into $(TOPDIR) as nuttx.bin.  boot.bin
+#      is a prebuilt bootloader and stays in prebuilt/ (flashed from there).
 #
 # The NP (km0) image2 is (re)built from the pinned SDK source in the NP POSTBUILD
 # step above (NuttX only owns the AP / km4 image2).  The SDK scripts/cmake/python
@@ -361,7 +362,7 @@ AMEBA_KM4_PROJ = $(AMEBA_SOC_PROJ)/project_km4
 AMEBA_PKGDIR = $(AMEBA_PREBUILT)$(DELIM)pkg
 
 define POSTBUILD
-	$(Q) echo "PACK: app.bin (Ameba AP km4 image2 + NP km0 image2)"
+	$(Q) echo "PACK: nuttx.bin (Ameba AP km4 image2 + NP km0 image2)"
 	$(Q) test -n "$(AMEBA_SDK)" || \
 	  { echo "ERROR: AMEBA_SDK is not set"; exit 1; }
 	$(Q) $(AMEBA_SETUP_ENV) $(AMEBA_SDK) $(AMEBA_TOOLCHAIN_DIR)
@@ -408,11 +409,10 @@ define POSTBUILD
 	  -Dc_IMAGE1_ALL_FILES= \
 	  -Dc_IMAGE2_ALL_FILES="$(AMEBA_PKGDIR)/km0_image2_all.bin;$(AMEBA_PKGDIR)/km4_image2_all.bin" \
 	  -Dc_IMAGE3_ALL_FILES= \
-	  -DFINAL_IMAGE_DIR=$(TOPDIR) \
+	  -DFINAL_IMAGE_DIR=$(AMEBA_PKGDIR) \
 	  -DANALYZE_MP_IMG=0 -DEXTERN_DIR=$(AMEBA_PKGDIR) \
 	  -P $(AMEBA_SOC_PROJ)/postbuild.cmake
-	$(Q) cp $(AMEBA_PREBUILT)$(DELIM)boot.bin $(TOPDIR)$(DELIM)boot.bin
-	$(Q) cp $(AMEBA_PREBUILT)$(DELIM)km0_image2_all.bin \
-	  $(TOPDIR)$(DELIM)km0_image2_all.bin
-	$(Q) echo "PACK: wrote $(TOPDIR)$(DELIM){app.bin,boot.bin,km0_image2_all.bin}"
+	$(Q) cp $(AMEBA_PKGDIR)$(DELIM)app.bin $(TOPDIR)$(DELIM)nuttx.bin
+	$(Q) echo "PACK: wrote $(TOPDIR)$(DELIM)nuttx.bin"
+	$(Q) echo "      Flash with: make flash AMEBA_PORT=/dev/ttyUSB0"
 endef

--- a/boards/arm/rtl8720f/rtl8720f_evb/CMakeLists.txt
+++ b/boards/arm/rtl8720f/rtl8720f_evb/CMakeLists.txt
@@ -23,10 +23,10 @@
 # The RTL8720F (Ameba WHC) port currently builds via the make-based build only.
 # The CMake path does not yet wire up the vendor-SDK machinery (SDK fetch,
 # libameba_fwlib.a/libameba_wifi.a, the image2 entry ameba_app_start.c, the SDK
-# image2 linker-script generation, the NP-image build and the app.bin packaging)
-# that boards/.../scripts/Make.defs -> arch/.../ameba_board.mk provides, so a
-# CMake configure would not produce a flashable image.  Fail fast with a clear
-# message instead of half-building.
+# image2 linker-script generation, the NP-image build and the nuttx.bin
+# packaging) that boards/.../scripts/Make.defs -> arch/.../ameba_board.mk
+# provides, so a CMake configure would not produce a flashable image.  Fail fast
+# with a clear message instead of half-building.
 message(
   FATAL_ERROR
     "rtl8720f_evb (RTL8720F, Ameba WHC) currently supports the make build "

--- a/boards/arm/rtl8721dx/pke8721daf/CMakeLists.txt
+++ b/boards/arm/rtl8721dx/pke8721daf/CMakeLists.txt
@@ -23,10 +23,10 @@
 # The RTL8721Dx (Ameba WHC) port currently builds via the make-based build only.
 # The CMake path does not yet wire up the vendor-SDK machinery (SDK fetch,
 # libameba_fwlib.a/libameba_wifi.a, the image2 entry ameba_app_start.c, the SDK
-# image2 linker-script generation, the NP-image build and the app.bin packaging)
-# that boards/.../scripts/Make.defs -> arch/.../ameba_board.mk provides, so a
-# CMake configure would not produce a flashable image.  Fail fast with a clear
-# message instead of half-building.
+# image2 linker-script generation, the NP-image build and the nuttx.bin
+# packaging) that boards/.../scripts/Make.defs -> arch/.../ameba_board.mk
+# provides, so a CMake configure would not produce a flashable image.  Fail fast
+# with a clear message instead of half-building.
 message(
   FATAL_ERROR
     "pke8721daf (RTL8721Dx, Ameba WHC) currently supports the make build "

--- a/tools/ameba/Config.mk
+++ b/tools/ameba/Config.mk
@@ -40,12 +40,36 @@
 
 AMEBA_BAUD ?= 1500000
 
+# Flash offsets are NOT hardcoded here: they are read from the SDK flash
+# layout, surfaced in the regenerated platform_autoconf.h (AMEBA_AUTOCONF)
+# on every build.  This way a layout change (e.g. a bigger boot region that
+# pushes the app offset) is tracked automatically -- the .rdev profile only
+# supplies the on-chip flash-loader firmware, not the image placement.
+
+# The app-slot macro is spelled CONFIG_FLASH_APP_OTA1_OFFSET on some ICs
+# (e.g. RTL8720F) and CONFIG_FLASH_OTA1_OFFSET on others (e.g. RTL8721Dx);
+# match either.  boot is CONFIG_FLASH_BOOT_OFFSET on all.
+
+AMEBA_BOOT_OFFSET = $(strip $(shell awk '$$2=="CONFIG_FLASH_BOOT_OFFSET"{print $$3}' $(AMEBA_AUTOCONF) 2>/dev/null))
+AMEBA_APP_OFFSET  = $(strip $(shell awk '$$2 ~ /^CONFIG_FLASH_(APP_)?OTA1_OFFSET$$/{print $$3}' $(AMEBA_AUTOCONF) 2>/dev/null))
+
 # FLASH -- Download the built images via the SDK's AmebaFlash.py
+#
+# Two images are written, each at its own offset:
+#   boot.bin  (SDK bootloader, prebuilt) @ CONFIG_FLASH_BOOT_OFFSET
+#   nuttx.bin (AP+NP application image)   @ CONFIG_FLASH_APP_OTA1_OFFSET
+# boot.bin stays in the board prebuilt/ dir; only nuttx.bin lives in $(TOPDIR).
 
 define FLASH
 	$(Q) if [ -z "$(AMEBA_PORT)" ]; then \
 		echo "FLASH error: Missing serial port device argument."; \
 		echo "USAGE: make flash AMEBA_PORT=/dev/ttyUSB0 [ AMEBA_BAUD=$(AMEBA_BAUD) ]"; \
+		exit 1; \
+	fi
+	$(Q) if [ -z "$(AMEBA_BOOT_OFFSET)" ] || [ -z "$(AMEBA_APP_OFFSET)" ]; then \
+		echo "FLASH error: could not read flash offsets from"; \
+		echo "  $(AMEBA_AUTOCONF)"; \
+		echo "  Run make first so platform_autoconf.h is generated."; \
 		exit 1; \
 	fi
 	$(Q) AMEBAPY="$$(cat $(AMEBA_SDK)/.amebapy/bindir 2>/dev/null)/python"; \
@@ -64,11 +88,22 @@ define FLASH
 			echo "  Set AMEBA_FLASH_PROFILE in the board's Make.defs."; \
 			exit 1; \
 		fi; \
-		$$AMEBAPY "$$SCRIPT" \
-			--download \
-			--profile "$$PROFILE" \
-			--image-dir "$(TOPDIR)" \
-			--port "$(AMEBA_PORT)" \
-			--baudrate "$(or $(AMEBA_BAUD),1500000)" \
-			--log-level info
+		for spec in "$(AMEBA_PREBUILT)/boot.bin:$(AMEBA_BOOT_OFFSET)" \
+		            "$(TOPDIR)/nuttx.bin:$(AMEBA_APP_OFFSET)"; do \
+			IMG="$${spec%:*}"; ADDR="$${spec##*:}"; \
+			if [ ! -f "$$IMG" ]; then \
+				echo "FLASH error: image not found: $$IMG (run make first)"; \
+				exit 1; \
+			fi; \
+			echo "FLASH: $$IMG @ $$ADDR"; \
+			$$AMEBAPY "$$SCRIPT" \
+				--download \
+				--profile "$$PROFILE" \
+				--memory-type nor \
+				--image "$$IMG" \
+				--start-address "$$ADDR" \
+				--port "$(AMEBA_PORT)" \
+				--baudrate "$(or $(AMEBA_BAUD),1500000)" \
+				--log-level info || exit 1; \
+		done
 endef


### PR DESCRIPTION
## Summary

  The RTL8721Dx / RTL8720F ports packed the flashable application as `app.bin`
  and also dropped several intermediate images (per-core `*_image2_all.bin`,
  `ota_all.bin`) plus `boot.bin` into the top-level build directory, and the
  `make flash` target relied on a fixed image directory. This reworks that to
  match the common NuttX convention and to be robust against flash-layout
  changes:

  - The packed application image is now named `nuttx.bin` and is the only image
    left in the top-level build directory (alongside the map files). The
    prebuilt bootloader `boot.bin` stays in the board `prebuilt/` directory. The
    redundant per-core and OTA image copies are no longer copied to the top.
  - `make flash` reads the boot and application flash offsets from the SDK flash
    (`CONFIG_FLASH_BOOT_OFFSET` / `CONFIG_FLASH_[APP_]OTA1_OFFSET`) and writes
    `boot.bin` and `nuttx.bin` each at its own offset, so a layout change is
    tracked automatically and no offset is hardcoded.
  - Board documentation updated accordingly.
  
  ## Impact
  
  - Users: the flashable image is `nuttx.bin` (was `app.bin`); the top-level
    build dir is cleaner. `make flash` is unchanged in usage
    (`make flash AMEBA_PORT=/dev/ttyUSB0`).
  - Build: affects only `boards/arm/rtl8721dx`, `boards/arm/rtl8720f` and their
    shared `arch/arm/src/{rtl8721dx,rtl8720f}` build glue. No other arch/board.
  - Hardware / runtime: no change to the firmware itself.
  - Documentation: RTL8721Dx / RTL8720F board pages updated.
  
  ## Testing
  
  **Build host:** Ubuntu 22.04 (x86_64, WSL2), GCC 11 for host tools; target
  toolchain: Realtek `arm-none-eabi` asdk (auto-fetched).
  
  **Targets:** `pke8721daf:nsh` (RTL8721Dx), `rtl8720f_evb:nsh` (RTL8720F).

  Both boards built, flashed and booted (NSH + Wi-Fi STA).

  Top-level artifacts after `make` (after change):
  $ ls *.bin nuttx
  nuttx  nuttx.bin
  $ ls boards/arm/rtl8721dx/pke8721daf/prebuilt/boot.bin
  boards/arm/rtl8721dx/pke8721daf/prebuilt/boot.bin

  `make flash` (offsets read from the generated layout):
  FLASH: .../prebuilt/boot.bin @ 0x08000000
  FLASH: .../nuttx.bin @ 0x08014000
  Device boots to NSH and connects to Wi-Fi after flashing.