### PR TITLE
arch/arm/stm32: STM32_DTS depends on SENSORS

### DIFF
--- a/arch/arm/src/common/stm32/Kconfig.periph
+++ b/arch/arm/src/common/stm32/Kconfig.periph
@@ -1131,7 +1131,7 @@ config STM32_FMAC
 
 config STM32_DTS
 	bool "DTS"
-	depends on STM32_HAVE_DTS
+	depends on STM32_HAVE_DTS && SENSORS
 	default n
 	---help---
 		Enable support for the on‑die digital temperature sensor (DTS)


### PR DESCRIPTION
## Summary

The H5 DTS driver registers with the sensor framework (sensor_register), so it requires SENSORS.

## Impact

fix kconfig dependency

## Testing

CI, found with a dedicated fuzzer for nuttx
