### PR TITLE
tools/nxstyle.c: Add exclusion for MQTTErrors

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -283,6 +283,7 @@ static const char *g_white_prefix[] =
   "SYSTIMER_",
   "SystemCoreClock",  /* SystemCoreClock, SystemCoreClockUpdate */
   "cmse_",            /* ARM CMSE TrustZone intrinsics (arm_cmse.h) */
+  "MQTTErrors",	      /* apps/tools/netutils/mqttc/MQTT-C/include/mqtt.h */
   NULL
 };
 


### PR DESCRIPTION
Added a Mixed case exclusion for MQTTErrors defined in apps/netutils/mqttc/MQTT-C/include/mqtt.h

## Summary

Added the linter exclusion for the enum MQTTErrors used by the mqttc library. 

## Testing

When running the coding style checker the lines where this enum is uses are flagged. 
Error: /home/runner/work/nuttx-apps/nuttx-apps/apps/examples/mqttc/mqttc_pub.c:470:7: error: Mixed case identifier found
Error: /home/runner/work/nuttx-apps/nuttx-apps/apps/examples/mqttc/mqttc_sub.c:644:7: error: Mixed case identifier found
Error: /home/runner/work/nuttx-apps/nuttx-apps/apps/examples/mqttc/mqttc_sub.c:711:7: error: Mixed case identifier found

After whitelisting the definition no more lines are flagged.