### PR TITLE
ci/platforms/darwin.sh: fix genromfs installation

### DIFF
--- a/tools/ci/platforms/darwin.sh
+++ b/tools/ci/platforms/darwin.sh
@@ -188,6 +188,15 @@ elf_toolchain() {
 gen_romfs() {
   if ! type genromfs > /dev/null 2>&1; then
     brew tap PX4/px4
+
+    # Trust each tap non-interactively before installing from it. Without this,
+    # `brew install` aborts before pouring any package (including ccache).
+    # `brew trust` only exists on Homebrew 6.0+; guard it so older versions,
+    # which don't gate untrusted taps, skip it silently.
+    if brew trust --help &> /dev/null; then
+      brew trust PX4/px4
+    fi
+
     brew install genromfs
   fi
 }


### PR DESCRIPTION
## Summary

fix

```
Error: Refusing to load formula px4/px4/genromfs from untrusted tap px4/px4. 
Run `brew trust --formula px4/px4/genromfs` or `brew trust px4/px4` to trust it. Error: Process completed with exit code 1.
```
https://github.com/NuttX/nuttx/actions/runs/27758491940/job/82126706912


Homebrew 6.0+ refuses to load formulae from third-party taps unless they are explicitly trusted ("Refusing to load formula ... from untrusted tap"). Trust each tap non-interactively before installing from it. Without this, `brew install` aborts before pouring any package (including ccache). `brew trust` only exists on Homebrew 6.0+.

https://github.com/PX4/PX4-Autopilot/blob/50161b1f09c31beade9a0bb5b4057276e9eac4ee/Tools/setup/macos.sh#L54-L64

## Impact

Impact on user: No changes to user-facing functionality
Impact on build: Build process remains the same

## Testing

GitHub 

Nuttx repository: simbit18/nuttx
    Nuttx branch: simbit18-macos
 Apps repository: apache/nuttx-apps
     Apps branch: master
    Architecture: all
   Host platform: macos

```
==> Would install 1 formula:
genromfs
==> Fetching downloads for: genromfs
✔︎ Formula genromfs (0.5.2)
✔︎ Formula genromfs (0.5.2)
==> Installing genromfs from px4/px4
==> Patching
==> make
==> make PREFIX=/usr/local/Cellar/genromfs/0.5.2 install-bin
🍺  /usr/local/Cellar/genromfs/0.5.2: 7 files, 50.2KB, built in 5 seconds
```

https://github.com/simbit18/manual-nuttx-ci/actions/runs/29193425477/job/86652110177