### PR TITLE
arch/arm/stm32: make STM32_FOC depend on MOTOR_FOC

### DIFF
--- a/arch/arm/src/common/stm32/Kconfig.foc
+++ b/arch/arm/src/common/stm32/Kconfig.foc
@@ -140,6 +140,7 @@ endchoice # "FOC0 device ADC selection"
 menuconfig STM32_FOC
 	bool "STM32 lower-half FOC support"
 	depends on STM32_HAVE_COMMON_FOC || ARCH_CHIP_STM32F7
+	depends on MOTOR_FOC
 	select ARCH_IRQPRIO
 	select STM32_ADC
 	select STM32_PWM_MULTICHAN


### PR DESCRIPTION
## Summary

Enabling STM32_FOC without MOTOR_FOC failed to build with "unknown type name 'foc_current_t'". Add the dependency on MOTOR_FOC.

## Impact

fix kconfig dependency

## Testing

CI, found with a dedicated fuzzer for nuttx