### PR TITLE
arch/arm/rp2040,rp23xx: fix CDC-NCM bulk/notify endpoint handling

### DIFF
--- a/arch/arm/src/rp2040/rp2040_usbdev.c
+++ b/arch/arm/src/rp2040/rp2040_usbdev.c
@@ -536,6 +536,20 @@ static int rp2040_epread(struct rp2040_ep_s *privep, uint16_t nbytes)
   uint32_t val;
   irqstate_t flags;
 
+  /* The hardware receives a single USB packet into the buffer, and the
+   * buffer-control LEN field is only 10 bits wide.  Arm the buffer for at
+   * most one maximum-size packet; rp2040_rxcomplete accumulates the request
+   * across multiple packets and re-arms until it is satisfied or a short
+   * packet arrives.  Passing the full (possibly multi-kByte) request length
+   * would overflow LEN and corrupt the neighbouring control bits, making the
+   * transfer complete immediately with zero bytes.
+   */
+
+  if (nbytes > privep->ep.maxpacket)
+    {
+      nbytes = privep->ep.maxpacket;
+    }
+
   val = nbytes |
         RP2040_USBCTRL_DPSRAM_EP_BUFF_CTRL_AVAIL |
         (privep->next_pid ?

--- a/arch/arm/src/rp2040/rp2040_usbdev.c
+++ b/arch/arm/src/rp2040/rp2040_usbdev.c
@@ -473,6 +473,7 @@ static void rp2040_update_buffer_control(struct rp2040_ep_s *privep,
                                          uint32_t or_mask)
 {
   uint32_t value = 0;
+  int i;
 
   if (and_mask)
     {
@@ -482,6 +483,24 @@ static void rp2040_update_buffer_control(struct rp2040_ep_s *privep,
   if (or_mask)
     {
       value |= or_mask;
+
+      if (or_mask & RP2040_USBCTRL_DPSRAM_EP_BUFF_CTRL_AVAIL)
+        {
+          /* RP2040 datasheet 4.1.2.5.1: the AVAILABLE bit must be set
+           * after the rest of the buffer control register has been
+           * written and had time to settle across the clock domain
+           * crossing, or the controller may act on a stale length/PID.
+           * 12 CPU cycles covers system clocks up to 12x clk_usb.
+           */
+
+          putreg32(value & ~RP2040_USBCTRL_DPSRAM_EP_BUFF_CTRL_AVAIL,
+                   privep->buf_ctrl);
+
+          for (i = 0; i < 12; i++)
+            {
+              __asm__ volatile("nop");
+            }
+        }
     }
 
   putreg32(value, privep->buf_ctrl);

--- a/arch/arm/src/rp2040/rp2040_usbdev.c
+++ b/arch/arm/src/rp2040/rp2040_usbdev.c
@@ -218,6 +218,7 @@ struct rp2040_req_s
 {
   struct usbdev_req_s req;        /* Standard USB request */
   struct rp2040_req_s *flink;     /* Supports a singly linked list */
+  bool armed;                     /* Hardware buffer armed for this request */
 };
 
 /* This is the internal representation of an endpoint */
@@ -647,6 +648,7 @@ static void rp2040_reqcomplete(struct rp2040_ep_s *privep, int16_t result)
 static void rp2040_txcomplete(struct rp2040_ep_s *privep)
 {
   struct rp2040_req_s *privreq;
+  bool completed = false;
 
   privreq = rp2040_rqpeek(privep);
   if (!privreq)
@@ -663,10 +665,31 @@ static void rp2040_txcomplete(struct rp2040_ep_s *privep)
           usbtrace(TRACE_COMPLETE(privep->epphy), privreq->req.xfrd);
           privep->txnullpkt = 0;
           rp2040_reqcomplete(privep, OK);
+          completed = true;
         }
     }
 
-  rp2040_wrrequest(privep);
+  if (completed)
+    {
+      /* Start the next queued request -- unless it was already armed.  The
+       * completion callback above may have submitted a new request on the
+       * now idle endpoint; epsubmit then armed the hardware buffer itself,
+       * and arming it a second time here would toggle the data PID twice
+       * and make the host silently discard the packet as a retransmission.
+       */
+
+      privreq = rp2040_rqpeek(privep);
+      if (privreq && !privreq->armed)
+        {
+          rp2040_wrrequest(privep);
+        }
+    }
+  else if (privreq)
+    {
+      /* Continue with the next packet of the in-progress request */
+
+      rp2040_wrrequest(privep);
+    }
 }
 
 /****************************************************************************
@@ -699,6 +722,7 @@ static int rp2040_wrrequest(struct rp2040_ep_s *privep)
     {
       if (privep->epphy == 0)
         {
+          privreq->armed = true;
           rp2040_epwrite(privep, NULL, 0);
         }
       else
@@ -724,6 +748,7 @@ static int rp2040_wrrequest(struct rp2040_ep_s *privep)
        * bytes to send.
        */
 
+      privreq->armed = true;
       privep->txnullpkt = 0;
       if (bytesleft > privep->ep.maxpacket)
         {
@@ -779,6 +804,16 @@ static void rp2040_rxcomplete(struct rp2040_ep_s *privep)
     {
       usbtrace(TRACE_COMPLETE(privep->epphy), privreq->req.xfrd);
       rp2040_reqcomplete(privep, OK);
+
+      /* Re-arm only if the completion callback didn't already do it by
+       * resubmitting a request (see rp2040_txcomplete).
+       */
+
+      privreq = rp2040_rqpeek(privep);
+      if (privreq && privreq->armed)
+        {
+          return;
+        }
     }
 
   rp2040_rdrequest(privep);
@@ -809,6 +844,7 @@ static int rp2040_rdrequest(struct rp2040_ep_s *privep)
 
   usbtrace(TRACE_READ(privep->epphy), privreq->req.len);
 
+  privreq->armed = true;
   return rp2040_epread(privep, privreq->req.len);
 }
 
@@ -1635,6 +1671,7 @@ static int rp2040_epsubmit(struct usbdev_ep_s *ep,
 
   req->result = -EINPROGRESS;
   req->xfrd = 0;
+  privreq->armed = false;
 
   flags = enter_critical_section();
 

--- a/arch/arm/src/rp23xx/rp23xx_usbdev.c
+++ b/arch/arm/src/rp23xx/rp23xx_usbdev.c
@@ -218,6 +218,7 @@ struct rp23xx_req_s
 {
   struct usbdev_req_s req;        /* Standard USB request */
   struct rp23xx_req_s *flink;     /* Supports a singly linked list */
+  bool armed;                     /* Hardware buffer armed for this request */
 };
 
 /* This is the internal representation of an endpoint */
@@ -472,6 +473,7 @@ static void rp23xx_update_buffer_control(struct rp23xx_ep_s *privep,
                                          uint32_t or_mask)
 {
   uint32_t value = 0;
+  int i;
 
   if (and_mask)
     {
@@ -481,6 +483,25 @@ static void rp23xx_update_buffer_control(struct rp23xx_ep_s *privep,
   if (or_mask)
     {
       value |= or_mask;
+
+      if (or_mask & RP23XX_USBCTRL_DPSRAM_EP_BUFF_CTRL_AVAIL)
+        {
+          /* The AVAILABLE bit must be set after the rest of the buffer
+           * control register has been written and had time to settle
+           * across the clock domain crossing, or the controller may act
+           * on a stale length/PID (RP2350 datasheet, USB buffer control;
+           * same semantics as RP2040 datasheet 4.1.2.5.1).  12 CPU cycles
+           * covers system clocks up to 12x clk_usb.
+           */
+
+          putreg32(value & ~RP23XX_USBCTRL_DPSRAM_EP_BUFF_CTRL_AVAIL,
+                   privep->buf_ctrl);
+
+          for (i = 0; i < 12; i++)
+            {
+              __asm__ volatile("nop");
+            }
+        }
     }
 
   putreg32(value, privep->buf_ctrl);
@@ -533,6 +554,20 @@ static int rp23xx_epread(struct rp23xx_ep_s *privep, uint16_t nbytes)
 {
   uint32_t val;
   irqstate_t flags;
+
+  /* The hardware receives a single USB packet into the buffer, and the
+   * buffer-control LEN field is only 10 bits wide.  Arm the buffer for at
+   * most one maximum-size packet; rp23xx_rxcomplete accumulates the request
+   * across multiple packets and re-arms until it is satisfied or a short
+   * packet arrives.  Passing the full (possibly multi-kByte) request length
+   * would overflow LEN and corrupt the neighbouring control bits, making the
+   * transfer complete immediately with zero bytes.
+   */
+
+  if (nbytes > privep->ep.maxpacket)
+    {
+      nbytes = privep->ep.maxpacket;
+    }
 
   val = nbytes |
         RP23XX_USBCTRL_DPSRAM_EP_BUFF_CTRL_AVAIL |
@@ -631,6 +666,7 @@ static void rp23xx_reqcomplete(struct rp23xx_ep_s *privep, int16_t result)
 static void rp23xx_txcomplete(struct rp23xx_ep_s *privep)
 {
   struct rp23xx_req_s *privreq;
+  bool completed = false;
 
   privreq = rp23xx_rqpeek(privep);
   if (!privreq)
@@ -647,10 +683,31 @@ static void rp23xx_txcomplete(struct rp23xx_ep_s *privep)
           usbtrace(TRACE_COMPLETE(privep->epphy), privreq->req.xfrd);
           privep->txnullpkt = 0;
           rp23xx_reqcomplete(privep, OK);
+          completed = true;
         }
     }
 
-  rp23xx_wrrequest(privep);
+  if (completed)
+    {
+      /* Start the next queued request -- unless it was already armed.  The
+       * completion callback above may have submitted a new request on the
+       * now idle endpoint; epsubmit then armed the hardware buffer itself,
+       * and arming it a second time here would toggle the data PID twice
+       * and make the host silently discard the packet as a retransmission.
+       */
+
+      privreq = rp23xx_rqpeek(privep);
+      if (privreq && !privreq->armed)
+        {
+          rp23xx_wrrequest(privep);
+        }
+    }
+  else if (privreq)
+    {
+      /* Continue with the next packet of the in-progress request */
+
+      rp23xx_wrrequest(privep);
+    }
 }
 
 /****************************************************************************
@@ -683,6 +740,7 @@ static int rp23xx_wrrequest(struct rp23xx_ep_s *privep)
     {
       if (privep->epphy == 0)
         {
+          privreq->armed = true;
           rp23xx_epwrite(privep, NULL, 0);
         }
       else
@@ -708,6 +766,7 @@ static int rp23xx_wrrequest(struct rp23xx_ep_s *privep)
        * bytes to send.
        */
 
+      privreq->armed = true;
       privep->txnullpkt = 0;
       if (bytesleft > privep->ep.maxpacket)
         {
@@ -763,6 +822,16 @@ static void rp23xx_rxcomplete(struct rp23xx_ep_s *privep)
     {
       usbtrace(TRACE_COMPLETE(privep->epphy), privreq->req.xfrd);
       rp23xx_reqcomplete(privep, OK);
+
+      /* Re-arm only if the completion callback didn't already do it by
+       * resubmitting a request (see rp23xx_txcomplete).
+       */
+
+      privreq = rp23xx_rqpeek(privep);
+      if (privreq && privreq->armed)
+        {
+          return;
+        }
     }
 
   rp23xx_rdrequest(privep);
@@ -793,6 +862,7 @@ static int rp23xx_rdrequest(struct rp23xx_ep_s *privep)
 
   usbtrace(TRACE_READ(privep->epphy), privreq->req.len);
 
+  privreq->armed = true;
   return rp23xx_epread(privep, privreq->req.len);
 }
 
@@ -1622,6 +1692,7 @@ static int rp23xx_epsubmit(struct usbdev_ep_s *ep,
 
   req->result = -EINPROGRESS;
   req->xfrd = 0;
+  privreq->armed = false;
 
   flags = enter_critical_section();
 


### PR DESCRIPTION
## Summary

Fixes three endpoint-handling bugs in the RP2040/RP2350 USB device driver
(`rp2040_usbdev.c`, and its line-for-line copy `rp23xx_usbdev.c`).  Together they
prevent CDC-NCM (and, for the second one, likely RNDIS) from working on these
controllers; with all three applied, a `CONFIG_NET_CDCNCM` gadget on a
Raspberry Pi Pico passes traffic in both directions with 0% packet loss.

The bugs were found by comparing the driver against the Pico SDK's TinyUSB
device controller driver (`dcd_rp2040.c` / `rp2040_usb.c`).

**1. Bulk OUT read length not clamped to the endpoint max packet size.**
`rp2040_epread()` armed the DPSRAM buffer-control register with the full usbdev
request length. The buffer-control `LEN` field is only 10 bits (max 1023), so a
class driver that posts a larger read request — cdcncm allocates a 16 KiB NTB read
buffer — overflows `LEN` (`16384 & 0x3ff == 0`) and corrupts the neighbouring
control bits. The controller then completes the transfer immediately with zero
bytes, forever, and no OUT data is ever received (cdcncm floods
`Wrong NTH SIGN, skblen 0`). The receive path already accumulates a request across
multiple packets, so the buffer only ever needs to be armed for one max-size
packet. This matches the transmit path, which already chunks to `ep.maxpacket`.
Bulk classes with small reads (cdcacm, usbmsc) were unaffected, which is why the
defect only surfaced on cdcncm.

**2. An endpoint request resubmitted from its own completion callback is armed
twice.** `rp2040_txcomplete()` / `rp2040_rxcomplete()` unconditionally started the
next transfer after invoking a request's completion callback. When that callback
resubmits a request on the same, now-idle endpoint — which cdcncm and rndis do from
their notify/interrupt completion handlers — `rp2040_epsubmit()` already armed the
hardware buffer, and the unconditional re-arm toggles the DATA0/DATA1 PID a second
time. The host discards the packet as a stale retransmission, so e.g. the cdcncm
`NETWORK_CONNECTION` / `SPEED_CHANGE` notifications never arrive and the interface
stays `NO-CARRIER`. A per-request `armed` flag now guards the redundant re-arm.
This is also the likely cause of the long-standing rndis control-response `-110`
timeout on this controller.

**3. Buffer `AVAILABLE` bit written together with length/PID.** The RP2040 datasheet
§4.1.2.5.1 requires the `AVAILABLE` bit to be set *after* the rest of buffer control
and after a short settle, because buffer control crosses into the USB clock domain.
`rp2040_update_buffer_control()` wrote the whole word at once. Now it writes the
control word with `AVAILABLE` cleared, waits ~12 CPU cycles, then sets `AVAILABLE`
— the sequence the datasheet and the Pico SDK use.

## Impact

- **CDC-NCM** now works on RP2040/RP2350 (previously enumerated but never passed
  data). Likely also fixes **RNDIS** (bug 2).
- No functional change for bulk classes that already worked (cdcacm, usbmsc) — their
  read lengths already fit in `LEN` and they don't resubmit from completion callbacks.
- Applies to both `rp2040_usbdev.c` and `rp23xx_usbdev.c` (RP2350), which is a
  byte-identical copy of the affected functions.

## Testing

Built and run on a Raspberry Pi Pico (RP2040), Linux host:

- **CDC-NCM, all three fixes:** `ping` 20/20 host→board and 4/4 board→host, 0% loss,
  ARP resolves, board `REACHABLE`. Before the fixes the board received nothing
  (`Wrong NTH SIGN, skblen 0` flood).
- **Bug 2 in isolation** confirmed with `usbmon`: the cdcncm interrupt-IN
  `SPEED_CHANGE` notification now completes and reaches the host
  (`C Ii:3:NN:1 0:4 16 = a12a...`); previously it never did.
- **No regression** on cdcacm / usbmsc.

RP2350: the affected functions in `rp23xx_usbdev.c` are byte-identical to their
RP2040 counterparts and the change compiles cleanly for `raspberrypi-pico-2`, but it
was not separately re-tested on RP2350 silicon.

Host-side note for reviewers reproducing this: NuttX gadgets ship with the
Linux-gadget VID/PID `0525:a4a2`, which is also claimed by the host `cdc_subset`
driver; if `cdc_subset` binds the data interface first you'll see
`cdc_ncm: failed to claim data intf`. Force NCM with
`echo 3-1:1.1 > /sys/bus/usb/drivers/cdc_subset/unbind; echo 3-1:1.0 > /sys/bus/usb/drivers/cdc_ncm/bind`.

---

*Disclosure: this change — the code, its validation, and this description — was
produced by an AI agent (Claude Code), operated and directed by me, and reviewed by
me before submission.*
