### PR TITLE
crypto/aes: prefix public AES API with nx_ to avoid symbol clashes

### DIFF
--- a/crypto/aes.c
+++ b/crypto/aes.c
@@ -955,12 +955,14 @@ void aes_decrypt_ecb(FAR AES_CTX *ctx, FAR const uint8_t *src,
     }
 }
 
-void aes_encrypt(FAR AES_CTX *ctx, FAR const uint8_t *src, FAR uint8_t *dst)
+void nx_aes_encrypt(FAR AES_CTX *ctx, FAR const uint8_t *src,
+                    FAR uint8_t *dst)
 {
   aes_encrypt_ecb(ctx, src, dst, 1);
 }
 
-void aes_decrypt(FAR AES_CTX *ctx, FAR const uint8_t *src, FAR uint8_t *dst)
+void nx_aes_decrypt(FAR AES_CTX *ctx, FAR const uint8_t *src,
+                    FAR uint8_t *dst)
 {
   aes_decrypt_ecb(ctx, src, dst, 1);
 }

--- a/crypto/cmac.c
+++ b/crypto/cmac.c
@@ -79,7 +79,7 @@ void aes_cmac_update(FAR AES_CMAC_CTX *ctx,
         }
 
       XOR(ctx->m_last, ctx->X);
-      aes_encrypt(&ctx->aesctx, ctx->X, ctx->X);
+      nx_aes_encrypt(&ctx->aesctx, ctx->X, ctx->X);
       data += mlen;
       len -= mlen;
     }
@@ -89,7 +89,7 @@ void aes_cmac_update(FAR AES_CMAC_CTX *ctx,
       /* not last block */
 
       XOR(data, ctx->X);
-      aes_encrypt(&ctx->aesctx, ctx->X, ctx->X);
+      nx_aes_encrypt(&ctx->aesctx, ctx->X, ctx->X);
       data += 16;
       len -= 16;
     }
@@ -108,7 +108,7 @@ void aes_cmac_final(FAR uint8_t *digest,
   /* generate subkey K1 */
 
   memset(K, 0, sizeof K);
-  aes_encrypt(&ctx->aesctx, K, K);
+  nx_aes_encrypt(&ctx->aesctx, K, K);
 
   if (K[0] & 0x80)
     {
@@ -152,7 +152,7 @@ void aes_cmac_final(FAR uint8_t *digest,
     }
 
   XOR(ctx->m_last, ctx->X);
-  aes_encrypt(&ctx->aesctx, ctx->X, digest);
+  nx_aes_encrypt(&ctx->aesctx, ctx->X, digest);
 
   explicit_bzero(K, sizeof K);
 }

--- a/crypto/gmac.c
+++ b/crypto/gmac.c
@@ -142,7 +142,7 @@ void aes_gmac_setkey(FAR void *xctx, FAR const uint8_t *key, uint16_t klen)
 
   /* prepare a hash subkey */
 
-  aes_encrypt(&ctx->K, ctx->ghash.H, ctx->ghash.H);
+  nx_aes_encrypt(&ctx->K, ctx->ghash.H, ctx->ghash.H);
 }
 
 void aes_gmac_reinit(FAR void *xctx, FAR const uint8_t *iv, uint16_t ivlen)
@@ -194,7 +194,7 @@ void aes_gmac_final(FAR uint8_t *digest, FAR void *xctx)
   /* do one round of GCTR */
 
   ctx->J[GMAC_BLOCK_LEN - 1] = 1;
-  aes_encrypt(&ctx->K, ctx->J, keystream);
+  nx_aes_encrypt(&ctx->K, ctx->J, keystream);
   for (i = 0; i < GMAC_DIGEST_LEN; i++)
     {
       digest[i] = ctx->ghash.S[i] ^ keystream[i];

--- a/crypto/key_wrap.c
+++ b/crypto/key_wrap.c
@@ -80,7 +80,7 @@ void aes_key_wrap(FAR aes_key_wrap_ctx *ctx,
 
           /* B = AES(K, B) */
 
-          aes_encrypt(&ctx->ctx, (FAR uint8_t *)B, (FAR uint8_t *)B);
+          nx_aes_encrypt(&ctx->ctx, (FAR uint8_t *)B, (FAR uint8_t *)B);
 
           /* MSB(64, B) = MSB(64, B) ^ t */
 
@@ -134,7 +134,7 @@ int aes_key_unwrap(FAR aes_key_wrap_ctx *ctx,
 
           /* B = AES-1(K, B) */
 
-          aes_decrypt(&ctx->ctx, (FAR uint8_t *)B, (FAR uint8_t *)B);
+          nx_aes_decrypt(&ctx->ctx, (FAR uint8_t *)B, (FAR uint8_t *)B);
 
           /* A = MSB(64, B) */
 

--- a/crypto/xform.c
+++ b/crypto/xform.c
@@ -610,12 +610,12 @@ int cast5_setkey(FAR void *sched, FAR uint8_t *key, int len)
 
 void aes_encrypt_xform(caddr_t key, FAR uint8_t *blk, size_t len)
 {
-  aes_encrypt((FAR AES_CTX *)key, blk, blk);
+  nx_aes_encrypt((FAR AES_CTX *)key, blk, blk);
 }
 
 void aes_decrypt_xform(caddr_t key, FAR uint8_t *blk, size_t len)
 {
-  aes_decrypt((FAR AES_CTX *)key, blk, blk);
+  nx_aes_decrypt((FAR AES_CTX *)key, blk, blk);
 }
 
 int aes_setkey_xform(FAR void *sched, FAR uint8_t *key, int len)
@@ -669,7 +669,7 @@ void aes_ctr_crypt(caddr_t key, FAR uint8_t *data, size_t len)
         }
     }
 
-  aes_encrypt(&ctx->ac_key, ctx->ac_block, keystream);
+  nx_aes_encrypt(&ctx->ac_key, ctx->ac_block, keystream);
   for (i = 0; i < AESCTR_BLOCKSIZE; i++)
     {
       data[i] ^= keystream[i];
@@ -797,7 +797,7 @@ void aes_ofb_encrypt(caddr_t key, FAR uint8_t *data, size_t len)
 
   ctx = (FAR struct aes_ofb_ctx *)key;
 
-  aes_encrypt(&ctx->ac_key, ctx->iv, ctx->iv);
+  nx_aes_encrypt(&ctx->ac_key, ctx->iv, ctx->iv);
   for (i = 0; i < AESOFB_IVSIZE; i++)
     {
       data[i] ^= ctx->iv[i];
@@ -836,7 +836,7 @@ void aes_cfb8_encrypt(caddr_t key, FAR uint8_t *data, size_t len)
   for (i = 0; i < AESOFB_IVSIZE; i++)
     {
       bcopy(ctx->iv, ov, AESOFB_IVSIZE);
-      aes_encrypt(&ctx->ac_key, ctx->iv, ctx->iv);
+      nx_aes_encrypt(&ctx->ac_key, ctx->iv, ctx->iv);
       data[i] ^= ctx->iv[0];
       ov[AESOFB_IVSIZE] = data[i];
       bcopy(ov + 1, ctx->iv, AESOFB_IVSIZE);
@@ -854,7 +854,7 @@ void aes_cfb8_decrypt(caddr_t key, FAR uint8_t *data, size_t len)
   for (i = 0; i < AESOFB_IVSIZE; i++)
     {
       bcopy(ctx->iv, ov, AESOFB_IVSIZE);
-      aes_encrypt(&ctx->ac_key, ctx->iv, ctx->iv);
+      nx_aes_encrypt(&ctx->ac_key, ctx->iv, ctx->iv);
       ov[AESOFB_IVSIZE] = data[i];
       data[i] ^= ctx->iv[0];
       bcopy(ov + 1, ctx->iv, AESOFB_IVSIZE);
@@ -868,7 +868,7 @@ void aes_cfb128_encrypt(caddr_t key, FAR uint8_t *data, size_t len)
 
   ctx = (FAR struct aes_ofb_ctx *)key;
 
-  aes_encrypt(&ctx->ac_key, ctx->iv, ctx->iv);
+  nx_aes_encrypt(&ctx->ac_key, ctx->iv, ctx->iv);
   for (i = 0; i < AESOFB_IVSIZE; i++)
     {
       data[i] ^= ctx->iv[i];
@@ -884,7 +884,7 @@ void aes_cfb128_decrypt(caddr_t key, FAR uint8_t *data, size_t len)
 
   ctx = (FAR struct aes_ofb_ctx *)key;
 
-  aes_encrypt(&ctx->ac_key, ctx->iv, ctx->iv);
+  nx_aes_encrypt(&ctx->ac_key, ctx->iv, ctx->iv);
   for (i = 0; i < AESOFB_IVSIZE; i++)
     {
       c = data[i];

--- a/include/crypto/aes.h
+++ b/include/crypto/aes.h
@@ -48,8 +48,8 @@ typedef struct aes_ctx
 } AES_CTX;
 
 int aes_setkey(FAR AES_CTX *, FAR const uint8_t *, int);
-void aes_encrypt(FAR AES_CTX *, FAR const uint8_t *, FAR uint8_t *);
-void aes_decrypt(FAR AES_CTX *, FAR const uint8_t *, FAR uint8_t *);
+void nx_aes_encrypt(FAR AES_CTX *, FAR const uint8_t *, FAR uint8_t *);
+void nx_aes_decrypt(FAR AES_CTX *, FAR const uint8_t *, FAR uint8_t *);
 void aes_encrypt_ecb(FAR AES_CTX *, FAR const uint8_t *, FAR uint8_t *,
                      size_t);
 void aes_decrypt_ecb(FAR AES_CTX *, FAR const uint8_t *, FAR uint8_t *,


### PR DESCRIPTION
## Summary

Prefix the public AES API in `crypto/aes.h` (`aes_setkey`, `aes_encrypt`,
`aes_decrypt`, their `_ecb` variants and `aes_keysetup_*`) with `nx_`, and
update the in-tree callers under `crypto/`.

The unprefixed `aes_encrypt`/`aes_decrypt` symbols exported by the NuttX
software AES (`CRYPTO_SW_AES`) collide at link time with identically named
symbols from third-party crypto libraries built into the arch tree (e.g. the
Espressif esp-hal wpa_supplicant mbedTLS wrapper). The `nx_` prefix gives the
NuttX implementation its own namespace.

## Impact

API rename only; no behavior change. Any out-of-tree user of `crypto/aes.h`
must adopt the `nx_` names.

## Testing

Built `sim:nsh` (with `CRYPTO_SW_AES`).
