### PR TITLE
fs/procfs: fix incorrect environ read for another task under CONFIG_A…

### DIFF
--- a/fs/procfs/fs_procfsproc.c
+++ b/fs/procfs/fs_procfsproc.c
@@ -46,6 +46,7 @@
 #  include <time.h>
 #endif
 
+#include <nuttx/addrenv.h>
 #include <nuttx/arch.h>
 #include <nuttx/nuttx.h>
 #include <nuttx/irq.h>
@@ -155,6 +156,9 @@ struct proc_envinfo_s
   size_t buflen;
   size_t remaining;
   size_t totalsize;
+#ifdef CONFIG_ARCH_ADDRENV
+  FAR struct tcb_s *tcb;
+#endif
 };
 
 /****************************************************************************
@@ -1433,8 +1437,17 @@ static int proc_groupenv_callback(FAR void *arg, FAR const char *pair)
   size_t linesize;
   size_t copysize;
   int namelen;
+#ifdef CONFIG_ARCH_ADDRENV
+  FAR struct addrenv_s *targetenv;
+#endif
 
   DEBUGASSERT(arg != NULL && pair != NULL);
+
+  /* This callback is invoked by env_foreach() with info->tcb's own address
+   * environment selected, since "pair" points into info->tcb's user heap
+   * (tg_envp).  Parse "pair" and format the result into the kernel-heap-
+   * backed procfile->line first, all done under info->tcb's environment.
+   */
 
   /* Parse the name from the name/value pair */
 
@@ -1470,9 +1483,30 @@ static int proc_groupenv_callback(FAR void *arg, FAR const char *pair)
   linesize        = procfs_snprintf(info->procfile->line,
                                     STATUS_LINELEN, "%s=%s\n",
                                     name, value);
+
+  /* info->buffer is the caller's receive buffer, not info->tcb's, so
+   * switch back to the caller's own address environment before touching
+   * it, then switch back to info->tcb's so the next env_foreach()
+   * iteration can dereference the next tg_envp[] entry correctly.
+   */
+
+#ifdef CONFIG_ARCH_ADDRENV
+  if (info->tcb->addrenv_own != NULL)
+    {
+      addrenv_select(nxsched_self()->addrenv_own, &targetenv);
+    }
+#endif
+
   copysize        = procfs_memcpy(info->procfile->line, linesize,
                                   info->buffer, info->remaining,
                                   &info->offset);
+
+#ifdef CONFIG_ARCH_ADDRENV
+  if (info->tcb->addrenv_own != NULL)
+    {
+      addrenv_restore(targetenv);
+    }
+#endif
 
   info->totalsize += copysize;
   info->buffer    += copysize;
@@ -1498,6 +1532,9 @@ static ssize_t proc_groupenv(FAR struct proc_file_s *procfile,
 {
   FAR struct task_group_s *group = tcb->group;
   struct proc_envinfo_s info;
+#ifdef CONFIG_ARCH_ADDRENV
+  FAR struct addrenv_s *oldenv;
+#endif
 
   DEBUGASSERT(group != NULL);
 
@@ -1509,10 +1546,37 @@ static ssize_t proc_groupenv(FAR struct proc_file_s *procfile,
   info.buflen     = buflen;
   info.remaining  = buflen;
   info.totalsize  = 0;
+#ifdef CONFIG_ARCH_ADDRENV
+  info.tcb        = tcb;
+#endif
+
+  /* tg_envp holds addresses in tcb's own address space.  Temporarily
+   * switch to it so the strings it points to are actually reachable,
+   * since the caller (e.g. nsh reading another task's /proc node) may
+   * be running under a different address environment.  The caller's own
+   * environment is recovered on demand via nxsched_self()->addrenv_own
+   * in proc_groupenv_callback(), since whichever task runs that callback
+   * is by definition the caller.
+   */
+
+#ifdef CONFIG_ARCH_ADDRENV
+  if (tcb->addrenv_own != NULL)
+    {
+      addrenv_select(tcb->addrenv_own, &oldenv);
+    }
+#endif
 
   /* Generate output for each environment variable */
 
   env_foreach(group, proc_groupenv_callback, &info);
+
+#ifdef CONFIG_ARCH_ADDRENV
+  if (tcb->addrenv_own != NULL)
+    {
+      addrenv_restore(oldenv);
+    }
+#endif
+
   return info.totalsize;
 }
 #endif


### PR DESCRIPTION
## Summary

Reading `/proc/<pid>/group/env` for another task dereferenced `tg_envp` under
the caller's own address environment instead of the target task's, since
`tg_envp` lives in the target's user heap. Switch to the target's address
environment around the traversal, and to the caller's own environment only
around the copy into the caller's buffer.

Under `CONFIG_BUILD_KERNEL` with `CONFIG_ARCH_ADDRENV` (MMU-backed, per-task
address environments), each task group has its own page table.
`proc_groupenv()` walks `tcb->group->tg_envp[]` for the *target* task, but for
an ordinary task `tg_envp` is allocated via `group_malloc()` (user heap), so
the pointer and the strings it points to are only valid under the *target's*
own page table — not whichever page table happens to be active when the
*caller* (e.g. nsh reading another task's `/proc` node) is running.

This is easy to miss because in many cases the caller's and target's
environments happen to contain identical content, so the wrong data looks
right by coincidence. It becomes visible once the two environments diverge
(e.g. after `cd` changes the caller's own `PWD`/`OLDPWD`).

Two remediation options were considered:

1. Store env in kernel-space memory (keeping a parallel userspace copy for
   `get_environ_ptr`) — more invasive, adds memory overhead, and complicates
   every env-mutation code path.
2. Temporarily switch to the target task's address environment while reading
   its `tg_envp` — some extra runtime cost per switch, but cross-task env
   reads are infrequent, so this is the better trade-off.

Went with option 2: `proc_groupenv()` now selects the target task's address
environment for the duration of the `env_foreach()` traversal, since
`env_foreach()` itself dereferences `tg_envp[i]` between callback
invocations (the loop condition check happens outside the callback). The
per-variable callback (`proc_groupenv_callback()`) briefly switches back to
the caller's own address environment — recovered on demand via
`nxsched_self()->addrenv_own`, no extra state needed — only around the
`procfs_memcpy()` that writes into the caller's receive buffer, then
switches back to the target's environment before returning so the next
iteration's dereference is still correct.

## Impact

- Affects `CONFIG_BUILD_KERNEL` + `CONFIG_ARCH_ADDRENV` configurations only
  (per-task-group address environments). Flat/protected builds are
  unaffected.
- Fixes a correctness bug in `/proc/<pid>/group/env`; no user-facing API
  change.

## Testing

Tested on QEMU rv-virt and Houmo M50 hardware,
`CONFIG_BUILD_KERNEL` + `CONFIG_ARCH_ADDRENV` enabled.

Observed behavior first, before the fix.

With `CONFIG_DEBUG_ASSERTIONS=y`:

```
NuttShell (NSH) NuttX-13.0.0-RC2
nsh>
nsh> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK COMMAND
    0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0003024 Idle_Task
    1     0     0 100 RR       Kthread   - Waiting  Semaphore 0000000000000000 0001936 lpwork 0x80600100 0x80600180
    3     3     0 100 RR       Task      - Running            0000000000000000 0002976 /system/bin/init
nsh> env
PWD=/
PATH=/system/bin
nsh> cat /proc/3/group/env
PWD=/
PATH=/system/bin
nsh> dd &
dd [0:100]
nsh> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK COMMAND
    0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0003024 Idle_Task
    1     0     0 100 RR       Kthread   - Waiting  Semaphore 0000000000000000 0001936 lpwork 0x80600100 0x80600180
    3     3     0 100 RR       Task      - Running            0000000000000000 0002976 /system/bin/init
    4     4     3 100 RR       Task      - Ready              0000000000000000 0008112 dd
nsh> cat /proc/4/group/env
PWD=/
PATH=/system/bin
nsh>
nsh> cd /proc
nsh> cat /proc/4/group/env
[   66.855000] dump_assert_info: Current Version: NuttX  13.0.0-RC2 1fc6f2bac8 Jul 10 2026 06:47:32 risc-v
[   66.855000] dump_assert_info: Assertion failed : at file: environ/env_foreach.c:98 task: /system/bin/init process: /system/bin/init 0xc0000092
[   66.855000] up_dump_register: EPC: 000000008021684a
[   66.855000] up_dump_register: A0: 00000000806090a0 A1: 0000000000000000 A2: 0000000000000000 A3: 000000000000007e
[   66.855000] up_dump_register: A4: 0000000000000002 A5: 0000000000000000 A6: 000000000000000a A7: 0000000080207bc0
[   66.855000] up_dump_register: T0: 0000000000000000 T1: 00000000000001c0 T2: 0000000000000000 T3: 0000000000080000
[   66.855000] up_dump_register: T4: 00000000c0800958 T5: 00000000c0802818 T6: 0000000000000000
[   66.855000] up_dump_register: S0: 00000000806107a0 S1: 000000008060b098 S2: 000000008060bb98 S3: 0000000200042020
[   66.855000] up_dump_register: S4: 0000000000000000 S5: 000000008021f550 S6: 0000000080609318 S7: 0000000000000006
[   66.855000] up_dump_register: S8: 0000000080609308 S9: 0000000000000062 S10: 00000000c000e1d0 S11: 0000000000000241
[   66.855000] up_dump_register: SP: 0000000080610650 FP: 00000000806107a0 TP: 0000000000000000 RA: 000000008021684a
```

With `CONFIG_DEBUG_ASSERTIONS` disabled:

```
NuttShell (NSH) NuttX-13.0.0-RC2
nsh>
nsh> env
PWD=/
PATH=/system/bin
nsh> dd &
dd [0:100]
nsh> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK COMMAND
    0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0003024 Idle_Task
    1     0     0 100 RR       Kthread   - Waiting  Semaphore 0000000000000000 0001936 lpwork 0x80600100 0x80600180
    3     3     0 100 RR       Task      - Running            0000000000000000 0002976 /system/bin/init
    4     4     3 100 RR       Task      - Ready              0000000000000000 0008112 dd
nsh> cat /proc/3/group/env
PWD=/
PATH=/system/bin
nsh> cat /proc/4/group/env
PWD=/
PATH=/system/bin
nsh>
nsh> cd /proc
nsh> cat /proc/3/group/env
OLDPWD=/
PATH=/system/bin
PWD=/proc
nsh>
nsh>
nsh> cat /proc/4/group/env
OLDPWD=/
PATH=/system/bin
PWD=/proc
nsh>
```
After the fix:

```
NuttShell (NSH) NuttX-13.0.0-RC2
nsh>
nsh> dd &
dd [0:100]
nsh> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK COMMAND
    0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0003024 Idle_Task
    1     0     0 100 RR       Kthread   - Waiting  Semaphore 0000000000000000 0001936 lpwork 0x80600100 0x80600180
    3     3     0 100 RR       Task      - Running            0000000000000000 0002976 /system/bin/init
    4     4     3 100 RR       Task      - Ready              0000000000000000 0008112 dd
nsh> cat /proc/3/group/env
PWD=/
PATH=/system/bin
nsh> cat /proc/4/group/env
PWD=/
PATH=/system/bin
nsh>
nsh> cd /proc
nsh>
nsh> cat /proc/3/group/env
OLDPWD=/
PATH=/system/bin
PWD=/proc
nsh> cat /proc/4/group/env
PWD=/
PATH=/system/bin
```