### PR TITLE
arch/arm/stm32: make STM32_ETHMAC depend on NET

### DIFF
--- a/arch/arm/src/common/stm32/Kconfig.periph
+++ b/arch/arm/src/common/stm32/Kconfig.periph
@@ -1112,7 +1112,7 @@ config STM32_QSPI
 
 config STM32_ETHMAC
 	bool "Ethernet MAC"
-	depends on STM32_HAVE_ETHERNET
+	depends on STM32_HAVE_ETHERNET && NET
 	select NETDEVICES
 	select ARCH_HAVE_PHY
 	select STM32_PHY_HAVE_POLLED if !STM32_COMMON_LEGACY


### PR DESCRIPTION
## Summary

STM32_ETHMAC selects NETDEVICES, but NETDEVICES depends on NET. Enabling ETHMAC without NET produced an invalid Kconfig

## Impact

fix kconfig dependency

## Testing

CI, found with a dedicated fuzzer for nuttx