### PR TITLE
drivers/net/w5500: fix wrong variable names in receive error path and d_private assignment

### DIFF
--- a/drivers/net/w5500.c
+++ b/drivers/net/w5500.c
@@ -1348,7 +1348,7 @@ static void w5500_receive(FAR struct w5500_driver_s *self)
         {
           nerr("Bad packet size dropped (%"PRIu16")\n", self->w_dev.d_len);
           self->w_dev.d_len = 0;
-          NETDEV_RXERRORS(&priv->dev);
+          NETDEV_RXERRORS(&self->w_dev);
           continue;
         }
 
@@ -2066,7 +2066,7 @@ int w5500_initialize(FAR struct spi_dev_s *spi_dev,
 #ifdef CONFIG_NETDEV_IOCTL
   self->w_dev.d_ioctl   = w5500_ioctl;                    /* Handle network IOCTL commands */
 #endif
-  self->w_dev.d_private = g_w5500;                        /* Used to recover private state from dev */
+  self->w_dev.d_private = self;                           /* Used to recover private state from dev */
   self->spi_dev         = spi_dev;                        /* SPI hardware interconnect */
   self->lower           = lower;                          /* Low-level MCU specific support */
 


### PR DESCRIPTION
## Summary

Fix two latent defects in the W5500 Ethernet driver:

1. **`NETDEV_RXERRORS()` references non-existent variables** (line 1351): In `w5500_receive()`, the error path uses `&priv->dev` but the function parameter is named `self` and the device field is `w_dev`. This compiles only because `NETDEV_RXERRORS()` expands to nothing without `CONFIG_NETDEV_STATISTICS`; enabling statistics breaks the build.

2. **`d_private` set to the device array instead of the instance** (line 2069): In `w5500_initialize()`, `d_private` was set to `g_w5500` (the global array) instead of `self` (the current instance). This is harmless for device 0 (`g_w5500 == &g_w5500[0]`) but wrong for any `devno > 0` — every callback that recovers the driver state via `dev->d_private` would operate on device 0's state.

Fixes #19306

## Impact

- Bug fix only, no functional changes for single-device configurations
- Fixes multi-device W5500 configurations where `devno > 0`
- Fixes build with `CONFIG_NETDEV_STATISTICS` enabled

## Testing

- Verified by code inspection against master
- Confirmed variable names match function signature and struct fields

Signed-off-by: hanzhijian <hanzhijian@zepp.com>