### PR TITLE
boards/rp23xx: copy .got into RAM at boot in the memmap linker scripts

### DIFF
--- a/boards/arm/rp23xx/pimoroni-pico-2-plus/scripts/memmap_copy_to_ram.ld
+++ b/boards/arm/rp23xx/pimoroni-pico-2-plus/scripts/memmap_copy_to_ram.ld
@@ -184,6 +184,16 @@ SECTIONS
         *(.data*)
         *(.sdata*)
 
+        /* GOT/PLT must live INSIDE the copied .data range so a flat
+         * -fPIC object (e.g. a PIC static library linked into an app)
+         * gets an initialised GOT in RAM at boot; otherwise an orphan
+         * .got lands after _edata, is never copied, and every GOT-
+         * indirected access reads a NULL pointer (hardfault). */
+        . = ALIGN(4);
+        *(.got)
+        *(.got.plt)
+        *(.got*)
+
         . = ALIGN(4);
         *(.after_data.*)
         . = ALIGN(4);

--- a/boards/arm/rp23xx/pimoroni-pico-2-plus/scripts/memmap_default.ld
+++ b/boards/arm/rp23xx/pimoroni-pico-2-plus/scripts/memmap_default.ld
@@ -211,6 +211,16 @@ SECTIONS
         *(.data*)
         *(.sdata*)
 
+        /* GOT/PLT must live INSIDE the copied .data range so a flat
+         * -fPIC object (e.g. a PIC static library linked into an app)
+         * gets an initialised GOT in RAM at boot; otherwise an orphan
+         * .got lands after _edata, is never copied, and every GOT-
+         * indirected access reads a NULL pointer (hardfault). */
+        . = ALIGN(4);
+        *(.got)
+        *(.got.plt)
+        *(.got*)
+
         . = ALIGN(4);
         *(.after_data.*)
         . = ALIGN(4);

--- a/boards/arm/rp23xx/pimoroni-pico-2-plus/scripts/memmap_no_flash.ld
+++ b/boards/arm/rp23xx/pimoroni-pico-2-plus/scripts/memmap_no_flash.ld
@@ -133,6 +133,16 @@ SECTIONS
         *(.data*)
         *(.sdata*)
 
+        /* GOT/PLT must live INSIDE the copied .data range so a flat
+         * -fPIC object (e.g. a PIC static library linked into an app)
+         * gets an initialised GOT in RAM at boot; otherwise an orphan
+         * .got lands after _edata, is never copied, and every GOT-
+         * indirected access reads a NULL pointer (hardfault). */
+        . = ALIGN(4);
+        *(.got)
+        *(.got.plt)
+        *(.got*)
+
         . = ALIGN(4);
         *(.after_data.*)
         . = ALIGN(4);

--- a/boards/arm/rp23xx/raspberrypi-pico-2/scripts/memmap_copy_to_ram.ld
+++ b/boards/arm/rp23xx/raspberrypi-pico-2/scripts/memmap_copy_to_ram.ld
@@ -184,6 +184,16 @@ SECTIONS
         *(.data*)
         *(.sdata*)
 
+        /* GOT/PLT must live INSIDE the copied .data range so a flat
+         * -fPIC object (e.g. a PIC static library linked into an app)
+         * gets an initialised GOT in RAM at boot; otherwise an orphan
+         * .got lands after _edata, is never copied, and every GOT-
+         * indirected access reads a NULL pointer (hardfault). */
+        . = ALIGN(4);
+        *(.got)
+        *(.got.plt)
+        *(.got*)
+
         . = ALIGN(4);
         *(.after_data.*)
         . = ALIGN(4);

--- a/boards/arm/rp23xx/raspberrypi-pico-2/scripts/memmap_default.ld
+++ b/boards/arm/rp23xx/raspberrypi-pico-2/scripts/memmap_default.ld
@@ -211,6 +211,16 @@ SECTIONS
         *(.data*)
         *(.sdata*)
 
+        /* GOT/PLT must live INSIDE the copied .data range so a flat
+         * -fPIC object (e.g. a PIC static library linked into an app)
+         * gets an initialised GOT in RAM at boot; otherwise an orphan
+         * .got lands after _edata, is never copied, and every GOT-
+         * indirected access reads a NULL pointer (hardfault). */
+        . = ALIGN(4);
+        *(.got)
+        *(.got.plt)
+        *(.got*)
+
         . = ALIGN(4);
         *(.after_data.*)
         . = ALIGN(4);

--- a/boards/arm/rp23xx/raspberrypi-pico-2/scripts/memmap_no_flash.ld
+++ b/boards/arm/rp23xx/raspberrypi-pico-2/scripts/memmap_no_flash.ld
@@ -133,6 +133,16 @@ SECTIONS
         *(.data*)
         *(.sdata*)
 
+        /* GOT/PLT must live INSIDE the copied .data range so a flat
+         * -fPIC object (e.g. a PIC static library linked into an app)
+         * gets an initialised GOT in RAM at boot; otherwise an orphan
+         * .got lands after _edata, is never copied, and every GOT-
+         * indirected access reads a NULL pointer (hardfault). */
+        . = ALIGN(4);
+        *(.got)
+        *(.got.plt)
+        *(.got*)
+
         . = ALIGN(4);
         *(.after_data.*)
         . = ALIGN(4);

--- a/boards/arm/rp23xx/xiao-rp2350/scripts/memmap_copy_to_ram.ld
+++ b/boards/arm/rp23xx/xiao-rp2350/scripts/memmap_copy_to_ram.ld
@@ -184,6 +184,16 @@ SECTIONS
         *(.data*)
         *(.sdata*)
 
+        /* GOT/PLT must live INSIDE the copied .data range so a flat
+         * -fPIC object (e.g. a PIC static library linked into an app)
+         * gets an initialised GOT in RAM at boot; otherwise an orphan
+         * .got lands after _edata, is never copied, and every GOT-
+         * indirected access reads a NULL pointer (hardfault). */
+        . = ALIGN(4);
+        *(.got)
+        *(.got.plt)
+        *(.got*)
+
         . = ALIGN(4);
         *(.after_data.*)
         . = ALIGN(4);

--- a/boards/arm/rp23xx/xiao-rp2350/scripts/memmap_default.ld
+++ b/boards/arm/rp23xx/xiao-rp2350/scripts/memmap_default.ld
@@ -211,6 +211,16 @@ SECTIONS
         *(.data*)
         *(.sdata*)
 
+        /* GOT/PLT must live INSIDE the copied .data range so a flat
+         * -fPIC object (e.g. a PIC static library linked into an app)
+         * gets an initialised GOT in RAM at boot; otherwise an orphan
+         * .got lands after _edata, is never copied, and every GOT-
+         * indirected access reads a NULL pointer (hardfault). */
+        . = ALIGN(4);
+        *(.got)
+        *(.got.plt)
+        *(.got*)
+
         . = ALIGN(4);
         *(.after_data.*)
         . = ALIGN(4);

--- a/boards/arm/rp23xx/xiao-rp2350/scripts/memmap_no_flash.ld
+++ b/boards/arm/rp23xx/xiao-rp2350/scripts/memmap_no_flash.ld
@@ -133,6 +133,16 @@ SECTIONS
         *(.data*)
         *(.sdata*)
 
+        /* GOT/PLT must live INSIDE the copied .data range so a flat
+         * -fPIC object (e.g. a PIC static library linked into an app)
+         * gets an initialised GOT in RAM at boot; otherwise an orphan
+         * .got lands after _edata, is never copied, and every GOT-
+         * indirected access reads a NULL pointer (hardfault). */
+        . = ALIGN(4);
+        *(.got)
+        *(.got.plt)
+        *(.got*)
+
         . = ALIGN(4);
         *(.after_data.*)
         . = ALIGN(4);


### PR DESCRIPTION
## Summary

The pico-sdk-derived rp23xx linker scripts place `.got`/`.got.plt` as **orphan
sections after the `.data` output section**, so the boot-time `.data` copy —
which runs to `_edata` — never copies the GOT into RAM. Any position-independent
(`-fPIC`) object linked into an application then reads an **uninitialised GOT full
of NULLs**: the first GOT-indirected access branches to 0 and the board hardfaults
before `main()`.

This is not hypothetical — a `-fPIC` static library is enough. In my case a NuttX
app linking a `-fPIC` `liboqs.a` (whose SHA3 dispatch reads its function pointers
through the GOT) wedged the board deterministically on its first crypto call.

The fix folds `*(.got)`/`*(.got.plt)` into the `.data{}` section, before `_edata`,
in all three boot-mode scripts (`memmap_default` / `memmap_copy_to_ram` /
`memmap_no_flash`) for every rp23xx board, so the GOT is initialised in RAM by the
standard startup copy.

## Impact

- Fixes a boot-time hardfault for any `-fPIC` library linked into an rp23xx app.
- **No effect on non-PIC images** — the GOT is empty, so the added sections copy
  zero bytes.
- Applies uniformly to `raspberrypi-pico-2`, `xiao-rp2350` and
  `pimoroni-pico-2-plus`.

## Testing

Reproduced and fixed on a Raspberry Pi Pico 2 W. With the original scripts, an app
linking a `-fPIC` `liboqs.a` hardfaulted on its first hardware crypto call (traced
to a NULL GOT-indirected dispatch pointer; the ELF showed `.got` landing exactly at
`_edata`, i.e. outside the copied range). After folding `.got` into `.data`, the
GOT is populated in RAM and the same app runs correctly.

---

*Disclosure: this change was prepared by an AI agent (Claude Code) at the direction
of the author, who root-caused and tested it on hardware before submission.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
