### PR TITLE
crypto: add CRYPTO_CHACHA20_DJB variant (64-bit counter/nonce)

### DIFF
--- a/crypto/chachapoly.c
+++ b/crypto/chachapoly.c
@@ -84,6 +84,32 @@ void chachapoly_reinit(caddr_t key, FAR uint8_t *iv)
   chacha_ivsetup((FAR chacha_ctx *)ctx->block, iv, ctx->nonce);
 }
 
+int chacha20_djb_setkey(FAR void *sched, FAR uint8_t *key, int len)
+{
+  FAR struct chacha20_ctx *ctx = (FAR struct chacha20_ctx *)sched;
+
+  if (len != CHACHA20_KEYSIZE)
+    {
+      return -1;
+    }
+
+  chacha_keysetup((FAR chacha_ctx *)ctx->block, key, CHACHA20_KEYSIZE * 8);
+  return 0;
+}
+
+void chacha20_djb_reinit(caddr_t key, FAR uint8_t *iv)
+{
+  FAR struct chacha20_ctx *ctx = (FAR struct chacha20_ctx *)key;
+
+  /* Original DJB ChaCha20 layout, as used by chacha20-poly1305@openssh.com
+   * (libtomcrypt chacha_ivctr64): the 16-byte IV is loaded verbatim into
+   * state words 12..15 as a 64-bit little-endian block counter followed by
+   * a 64-bit nonce.
+   */
+
+  chacha_ivsetup((FAR chacha_ctx *)ctx->block, iv + 4, iv);
+}
+
 void chacha20_poly1305_init(FAR void *xctx)
 {
   FAR CHACHA20_POLY1305_CTX *ctx = xctx;

--- a/crypto/cryptodev.c
+++ b/crypto/cryptodev.c
@@ -237,6 +237,7 @@ static int cryptof_ioctl(FAR struct file *filep,
             case CRYPTO_AES_CFB_8:
             case CRYPTO_AES_CFB_128:
             case CRYPTO_CHACHA20:
+            case CRYPTO_CHACHA20_DJB:
             case CRYPTO_CHACHA20_POLY1305:
             case CRYPTO_NULL:
               txform = true;

--- a/crypto/cryptosoft.c
+++ b/crypto/cryptosoft.c
@@ -1645,6 +1645,9 @@ int swcr_newsession(FAR uint32_t *sid, FAR struct cryptoini *cri)
           case CRYPTO_CHACHA20:
             txf = &enc_xform_chacha20;
             goto enccommon;
+          case CRYPTO_CHACHA20_DJB:
+            txf = &enc_xform_chacha20_djb;
+            goto enccommon;
           case CRYPTO_CHACHA20_POLY1305:
             txf = &enc_xform_chacha20_poly1305;
             goto enccommon;
@@ -1908,6 +1911,7 @@ int swcr_freesession(uint64_t tid)
           case CRYPTO_AES_CFB_8:
           case CRYPTO_AES_CFB_128:
           case CRYPTO_CHACHA20:
+          case CRYPTO_CHACHA20_DJB:
           case CRYPTO_CHACHA20_POLY1305:
           case CRYPTO_NULL:
             txf = swd->sw_exf;
@@ -2047,6 +2051,7 @@ int swcr_process(struct cryptop *crp)
           case CRYPTO_AES_CFB_8:
           case CRYPTO_AES_CFB_128:
           case CRYPTO_CHACHA20:
+          case CRYPTO_CHACHA20_DJB:
             txf = sw->sw_exf;
 
             if (crp->crp_iv)
@@ -2452,6 +2457,7 @@ void swcr_init(void)
   algs[CRYPTO_AES_CFB_8] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_AES_CFB_128] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_CHACHA20] = CRYPTO_ALG_FLAG_SUPPORTED;
+  algs[CRYPTO_CHACHA20_DJB] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_CHACHA20_POLY1305] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_CHACHA20_POLY1305_MAC] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_MD5] = CRYPTO_ALG_FLAG_SUPPORTED;

--- a/crypto/xform.c
+++ b/crypto/xform.c
@@ -318,6 +318,17 @@ const struct enc_xform enc_xform_chacha20 =
   chacha20_reinit
 };
 
+const struct enc_xform enc_xform_chacha20_djb =
+{
+  CRYPTO_CHACHA20_DJB, "CHACHA20-DJB",
+  64, 16, 32, 32,
+  sizeof(struct chacha20_ctx),
+  chacha20_crypt,
+  chacha20_crypt,
+  chacha20_djb_setkey,
+  chacha20_djb_reinit
+};
+
 const struct enc_xform enc_xform_chacha20_poly1305 =
 {
   CRYPTO_CHACHA20_POLY1305, "CHACHA20-POLY1305",

--- a/include/crypto/chachapoly.h
+++ b/include/crypto/chachapoly.h
@@ -36,6 +36,8 @@ int chacha20_setkey(FAR void *, FAR uint8_t *, int);
 void chacha20_reinit(caddr_t, FAR uint8_t *);
 void chacha20_crypt(caddr_t, FAR uint8_t *, size_t);
 void chachapoly_reinit(caddr_t, FAR uint8_t *);
+int chacha20_djb_setkey(FAR void *, FAR uint8_t *, int);
+void chacha20_djb_reinit(caddr_t, FAR uint8_t *);
 
 #define POLY1305_KEYLEN 64
 #define POLY1305_TAGLEN 16

--- a/include/crypto/cryptodev.h
+++ b/include/crypto/cryptodev.h
@@ -141,7 +141,8 @@
 #define CRYPTO_ESN              40 /* Support for Extended Sequence Numbers */
 #define CRYPTO_SHA2_224_HMAC    41
 #define CRYPTO_CHACHA20         42
-#define CRYPTO_ALGORITHM_MAX    42 /* Keep updated */
+#define CRYPTO_CHACHA20_DJB     43
+#define CRYPTO_ALGORITHM_MAX    43 /* Keep updated */
 
 /* Algorithm flags */
 

--- a/include/crypto/xform.h
+++ b/include/crypto/xform.h
@@ -113,6 +113,7 @@ extern const struct enc_xform enc_xform_aes_ofb;
 extern const struct enc_xform enc_xform_aes_cfb_8;
 extern const struct enc_xform enc_xform_aes_cfb_128;
 extern const struct enc_xform enc_xform_chacha20;
+extern const struct enc_xform enc_xform_chacha20_djb;
 extern const struct enc_xform enc_xform_chacha20_poly1305;
 extern const struct enc_xform enc_xform_null;
 


### PR DESCRIPTION
## Summary

This PR adds a new OCF algorithm ID, `CRYPTO_CHACHA20_DJB`, implementing the
original ChaCha20 construction as designed by Daniel J. Bernstein (DJB),
alongside the already-supported IETF variant.

ChaCha20 exists in two standard parameterizations that differ only in how the
last four words of the cipher state (words 12..15) are split:

- **Original DJB construction (2008)**: 64-bit little-endian block counter
  (state words 12–13) + 64-bit nonce (state words 14–15). This is the layout
  used by OpenSSH's `chacha20-poly1305@openssh.com` and by libtomcrypt's
  `chacha_ivctr64()`.
- **IETF variant (RFC 8439)**: 32-bit block counter (word 12) + 96-bit nonce
  (words 13–15). This is what the existing `CRYPTO_CHACHA20` implements, and
  what TLS uses.

## Impact

- **Users**: no impact on existing code paths. `CRYPTO_CHACHA20` (IETF) is
  unchanged; `CRYPTO_CHACHA20_DJB` is a new, separate algorithm ID in
  `include/crypto/cryptodev.h` (`CRYPTO_ALGORITHM_MAX` bumped accordingly).
- **Security**: implements a well-established construction (original ChaCha20
  by D. J. Bernstein); no changes to existing algorithms.

## Testing

Host: Ubuntu 24.04 (aarch64), GCC 13.3.0
Target: `sim:nsh` + `CONFIG_CRYPTO_CRYPTODEV=y` +
`CONFIG_CRYPTO_CRYPTODEV_SOFTWARE_CRYPTO=y`

The new transform was verified on the simulator with a small `/dev/crypto`
test program (session with `cipher = CRYPTO_CHACHA20_DJB`, `CIOCCRYPT` over
64 zero bytes) against ChaCha20 keystreams computed independently with
OpenSSL on the host. The DJB 16-byte IV (64-bit LE counter || 64-bit nonce)
is byte-for-byte the same layout OpenSSL's `enc -chacha20` takes as `-iv`
(32-bit LE counter || 96-bit nonce), so the same 16 bytes must produce the
same keystream — while NuttX's IETF `CRYPTO_CHACHA20`, which parses the IV
differently, must diverge:

```console
$ K=000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f
$ head -c 64 /dev/zero | openssl enc -chacha20 -K $K -iv 00000000000000000001020304050607 | xxd -p -c 32
f798a189f195e66982105ffb640bb7757f579da31602fc93ec01ac56f85ac3c1
34a4547b733b46413042c9440049176905d3be59ea1c53f15916155c2be8241a
$ head -c 64 /dev/zero | openssl enc -chacha20 -K $K -iv 01000000000000000001020304050607 | xxd -p -c 32
38008b9a26bc35941e2444177c8ade6689de95264986d95889fb60e84629c9bd
9a5acb1cc118be563eb9b3a4a472f82e09a7e778492b562ef7130e88dfe031c7
```

(The first keystream matches the well-known ChaCha20 test vector for
key `00 01 02 .. 1f` / nonce `00 01 02 03 04 05 06 07`.)

On the simulator (test program run as the `hello` built-in):

```console
$ ./tools/configure.sh sim:nsh
$ kconfig-tweak --enable CONFIG_ALLOW_BSD_COMPONENTS
$ kconfig-tweak --enable CONFIG_CRYPTO
$ kconfig-tweak --enable CONFIG_CRYPTO_SW_AES
$ kconfig-tweak --enable CONFIG_CRYPTO_CRYPTODEV
$ kconfig-tweak --enable CONFIG_CRYPTO_CRYPTODEV_SOFTWARE_CRYPTO
$ make olddefconfig && make -j4
$ ./nuttx
NuttShell (NSH) NuttX-12.6.0-RC1
nsh> hello
CRYPTO_CHACHA20_DJB /dev/crypto test
PASS: DJB ctr=0 keystream matches OpenSSL
PASS: DJB ctr=1 keystream matches OpenSSL
PASS: IETF CRYPTO_CHACHA20 diverges from DJB layout
chacha20-djb: 3 passed, 0 failed
```

The second vector exercises the DJB IV layout with block counter = 1,
confirming the counter is taken from IV bytes 0..7 (words 12..13). The third
check creates a `CRYPTO_CHACHA20` (IETF) session with the same key and IV
bytes and confirms its keystream differs, demonstrating the two
parameterizations are distinct and the new ID is required for OpenSSH
interoperability.