### PR TITLE
arch/mips: Add option to use mips syscall instruction for syscalls

### DIFF
--- a/arch/mips/src/mips32/Kconfig
+++ b/arch/mips/src/mips32/Kconfig
@@ -92,6 +92,10 @@ config MIPS32_FRAMEPOINTER
 		Register r30 may be a frame pointer in some ABIs.  Or may just be
 		saved register s8.  It makes a difference for fork handling.
 
+config MIPS32_USE_SYSCALL_INSTRUCTION
+	bool
+	default n
+
 config MIPS32_HAVE_ICACHE
 	bool
 	default n

--- a/arch/mips/src/mips32/mips_irq.c
+++ b/arch/mips/src/mips32/mips_irq.c
@@ -56,7 +56,9 @@ irqstate_t up_irq_save(void)
   status  = cp0_getstatus();       /* Get CP0 status */
   ret     = status;                /* Save the status */
   status &= ~CP0_STATUS_INT_MASK;  /* Clear all interrupt mask bits */
+#ifndef CONFIG_MIPS32_USE_SYSCALL_INSTRUCTION
   status |= CP0_STATUS_INT_SW0;    /* Enable only the SW0 interrupt */
+#endif
   cp0_putstatus(status);           /* Disable the rest of interrupts */
   return ret;                      /* Return saved status */
 }

--- a/arch/mips/src/mips32/mips_schedulesigaction.c
+++ b/arch/mips/src/mips32/mips_schedulesigaction.c
@@ -106,7 +106,9 @@ void up_schedule_sigaction(struct tcb_s *tcb)
       up_current_regs()[REG_EPC] = (uint32_t)mips_sigdeliver;
       status  = up_current_regs()[REG_STATUS];
       status &= ~CP0_STATUS_INT_MASK;
+#ifndef CONFIG_MIPS32_USE_SYSCALL_INSTRUCTION
       status |= CP0_STATUS_INT_SW0;
+#endif
       up_current_regs()[REG_STATUS]  = status;
 
       /* And make sure that the saved context in the TCB
@@ -145,7 +147,9 @@ void up_schedule_sigaction(struct tcb_s *tcb)
       tcb->xcp.regs[REG_EPC]     = (uint32_t)mips_sigdeliver;
       status                     = tcb->xcp.regs[REG_STATUS];
       status                    &= ~CP0_STATUS_INT_MASK;
+#ifndef CONFIG_MIPS32_USE_SYSCALL_INSTRUCTION
       status                    |= CP0_STATUS_INT_SW0;
+#endif
       tcb->xcp.regs[REG_STATUS]  = status;
 
       sinfo("PC/STATUS Saved: %08" PRIx32 "/%08" PRIx32

--- a/arch/mips/src/mips32/mips_syscall0.S
+++ b/arch/mips/src/mips32/mips_syscall0.S
@@ -60,6 +60,39 @@
  *   up_syscall2 - System call SYS_ argument and two additional parameters.
  *   up_syscall3 - System call SYS_ argument and three additional parameters.
  *
+ ****************************************************************************/
+
+#ifdef CONFIG_MIPS32_USE_SYSCALL_INSTRUCTION
+
+	.text
+	.set	noreorder
+	.set	nomips16
+#ifdef CONFIG_MIPS_MICROMIPS
+	.set	micromips
+#endif
+	.ent	sys_call0
+
+sys_call0:
+sys_call1:
+sys_call2:
+sys_call3:
+
+	syscall
+
+	j		ra
+	nop
+
+#else
+
+/****************************************************************************
+ * Name: up_syscall0, up_syscall1, up_syscall2, up_syscall3
+ *
+ * Description:
+ *   up_syscall0 - System call SYS_ argument and no additional parameters.
+ *   up_syscall1 - System call SYS_ argument and one additional parameter.
+ *   up_syscall2 - System call SYS_ argument and two additional parameters.
+ *   up_syscall3 - System call SYS_ argument and three additional parameters.
+ *
  * Assumption:
  *   All interrupts are disabled except for the software interrupts.
  *
@@ -102,4 +135,6 @@ sys_call3:	/* r4 holds the syscall number, arguments in r5, r6, and r7 */
 
 	j		ra
 	nop
+#endif
+
 	.end	sys_call0


### PR DESCRIPTION
## Summary

When enabled, the change fixes random crashing on Ingenic JZ4780.
Without this feature, the board never makes it to NuttShell if USB host is enabled.

## Impact

None. Feature is disabled by default.

## Testing
Tested on MIPS CI20 board (not in NuttX repo). 
Boots to NuttShell and tc app works with USB mouse. 

NuttShell (NSH) NuttX-13.0.0-RC2
nsh> tc
tc_main: nsamples: 0
tc_main: Opening /dev/mouse0
Sample     :
   buttons : 00
         x : 684
         y : 385
Sample     :
   buttons : 00
         x : 697
         y : 391
Sample     :
   buttons : 00
         x : 709
         y : 396
