### PR TITLE
drivers/timers, sched/clock: use file_get/file_put

### DIFF
--- a/drivers/timers/ptp_clock.c
+++ b/drivers/timers/ptp_clock.c
@@ -28,6 +28,7 @@
 #include <errno.h>
 #include <nuttx/debug.h>
 
+#include <nuttx/fs/fs.h>
 #include <nuttx/kmalloc.h>
 #include <nuttx/mutex.h>
 #include <nuttx/timers/ptp_clock.h>
@@ -378,7 +379,7 @@ int ptp_clockid_to_filep(clockid_t clock_id, FAR struct file **filep)
   ret = clock_id >> CLOCK_SHIFT;
   if (ret >= 0)
     {
-      ret = fs_getfilep(ret, filep);
+      ret = file_get(ret, filep);
     }
 
   if (ret < 0)
@@ -389,7 +390,7 @@ int ptp_clockid_to_filep(clockid_t clock_id, FAR struct file **filep)
   ops = (*filep)->f_inode->u.i_ops;
   if (ops != &g_ptp_clock_file_ops)
     {
-      fs_putfilep(*filep);
+      file_put(*filep);
       return -EINVAL;
     }
 

--- a/sched/clock/clock_adjtime.c
+++ b/sched/clock/clock_adjtime.c
@@ -261,7 +261,7 @@ int nxclock_adjtime(clockid_t clock_id, FAR struct timex *buf)
 
       ret = file_ioctl(filep, PTP_CLOCK_ADJTIME,
                        (unsigned long)(uintptr_t)buf);
-      fs_putfilep(filep);
+      file_put(filep);
     }
 #endif
 

--- a/sched/clock/clock_getres.c
+++ b/sched/clock/clock_getres.c
@@ -87,7 +87,7 @@ int clock_getres(clockid_t clock_id, struct timespec *res)
             }
 
           ret = file_ioctl(filep, PTP_CLOCK_GETRES, res);
-          fs_putfilep(filep);
+          file_put(filep);
         }
         break;
 #endif

--- a/sched/clock/clock_gettime.c
+++ b/sched/clock/clock_gettime.c
@@ -145,7 +145,7 @@ int nxclock_gettime(clockid_t clock_id, FAR struct timespec *tp)
         }
 
       ret = file_ioctl(filep, PTP_CLOCK_GETTIME, tp);
-      fs_putfilep(filep);
+      file_put(filep);
     }
 #endif
   else

--- a/sched/clock/clock_settime.c
+++ b/sched/clock/clock_settime.c
@@ -160,7 +160,7 @@ int clock_settime(clockid_t clock_id, FAR const struct timespec *tp)
           if (ret >= 0)
             {
               ret = file_ioctl(filep, PTP_CLOCK_SETTIME, tp);
-              fs_putfilep(filep);
+              file_put(filep);
             }
         }
 #endif


### PR DESCRIPTION
## Summary

- drivers/timers, sched/clock: use file_get/file_put
  fs_getfilep()/fs_putfilep() were renamed to file_get()/file_put().
  The PTP clock paths still used the old names, breaking the PTP_CLOCK build.

## Impact

fix build

## Testing

CI, found with a dedicated fuzzer for nuttx
