### PR TITLE
arch/arm/stm32: fix H5 I2C kernel-clock register names

### DIFF
--- a/arch/arm/src/stm32h5/stm32_i2c.c
+++ b/arch/arm/src/stm32h5/stm32_i2c.c
@@ -2421,7 +2421,7 @@ static int stm32_i2c_init(struct stm32_i2c_priv_s *priv)
 #  elif defined(CONFIG_STM32_I2C2_CLK_PCLK1)
       modifyreg32(STM32_RCC_CCIPR4,
                   RCC_CCIPR4_I2C2SEL_MASK,
-                  RCC_CCIPR4_I2C2SEL_PCLK1);
+                  RCC_CCIPR4_I2C2SEL_RCCPCLK1);
 #  else
       modifyreg32(STM32_RCC_CCIPR4,
                   RCC_CCIPR4_I2C2SEL_MASK,
@@ -2442,7 +2442,7 @@ static int stm32_i2c_init(struct stm32_i2c_priv_s *priv)
 #  elif defined(CONFIG_STM32_I2C3_CLK_PCLK3)
       modifyreg32(STM32_RCC_CCIPR4,
                   RCC_CCIPR4_I2C3SEL_MASK,
-                  RCC_CCIPR4_I2C3SEL_PCLK3);
+                  RCC_CCIPR4_I2C3SEL_RCCPCLK3);
 #  else
       modifyreg32(STM32_RCC_CCIPR4,
                   RCC_CCIPR4_I2C3SEL_MASK,
@@ -2463,7 +2463,7 @@ static int stm32_i2c_init(struct stm32_i2c_priv_s *priv)
 #  elif defined(CONFIG_STM32_I2C4_CLK_PCLK3)
       modifyreg32(STM32_RCC_CCIPR4,
                   RCC_CCIPR4_I2C4SEL_MASK,
-                  RCC_CCIPR4_I2C4SEL_PCLK3);
+                  RCC_CCIPR4_I2C4SEL_RCCPCLK3);
 #  else
       modifyreg32(STM32_RCC_CCIPR4,
                   RCC_CCIPR4_I2C4SEL_MASK,


### PR DESCRIPTION
## Summary

stm32h5/stm32_i2c.c selected the I2C2/3/4 kernel clock with RCC_CCIPR4_I2CnSEL_PCLKx, but the H5 RCC header names those values RCC_CCIPR4_I2CnSEL_RCCPCLKx.

## Impact

fix build

## Testing

CI, found with a dedicated fuzzer for nuttx
