### PR TITLE
drivers/timers/watchdog: add missing parameters to watchdog_automonitor_timeout

### DIFF
--- a/drivers/timers/watchdog.c
+++ b/drivers/timers/watchdog.c
@@ -760,7 +760,7 @@ void watchdog_notifier_chain_unregister(FAR struct notifier_block *nb)
  *
  ****************************************************************************/
 
-void watchdog_automonitor_timeout(void)
+void watchdog_automonitor_timeout(unsigned long action, FAR void *data)
 {
   atomic_notifier_call_chain(&g_watchdog_notifier_list, action, data);
 }

--- a/include/nuttx/timers/watchdog.h
+++ b/include/nuttx/timers/watchdog.h
@@ -264,7 +264,7 @@ void watchdog_notifier_chain_unregister(FAR struct notifier_block *nb);
  *
  ****************************************************************************/
 
-void watchdog_automonitor_timeout(void);
+void watchdog_automonitor_timeout(unsigned long action, FAR void *data);
 
 #endif /* CONFIG_WATCHDOG_TIMEOUT_NOTIFIER */
 


### PR DESCRIPTION
## Summary

Fix incomplete implementation of watchdog timeout notifier chain.

The function `watchdog_automonitor_timeout()` was declared with `void` parameters but used undefined `action` and `data` variables in its body when calling `atomic_notifier_call_chain()`.

Add `action` and `data` parameters to the function signature in both the implementation and header file.

## Impact

- [x] Bug fix only, completes the notifier chain feature
- [x] No functional changes (function has no callers yet)
- [x] Enables future use of watchdog timeout notifications

## Testing

- Verified by code inspection against master
- checkpatch passes
- Builds successfully with sim:nsh + CONFIG_WATCHDOG_TIMEOUT_NOTIFIER=y

Signed-off-by: hanzhijian <hanzhijian@zepp.com>