### PR TITLE
drivers/efuse: Multiple Drivers Are Registered With World Writable

### DIFF
--- a/arch/arm/src/c5471/c5471_watchdog.c
+++ b/arch/arm/src/c5471/c5471_watchdog.c
@@ -359,7 +359,7 @@ int arm_wdtinit(void)
 
   /* Register as /dev/wdt */
 
-  ret = register_driver("/dev/wdt", &g_wdtops, 0666, NULL);
+  ret = register_driver("/dev/wdt", &g_wdtops, 0600, NULL);
   if (ret)
     {
       return ERROR;

--- a/arch/arm/src/common/stm32/stm32_bbsram_m3m4_v1.c
+++ b/arch/arm/src/common/stm32/stm32_bbsram_m3m4_v1.c
@@ -757,7 +757,7 @@ int stm32_bbsraminitialize(char *devpath, int *sizes)
     {
       snprintf(devname, sizeof(devname), "%s%d", devpath, i);
       ret = register_driver(devname, &g_stm32_bbsram_fops,
-                            0666, &g_bbsram[i]);
+                            0600, &g_bbsram[i]);
     }
 
   /* Disallow Access */

--- a/arch/arm/src/common/stm32/stm32_hrtim_m3m4_v1.c
+++ b/arch/arm/src/common/stm32/stm32_hrtim_m3m4_v1.c
@@ -6037,7 +6037,7 @@ int hrtim_register(const char *path, struct hrtim_dev_s *dev)
 
   /* Register the HRTIM character driver */
 
-  return register_driver(path, &g_hrtim_fops, 0444, dev);
+  return register_driver(path, &g_hrtim_fops, 0440, dev);
 }
 #endif /* CONFIG_STM32_HRTIM_DISABLE_CHARDRV */
 

--- a/arch/arm/src/cxd56xx/cxd56_adc.c
+++ b/arch/arm/src/cxd56xx/cxd56_adc.c
@@ -1105,7 +1105,7 @@ int cxd56_adcinitialize(void)
   int ret = OK;
 
 #if defined (CONFIG_CXD56_LPADC0) || defined (CONFIG_CXD56_LPADC0_1) || defined (CONFIG_CXD56_LPADC_ALL)
-  ret = register_driver("/dev/lpadc0", &g_adcops, 0666, &g_lpadc0priv);
+  ret = register_driver("/dev/lpadc0", &g_adcops, 0600, &g_lpadc0priv);
   if (ret < 0)
     {
       aerr("Failed to register driver(lpadc0): %d\n", ret);
@@ -1114,7 +1114,7 @@ int cxd56_adcinitialize(void)
 #endif
 
 #if defined (CONFIG_CXD56_LPADC1) || defined (CONFIG_CXD56_LPADC0_1) || defined (CONFIG_CXD56_LPADC_ALL)
-  ret = register_driver("/dev/lpadc1", &g_adcops, 0666, &g_lpadc1priv);
+  ret = register_driver("/dev/lpadc1", &g_adcops, 0600, &g_lpadc1priv);
   if (ret < 0)
     {
       aerr("Failed to register driver(lpadc1): %d\n", ret);
@@ -1123,7 +1123,7 @@ int cxd56_adcinitialize(void)
 #endif
 
 #if defined (CONFIG_CXD56_LPADC2) || defined (CONFIG_CXD56_LPADC_ALL)
-  ret = register_driver("/dev/lpadc2", &g_adcops, 0666, &g_lpadc2priv);
+  ret = register_driver("/dev/lpadc2", &g_adcops, 0600, &g_lpadc2priv);
   if (ret < 0)
     {
       aerr("Failed to register driver(lpadc2): %d\n", ret);
@@ -1132,7 +1132,7 @@ int cxd56_adcinitialize(void)
 #endif
 
 #if defined (CONFIG_CXD56_LPADC3) || defined (CONFIG_CXD56_LPADC_ALL)
-  ret = register_driver("/dev/lpadc3", &g_adcops, 0666, &g_lpadc3priv);
+  ret = register_driver("/dev/lpadc3", &g_adcops, 0600, &g_lpadc3priv);
   if (ret < 0)
     {
       aerr("Failed to register driver(lpadc3): %d\n", ret);
@@ -1141,7 +1141,7 @@ int cxd56_adcinitialize(void)
 #endif
 
 #ifdef CONFIG_CXD56_HPADC0
-  ret = register_driver("/dev/hpadc0", &g_adcops, 0666, &g_hpadc0priv);
+  ret = register_driver("/dev/hpadc0", &g_adcops, 0600, &g_hpadc0priv);
   if (ret < 0)
     {
       aerr("Failed to register driver(hpadc0): %d\n", ret);
@@ -1150,7 +1150,7 @@ int cxd56_adcinitialize(void)
 #endif
 
 #ifdef CONFIG_CXD56_HPADC1
-  ret = register_driver("/dev/hpadc1", &g_adcops, 0666, &g_hpadc1priv);
+  ret = register_driver("/dev/hpadc1", &g_adcops, 0600, &g_hpadc1priv);
   if (ret < 0)
     {
       aerr("Failed to register driver(hpadc1): %d\n", ret);

--- a/arch/arm/src/cxd56xx/cxd56_charger.c
+++ b/arch/arm/src/cxd56xx/cxd56_charger.c
@@ -623,7 +623,7 @@ int cxd56_charger_initialize(const char *devpath)
 
   /* Register battery driver */
 
-  ret = register_driver(devpath, &g_chargerops, 0666, priv);
+  ret = register_driver(devpath, &g_chargerops, 0600, priv);
   if (ret < 0)
     {
       baterr("ERROR: register_driver failed: %d\n", ret);

--- a/arch/arm/src/cxd56xx/cxd56_gauge.c
+++ b/arch/arm/src/cxd56xx/cxd56_gauge.c
@@ -347,7 +347,7 @@ int cxd56_gauge_initialize(const char *devpath)
 
   /* Register battery driver */
 
-  ret = register_driver(devpath, &g_gaugeops, 0666, priv);
+  ret = register_driver(devpath, &g_gaugeops, 0600, priv);
   if (ret < 0)
     {
       baterr("ERROR: register_driver failed: %d\n", ret);

--- a/arch/arm/src/cxd56xx/cxd56_ge2d.c
+++ b/arch/arm/src/cxd56xx/cxd56_ge2d.c
@@ -186,7 +186,7 @@ int cxd56_ge2dinitialize(const char *devname)
 {
   int ret;
 
-  ret = register_driver(devname, &g_ge2dfops, 0666, NULL);
+  ret = register_driver(devname, &g_ge2dfops, 0600, NULL);
   if (ret != 0)
     {
       return ERROR;

--- a/arch/arm/src/cxd56xx/cxd56_geofence.c
+++ b/arch/arm/src/cxd56xx/cxd56_geofence.c
@@ -649,7 +649,7 @@ static int cxd56_geofence_register(const char *devpath)
       goto err0;
     }
 
-  ret = register_driver(devpath, &g_geofencefops, 0666, priv);
+  ret = register_driver(devpath, &g_geofencefops, 0600, priv);
   if (ret < 0)
     {
       gnsserr("Failed to register driver: %d\n", ret);

--- a/arch/arm/src/cxd56xx/cxd56_gnss.c
+++ b/arch/arm/src/cxd56xx/cxd56_gnss.c
@@ -3207,7 +3207,7 @@ static int cxd56_gnss_register(const char *devpath)
       goto err0;
     }
 
-  ret = register_driver(devpath, &g_gnssfops, 0666, priv);
+  ret = register_driver(devpath, &g_gnssfops, 0600, priv);
   if (ret < 0)
     {
       gnsserr("Failed to register driver: %d\n", ret);

--- a/arch/arm/src/cxd56xx/cxd56_hostif.c
+++ b/arch/arm/src/cxd56xx/cxd56_hostif.c
@@ -416,7 +416,7 @@ static int hif_initialize(struct hostif_buff_s *buffer)
       snprintf(devpath, sizeof(devpath), "/dev/hostif%c%d",
                (priv->flags & HOSTIF_BUFF_ATTR_READ) ? 'r' : 'w', num);
 
-      ret = register_driver(devpath, &g_hif_fops, 0666, priv);
+      ret = register_driver(devpath, &g_hif_fops, 0600, priv);
       if (ret < 0)
         {
           hiferr("ERROR: Failed to register %s (%d)\n", devpath, ret);

--- a/arch/arm/src/cxd56xx/cxd56_sph.c
+++ b/arch/arm/src/cxd56xx/cxd56_sph.c
@@ -226,7 +226,7 @@ static inline int cxd56_sphdevinit(const char *devname, int num)
 
   snprintf(fullpath, sizeof(fullpath), "/dev/%s%d", devname, num);
 
-  ret = register_driver(fullpath, &g_sph_fops, 0666, (void *)priv);
+  ret = register_driver(fullpath, &g_sph_fops, 0600, (void *)priv);
   if (ret != 0)
     {
       return ERROR;

--- a/arch/arm/src/cxd56xx/cxd56_sysctl.c
+++ b/arch/arm/src/cxd56xx/cxd56_sysctl.c
@@ -162,5 +162,5 @@ void cxd56_sysctlinitialize(void)
 {
   cxd56_iccinit(CXD56_PROTO_SYSCTL);
   cxd56_iccregisterhandler(CXD56_PROTO_SYSCTL, sysctl_rxhandler, NULL);
-  register_driver("/dev/sysctl", &g_sysctlfops, 0666, NULL);
+  register_driver("/dev/sysctl", &g_sysctlfops, 0600, NULL);
 }

--- a/arch/arm/src/cxd56xx/cxd56_uart0.c
+++ b/arch/arm/src/cxd56xx/cxd56_uart0.c
@@ -233,7 +233,7 @@ static ssize_t uart0_write(struct file *filep,
 
 int cxd56_uart0initialize(const char *devname)
 {
-  return register_driver(devname, &g_uart0fops, 0666, NULL);
+  return register_driver(devname, &g_uart0fops, 0600, NULL);
 }
 
 /****************************************************************************

--- a/arch/arm/src/phy62xx/phyplus_stub.c
+++ b/arch/arm/src/phy62xx/phyplus_stub.c
@@ -752,7 +752,7 @@ int phyplus_stub_register(void)
 {
   char devname[16];
   snprintf(devname, sizeof(devname), "/dev/phyplus");
-  return register_driver(devname, &g_stub_drvrops, 0666, NULL);
+  return register_driver(devname, &g_stub_drvrops, 0600, NULL);
 }
 
 /****************************************************************************

--- a/arch/arm/src/rtl8720c/ameba_hci.c
+++ b/arch/arm/src/rtl8720c/ameba_hci.c
@@ -507,6 +507,6 @@ static hci_dev_t g_hcidev =
 
 int amebaz_bt_hci_uart_register(const char *path)
 {
-  return register_driver(path, &g_hcidev.i_ops, 0666, &g_hcidev);
+  return register_driver(path, &g_hcidev.i_ops, 0600, &g_hcidev);
 }
 

--- a/arch/arm/src/sama5/sam_tsd.c
+++ b/arch/arm/src/sama5/sam_tsd.c
@@ -1818,7 +1818,7 @@ int sam_tsd_register(struct sam_adc_s *adc, int minor)
   snprintf(devname, sizeof(devname), DEV_FORMAT, minor);
   iinfo("Registering %s\n", devname);
 
-  ret = register_driver(devname, &g_tsdops, 0666, priv);
+  ret = register_driver(devname, &g_tsdops, 0600, priv);
   if (ret < 0)
     {
       ierr("ERROR: register_driver() failed: %d\n", ret);

--- a/arch/arm/src/stm32f7/stm32_bbsram.c
+++ b/arch/arm/src/stm32f7/stm32_bbsram.c
@@ -757,7 +757,7 @@ int stm32_bbsraminitialize(char *devpath, int *sizes)
     {
       snprintf(devname, sizeof(devname), "%s%d", devpath, i);
       ret = register_driver(devname, &g_stm32_bbsram_fops,
-                            0666, &g_bbsram[i]);
+                            0600, &g_bbsram[i]);
     }
 
   /* Disallow Access */

--- a/arch/arm/src/stm32h7/stm32_bbsram.c
+++ b/arch/arm/src/stm32h7/stm32_bbsram.c
@@ -828,7 +828,7 @@ int stm32_bbsraminitialize(char *devpath, int *sizes)
     {
       snprintf(devname, sizeof(devname), "%s%d", devpath, i);
       ret = register_driver(devname, &g_stm32_bbsram_fops,
-                            0666, &g_bbsram[i]);
+                            0600, &g_bbsram[i]);
     }
 
   /* Disallow Access */

--- a/arch/arm/src/tlsr82/tlsr82_spi_console.c
+++ b/arch/arm/src/tlsr82/tlsr82_spi_console.c
@@ -306,7 +306,7 @@ void spi_console_init(void)
 
   /* Driver register */
 
-  ret = register_driver("/dev/console", &g_consoleops, 0666, NULL);
+  ret = register_driver("/dev/console", &g_consoleops, 0600, NULL);
   if (ret < 0)
     {
       syslog(LOG_DEBUG, "register spi_console failed\n");

--- a/arch/renesas/src/rx65n/rx65n_sbram.c
+++ b/arch/renesas/src/rx65n/rx65n_sbram.c
@@ -662,7 +662,7 @@ int rx65n_sbraminitialize(char *devpath, int *sizes)
   for (i = 0; i < fcnt && ret >= OK; i++)
     {
       snprintf(devname, sizeof(devname), "%s%d", devpath, i);
-      ret = register_driver(devname, &g_rx65n_sbram_fops, 0666, &g_sbram[i]);
+      ret = register_driver(devname, &g_rx65n_sbram_fops, 0660, &g_sbram[i]);
     }
 
   /* Disallow Access */

--- a/arch/risc-v/src/common/espressif/esp_dedic_gpio.c
+++ b/arch/risc-v/src/common/espressif/esp_dedic_gpio.c
@@ -403,7 +403,7 @@ struct file *esp_dedic_gpio_new_bundle(
   dedic_gpio_common.refs++;
 
   register_driver(config->path, &dedic_gpio_ops,
-                  0666, priv);
+                  0600, priv);
   return (struct file *)priv;
 }
 

--- a/arch/risc-v/src/common/espressif/esp_lp_mailbox.c
+++ b/arch/risc-v/src/common/espressif/esp_lp_mailbox.c
@@ -322,6 +322,6 @@ int esp_lp_mailbox_init(void)
     }
 
   register_driver("/dev/lp_mailbox", esp_lp_mailbox_priv.ops,
-                  0666, (void *)&esp_lp_mailbox_priv);
+                  0600, (void *)&esp_lp_mailbox_priv);
   return OK;
 }

--- a/arch/risc-v/src/common/espressif/esp_nxdiag.c
+++ b/arch/risc-v/src/common/espressif/esp_nxdiag.c
@@ -306,7 +306,7 @@ static ssize_t esp_nxdiag_read(struct file *filep,
 
 static int esp_nxdiag_register(void)
 {
-  return register_driver("/dev/nxdiag", &g_nxdiagops, 0444, NULL);
+  return register_driver("/dev/nxdiag", &g_nxdiagops, 0440, NULL);
 }
 
 /****************************************************************************

--- a/arch/risc-v/src/common/espressif/esp_temperature_sensor.c
+++ b/arch/risc-v/src/common/espressif/esp_temperature_sensor.c
@@ -417,7 +417,7 @@ static void esp_temp_sensor_register(struct esp_temp_priv_s *priv)
 {
 #ifndef CONFIG_ESPRESSIF_TEMP_UORB
   register_driver(CONFIG_ESPRESSIF_TEMP_PATH, &g_esp_temp_sensor_fops,
-                  0666, priv);
+                  0660, priv);
 #else
   priv->lower.type = SENSOR_TYPE_TEMPERATURE;
   sensor_register(&priv->lower, CONFIG_ESPRESSIF_TEMP_PATH_DEVNO);

--- a/arch/risc-v/src/common/espressif/esp_ulp.c
+++ b/arch/risc-v/src/common/espressif/esp_ulp.c
@@ -423,7 +423,7 @@ static int esp_ulp_write(struct file *filep,
 
 static void esp_ulp_register(void)
 {
-  register_driver("/dev/ulp", &g_esp_ulp_fops, 0666, NULL);
+  register_driver("/dev/ulp", &g_esp_ulp_fops, 0660, NULL);
 }
 
 /****************************************************************************

--- a/arch/x86/src/qemu/qemu_keypad.c
+++ b/arch/x86/src/qemu/qemu_keypad.c
@@ -303,5 +303,5 @@ static ssize_t keypad_read(struct file *filep, char *buf, size_t buflen)
 
 void qemu_keypad(void)
 {
-  register_driver("/dev/keypad", &g_keypadops, 0444, NULL);
+  register_driver("/dev/keypad", &g_keypadops, 0440, NULL);
 }

--- a/arch/x86/src/qemu/qemu_vga.c
+++ b/arch/x86/src/qemu/qemu_vga.c
@@ -588,7 +588,7 @@ int qemu_vga(void)
       return ret;
     }
 
-  register_driver("/dev/lcd", &g_vgaops, 0666, NULL);
+  register_driver("/dev/lcd", &g_vgaops, 0660, NULL);
 
   return OK;
 }

--- a/arch/xtensa/src/common/espressif/esp_nxdiag.c
+++ b/arch/xtensa/src/common/espressif/esp_nxdiag.c
@@ -313,7 +313,7 @@ static ssize_t esp_nxdiag_read(struct file *filep,
 
 static int esp_nxdiag_register(void)
 {
-  return register_driver("/dev/nxdiag", &g_nxdiagops, 0444, NULL);
+  return register_driver("/dev/nxdiag", &g_nxdiagops, 0440, NULL);
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/common/espressif/esp_ulp.c
+++ b/arch/xtensa/src/common/espressif/esp_ulp.c
@@ -173,7 +173,7 @@ static int esp_ulp_write(struct file *filep,
 
 static void esp_ulp_register(void)
 {
-  register_driver("/dev/ulp", &g_esp_ulp_fops, 0666, NULL);
+  register_driver("/dev/ulp", &g_esp_ulp_fops, 0600, NULL);
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/esp32/esp32_himem.c
+++ b/arch/xtensa/src/esp32/esp32_himem.c
@@ -249,7 +249,7 @@ int esp_himem_init(void)
 
   /* Register the character driver */
 
-  ret = register_driver("/dev/himem", &g_himemfops, 0666, NULL);
+  ret = register_driver("/dev/himem", &g_himemfops, 0600, NULL);
   if (ret < 0)
     {
       merr("ERROR: Failed to register driver: %d\n", ret);

--- a/arch/xtensa/src/esp32/esp32_himem_chardev.c
+++ b/arch/xtensa/src/esp32/esp32_himem_chardev.c
@@ -324,7 +324,7 @@ int himem_chardev_register(char *name, size_t size)
       return ret;
     }
 
-  ret = register_driver(dev->name, &g_fops, 0666, dev);
+  ret = register_driver(dev->name, &g_fops, 0600, dev);
   if (ret != 0)
     {
       merr("Failed to register driver. dev=%s\n", dev->name);

--- a/arch/xtensa/src/esp32s3/esp32s3_himem.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_himem.c
@@ -1070,7 +1070,7 @@ int esp_himem_init(void)
 
   /* Register the character driver */
 
-  ret = register_driver("/dev/himem", &g_himemfops, 0666, NULL);
+  ret = register_driver("/dev/himem", &g_himemfops, 0600, NULL);
   if (ret < 0)
     {
       merr("ERROR: Failed to register driver: %d\n", ret);

--- a/audio/audio.c
+++ b/audio/audio.c
@@ -1863,7 +1863,7 @@ int audio_register(FAR const char *name, FAR struct audio_lowerhalf_s *dev)
   dev->priv = upper;
 
   audinfo("Registering %s\n", path);
-  return register_driver(path, &g_audioops, 0666, upper);
+  return register_driver(path, &g_audioops, 0660, upper);
 }
 
 #endif /* CONFIG_AUDIO */

--- a/boards/arm/cxd56xx/drivers/sensors/ak09912_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/ak09912_scu.c
@@ -556,7 +556,7 @@ int ak09912_scu_register(const char *devpath, int minor,
   /* Register the character driver */
 
   snprintf(path, sizeof(path), "%s%d", devpath, minor);
-  ret = register_driver(path, &g_ak09912fops, 0666, priv);
+  ret = register_driver(path, &g_ak09912fops, 0660, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);

--- a/boards/arm/cxd56xx/drivers/sensors/apds9930_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/apds9930_scu.c
@@ -974,7 +974,7 @@ int apds9930als_register(const char *devpath, int minor,
   /* Register the character driver */
 
   snprintf(path, sizeof(path), "%s%d", devpath, minor);
-  ret = register_driver(path, &g_apds9930alsfops, 0666, priv);
+  ret = register_driver(path, &g_apds9930alsfops, 0660, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);
@@ -1028,7 +1028,7 @@ int apds9930ps_register(const char *devpath, int minor,
   /* Register the character driver */
 
   snprintf(path, sizeof(path), "%s%d", devpath, minor);
-  ret = register_driver(path, &g_apds9930psfops, 0666, priv);
+  ret = register_driver(path, &g_apds9930psfops, 0660, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);

--- a/boards/arm/cxd56xx/drivers/sensors/bh1721fvc_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/bh1721fvc_scu.c
@@ -376,7 +376,7 @@ int bh1721fvc_register(const char *devpath, int minor,
   /* Register the character driver */
 
   snprintf(path, sizeof(path), "%s%d", devpath, minor);
-  ret = register_driver(path, &g_bh1721fvcfops, 0666, priv);
+  ret = register_driver(path, &g_bh1721fvcfops, 0660, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);

--- a/boards/arm/cxd56xx/drivers/sensors/bh1745nuc_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/bh1745nuc_scu.c
@@ -510,7 +510,7 @@ int bh1745nuc_register(const char *devpath, int minor,
   /* Register the character driver */
 
   snprintf(path, sizeof(path), "%s%d", devpath, minor);
-  ret = register_driver(path, &g_bh1745nucfops, 0666, priv);
+  ret = register_driver(path, &g_bh1745nucfops, 0660, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);

--- a/boards/arm/cxd56xx/drivers/sensors/bm1383glv_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/bm1383glv_scu.c
@@ -541,7 +541,7 @@ int bm1383glv_register(const char *devpath, int minor,
   /* Register the character driver */
 
   snprintf(path, sizeof(path), "%s%d", devpath, minor);
-  ret = register_driver(path, &g_bm1383glvfops, 0666, priv);
+  ret = register_driver(path, &g_bm1383glvfops, 0660, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);

--- a/boards/arm/cxd56xx/drivers/sensors/bm1422gmv_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/bm1422gmv_scu.c
@@ -525,7 +525,7 @@ int bm1422gmv_register(const char *devpath, int minor,
   /* Register the character driver */
 
   snprintf(path, sizeof(path), "%s%d", devpath, minor);
-  ret = register_driver(path, &g_bm1422gmvfops, 0666, priv);
+  ret = register_driver(path, &g_bm1422gmvfops, 0660, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);

--- a/boards/arm/cxd56xx/drivers/sensors/bmi160_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/bmi160_scu.c
@@ -828,7 +828,7 @@ static int bmi160_devregister(const char *devpath,
 
 #endif
   snprintf(path, sizeof(path), "%s%d", devpath, minor);
-  ret = register_driver(path, fops, 0666, priv);
+  ret = register_driver(path, fops, 0660, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);

--- a/boards/arm/cxd56xx/drivers/sensors/bmp280_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/bmp280_scu.c
@@ -931,7 +931,7 @@ int bmp280press_register(const char *devpath, int minor,
   /* Register the character driver */
 
   snprintf(path, sizeof(path), "%s%d", devpath, minor);
-  ret = register_driver(path, &g_bmp280pressfops, 0666, priv);
+  ret = register_driver(path, &g_bmp280pressfops, 0660, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);
@@ -982,7 +982,7 @@ int bmp280temp_register(const char *devpath, int minor,
   /* Register the character driver */
 
   snprintf(path, sizeof(path), "%s%d", devpath, minor);
-  ret = register_driver(path, &g_bmp280tempfops, 0666, priv);
+  ret = register_driver(path, &g_bmp280tempfops, 0660, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);

--- a/boards/arm/cxd56xx/drivers/sensors/cxd5610_gnss.c
+++ b/boards/arm/cxd56xx/drivers/sensors/cxd5610_gnss.c
@@ -2268,7 +2268,7 @@ int cxd5610_gnss_register(const char *devpath,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_cxd5610fops, 0666, priv);
+  ret = register_driver(devpath, &g_cxd5610fops, 0660, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/boards/arm/cxd56xx/drivers/sensors/kx022_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/kx022_scu.c
@@ -510,7 +510,7 @@ int kx022_register(const char *devpath, int minor,
   /* Register the character driver */
 
   snprintf(path, sizeof(path), "%s%d", devpath, minor);
-  ret = register_driver(path, &g_kx022fops, 0666, priv);
+  ret = register_driver(path, &g_kx022fops, 0660, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);

--- a/boards/arm/cxd56xx/drivers/sensors/lt1pa01_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/lt1pa01_scu.c
@@ -814,7 +814,7 @@ int lt1pa01als_register(const char *devpath, int minor,
   /* Register the character driver */
 
   snprintf(path, sizeof(path), "%s%d", devpath, minor);
-  ret = register_driver(path, &g_lt1pa01alsfops, 0666, priv);
+  ret = register_driver(path, &g_lt1pa01alsfops, 0660, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);
@@ -868,7 +868,7 @@ int lt1pa01prox_register(const char *devpath, int minor,
   /* Register the character driver */
 
   snprintf(path, sizeof(path), "%s%d", devpath, minor);
-  ret = register_driver(path, &g_lt1pa01proxfops, 0666, priv);
+  ret = register_driver(path, &g_lt1pa01proxfops, 0660, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);

--- a/boards/arm/cxd56xx/drivers/sensors/rpr0521rs_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/rpr0521rs_scu.c
@@ -931,7 +931,7 @@ int rpr0521rsals_register(const char *devpath, int minor,
   /* Register the character driver */
 
   snprintf(path, sizeof(path), "%s%d", devpath, minor);
-  ret = register_driver(path, &g_rpr0521rsalsfops, 0666, priv);
+  ret = register_driver(path, &g_rpr0521rsalsfops, 0660, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);
@@ -985,7 +985,7 @@ int rpr0521rsps_register(const char *devpath, int minor,
   /* Register the character driver */
 
   snprintf(path, sizeof(path), "%s%d", devpath, minor);
-  ret = register_driver(path, &g_rpr0521rspsfops, 0666, priv);
+  ret = register_driver(path, &g_rpr0521rspsfops, 0660, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);

--- a/boards/arm/kl/freedom-kl25z/src/kl_tsi.c
+++ b/boards/arm/kl/freedom-kl25z/src/kl_tsi.c
@@ -244,7 +244,7 @@ void kl_tsi_initialize(void)
 
   /* And finally register the TSI character driver */
 
-  register_driver("/dev/tsi", &g_tsi_ops, 0444, NULL);
+  register_driver("/dev/tsi", &g_tsi_ops, 0440, NULL);
 }
 
 #endif /* CONFIG_KL_TSI */

--- a/boards/arm/kl/freedom-kl26z/src/kl_tsi.c
+++ b/boards/arm/kl/freedom-kl26z/src/kl_tsi.c
@@ -245,7 +245,7 @@ void kl_tsi_initialize(void)
 
   /* And finally register the TSI character driver */
 
-  register_driver("/dev/tsi", &g_tsi_ops, 0444, NULL);
+  register_driver("/dev/tsi", &g_tsi_ops, 0440, NULL);
 }
 
 #endif /* CONFIG_KL_TSI */

--- a/boards/arm/sam34/sam4l-xplained/src/sam_slcd.c
+++ b/boards/arm/sam34/sam4l-xplained/src/sam_slcd.c
@@ -1267,7 +1267,7 @@ int sam_slcd_initialize(void)
 
       /* Register the LCD device driver */
 
-      ret = register_driver("/dev/slcd0", &g_slcdops, 0644, &g_slcdstate);
+      ret = register_driver("/dev/slcd0", &g_slcdops, 0640, &g_slcdstate);
       g_slcdstate.initialized = true;
 
       /* Turn on the backlight */

--- a/boards/arm/stm32f4/mikroe-stm32f4/src/stm32_touchscreen.c
+++ b/boards/arm/stm32f4/mikroe-stm32f4/src/stm32_touchscreen.c
@@ -1508,7 +1508,7 @@ int stm32_tsc_setup(int minor)
   snprintf(devname, sizeof(devname), DEV_FORMAT, minor);
   iinfo("Registering %s\n", devname);
 
-  ret = register_driver(devname, &g_tc_fops, 0666, priv);
+  ret = register_driver(devname, &g_tc_fops, 0660, priv);
   if (ret < 0)
     {
       ierr("ERROR: register_driver() failed: %d\n", ret);

--- a/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
+++ b/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
@@ -1371,7 +1371,7 @@ int pic32mx_tsc_setup(int minor)
   snprintf(devname, sizeof(devname), DEV_FORMAT, minor);
   iinfo("Registering %s\n", devname);
 
-  ret = register_driver(devname, &g_tc_fops, 0666, priv);
+  ret = register_driver(devname, &g_tc_fops, 0660, priv);
   if (ret < 0)
     {
       ierr("ERROR: register_driver() failed: %d\n", ret);

--- a/crypto/cryptodev.c
+++ b/crypto/cryptodev.c
@@ -1174,7 +1174,7 @@ static int csefree(FAR struct csession *cse)
 
 void devcrypto_register(void)
 {
-  register_driver("/dev/crypto", &g_cryptoops, 0666, NULL);
+  register_driver("/dev/crypto", &g_cryptoops, 0660, NULL);
 
 #ifdef CONFIG_CRYPTO_CRYPTODEV_SOFTWARE_CRYPTO
   swcr_init();

--- a/drivers/1wire/1wire_ds2xxx.c
+++ b/drivers/1wire/1wire_ds2xxx.c
@@ -826,5 +826,5 @@ int ds2xxx_initialize(FAR struct onewire_dev_s *dev,
   priv->master->dev = dev;
   priv->devtype     = devtype;
 
-  return register_driver(devname, &g_ds2xxx_fops, 0666, priv);
+  return register_driver(devname, &g_ds2xxx_fops, 0600, priv);
 }

--- a/drivers/aie/ai_engine.c
+++ b/drivers/aie/ai_engine.c
@@ -243,7 +243,7 @@ int aie_register(FAR const char *path,
 
   /* Register the aie device */
 
-  ret = register_driver(path, &g_aie_ops, 0666, upper);
+  ret = register_driver(path, &g_aie_ops, 0600, upper);
   if (ret < 0)
     {
       _err("register aie driver failed: %d\n", ret);

--- a/drivers/analog/adc.c
+++ b/drivers/analog/adc.c
@@ -803,7 +803,7 @@ int adc_register(FAR const char *path, FAR struct adc_dev_s *dev)
 
   /* Register the ADC character driver */
 
-  ret = register_driver(path, &g_adc_fops, 0444, dev);
+  ret = register_driver(path, &g_adc_fops, 0400, dev);
   if (ret < 0)
     {
       if (alloc_channel)

--- a/drivers/analog/ads1242.c
+++ b/drivers/analog/ads1242.c
@@ -600,7 +600,7 @@ int ads1242_register(FAR const char *devpath, FAR struct spi_dev_s *spi,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_ads1242_fops, 0666, priv);
+  ret = register_driver(devpath, &g_ads1242_fops, 0600, priv);
   if (ret < 0)
     {
        _err("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/analog/ads7046.c
+++ b/drivers/analog/ads7046.c
@@ -270,7 +270,7 @@ int ads7046_register(FAR const char *devpath, FAR struct spi_dev_s *spi,
 
   /* Register the character driver */
 
-  int ret = register_driver(devpath, &ads7046_fops, 0666, priv);
+  int ret = register_driver(devpath, &ads7046_fops, 0600, priv);
   if (ret < 0)
     {
       aerr("ERROR: Failed to register driver: %s (%d)\n", strerror(-ret),

--- a/drivers/analog/comp.c
+++ b/drivers/analog/comp.c
@@ -372,7 +372,7 @@ int comp_register(FAR const char *path, FAR struct comp_dev_s *dev)
 
   /* Register the COMP character driver */
 
-  ret = register_driver(path, &g_comp_fops, 0444, dev);
+  ret = register_driver(path, &g_comp_fops, 0400, dev);
   if (ret < 0)
     {
       nxmutex_destroy(&dev->ad_lock);

--- a/drivers/analog/dac.c
+++ b/drivers/analog/dac.c
@@ -503,5 +503,5 @@ int dac_register(FAR const char *path, FAR struct dac_dev_s *dev)
 
   dev->ad_ops->ao_reset(dev);
 
-  return register_driver(path, &g_dac_fops, 0222, dev);
+  return register_driver(path, &g_dac_fops, 0200, dev);
 }

--- a/drivers/analog/hx711.c
+++ b/drivers/analog/hx711.c
@@ -949,7 +949,7 @@ int hx711_register(unsigned char minor, FAR struct hx711_lower_s *lower)
     }
 
   snprintf(devname, sizeof(devname), DEVNAME_FMT, minor);
-  ret = register_driver(devname, &g_hx711_fops, 0666, dev);
+  ret = register_driver(devname, &g_hx711_fops, 0600, dev);
   if (ret)
     {
       kmm_free(dev);

--- a/drivers/analog/opamp.c
+++ b/drivers/analog/opamp.c
@@ -211,7 +211,7 @@ int opamp_register(FAR const char *path, FAR struct opamp_dev_s *dev)
 
   /* Register the OPAMP character driver */
 
-  ret = register_driver(path, &g_opamp_fops, 0444, dev);
+  ret = register_driver(path, &g_opamp_fops, 0400, dev);
   if (ret < 0)
     {
       nxmutex_destroy(&dev->ad_closelock);

--- a/drivers/audio/tone.c
+++ b/drivers/audio/tone.c
@@ -966,7 +966,7 @@ int tone_register(FAR const char *path, FAR struct pwm_lowerhalf_s *tone,
   /* Register the PWM device */
 
   audinfo("Registering %s\n", path);
-  return register_driver(path, &g_toneops, 0666, upper);
+  return register_driver(path, &g_toneops, 0600, upper);
 }
 
 #endif /* CONFIG_AUDIO_TONE */

--- a/drivers/bch/bchdev_register.c
+++ b/drivers/bch/bchdev_register.c
@@ -69,7 +69,7 @@ int bchdev_register(FAR const char *blkdev, FAR const char *chardev,
 
   /* Then setup the character device */
 
-  ret = register_driver(chardev, &g_bch_fops, 0666, handle);
+  ret = register_driver(chardev, &g_bch_fops, 0600, handle);
   if (ret < 0)
     {
       ferr("ERROR: register_driver failed: %d\n", -ret);

--- a/drivers/can/can.c
+++ b/drivers/can/can.c
@@ -1291,7 +1291,7 @@ int can_register(FAR const char *path, FAR struct can_dev_s *dev)
   /* Register the CAN device */
 
   caninfo("Registering %s\n", path);
-  return register_driver(path, &g_canops, 0666, dev);
+  return register_driver(path, &g_canops, 0600, dev);
 }
 
 /****************************************************************************

--- a/drivers/contactless/mfrc522.c
+++ b/drivers/contactless/mfrc522.c
@@ -1682,7 +1682,7 @@ int mfrc522_register(FAR const char *devpath, FAR struct spi_dev_s *spi)
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_mfrc522fops, 0666, dev);
+  ret = register_driver(devpath, &g_mfrc522fops, 0600, dev);
   if (ret < 0)
     {
       ctlserr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/contactless/pn532.c
+++ b/drivers/contactless/pn532.c
@@ -1158,7 +1158,7 @@ int pn532_register(FAR const char *devpath, FAR struct spi_dev_s *spi,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_pn532fops, 0666, dev);
+  ret = register_driver(devpath, &g_pn532fops, 0600, dev);
   if (ret < 0)
     {
       ctlserr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/coresight/coresight_tmc_etr.c
+++ b/drivers/coresight/coresight_tmc_etr.c
@@ -484,7 +484,7 @@ int tmc_etr_register(FAR struct coresight_tmc_dev_s *tmcdev,
     }
 
   snprintf(pathname, sizeof(pathname), "/dev/%s", desc->name);
-  ret = register_driver(pathname, &g_tmc_fops, 0444, tmcdev);
+  ret = register_driver(pathname, &g_tmc_fops, 0400, tmcdev);
   if (ret < 0)
     {
       cserr("%s:driver register failed\n", desc->name);

--- a/drivers/crypto/dev_urandom.c
+++ b/drivers/crypto/dev_urandom.c
@@ -324,7 +324,7 @@ void devurandom_register(void)
   g_prng.state.z = g_prng.state.x << 25;
 #endif
 
-  register_driver("/dev/urandom", &g_urand_fops, 0666, NULL);
+  register_driver("/dev/urandom", &g_urand_fops, 0600, NULL);
 }
 
 #endif /* CONFIG_DEV_URANDOM && CONFIG_DEV_URANDOM_ARCH */

--- a/drivers/crypto/rng90.c
+++ b/drivers/crypto/rng90.c
@@ -359,7 +359,7 @@ int rng90_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_rng90_fops, 0666, priv);
+  ret = register_driver(devpath, &g_rng90_fops, 0600, priv);
   if (ret < 0)
     {
       crypterr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/crypto/se05x.c
+++ b/drivers/crypto/se05x.c
@@ -263,7 +263,7 @@ int se05x_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register driver */
 
-  ret = register_driver(devpath, &g_fops, 0666, priv);
+  ret = register_driver(devpath, &g_fops, 0600, priv);
   if (ret < 0)
     {
       crypterr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/eeprom/i2c_xx24xx.c
+++ b/drivers/eeprom/i2c_xx24xx.c
@@ -1086,7 +1086,7 @@ int ee24xx_initialize(FAR struct i2c_master_s *bus, uint8_t devaddr,
 
   strlcpy(uuidname, devname, size);
   strlcat(uuidname, ".uuid", size);
-  ret = register_driver(uuidname, &g_at24cs_uuid_fops, 0444, eedev);
+  ret = register_driver(uuidname, &g_at24cs_uuid_fops, 0400, eedev);
 
   kmm_free(uuidname);
 
@@ -1097,6 +1097,6 @@ int ee24xx_initialize(FAR struct i2c_master_s *bus, uint8_t devaddr,
     }
 #endif
 
-  return register_driver_with_size(devname, &g_ee24xx_fops, 0666, eedev,
+  return register_driver_with_size(devname, &g_ee24xx_fops, 0600, eedev,
                                    eedev->size);
 }

--- a/drivers/eeprom/spi_xx25xx.c
+++ b/drivers/eeprom/spi_xx25xx.c
@@ -1520,7 +1520,7 @@ int ee25xx_initialize(FAR struct spi_dev_s *dev, uint16_t spi_devid,
       "readonly %d\n", devname, eedev->size, eedev->pgsize,
       eedev->addrlen, eedev->readonly);
 
-  return register_driver(devname, &g_ee25xx_fops, 0666, eedev);
+  return register_driver(devname, &g_ee25xx_fops, 0600, eedev);
 }
 
 /****************************************************************************

--- a/drivers/efuse/efuse.c
+++ b/drivers/efuse/efuse.c
@@ -303,7 +303,7 @@ FAR void *efuse_register(FAR const char *path,
 
   /* Register the efuse timer device */
 
-  ret = register_driver(path, &g_efuseops, 0666, upper);
+  ret = register_driver(path, &g_efuseops, 0600, upper);
   if (ret < 0)
     {
       merr("register_driver failed: %d\n", ret);

--- a/drivers/i2c/i2c_driver.c
+++ b/drivers/i2c/i2c_driver.c
@@ -416,7 +416,7 @@ int i2c_register(FAR struct i2c_master_s *i2c, int bus)
       /* Create the character device name */
 
       snprintf(devname, sizeof(devname), DEVNAME_FMT, bus);
-      ret = register_driver(devname, &g_i2cdrvr_fops, 0666, priv);
+      ret = register_driver(devname, &g_i2cdrvr_fops, 0600, priv);
       if (ret < 0)
         {
           /* Free the device structure if we failed to create the character

--- a/drivers/i2c/i2c_slave_driver.c
+++ b/drivers/i2c/i2c_slave_driver.c
@@ -567,7 +567,7 @@ int i2c_slave_register(FAR struct i2c_slave_s *dev, int bus, int addr,
     }
 
   snprintf(devname, sizeof(devname), DEVNAME_FMT, bus);
-  ret = register_driver(devname, &g_i2cslavefops, 0666, priv);
+  ret = register_driver(devname, &g_i2cslavefops, 0600, priv);
   if (ret < 0)
     {
       kmm_free(priv);

--- a/drivers/i2s/i2schar.c
+++ b/drivers/i2s/i2schar.c
@@ -692,7 +692,7 @@ int i2schar_register(FAR struct i2s_dev_s *i2s, int minor)
       /* Create the character device name */
 
       snprintf(devname, sizeof(devname), DEVNAME_FMT, minor);
-      ret = register_driver(devname, &g_i2schar_fops, 0666, priv);
+      ret = register_driver(devname, &g_i2schar_fops, 0600, priv);
       if (ret < 0)
         {
           /* Free the device structure if we failed to create the character


### PR DESCRIPTION
drivers/: Multiple Drivers Are Registered With World Writable

## Summary
Permissions (Part 1/3)

Description:

In kernel builds, any unprivileged process running on the NuttX
device can open /dev/efuse and attempt to read/write fuse content.
Reading the fuses may provide valuable information to an attacker
controlling the user process. The write operation, in extreme cases
where the fuse blocks are not locked, may brick the device.

DISCLAIMER: I tried to be strict with the settings, better to relax them later if it's needed.

This is part of https://github.com/apache/nuttx/issues/19410

## Impact

See https://github.com/apache/nuttx/issues/19410

## Testing

Compiles ok.