### PR TITLE
drivers/usbdev: re-assert soft connect in cdcecm/cdcncm disconnect()

### DIFF
--- a/drivers/usbdev/cdcecm.c
+++ b/drivers/usbdev/cdcecm.c
@@ -1916,6 +1916,17 @@ static void cdcecm_disconnect(FAR struct usbdevclass_driver_s *driver,
                               FAR struct usbdev_s *dev)
 {
   uinfo("\n");
+
+  /* Perform the soft connect function so that we will we can be
+   * re-enumerated (unless we are part of a composite device).  The USB
+   * device controller calls CLASS_DISCONNECT() on every bus reset, which
+   * is the first step of any enumeration, so without this the device is
+   * left soft-disconnected and never enumerates on the host.
+   */
+
+#ifndef CONFIG_CDCECM_COMPOSITE
+  DEV_CONNECT(dev);
+#endif
 }
 
 /****************************************************************************

--- a/drivers/usbdev/cdcncm.c
+++ b/drivers/usbdev/cdcncm.c
@@ -2868,6 +2868,17 @@ static void cdcncm_disconnect(FAR struct usbdevclass_driver_s *driver,
 
   cdcncm_resetconfig(self);
   uinfo("\n");
+
+  /* Perform the soft connect function so that we can be
+   * re-enumerated (unless we are part of a composite device).  The USB
+   * device controller calls CLASS_DISCONNECT() on every bus reset, which
+   * is the first step of any enumeration, so without this the device is
+   * left soft-disconnected and never enumerates on the host.
+   */
+
+#ifndef CONFIG_CDCNCM_COMPOSITE
+  DEV_CONNECT(dev);
+#endif
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

USB device controller drivers invoke `CLASS_DISCONNECT()` on every USB bus reset, and a bus reset is the first step of normal host enumeration. Every other class driver (`cdcacm`, `usbmsc`, `rndis`) re-asserts `DEV_CONNECT()` at the end of its `disconnect()` handler ("perform the soft connect function so that we can be re-enumerated"), so on controllers that soft-disconnect around bus reset the pull-up glitch is microseconds long and invisible to the host. `cdcecm_disconnect()` and `cdcncm_disconnect()` did not, so the first bus reset of enumeration leaves a standalone CDC-ECM or CDC-NCM device soft-disconnected and it never appears on the host. On RP2040, `rp2040_usbintr_busreset()` explicitly drops the pull-up, so a standalone device never enumerates at all.

This mirrors the cdcacm behavior and performs the soft connect in both `disconnect()` methods, unless part of a composite device (`composite.c` already re-connects in its own disconnect handler).

Addresses the standalone CDC-ECM case of #15880 (root-cause analysis in [this comment](https://github.com/apache/nuttx/issues/15880#issuecomment-4915349759)).

## Impact

Standalone (non-composite) CDC-ECM and CDC-NCM devices become able to enumerate on controllers that call `CLASS_DISCONNECT()` on bus reset. Composite configurations are unaffected (the added call is guarded by `!CONFIG_CDCECM_COMPOSITE` / `!CONFIG_CDCNCM_COMPOSITE`). Other class drivers are unaffected; this makes cdcecm/cdcncm consistent with the existing cdcacm/usbmsc/rndis convention.

## Testing

Validated on raspberrypi-pico (RP2040, arm-none-eabi-gcc 13.2, no new warnings):

- **CDC-ECM (standalone `CONFIG_NET_CDCECM`)**: before this change the device never appears on a Linux host (no enumeration at all); with this change it enumerates via `cdc_ether` and ICMP ping across the link runs at 0% loss (~0.5 ms RTT).
- **CDC-NCM (standalone `CONFIG_NET_CDCNCM`)**: before this change the device never attaches; with this change it enumerates and binds the host `cdc_ncm` driver. (Full NCM datapath on RP2040 is blocked by a separate, pre-existing interrupt-IN endpoint delivery issue that also affects other classes on this controller; under separate investigation.)

## Disclosure

This root-cause analysis, patch, and hardware validation were performed by an AI agent (Claude Code, operated and directed by the submitter), and the result was reviewed by the submitter before posting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AHJRvWeBMTHwzpwjaUg4HW
