### PR TITLE
drivers/: Multiple Drivers Are Registered With World Writable - Part 2

### DIFF
--- a/arch/xtensa/src/common/espressif/esp_dedic_gpio.c
+++ b/arch/xtensa/src/common/espressif/esp_dedic_gpio.c
@@ -684,7 +684,7 @@ struct file *esp_dedic_gpio_new_bundle(
   dedic_gpio_common[cpu].refs++;
 
   register_driver(config->path, &dedic_gpio_ops,
-                  0666, priv);
+                  0600, priv);
   return (struct file *)priv;
 }
 

--- a/arch/xtensa/src/common/espressif/esp_nxdiag.c
+++ b/arch/xtensa/src/common/espressif/esp_nxdiag.c
@@ -313,7 +313,7 @@ static ssize_t esp_nxdiag_read(struct file *filep,
 
 static int esp_nxdiag_register(void)
 {
-  return register_driver("/dev/nxdiag", &g_nxdiagops, 0440, NULL);
+  return register_driver("/dev/nxdiag", &g_nxdiagops, 0400, NULL);
 }
 
 /****************************************************************************

--- a/arch/xtensa/src/common/espressif/esp_temperature_sensor.c
+++ b/arch/xtensa/src/common/espressif/esp_temperature_sensor.c
@@ -415,7 +415,7 @@ static void esp_temp_sensor_register(struct esp_temp_priv_s *priv)
 {
 #ifndef CONFIG_ESPRESSIF_TEMP_UORB
   register_driver(CONFIG_ESPRESSIF_TEMP_PATH, &g_esp_temp_sensor_fops,
-                  0666, priv);
+                  0600, priv);
 #else
   priv->lower.type = SENSOR_TYPE_TEMPERATURE;
   sensor_register(&priv->lower, CONFIG_ESPRESSIF_TEMP_PATH_DEVNO);

--- a/boards/arm/cxd56xx/drivers/sensors/ak09912_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/ak09912_scu.c
@@ -556,7 +556,7 @@ int ak09912_scu_register(const char *devpath, int minor,
   /* Register the character driver */
 
   snprintf(path, sizeof(path), "%s%d", devpath, minor);
-  ret = register_driver(path, &g_ak09912fops, 0660, priv);
+  ret = register_driver(path, &g_ak09912fops, 0640, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);

--- a/boards/arm/cxd56xx/drivers/sensors/bm1383glv_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/bm1383glv_scu.c
@@ -541,7 +541,7 @@ int bm1383glv_register(const char *devpath, int minor,
   /* Register the character driver */
 
   snprintf(path, sizeof(path), "%s%d", devpath, minor);
-  ret = register_driver(path, &g_bm1383glvfops, 0660, priv);
+  ret = register_driver(path, &g_bm1383glvfops, 0640, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);

--- a/boards/arm/cxd56xx/drivers/sensors/bm1422gmv_scu.c
+++ b/boards/arm/cxd56xx/drivers/sensors/bm1422gmv_scu.c
@@ -525,7 +525,7 @@ int bm1422gmv_register(const char *devpath, int minor,
   /* Register the character driver */
 
   snprintf(path, sizeof(path), "%s%d", devpath, minor);
-  ret = register_driver(path, &g_bm1422gmvfops, 0660, priv);
+  ret = register_driver(path, &g_bm1422gmvfops, 0640, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);

--- a/boards/arm/samv7/common/src/sam_progmem.c
+++ b/boards/arm/samv7/common/src/sam_progmem.c
@@ -79,7 +79,7 @@ static int sam_progmem_register_driver(int minor, struct mtd_dev_s *mtd,
 
   /* Register the MTD driver */
 
-  ret = register_mtddriver(devpath, mtd, 0755, NULL);
+  ret = register_mtddriver(devpath, mtd, 0750, NULL);
   if (ret < 0)
     {
       ferr("ERROR: register_mtddriver %s failed: %d\n", devpath, ret);

--- a/boards/arm/stm32l1/stm32ldiscovery/src/stm32_lcd.c
+++ b/boards/arm/stm32l1/stm32ldiscovery/src/stm32_lcd.c
@@ -1584,7 +1584,7 @@ int stm32_slcd_initialize(void)
 
       /* Register the LCD device driver */
 
-      ret = register_driver("/dev/slcd0", &g_slcdops, 0644, &g_slcdstate);
+      ret = register_driver("/dev/slcd0", &g_slcdops, 0640, &g_slcdstate);
       g_slcdstate.initialized = true;
 
       /* Then clear the display */

--- a/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
+++ b/boards/mips/pic32mx/pic32mx7mmb/src/pic32_touchscreen.c
@@ -1371,7 +1371,7 @@ int pic32mx_tsc_setup(int minor)
   snprintf(devname, sizeof(devname), DEV_FORMAT, minor);
   iinfo("Registering %s\n", devname);
 
-  ret = register_driver(devname, &g_tc_fops, 0660, priv);
+  ret = register_driver(devname, &g_tc_fops, 0640, priv);
   if (ret < 0)
     {
       ierr("ERROR: register_driver() failed: %d\n", ret);

--- a/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_lcd1602.c
+++ b/boards/mips/pic32mx/sure-pic32mx/src/pic32mx_lcd1602.c
@@ -1076,7 +1076,7 @@ int up_lcd1602_initialize(void)
 
       /* Register the LCD device driver */
 
-      ret = register_driver("/dev/lcd1602", &g_lcdops, 0644, &g_lcd1602);
+      ret = register_driver("/dev/lcd1602", &g_lcdops, 0640, &g_lcd1602);
       g_lcd1602.initialized = true;
     }
 

--- a/drivers/coresight/coresight_etb.c
+++ b/drivers/coresight/coresight_etb.c
@@ -463,7 +463,7 @@ etb_register(FAR const struct coresight_desc_s *desc)
     }
 
   snprintf(pathname, sizeof(pathname), "/dev/%s", desc->name);
-  ret = register_driver(pathname, &g_etb_fops, 0444, etbdev);
+  ret = register_driver(pathname, &g_etb_fops, 0400, etbdev);
   if (ret < 0)
     {
       cserr("%s:driver register failed\n", desc->name);

--- a/drivers/coresight/coresight_tmc_etf.c
+++ b/drivers/coresight/coresight_tmc_etf.c
@@ -511,7 +511,7 @@ int tmc_etf_register(FAR struct coresight_tmc_dev_s * tmcdev,
         }
 
       snprintf(pathname, sizeof(pathname), "/dev/%s", desc->name);
-      ret = register_driver(pathname, &g_tmc_fops, 0444, tmcdev);
+      ret = register_driver(pathname, &g_tmc_fops, 0400, tmcdev);
       if (ret < 0)
         {
           cserr("%s:driver register failed\n", desc->name);

--- a/drivers/i3c/i3c_driver.c
+++ b/drivers/i3c/i3c_driver.c
@@ -384,7 +384,7 @@ int i3c_register(FAR struct i3c_master_controller *master, int bus)
   /* Create the character device name */
 
   snprintf(devname, sizeof(devname), DEVNAME_FMT, bus);
-  ret = register_driver(devname, &g_i3cdrvr_fops, 0666, priv);
+  ret = register_driver(devname, &g_i3cdrvr_fops, 0600, priv);
   if (ret < 0)
     {
       /* Free the device structure if we failed to create the character

--- a/drivers/input/ads7843e.c
+++ b/drivers/input/ads7843e.c
@@ -1166,7 +1166,7 @@ int ads7843e_register(FAR struct spi_dev_s *spi,
   snprintf(devname, sizeof(devname), DEV_FORMAT, minor);
   iinfo("Registering %s\n", devname);
 
-  ret = register_driver(devname, &g_ads7843e_fops, 0666, priv);
+  ret = register_driver(devname, &g_ads7843e_fops, 0600, priv);
   if (ret < 0)
     {
       ierr("ERROR: register_driver() failed: %d\n", ret);

--- a/drivers/input/ajoystick.c
+++ b/drivers/input/ajoystick.c
@@ -730,7 +730,7 @@ int ajoy_register(FAR const char *devname,
 
   /* And register the ajoystick driver */
 
-  ret = register_driver(devname, &g_ajoy_fops, 0666, priv);
+  ret = register_driver(devname, &g_ajoy_fops, 0600, priv);
   if (ret < 0)
     {
       ierr("ERROR: register_driver failed: %d\n", ret);

--- a/drivers/input/button_upper.c
+++ b/drivers/input/button_upper.c
@@ -810,7 +810,7 @@ int btn_register(FAR const char *devname,
 
   /* And register the button driver */
 
-  ret = register_driver(devname, &g_btn_fops, 0666, priv);
+  ret = register_driver(devname, &g_btn_fops, 0600, priv);
   if (ret < 0)
     {
       ierr("ERROR: register_driver failed: %d\n", ret);

--- a/drivers/input/cypress_mbr3108.c
+++ b/drivers/input/cypress_mbr3108.c
@@ -1105,7 +1105,7 @@ cypress_mbr3108_register(FAR const char *devpath,
 
   nxmutex_init(&priv->devlock);
 
-  ret = register_driver(devpath, &g_mbr3108_fileops, 0666, priv);
+  ret = register_driver(devpath, &g_mbr3108_fileops, 0600, priv);
   if (ret < 0)
     {
       nxmutex_destroy(&priv->devlock);

--- a/drivers/input/djoystick.c
+++ b/drivers/input/djoystick.c
@@ -721,7 +721,7 @@ int djoy_register(FAR const char *devname,
 
   /* And register the djoystick driver */
 
-  ret = register_driver(devname, &g_djoy_fops, 0666, priv);
+  ret = register_driver(devname, &g_djoy_fops, 0600, priv);
   if (ret < 0)
     {
       ierr("ERROR: register_driver failed: %d\n", ret);

--- a/drivers/input/ff_upper.c
+++ b/drivers/input/ff_upper.c
@@ -543,7 +543,7 @@ int ff_register(FAR struct ff_lowerhalf_s *lower, FAR const char *path,
   upper->effects     = (FAR struct ff_effect_s *)(upper + 1);
   nxmutex_init(&upper->lock);
 
-  ret = register_driver(path, &g_ff_fops, 0666, upper);
+  ret = register_driver(path, &g_ff_fops, 0600, upper);
   if (ret < 0)
     {
       nxmutex_destroy(&upper->lock);

--- a/drivers/input/gt9xx.c
+++ b/drivers/input/gt9xx.c
@@ -931,7 +931,7 @@ int gt9xx_register(FAR const char *devpath,
 
   /* Register the Touch Input Driver */
 
-  ret = register_driver(devpath, &g_gt9xx_fileops, 0666, priv);
+  ret = register_driver(devpath, &g_gt9xx_fileops, 0600, priv);
   if (ret < 0)
     {
       nxmutex_destroy(&priv->devlock);

--- a/drivers/input/keyboard_upper.c
+++ b/drivers/input/keyboard_upper.c
@@ -347,7 +347,7 @@ int keyboard_register(FAR struct keyboard_lowerhalf_s *lower,
   list_initialize(&upper->head);
   nxmutex_init(&upper->lock);
 
-  ret = register_driver(path, &g_keyboard_fops, 0666, upper);
+  ret = register_driver(path, &g_keyboard_fops, 0600, upper);
   if (ret < 0)
     {
       nxmutex_destroy(&upper->lock);

--- a/drivers/input/max11802.c
+++ b/drivers/input/max11802.c
@@ -1200,7 +1200,7 @@ int max11802_register(FAR struct spi_dev_s *spi,
   snprintf(devname, sizeof(devname), DEV_FORMAT, minor);
   iinfo("Registering %s\n", devname);
 
-  ret = register_driver(devname, &g_max11802_fops, 0666, priv);
+  ret = register_driver(devname, &g_max11802_fops, 0600, priv);
   if (ret < 0)
     {
       ierr("ERROR: register_driver() failed: %d\n", ret);

--- a/drivers/input/mouse_upper.c
+++ b/drivers/input/mouse_upper.c
@@ -379,7 +379,7 @@ int mouse_register(FAR struct mouse_lowerhalf_s *lower,
   list_initialize(&upper->head);
   nxmutex_init(&upper->lock);
 
-  ret = register_driver(path, &g_mouse_fops, 0666, upper);
+  ret = register_driver(path, &g_mouse_fops, 0600, upper);
   if (ret < 0)
     {
       nxmutex_destroy(&upper->lock);

--- a/drivers/input/mxt.c
+++ b/drivers/input/mxt.c
@@ -1883,7 +1883,7 @@ int mxt_register(FAR struct i2c_master_s *i2c,
   snprintf(devname, sizeof(devname), DEV_FORMAT, minor);
   iinfo("Registering %s\n", devname);
 
-  ret = register_driver(devname, &g_mxt_fops, 0666, priv);
+  ret = register_driver(devname, &g_mxt_fops, 0600, priv);
   if (ret < 0)
     {
       ierr("ERROR: register_driver() failed: %d\n", ret);

--- a/drivers/input/nunchuck.c
+++ b/drivers/input/nunchuck.c
@@ -564,7 +564,7 @@ int nunchuck_register(FAR const char *devname, FAR struct i2c_master_s *i2c)
 
   /* And register the nunchuck driver */
 
-  ret = register_driver(devname, &g_nunchuck_fops, 0666, priv);
+  ret = register_driver(devname, &g_nunchuck_fops, 0600, priv);
   if (ret < 0)
     {
       ierr("ERROR: register_driver failed: %d\n", ret);

--- a/drivers/input/spq10kbd.c
+++ b/drivers/input/spq10kbd.c
@@ -1032,7 +1032,7 @@ int spq10kbd_register(FAR struct i2c_master_s *i2c,
 
   snprintf(kbddevname, sizeof(kbddevname), DEV_FORMAT, kbdminor);
   iinfo("Registering %s\n", kbddevname);
-  ret = register_driver(kbddevname, &g_hidkbd_fops, 0666, priv);
+  ret = register_driver(kbddevname, &g_hidkbd_fops, 0600, priv);
 
 #ifdef CONFIG_SPQ10KBD_DJOY
   iinfo("Registering %s\n", joydevname);

--- a/drivers/input/stmpe811_tsc.c
+++ b/drivers/input/stmpe811_tsc.c
@@ -904,7 +904,7 @@ int stmpe811_register(STMPE811_HANDLE handle, int minor)
   /* Register the character driver */
 
   snprintf(devname, sizeof(devname), DEV_FORMAT, minor);
-  ret = register_driver(devname, &g_stmpe811fops, 0666, priv);
+  ret = register_driver(devname, &g_stmpe811fops, 0600, priv);
   if (ret < 0)
     {
       ierr("ERROR: Failed to register driver %s: %d\n", devname, ret);

--- a/drivers/input/touchscreen_upper.c
+++ b/drivers/input/touchscreen_upper.c
@@ -492,7 +492,7 @@ int touch_register(FAR struct touch_lowerhalf_s *lower,
   list_initialize(&upper->head);
   nxmutex_init(&upper->lock);
 
-  ret = register_driver(path, &g_touch_fops, 0666, upper);
+  ret = register_driver(path, &g_touch_fops, 0600, upper);
   if (ret < 0)
     {
       nxmutex_destroy(&upper->lock);

--- a/drivers/input/tsc2007.c
+++ b/drivers/input/tsc2007.c
@@ -1247,7 +1247,7 @@ int tsc2007_register(FAR struct i2c_master_s *dev,
   snprintf(devname, sizeof(devname), DEV_FORMAT, minor);
   iinfo("Registering %s\n", devname);
 
-  ret = register_driver(devname, &g_tsc2007_fops, 0666, priv);
+  ret = register_driver(devname, &g_tsc2007_fops, 0600, priv);
   if (ret < 0)
     {
       ierr("ERROR: register_driver() failed: %d\n", ret);

--- a/drivers/ioexpander/gpio.c
+++ b/drivers/ioexpander/gpio.c
@@ -791,7 +791,7 @@ int gpio_pin_register_byname(FAR struct gpio_dev_s *dev,
 
   gpioinfo("Registering %s\n", devname);
 
-  return register_driver(devname, &g_gpio_drvrops, 0666, dev);
+  return register_driver(devname, &g_gpio_drvrops, 0600, dev);
 }
 
 /****************************************************************************

--- a/drivers/ipcc/ipcc_register.c
+++ b/drivers/ipcc/ipcc_register.c
@@ -167,7 +167,7 @@ int ipcc_register(FAR struct ipcc_lower_s *ipcc)
   /* Create the character device name */
 
   snprintf(devname, sizeof(devname), DEVNAME_FMT, ipcc->chan);
-  if ((ret = register_driver(devname, &g_ipcc_fops, 0666, priv)))
+  if ((ret = register_driver(devname, &g_ipcc_fops, 0600, priv)))
     {
       goto error;
     }

--- a/drivers/lcd/ft80x.c
+++ b/drivers/lcd/ft80x.c
@@ -1575,7 +1575,7 @@ int ft80x_register(FAR struct i2c_master_s *i2c,
 
   /* Register the FT80x character driver */
 
-  ret = register_driver(DEVNAME, &g_ft80x_fops, 0666, priv);
+  ret = register_driver(DEVNAME, &g_ft80x_fops, 0600, priv);
   if (ret < 0)
     {
       goto errout_with_interrupts;

--- a/drivers/lcd/ht16k33_14seg.c
+++ b/drivers/lcd/ht16k33_14seg.c
@@ -1094,7 +1094,7 @@ int ht16k33_register(int devno, FAR struct i2c_master_s *i2c)
 
   /* Register the driver */
 
-  ret = register_driver(devname, &g_ht16k33fops, 0666, priv);
+  ret = register_driver(devname, &g_ht16k33fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/lcd/lcd_dev.c
+++ b/drivers/lcd/lcd_dev.c
@@ -443,7 +443,7 @@ int lcddev_register(int devno)
     }
 
   snprintf(devname, sizeof(devname), "/dev/lcd%i", devno);
-  ret = register_driver(devname, &g_lcddev_fops, 0666, priv);
+  ret = register_driver(devname, &g_lcddev_fops, 0600, priv);
   if (ret < 0)
     {
       goto err;

--- a/drivers/lcd/pcf8574_lcd_backpack.c
+++ b/drivers/lcd/pcf8574_lcd_backpack.c
@@ -1632,7 +1632,7 @@ int pcf8574_lcd_backpack_register(FAR const char *devpath,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_pcf8574_lcd_fops, 0666, priv);
+  ret = register_driver(devpath, &g_pcf8574_lcd_fops, 0600, priv);
   if (ret < 0)
     {
       lcdinfo("Failed to register driver: %d\n", ret);

--- a/drivers/lcd/st7032.c
+++ b/drivers/lcd/st7032.c
@@ -1020,7 +1020,7 @@ int st7032_register(FAR const char *devpath, FAR struct i2c_master_s *i2c)
 
   /* Register the driver */
 
-  ret = register_driver(devpath, &g_st7032fops, 0666, priv);
+  ret = register_driver(devpath, &g_st7032fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/lcd/tda19988.c
+++ b/drivers/lcd/tda19988.c
@@ -1682,7 +1682,7 @@ TDA19988_HANDLE tda19988_register(FAR const char *devpath,
 
   /* Register the driver */
 
-  ret = register_driver(devpath, &g_tda19988_fops, 0666, NULL);
+  ret = register_driver(devpath, &g_tda19988_fops, 0600, NULL);
   if (ret < 0)
     {
       lcderr("ERROR: register_driver() failed: %d\n", ret);

--- a/drivers/leds/apa102.c
+++ b/drivers/leds/apa102.c
@@ -249,7 +249,7 @@ int apa102_register(FAR const char *devpath, FAR struct spi_dev_s *spi)
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_apa102fops, 0666, priv);
+  ret = register_driver(devpath, &g_apa102fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/leds/ktd2052.c
+++ b/drivers/leds/ktd2052.c
@@ -741,7 +741,7 @@ int ktd2052_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_ktd2052_fops, 0666, priv);
+  ret = register_driver(devpath, &g_ktd2052_fops, 0600, priv);
   if (ret < 0)
     {
       kmm_free(priv);

--- a/drivers/leds/lp503x.c
+++ b/drivers/leds/lp503x.c
@@ -947,7 +947,7 @@ int lp503x_register(const char *devpath, struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_lp503x_fileops, 0222, priv);
+  ret = register_driver(devpath, &g_lp503x_fileops, 0200, priv);
   if (ret != OK)
     {
       lederr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/leds/max7219.c
+++ b/drivers/leds/max7219.c
@@ -349,7 +349,7 @@ int max7219_leds_register(FAR const char *devpath, FAR struct spi_dev_s *spi)
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_max7219fops, 0666, priv);
+  ret = register_driver(devpath, &g_max7219fops, 0600, priv);
   if (ret < 0)
     {
       lederr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/leds/ncp5623c.c
+++ b/drivers/leds/ncp5623c.c
@@ -284,7 +284,7 @@ int ncp5623c_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  int const ret = register_driver(devpath, &g_ncp5623c_fileops, 0666, priv);
+  int const ret = register_driver(devpath, &g_ncp5623c_fileops, 0600, priv);
   if (ret != OK)
     {
       lcderr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/leds/pca9635pw.c
+++ b/drivers/leds/pca9635pw.c
@@ -356,7 +356,7 @@ int pca9635pw_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  int const ret = register_driver(devpath, &g_pca9635pw_fileops, 0222, priv);
+  int const ret = register_driver(devpath, &g_pca9635pw_fileops, 0200, priv);
   if (ret != OK)
     {
       lcderr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/leds/rgbled.c
+++ b/drivers/leds/rgbled.c
@@ -496,7 +496,7 @@ int rgbled_register(FAR const char *path, FAR struct pwm_lowerhalf_s *ledr,
   /* Register the PWM device */
 
   lcdinfo("Registering %s\n", path);
-  return register_driver(path, &g_rgbledops, 0666, upper);
+  return register_driver(path, &g_rgbledops, 0600, upper);
 }
 
 #endif /* CONFIG_RGBLED */

--- a/drivers/leds/userled_upper.c
+++ b/drivers/leds/userled_upper.c
@@ -550,7 +550,7 @@ int userled_register(FAR const char *devname,
 
   /* And register the LED driver */
 
-  ret = register_driver(devname, &g_userled_fops, 0666, priv);
+  ret = register_driver(devname, &g_userled_fops, 0600, priv);
   if (ret < 0)
     {
       lederr("ERROR: register_driver failed: %d\n", ret);

--- a/drivers/leds/ws2812.c
+++ b/drivers/leds/ws2812.c
@@ -614,7 +614,7 @@ int ws2812_register(FAR const char          *dev_path,
 {
   /* Register the character driver */
 
-  int ret = register_driver(dev_path, &g_ws2812fops, 0666, dev_data);
+  int ret = register_driver(dev_path, &g_ws2812fops, 0600, dev_data);
   if (ret < 0)
     {
       lederr("ERROR: Failed to register ws2812 driver: %d\n", ret);
@@ -685,7 +685,7 @@ int ws2812_leds_register(FAR const char *devpath, FAR struct spi_dev_s *spi,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_ws2812fops, 0666, priv);
+  ret = register_driver(devpath, &g_ws2812fops, 0600, priv);
   if (ret < 0)
     {
       lederr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/loop/loop.c
+++ b/drivers/loop/loop.c
@@ -168,7 +168,7 @@ static int loop_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
 void loop_register(void)
 {
-  register_driver("/dev/loop", &g_loop_fops, 0666, NULL);
+  register_driver("/dev/loop", &g_loop_fops, 0600, NULL);
 }
 
 #endif /* CONFIG_DEV_LOOP */

--- a/drivers/math/math.c
+++ b/drivers/math/math.c
@@ -220,7 +220,7 @@ int math_register(FAR const char *path,
 
   /* Register the math timer device */
 
-  ret = register_driver(path, &g_math_ops, 0666, upper);
+  ret = register_driver(path, &g_math_ops, 0600, upper);
   if (ret < 0)
     {
       _err("register math driver failed: %d\n", ret);

--- a/drivers/misc/dev_ascii.c
+++ b/drivers/misc/dev_ascii.c
@@ -137,5 +137,5 @@ static int devascii_poll(FAR struct file *filep, FAR struct pollfd *fds,
 
 void devascii_register(void)
 {
-  register_driver("/dev/ascii", &g_devascii_fops, 0666, NULL);
+  register_driver("/dev/ascii", &g_devascii_fops, 0644, NULL);
 }

--- a/drivers/misc/dev_mem.c
+++ b/drivers/misc/dev_mem.c
@@ -198,5 +198,5 @@ static int devmem_mmap(FAR struct file *filep,
 int devmem_register(void)
 {
   return register_driver("/dev/mem", &g_devmem_fops,
-                         0666, (FAR void *)g_memory_region);
+                         0600, (FAR void *)g_memory_region);
 }

--- a/drivers/misc/lwl_console.c
+++ b/drivers/misc/lwl_console.c
@@ -316,5 +316,5 @@ void up_putc(int ch)
 
 void lwlconsole_init(void)
 {
-  register_driver("/dev/console", &g_consoleops, 0666, NULL);
+  register_driver("/dev/console", &g_consoleops, 0620, NULL);
 }

--- a/drivers/misc/optee.c
+++ b/drivers/misc/optee.c
@@ -1501,7 +1501,7 @@ int optee_register(void)
     }
 
 #ifdef CONFIG_DEV_OPTEE_SUPPLICANT
-  ret = register_driver(OPTEE_SUPPLICANT_DEV_PATH, &g_optee_ops, 0666,
+  ret = register_driver(OPTEE_SUPPLICANT_DEV_PATH, &g_optee_ops, 0600,
                         (FAR void *)OPTEE_ROLE_SUPPLICANT);
   if (ret < 0)
     {
@@ -1509,7 +1509,7 @@ int optee_register(void)
     }
 #endif
 
-  return register_driver(OPTEE_DEV_PATH, &g_optee_ops, 0666,
+  return register_driver(OPTEE_DEV_PATH, &g_optee_ops, 0600,
                          (FAR void *)OPTEE_ROLE_CA);
 }
 

--- a/drivers/misc/rpmsgblk.c
+++ b/drivers/misc/rpmsgblk.c
@@ -1307,7 +1307,7 @@ int rpmsgblk_register(FAR const char *remotecpu, FAR const char *remotepath,
       localpath = remotepath;
     }
 
-  ret = register_blockdriver(localpath, &dev->blk, 0755, dev);
+  ret = register_blockdriver(localpath, &dev->blk, 0750, dev);
   if (ret < 0)
     {
       ferr("ERROR: register driver failed, ret=%d\n", ret);

--- a/drivers/misc/rpmsgdev.c
+++ b/drivers/misc/rpmsgdev.c
@@ -1196,7 +1196,7 @@ int rpmsgdev_register(FAR const char *remotecpu, FAR const char *remotepath,
       localpath = remotepath;
     }
 
-  ret = register_driver(localpath, &g_rpmsgdev_ops, 0666, dev);
+  ret = register_driver(localpath, &g_rpmsgdev_ops, 0600, dev);
   if (ret < 0)
     {
       rpmsgdeverr("register driver failed, ret=%d\n", ret);

--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -4407,7 +4407,7 @@ static int mmcsd_probe(FAR struct mmcsd_state_s *priv)
                 {
                   snprintf(devname, sizeof(devname), "/dev/mmcsd%d%s",
                            priv->minor, g_partname[i]);
-                  register_blockdriver(devname, &g_bops, 0666,
+                  register_blockdriver(devname, &g_bops, 0660,
                                        &priv->part[i]);
                 }
             }

--- a/drivers/modem/alt1250/alt1250.c
+++ b/drivers/modem/alt1250/alt1250.c
@@ -1511,7 +1511,7 @@ FAR void *alt1250_register(FAR const char *devpath,
   nxsem_init(&g_alt1250_res_s.sem, 0, 0);
 #endif
 
-  ret = register_driver(devpath, &g_alt1250fops, 0666, priv);
+  ret = register_driver(devpath, &g_alt1250fops, 0600, priv);
   if (ret < 0)
     {
       m_err("Failed to register driver: %d\n", ret);

--- a/drivers/modem/u-blox.c
+++ b/drivers/modem/u-blox.c
@@ -294,7 +294,7 @@ FAR void *ubxmdm_register(FAR const char *path,
       goto errout_with_upper;
     }
 
-  ret = register_driver(path, &g_ubxmdm_fops, 0666, upper);
+  ret = register_driver(path, &g_ubxmdm_fops, 0600, upper);
   if (ret < 0)
     {
       m_err("ERROR: register_driver failed: %d\n", ret);

--- a/drivers/motor/foc/foc_dev.c
+++ b/drivers/motor/foc/foc_dev.c
@@ -915,7 +915,7 @@ int foc_register(FAR const char *path, FAR struct foc_dev_s *dev)
 
   /* Register the FOC character driver */
 
-  ret = register_driver(path, &g_foc_fops, 0666, dev);
+  ret = register_driver(path, &g_foc_fops, 0600, dev);
   if (ret < 0)
     {
       nxmutex_destroy(&dev->closelock);

--- a/drivers/motor/motor.c
+++ b/drivers/motor/motor.c
@@ -587,7 +587,7 @@ int motor_register(FAR const char *path,
 
   /* Register the motor character driver */
 
-  ret = register_driver(path, &g_motor_fops, 0666, upper);
+  ret = register_driver(path, &g_motor_fops, 0600, upper);
   if (ret < 0)
     {
       nxmutex_destroy(&upper->closelock);

--- a/drivers/motor/stepper.c
+++ b/drivers/motor/stepper.c
@@ -338,7 +338,7 @@ int stepper_register(FAR const char *path,
 
   /* Register the stepper character driver */
 
-  ret = register_driver(path, &g_stepper_fops, 0666, stepper);
+  ret = register_driver(path, &g_stepper_fops, 0600, stepper);
   if (ret < 0)
     {
       nxmutex_destroy(&stepper->lock);

--- a/drivers/mtd/dhara.c
+++ b/drivers/mtd/dhara.c
@@ -754,7 +754,7 @@ int dhara_initialize_by_path(FAR const char *path,
    * DHARA_MTDBLOCK device structure
    */
 
-  ret = register_blockdriver(path, &g_dhara_bops, 0666, dev);
+  ret = register_blockdriver(path, &g_dhara_bops, 0660, dev);
   if (ret < 0)
     {
       ferr("register_blockdriver failed: %d\n", ret);

--- a/drivers/mtd/filemtd.c
+++ b/drivers/mtd/filemtd.c
@@ -948,6 +948,6 @@ bool filemtd_isfilemtd(FAR struct mtd_dev_s *dev)
 #ifdef CONFIG_MTD_LOOP
 int mtd_loop_register(void)
 {
-  return register_driver("/dev/loopmtd", &g_fops, 0666, NULL);
+  return register_driver("/dev/loopmtd", &g_fops, 0600, NULL);
 }
 #endif

--- a/drivers/mtd/mtd_config.c
+++ b/drivers/mtd/mtd_config.c
@@ -1784,7 +1784,7 @@ int mtdconfig_register_by_path(FAR struct mtd_dev_s *mtd,
         }
 
       nxmutex_init(&dev->lock);
-      register_driver(path, &g_mtdconfig_fops, 0666, dev);
+      register_driver(path, &g_mtdconfig_fops, 0600, dev);
     }
 
 errout:

--- a/drivers/mtd/mtd_config_nvs.c
+++ b/drivers/mtd/mtd_config_nvs.c
@@ -2489,7 +2489,7 @@ int mtdconfig_register_by_path(FAR struct mtd_dev_s *mtd,
       goto mutex_err;
     }
 
-  rc = register_driver(path, &g_mtdnvs_fops, 0666, fs);
+  rc = register_driver(path, &g_mtdnvs_fops, 0600, fs);
   if (rc < 0)
     {
       ferr("ERROR: register mtd config failed: %d\n", rc);

--- a/drivers/mtd/nvblk.c
+++ b/drivers/mtd/nvblk.c
@@ -542,7 +542,7 @@ int nvblk_initialize(FAR const char *path,
    * NVBLK_MTDBLOCK device structure
    */
 
-  ret = register_blockdriver(path, &g_nvblk_bops, 0666, dev);
+  ret = register_blockdriver(path, &g_nvblk_bops, 0660, dev);
   if (ret < 0)
     {
       ferr("register_blockdriver failed: %d\n", ret);

--- a/drivers/mtd/smart.c
+++ b/drivers/mtd/smart.c
@@ -6346,7 +6346,7 @@ errout:
 #ifdef CONFIG_SMART_DEV_LOOP
 int smart_loop_register_driver(void)
 {
-  return register_driver("/dev/smart", &g_fops, 0666, NULL);
+  return register_driver("/dev/smart", &g_fops, 0600, NULL);
 }
 #endif
 

--- a/drivers/net/telnet.c
+++ b/drivers/net/telnet.c
@@ -1023,7 +1023,7 @@ static int telnet_session(FAR struct telnet_session_s *session)
 
   /* Register the driver */
 
-  ret = register_driver(session->ts_devpath, &g_telnet_fops, 0666, priv);
+  ret = register_driver(session->ts_devpath, &g_telnet_fops, 0600, priv);
   if (ret < 0)
     {
       nerr("ERROR: Failed to register the driver %s: %d\n",
@@ -1274,7 +1274,7 @@ static int factory_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
 int telnet_initialize(void)
 {
-  return register_driver("/dev/telnet", &g_factory_fops, 0666, NULL);
+  return register_driver("/dev/telnet", &g_factory_fops, 0600, NULL);
 }
 
 #endif /* CONFIG_NETDEV_TELNET */

--- a/drivers/note/notectl_driver.c
+++ b/drivers/note/notectl_driver.c
@@ -237,5 +237,5 @@ static int notectl_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
 int notectl_register(void)
 {
-  return register_driver("/dev/notectl", &g_notectl_fops, 0666, NULL);
+  return register_driver("/dev/notectl", &g_notectl_fops, 0600, NULL);
 }

--- a/drivers/note/noteram_driver.c
+++ b/drivers/note/noteram_driver.c
@@ -1359,7 +1359,7 @@ int noteram_register(void)
 #ifdef CONFIG_DRIVERS_NOTERAM_CRASH_DUMP
   noteram_crash_dump_register(&g_noteram_driver);
 #endif
-  return register_driver("/dev/note/ram", &g_noteram_fops, 0666,
+  return register_driver("/dev/note/ram", &g_noteram_fops, 0400,
                          &g_noteram_driver);
 }
 
@@ -1438,7 +1438,7 @@ noteram_initialize(FAR const char *devpath, size_t bufsize,
       return &drv->driver;
     }
 
-  ret = register_driver(devpath, &g_noteram_fops, 0666, drv);
+  ret = register_driver(devpath, &g_noteram_fops, 0400, drv);
   if (ret < 0)
     {
       kmm_free(drv);

--- a/drivers/pci/pci.c
+++ b/drivers/pci/pci.c
@@ -2354,7 +2354,7 @@ uint8_t pci_bus_find_capability(FAR struct pci_bus_s *bus,
 
 int pci_dev_register(void)
 {
-  return register_driver("/dev/pci", &g_pci_fops, 0666, NULL);
+  return register_driver("/dev/pci", &g_pci_fops, 0600, NULL);
 }
 
 /****************************************************************************

--- a/drivers/pci/pci_ep_test.c
+++ b/drivers/pci/pci_ep_test.c
@@ -827,7 +827,7 @@ static int pci_ep_test_probe(FAR struct pci_device_s *dev)
 
   snprintf(test->name, sizeof(test->name),
            PCI_EP_TEST_DEVICE_NAME ".%d", g_pci_ep_idr++);
-  register_driver(test->name, &g_pci_ep_test_fops, 0666, test);
+  register_driver(test->name, &g_pci_ep_test_fops, 0600, test);
   pciinfo("pci ep test device register success.\n");
 
   return 0;

--- a/drivers/pci/pci_uio_ivshmem.c
+++ b/drivers/pci/pci_uio_ivshmem.c
@@ -483,7 +483,7 @@ static int uio_ivshmem_probe(FAR struct ivshmem_device_s *dev)
   ivshmem_control_irq(dev, true);
 
   snprintf(udev->name, sizeof(udev->name), "/dev/uio%d", udev->drv.id);
-  ret = register_driver(udev->name, &g_uio_ivshmem_fops, 0666, udev);
+  ret = register_driver(udev->name, &g_uio_ivshmem_fops, 0600, udev);
   if (ret < 0)
     {
       pcierr("ERROR: Ivshmem register_driver failed, ret=%d\n", ret);

--- a/drivers/pinctrl/pinctrl.c
+++ b/drivers/pinctrl/pinctrl.c
@@ -227,7 +227,7 @@ int pinctrl_register(FAR struct pinctrl_dev_s *dev, int minor)
   char devname[32];
 
   snprintf(devname, 16, "/dev/pinctrl%u", (unsigned int)minor);
-  return register_driver(devname, &g_pinctrl_drvrops, 0666, dev);
+  return register_driver(devname, &g_pinctrl_drvrops, 0600, dev);
 }
 
 /****************************************************************************

--- a/drivers/power/battery/battery_charger.c
+++ b/drivers/power/battery/battery_charger.c
@@ -559,7 +559,7 @@ int battery_charger_register(FAR const char *devpath,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_batteryops, 0666, dev);
+  ret = register_driver(devpath, &g_batteryops, 0600, dev);
   if (ret < 0)
     {
       baterr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/power/battery/battery_gauge.c
+++ b/drivers/power/battery/battery_gauge.c
@@ -519,7 +519,7 @@ int battery_gauge_register(FAR const char *devpath,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_batteryops, 0666, dev);
+  ret = register_driver(devpath, &g_batteryops, 0600, dev);
   if (ret < 0)
     {
       baterr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/power/battery/battery_monitor.c
+++ b/drivers/power/battery/battery_monitor.c
@@ -585,7 +585,7 @@ int battery_monitor_register(FAR const char *devpath,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_batteryops, 0555, dev);
+  ret = register_driver(devpath, &g_batteryops, 0500, dev);
   if (ret < 0)
     {
       baterr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/power/relay/relay.c
+++ b/drivers/power/relay/relay.c
@@ -158,5 +158,5 @@ int relay_register(FAR struct relay_dev_s *dev, FAR const char *devname)
 
   nxmutex_init(&dev->lock);
 
-  return register_driver(devname, &g_relay_ops, 0666, dev);
+  return register_driver(devname, &g_relay_ops, 0600, dev);
 }

--- a/drivers/power/supply/powerled.c
+++ b/drivers/power/supply/powerled.c
@@ -414,7 +414,7 @@ int powerled_register(FAR const char *path, FAR struct powerled_dev_s *dev,
 
   /* Register the POWERLED character driver */
 
-  ret = register_driver(path, &g_powerled_fops, 0666, dev);
+  ret = register_driver(path, &g_powerled_fops, 0600, dev);
   if (ret < 0)
     {
       nxmutex_destroy(&dev->closelock);

--- a/drivers/power/supply/smps.c
+++ b/drivers/power/supply/smps.c
@@ -511,7 +511,7 @@ int smps_register(FAR const char *path, FAR struct smps_dev_s *dev,
 
   /* Register the SMPS character driver */
 
-  ret = register_driver(path, &g_smps_fops, 0666, dev);
+  ret = register_driver(path, &g_smps_fops, 0600, dev);
   if (ret < 0)
     {
       nxmutex_destroy(&dev->closelock);

--- a/drivers/rc/lirc_dev.c
+++ b/drivers/rc/lirc_dev.c
@@ -796,7 +796,7 @@ int lirc_register(FAR struct lirc_lowerhalf_s *lower, int devno)
   /* Register remote control character device */
 
   snprintf(path, DEVNAME_MAX, DEVNAME_FMT, devno);
-  ret = register_driver(path, &g_lirc_fops, 0666, upper);
+  ret = register_driver(path, &g_lirc_fops, 0600, upper);
   if (ret < 0)
     {
       goto drv_err;

--- a/drivers/rf/dat-31r5-sp.c
+++ b/drivers/rf/dat-31r5-sp.c
@@ -248,7 +248,7 @@ int dat31r5sp_register(FAR const char *devpath,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_dat31r5sp_fops, 0666, priv);
+  ret = register_driver(devpath, &g_dat31r5sp_fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/rpmsg/rpmsg.c
+++ b/drivers/rpmsg/rpmsg.c
@@ -521,7 +521,7 @@ int rpmsg_register(FAR const char *path, FAR struct rpmsg_s *rpmsg,
       return ret;
     }
 
-  ret = register_driver(path, &g_rpmsg_dev_ops, 0222, rpmsg);
+  ret = register_driver(path, &g_rpmsg_dev_ops, 0200, rpmsg);
   if (ret < 0)
     {
       metal_finish();

--- a/drivers/rptun/rptun.c
+++ b/drivers/rptun/rptun.c
@@ -1226,7 +1226,7 @@ int rptun_initialize(FAR struct rptun_dev_s *dev)
   remoteproc_init(&priv->rproc, &g_rptun_ops, priv);
 
   snprintf(name, sizeof(name), "/dev/rptun/%s", RPTUN_GET_CPUNAME(dev));
-  ret = register_driver(name, &g_rptun_fops, 0222, priv);
+  ret = register_driver(name, &g_rptun_fops, 0200, priv);
   if (ret < 0)
     {
       rptunerr("rptun register driver failed %d\n", ret);

--- a/drivers/sensors/adt7320.c
+++ b/drivers/sensors/adt7320.c
@@ -618,7 +618,7 @@ int adt7320_register(FAR const char *devpath,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_adt7320fops, 0666, priv);
+  ret = register_driver(devpath, &g_adt7320fops, 0440, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/adxl345_base.c
+++ b/drivers/sensors/adxl345_base.c
@@ -173,7 +173,7 @@ int adxl345_register(ADXL345_HANDLE handle, int minor)
   /* Register the character driver */
 
   snprintf(devname, sizeof(devname), DEV_FORMAT, minor);
-  ret = register_driver(devname, &g_adxl345fops, 0444, priv);
+  ret = register_driver(devname, &g_adxl345fops, 0440, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver %s: %d\n", devname, ret);

--- a/drivers/sensors/adxl372.c
+++ b/drivers/sensors/adxl372.c
@@ -876,7 +876,7 @@ int adxl372_register(FAR const char *devpath,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_adxl372_fops, 0666, priv);
+  ret = register_driver(devpath, &g_adxl372_fops, 0440, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register accelerometer driver: %d\n", ret);

--- a/drivers/sensors/aht10.c
+++ b/drivers/sensors/aht10.c
@@ -628,7 +628,7 @@ int aht10_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_aht10fops, 0666, priv);
+  ret = register_driver(devpath, &g_aht10fops, 0400, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/ak09912.c
+++ b/drivers/sensors/ak09912.c
@@ -714,7 +714,7 @@ int ak09912_register(FAR const char *devpath, FAR struct i2c_master_s *i2c)
   /* Register the character driver */
 
   snprintf(path, sizeof(path), "%s%d", devpath, 0);
-  ret = register_driver(path, &g_ak09912fops, 0666, priv);
+  ret = register_driver(path, &g_ak09912fops, 0640, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);

--- a/drivers/sensors/amg88xx.c
+++ b/drivers/sensors/amg88xx.c
@@ -622,7 +622,7 @@ int amg88xx_register(FAR const char *devpath,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_amg88xx_fops, 0666, priv);
+  ret = register_driver(devpath, &g_amg88xx_fops, 0600, priv);
 
   if (ret < 0)
     {

--- a/drivers/sensors/apds9922.c
+++ b/drivers/sensors/apds9922.c
@@ -2506,7 +2506,7 @@ int apds9922_register(FAR const char *devpath_als,
 
   if (devpath_als != NULL)
     {
-      ret = register_driver(devpath_als, &g_apds9922_alsfops, 0666, priv);
+      ret = register_driver(devpath_als, &g_apds9922_alsfops, 0600, priv);
       if (ret < 0)
         {
           snerr("ERROR: Failed to register driver %s: %d\n",
@@ -2518,7 +2518,7 @@ int apds9922_register(FAR const char *devpath_als,
 
   if (devpath_ps != NULL)
     {
-      ret = register_driver(devpath_ps, &g_apds9922_psfops, 0666, priv);
+      ret = register_driver(devpath_ps, &g_apds9922_psfops, 0600, priv);
       if (ret < 0)
         {
           snerr("ERROR: Failed to register driver %s: %d\n",

--- a/drivers/sensors/apds9960.c
+++ b/drivers/sensors/apds9960.c
@@ -1287,7 +1287,7 @@ int apds9960_register(FAR const char *devpath,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_apds9960_fops, 0666, priv);
+  ret = register_driver(devpath, &g_apds9960_fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/as726x.c
+++ b/drivers/sensors/as726x.c
@@ -476,7 +476,7 @@ int as726x_register(FAR const char *devpath, FAR struct i2c_master_s *i2c)
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_as726x_fops, 0666, priv);
+  ret = register_driver(devpath, &g_as726x_fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/bh1749nuc.c
+++ b/drivers/sensors/bh1749nuc.c
@@ -231,7 +231,7 @@ int bh1749nuc_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_bh1749nucfops, 0666, priv);
+  ret = register_driver(devpath, &g_bh1749nucfops, 0600, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);

--- a/drivers/sensors/bh1750fvi.c
+++ b/drivers/sensors/bh1750fvi.c
@@ -409,7 +409,7 @@ int bh1750fvi_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_bh1750fvi_fops, 0666, priv);
+  ret = register_driver(devpath, &g_bh1750fvi_fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/bmg160.c
+++ b/drivers/sensors/bmg160.c
@@ -559,7 +559,7 @@ int bmg160_register(FAR const char *devpath, FAR struct spi_dev_s *spi,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_bmg160_fops, 0666, priv);
+  ret = register_driver(devpath, &g_bmg160_fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/bmi088.c
+++ b/drivers/sensors/bmi088.c
@@ -375,7 +375,7 @@ int bmi088_acc_register(FAR const char *devpath, FAR struct spi_dev_s *dev)
       return ret;
     }
 
-  ret = register_driver(devpath, &g_bmi088_acc_fops, 0666, priv);
+  ret = register_driver(devpath, &g_bmi088_acc_fops, 0600, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);
@@ -437,7 +437,7 @@ int bmi088_gyro_register(FAR const char *devpath, FAR struct spi_dev_s *dev)
       return ret;
     }
 
-  ret = register_driver(devpath, &g_bmi088_gyro_fops, 0666, priv);
+  ret = register_driver(devpath, &g_bmi088_gyro_fops, 0600, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);

--- a/drivers/sensors/bmi160.c
+++ b/drivers/sensors/bmi160.c
@@ -296,7 +296,7 @@ int bmi160_register(FAR const char *devpath, FAR struct spi_dev_s *dev)
 
   bmi160_putreg8(priv, BMI160_PMU_TRIGGER, 0);
 
-  ret = register_driver(devpath, &g_bmi160fops, 0666, priv);
+  ret = register_driver(devpath, &g_bmi160fops, 0600, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);

--- a/drivers/sensors/bmi270.c
+++ b/drivers/sensors/bmi270.c
@@ -234,7 +234,7 @@ int bmi270_register(FAR const char *devpath, FAR struct spi_dev_s *dev)
 
   /* Register driver */
 
-  ret = register_driver(devpath, &g_bmi270fops, 0666, priv);
+  ret = register_driver(devpath, &g_bmi270fops, 0600, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);

--- a/drivers/sensors/bmp180.c
+++ b/drivers/sensors/bmp180.c
@@ -167,7 +167,7 @@ int bmp180_register(FAR const char *devpath, FAR struct i2c_master_s *i2c)
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_bmp180fops, 0666, priv);
+  ret = register_driver(devpath, &g_bmp180fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/cxd5602pwbimu.c
+++ b/drivers/sensors/cxd5602pwbimu.c
@@ -1813,7 +1813,7 @@ int cxd5602pwbimu_register(FAR const char *devpath,
   nxsem_init(&priv->dataready, 0, 0);
   nxsem_init(&priv->bufsem, 0, 1);
 
-  ret = register_driver(devpath, &g_cxd5602pwbimufops, 0666, priv);
+  ret = register_driver(devpath, &g_cxd5602pwbimufops, 0600, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);

--- a/drivers/sensors/dhtxx.c
+++ b/drivers/sensors/dhtxx.c
@@ -574,7 +574,7 @@ int dhtxx_register(FAR const char *devpath,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_dhtxxfops, 0666, priv);
+  ret = register_driver(devpath, &g_dhtxxfops, 0600, priv);
   if (ret < 0)
     {
       nxmutex_destroy(&priv->devlock);

--- a/drivers/sensors/fxos8700cq.c
+++ b/drivers/sensors/fxos8700cq.c
@@ -450,7 +450,7 @@ int fxos8700cq_register(FAR const char *devpath,
       return ret;
     }
 
-  ret = register_driver(devpath, &g_fxos8700cqfops, 0444, priv);
+  ret = register_driver(devpath, &g_fxos8700cqfops, 0400, priv);
   if (ret < 0)
     {
       snerr("Failed to register driver: %d\n", ret);

--- a/drivers/sensors/gnss_uorb.c
+++ b/drivers/sensors/gnss_uorb.c
@@ -862,7 +862,7 @@ int gnss_register(FAR struct gnss_lowerhalf_s *lower, int devno,
     }
 
   snprintf(path, PATH_MAX, GNSS_PATH_FMT, devno);
-  ret = register_driver(path, &g_gnss_fops, 0666, upper);
+  ret = register_driver(path, &g_gnss_fops, 0600, upper);
   if (ret < 0)
     {
       goto driver_err;

--- a/drivers/sensors/hall3ph.c
+++ b/drivers/sensors/hall3ph.c
@@ -353,5 +353,5 @@ int hall3_register(FAR const char *devpath,
   /* Register the Hall effect sensor device */
 
   sninfo("Registering %s\n", devpath);
-  return register_driver(devpath, &g_hall3ops, 0666, upper);
+  return register_driver(devpath, &g_hall3ops, 0600, upper);
 }

--- a/drivers/sensors/hc_sr04.c
+++ b/drivers/sensors/hc_sr04.c
@@ -433,7 +433,7 @@ int hcsr04_register(FAR const char *devpath,
   nxmutex_init(&priv->devlock);
   nxsem_init(&priv->conv_donesem, 0, 0);
 
-  ret = register_driver(devpath, &g_hcsr04ops, 0666, priv);
+  ret = register_driver(devpath, &g_hcsr04ops, 0600, priv);
   if (ret < 0)
     {
       nxmutex_destroy(&priv->devlock);

--- a/drivers/sensors/hdc1008.c
+++ b/drivers/sensors/hdc1008.c
@@ -972,7 +972,7 @@ int hdc1008_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the driver */
 
-  ret = register_driver(devpath, &g_hdc1008fops, 0666, priv);
+  ret = register_driver(devpath, &g_hdc1008fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/hts221.c
+++ b/drivers/sensors/hts221.c
@@ -1192,7 +1192,7 @@ int hts221_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
       return ret;
     }
 
-  ret = register_driver(devpath, &g_humidityops, 0666, priv);
+  ret = register_driver(devpath, &g_humidityops, 0600, priv);
 
   hts221_dbg("Registered with %d\n", ret);
 

--- a/drivers/sensors/ina219.c
+++ b/drivers/sensors/ina219.c
@@ -402,7 +402,7 @@ int ina219_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_ina219fops, 0666, priv);
+  ret = register_driver(devpath, &g_ina219fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/ina226.c
+++ b/drivers/sensors/ina226.c
@@ -382,7 +382,7 @@ int ina226_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_ina226fops, 0666, priv);
+  ret = register_driver(devpath, &g_ina226fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/isl29023.c
+++ b/drivers/sensors/isl29023.c
@@ -465,7 +465,7 @@ int isl29023_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_isl29023fops, 0666, priv);
+  ret = register_driver(devpath, &g_isl29023fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/kxtj9.c
+++ b/drivers/sensors/kxtj9.c
@@ -635,7 +635,7 @@ int kxtj9_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_fops, 0666, priv);
+  ret = register_driver(devpath, &g_fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/lis2dh.c
+++ b/drivers/sensors/lis2dh.c
@@ -2041,7 +2041,7 @@ int lis2dh_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
   priv->addr = addr;
   priv->config = config;
 
-  ret = register_driver(devpath, &g_lis2dhops, 0666, priv);
+  ret = register_driver(devpath, &g_lis2dhops, 0600, priv);
   if (ret < 0)
     {
       lis2dh_dbg("lis2dh: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/lis3dh.c
+++ b/drivers/sensors/lis3dh.c
@@ -990,7 +990,7 @@ int lis3dh_register(FAR const char *devpath, FAR struct spi_dev_s *spi,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_lis3dh_fops, 0666, priv);
+  ret = register_driver(devpath, &g_lis3dh_fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/lis3dsh.c
+++ b/drivers/sensors/lis3dsh.c
@@ -558,7 +558,7 @@ int lis3dsh_register(FAR const char *devpath, FAR struct spi_dev_s *spi,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_lis3dsh_fops, 0666, priv);
+  ret = register_driver(devpath, &g_lis3dsh_fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/lis3mdl.c
+++ b/drivers/sensors/lis3mdl.c
@@ -615,7 +615,7 @@ int lis3mdl_register(FAR const char *devpath, FAR struct spi_dev_s *spi,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_lis3mdl_fops, 0666, priv);
+  ret = register_driver(devpath, &g_lis3mdl_fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/lm75.c
+++ b/drivers/sensors/lm75.c
@@ -571,7 +571,7 @@ int lm75_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_lm75fops, 0666, priv);
+  ret = register_driver(devpath, &g_lm75fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/lm92.c
+++ b/drivers/sensors/lm92.c
@@ -652,7 +652,7 @@ int lm92_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_lm92fops, 0666, priv);
+  ret = register_driver(devpath, &g_lm92fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/lps25h.c
+++ b/drivers/sensors/lps25h.c
@@ -769,7 +769,7 @@ int lps25h_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
       dev->config->irq_clear(dev->config);
     }
 
-  ret = register_driver(devpath, &g_lps25hops, 0666, dev);
+  ret = register_driver(devpath, &g_lps25hops, 0600, dev);
 
   lps25h_dbg("Registered with %d\n", ret);
 

--- a/drivers/sensors/lsm303agr.c
+++ b/drivers/sensors/lsm303agr.c
@@ -1194,7 +1194,7 @@ static int lsm303agr_register(FAR const char *devpath,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_fops, 0666, priv);
+  ret = register_driver(devpath, &g_fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/lsm330_spi.c
+++ b/drivers/sensors/lsm330_spi.c
@@ -1357,7 +1357,7 @@ int lsm330_register(FAR const char *devpath_acl,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath_acl, &g_lsm330a_fops, 0666, priv);
+  ret = register_driver(devpath_acl, &g_lsm330a_fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register accelerometer driver: %d\n", ret);
@@ -1396,7 +1396,7 @@ int lsm330_register(FAR const char *devpath_acl,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath_gyro, &g_lsm330g_fops, 0666, priv);
+  ret = register_driver(devpath_gyro, &g_lsm330g_fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register gyroscope driver: %d\n", ret);

--- a/drivers/sensors/lsm6dsl.c
+++ b/drivers/sensors/lsm6dsl.c
@@ -1210,7 +1210,7 @@ static int lsm6dsl_register(FAR const char *devpath,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_fops, 0666, priv);
+  ret = register_driver(devpath, &g_fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/lsm9ds1.c
+++ b/drivers/sensors/lsm9ds1.c
@@ -342,7 +342,7 @@ static int lsm9ds1_register(FAR const char *devpath,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_fops, 0666, priv);
+  ret = register_driver(devpath, &g_fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/ltc4151.c
+++ b/drivers/sensors/ltc4151.c
@@ -312,7 +312,7 @@ int ltc4151_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_ltc4151fops, 0666, priv);
+  ret = register_driver(devpath, &g_ltc4151fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/max31855.c
+++ b/drivers/sensors/max31855.c
@@ -307,7 +307,7 @@ int max31855_register(FAR const char *devpath, FAR struct spi_dev_s *spi,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_max31855fops, 0666, priv);
+  ret = register_driver(devpath, &g_max31855fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/max31865.c
+++ b/drivers/sensors/max31865.c
@@ -337,7 +337,7 @@ int max31865_register(FAR const char *devpath, FAR struct spi_dev_s *spi,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_max31865fops, 0666, priv);
+  ret = register_driver(devpath, &g_max31865fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/max44009.c
+++ b/drivers/sensors/max44009.c
@@ -899,7 +899,7 @@ int max44009_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
   priv->config = config;
   nxmutex_init(&priv->dev_lock);
 
-  ret = register_driver(devpath, &g_alsops, 0666, priv);
+  ret = register_driver(devpath, &g_alsops, 0600, priv);
   max44009_dbg("Registered with %d\n", ret);
   if (ret < 0)
     {

--- a/drivers/sensors/max6675.c
+++ b/drivers/sensors/max6675.c
@@ -272,7 +272,7 @@ int max6675_register(FAR const char *devpath, FAR struct spi_dev_s *spi)
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_max6675fops, 0666, priv);
+  ret = register_driver(devpath, &g_max6675fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/mb7040.c
+++ b/drivers/sensors/mb7040.c
@@ -352,7 +352,7 @@ int mb7040_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_fops, 0666, priv);
+  ret = register_driver(devpath, &g_fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/mcp9844.c
+++ b/drivers/sensors/mcp9844.c
@@ -382,7 +382,7 @@ int mcp9844_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  int ret = register_driver(devpath, &g_mcp9844_fops, 0666, priv);
+  int ret = register_driver(devpath, &g_mcp9844_fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/mlx90393.c
+++ b/drivers/sensors/mlx90393.c
@@ -593,7 +593,7 @@ int mlx90393_register(FAR const char *devpath, FAR struct spi_dev_s *spi,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_mlx90393_fops, 0666, priv);
+  ret = register_driver(devpath, &g_mlx90393_fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/mlx90614.c
+++ b/drivers/sensors/mlx90614.c
@@ -427,7 +427,7 @@ int mlx90614_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_mlx90614_fops, 0666, priv);
+  ret = register_driver(devpath, &g_mlx90614_fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/mpl115a.c
+++ b/drivers/sensors/mpl115a.c
@@ -392,7 +392,7 @@ int mpl115a_register(FAR const char *devpath, FAR struct spi_dev_s *spi)
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_mpl115afops, 0666, priv);
+  ret = register_driver(devpath, &g_mpl115afops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/mpu60x0.c
+++ b/drivers/sensors/mpu60x0.c
@@ -1187,7 +1187,7 @@ int mpu60x0_register(FAR const char *path, FAR struct mpu_config_s *config)
 
   /* Register the device node. */
 
-  ret = register_driver(path, &g_mpu_fops, 0666, priv);
+  ret = register_driver(path, &g_mpu_fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register mpu60x0 interface: %d\n", ret);

--- a/drivers/sensors/ms58xx.c
+++ b/drivers/sensors/ms58xx.c
@@ -1106,7 +1106,7 @@ int ms58xx_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_fops, 0666, priv);
+  ret = register_driver(devpath, &g_fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/msa301.c
+++ b/drivers/sensors/msa301.c
@@ -702,7 +702,7 @@ static int msa301_register(FAR const char *devpath,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_fops, 0666, priv);
+  ret = register_driver(devpath, &g_fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/qencoder.c
+++ b/drivers/sensors/qencoder.c
@@ -407,7 +407,7 @@ int qe_register(FAR const char *devpath, FAR struct qe_lowerhalf_s *lower)
   /* Register the QEncoder device */
 
   sninfo("Registering %s\n", devpath);
-  return register_driver(devpath, &g_qeops, 0666, upper);
+  return register_driver(devpath, &g_qeops, 0600, upper);
 }
 
 #endif /* CONFIG_SENSORS_QENCODER */

--- a/drivers/sensors/scd30.c
+++ b/drivers/sensors/scd30.c
@@ -1075,7 +1075,7 @@ int scd30_register_i2c(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_scd30fops, 0666, priv);
+  ret = register_driver(devpath, &g_scd30fops, 0600, priv);
   if (ret < 0)
     {
       scd30_dbg("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/scd41.c
+++ b/drivers/sensors/scd41.c
@@ -1028,7 +1028,7 @@ int scd41_register_i2c(FAR const char *devpath, FAR struct i2c_master_s *i2c)
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_scd41fops, 0666, priv);
+  ret = register_driver(devpath, &g_scd41fops, 0600, priv);
   if (ret < 0)
     {
       scd41_dbg("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -1497,7 +1497,7 @@ int sensor_custom_register(FAR struct sensor_lowerhalf_s *lower,
   upper->state.nbuffer = lower->nbuffer;
   upper->lower = lower;
   sminfo(upper->name, "Registering %s", path);
-  ret = register_driver(path, &g_sensor_fops, 0666, upper);
+  ret = register_driver(path, &g_sensor_fops, 0600, upper);
   if (ret)
     {
       goto drv_err;

--- a/drivers/sensors/sgp30.c
+++ b/drivers/sensors/sgp30.c
@@ -1080,7 +1080,7 @@ int sgp30_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_sgp30fops, 0666, priv);
+  ret = register_driver(devpath, &g_sgp30fops, 0600, priv);
   if (ret < 0)
     {
       sgp30_dbg("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/sht21.c
+++ b/drivers/sensors/sht21.c
@@ -681,7 +681,7 @@ int sht21_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_sht21fops, 0666, priv);
+  ret = register_driver(devpath, &g_sht21fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/sht3x.c
+++ b/drivers/sensors/sht3x.c
@@ -698,7 +698,7 @@ int sht3x_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_sht3xfops, 0666, priv);
+  ret = register_driver(devpath, &g_sht3xfops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/sps30.c
+++ b/drivers/sensors/sps30.c
@@ -1089,7 +1089,7 @@ int sps30_register_i2c(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_sps30fops, 0666, priv);
+  ret = register_driver(devpath, &g_sps30fops, 0600, priv);
   if (ret < 0)
     {
       sps30_dbg("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/t67xx.c
+++ b/drivers/sensors/t67xx.c
@@ -739,7 +739,7 @@ int t67xx_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver. */
 
-  ret = register_driver(devpath, &g_t67xxfops, 0666, priv);
+  ret = register_driver(devpath, &g_t67xxfops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/tmp112.c
+++ b/drivers/sensors/tmp112.c
@@ -305,7 +305,7 @@ int tmp112_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_tmp112fops, 0666, priv);
+  ret = register_driver(devpath, &g_tmp112fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/usensor.c
+++ b/drivers/sensors/usensor.c
@@ -266,7 +266,7 @@ int usensor_initialize(void)
   nxmutex_init(&usensor->lock);
   list_initialize(&usensor->list);
 
-  ret = register_driver(USENSOR_PATH, &g_usensor_fops, 0666, usensor);
+  ret = register_driver(USENSOR_PATH, &g_usensor_fops, 0600, usensor);
   if (ret < 0)
     {
       goto errout_with_lock;

--- a/drivers/sensors/veml6070.c
+++ b/drivers/sensors/veml6070.c
@@ -302,7 +302,7 @@ int veml6070_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_veml6070_fops, 0666, priv);
+  ret = register_driver(devpath, &g_veml6070_fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/vl53l1x.c
+++ b/drivers/sensors/vl53l1x.c
@@ -1156,7 +1156,7 @@ int vl53l1x_register(FAR const char *devpath, FAR struct i2c_master_s *i2c)
       return 0;
     }
 
-  register_driver(devpath, &g_vl53l1xfops, 0666, priv);
+  register_driver(devpath, &g_vl53l1xfops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/sensors/xen1210.c
+++ b/drivers/sensors/xen1210.c
@@ -349,7 +349,7 @@ int xen1210_register(XEN1210_HANDLE handle, int minor)
   /* Register the character driver */
 
   snprintf(devname, sizeof(devname), DEV_FORMAT, minor);
-  ret = register_driver(devname, &g_xen1210fops, 0444, priv);
+  ret = register_driver(devname, &g_xen1210fops, 0400, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver %s: %d\n", devname, ret);

--- a/drivers/sensors/zerocross.c
+++ b/drivers/sensors/zerocross.c
@@ -507,7 +507,7 @@ int zc_register(FAR const char *devname, FAR struct zc_lowerhalf_s *lower)
 
   /* And register the zero cross driver */
 
-  ret = register_driver(devname, &g_zcops, 0666, priv);
+  ret = register_driver(devname, &g_zcops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: register_driver failed: %d\n", ret);

--- a/drivers/serial/ptmx.c
+++ b/drivers/serial/ptmx.c
@@ -267,7 +267,7 @@ int ptmx_register(void)
 {
   /* Register the PTMX driver */
 
-  return register_driver("/dev/ptmx", &g_ptmx_fops, 0666, NULL);
+  return register_driver("/dev/ptmx", &g_ptmx_fops, 0600, NULL);
 }
 
 /****************************************************************************

--- a/drivers/serial/pty.c
+++ b/drivers/serial/pty.c
@@ -1120,7 +1120,7 @@ int pty_register2(int minor, bool susv1)
 
   snprintf(devname, sizeof(devname), "/dev/pty%d", minor);
 
-  ret = register_driver(devname, &g_pty_fops, 0666, &devpair->pp_master);
+  ret = register_driver(devname, &g_pty_fops, 0600, &devpair->pp_master);
   if (ret < 0)
     {
       goto errout_with_devpair;
@@ -1143,7 +1143,7 @@ int pty_register2(int minor, bool susv1)
       snprintf(devname, sizeof(devname), "/dev/ttyp%d", minor);
     }
 
-  ret = register_driver(devname, &g_pty_fops, 0666, &devpair->pp_slave);
+  ret = register_driver(devname, &g_pty_fops, 0600, &devpair->pp_slave);
   if (ret < 0)
     {
       goto errout_with_master;

--- a/drivers/serial/serial.c
+++ b/drivers/serial/serial.c
@@ -2181,7 +2181,7 @@ int uart_register(FAR const char *path, FAR uart_dev_t *dev)
 #endif
 
   sinfo("Registering %s\n", path);
-  return register_driver(path, &g_serialops, 0666, dev);
+  return register_driver(path, &g_serialops, 0600, dev);
 }
 
 /****************************************************************************

--- a/drivers/serial/uart_bth4.c
+++ b/drivers/serial/uart_bth4.c
@@ -475,7 +475,7 @@ int uart_bth4_register(FAR const char *path, FAR struct bt_driver_s *drv)
   nxmutex_init(&dev->openlock);
   nxsem_init(&dev->recvsem, 0, 0);
 
-  ret = register_driver(path, &g_uart_bth4_ops, 0666, dev);
+  ret = register_driver(path, &g_uart_bth4_ops, 0600, dev);
   if (ret < 0)
     {
       nxmutex_destroy(&dev->sendlock);

--- a/drivers/spi/ice40.c
+++ b/drivers/spi/ice40.c
@@ -405,7 +405,7 @@ int ice40_register(FAR const char *path, FAR struct ice40_dev_s *dev)
 
   /* Register the character driver */
 
-  ret = register_driver(path, &g_ice40_fops, 0666, dev);
+  ret = register_driver(path, &g_ice40_fops, 0600, dev);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/spi/spi_driver.c
+++ b/drivers/spi/spi_driver.c
@@ -374,7 +374,7 @@ int spi_register(FAR struct spi_dev_s *spi, int bus)
       /* Create the character device name */
 
       snprintf(devname, sizeof(devname), DEVNAME_FMT, bus);
-      ret = register_driver(devname, &g_spidrvr_fops, 0666, priv);
+      ret = register_driver(devname, &g_spidrvr_fops, 0600, priv);
       if (ret < 0)
         {
           /* Free the device structure if we failed to create the character

--- a/drivers/spi/spi_slave_driver.c
+++ b/drivers/spi/spi_slave_driver.c
@@ -814,7 +814,7 @@ int spi_slave_register(FAR struct spi_slave_ctrlr_s *ctrlr, int bus)
 
   /* Register the character driver */
 
-  ret = register_driver(devname, &g_spislavefops, 0666, priv);
+  ret = register_driver(devname, &g_spislavefops, 0600, priv);
   if (ret < 0)
     {
       spierr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/syslog/ramlog.c
+++ b/drivers/syslog/ramlog.c
@@ -786,7 +786,7 @@ int ramlog_register(FAR const char *devpath, FAR char *buffer, size_t buflen)
 
       /* Register the character driver */
 
-      ret = register_driver(devpath, &g_ramlogfops, 0666, priv);
+      ret = register_driver(devpath, &g_ramlogfops, 0600, priv);
       if (ret < 0)
         {
           kmm_free(priv);
@@ -810,7 +810,7 @@ void ramlog_syslog_register(void)
 {
   /* Register the syslog character driver */
 
-  register_driver(CONFIG_SYSLOG_DEVPATH, &g_ramlogfops, 0666, &g_sysdev);
+  register_driver(CONFIG_SYSLOG_DEVPATH, &g_ramlogfops, 0600, &g_sysdev);
 }
 #endif
 

--- a/drivers/syslog/syslog_chardev.c
+++ b/drivers/syslog/syslog_chardev.c
@@ -161,7 +161,7 @@ static int syslog_chardev_ioctl(FAR struct file *filep,
 
 void syslog_register(void)
 {
-  register_driver("/dev/log", &g_syslog_fops, 0222, NULL);
+  register_driver("/dev/log", &g_syslog_fops, 0220, NULL);
 }
 
 #endif /* CONFIG_SYSLOG_CHARDEV */

--- a/drivers/syslog/syslog_console.c
+++ b/drivers/syslog/syslog_console.c
@@ -91,5 +91,5 @@ static ssize_t syslog_console_write(FAR struct file *filep,
 
 void syslog_console_init(void)
 {
-  register_driver("/dev/console", &g_consoleops, 0666, NULL);
+  register_driver("/dev/console", &g_consoleops, 0600, NULL);
 }

--- a/drivers/syslog/syslog_rpmsg.c
+++ b/drivers/syslog/syslog_rpmsg.c
@@ -488,7 +488,7 @@ int syslog_rpmsg_init(void)
   int ret;
 
   ret = register_driver(CONFIG_SYSLOG_DEVPATH, &g_syslog_rpmsgfops,
-                        0666, &g_syslog_rpmsg);
+                        0600, &g_syslog_rpmsg);
   if (ret < 0)
     {
       return ret;

--- a/drivers/syslog/syslog_rpmsg_server.c
+++ b/drivers/syslog/syslog_rpmsg_server.c
@@ -299,7 +299,7 @@ int syslog_rpmsg_server_init(void)
 #ifdef CONFIG_SYSLOG_RPMSG_SERVER_CHARDEV
   int ret;
 
-  ret = register_driver("/dev/logrpmsg", &g_syslog_rpmsg_fops, 0666, NULL);
+  ret = register_driver("/dev/logrpmsg", &g_syslog_rpmsg_fops, 0600, NULL);
   if (ret < 0)
     {
       return ret;

--- a/drivers/timers/capture.c
+++ b/drivers/timers/capture.c
@@ -581,7 +581,7 @@ int cap_register(FAR const char *devpath, FAR struct cap_lowerhalf_s *lower)
 
   /* Register the PWM Capture device */
 
-  return register_driver(devpath, &g_capops, 0666, upper);
+  return register_driver(devpath, &g_capops, 0600, upper);
 }
 
 int cap_register_multiple(FAR const char *devpath,

--- a/drivers/timers/dshot.c
+++ b/drivers/timers/dshot.c
@@ -624,7 +624,7 @@ int dshot_register(FAR const char *path, FAR struct dshot_lowerhalf_s *dev)
   nxmutex_init(&upper->lock);
   upper->dev = dev;
 
-  ret = register_driver(path, &g_dshotops, 0666, upper);
+  ret = register_driver(path, &g_dshotops, 0600, upper);
   if (ret < 0)
     {
       nxmutex_destroy(&upper->lock);

--- a/drivers/timers/oneshot.c
+++ b/drivers/timers/oneshot.c
@@ -328,7 +328,7 @@ int oneshot_register(FAR const char *devname,
 
   /* And register the oneshot timer driver */
 
-  ret = register_driver(devname, &g_oneshot_ops, 0666, priv);
+  ret = register_driver(devname, &g_oneshot_ops, 0600, priv);
   if (ret < 0)
     {
       tmrerr("ERROR: register_driver failed: %d\n", ret);

--- a/drivers/timers/ptp_clock.c
+++ b/drivers/timers/ptp_clock.c
@@ -443,7 +443,7 @@ int ptp_clock_register(FAR struct ptp_lowerhalf_s *lower, int32_t max_adj,
 
   snprintf(path, sizeof(path), "/dev/ptp%d", devno);
   ptpinfo("Registering %s\n", path);
-  ret = register_driver(path, &g_ptp_clock_file_ops, 0666, upper);
+  ret = register_driver(path, &g_ptp_clock_file_ops, 0600, upper);
   if (ret < 0)
     {
       nxmutex_destroy(&upper->lock);

--- a/drivers/timers/pulsecount.c
+++ b/drivers/timers/pulsecount.c
@@ -338,7 +338,7 @@ int pulsecount_register(FAR const char *path,
   upper->dev = dev;
 
   _info("Registering %s\n", path);
-  return register_driver(path, &g_pulsecount_fops, 0666, upper);
+  return register_driver(path, &g_pulsecount_fops, 0600, upper);
 }
 
 void pulsecount_expired(FAR void *handle)

--- a/drivers/timers/pwm.c
+++ b/drivers/timers/pwm.c
@@ -501,7 +501,7 @@ int pwm_register(FAR const char *path, FAR struct pwm_lowerhalf_s *dev)
   /* Register the PWM device */
 
   pwminfo("Registering %s\n", path);
-  return register_driver(path, &g_pwmops, 0666, upper);
+  return register_driver(path, &g_pwmops, 0600, upper);
 }
 
 #endif /* CONFIG_PWM */

--- a/drivers/timers/rtc.c
+++ b/drivers/timers/rtc.c
@@ -854,7 +854,7 @@ int rtc_initialize(int minor, FAR struct rtc_lowerhalf_s *lower)
 
   /* And, finally, register the new RTC driver */
 
-  ret = register_driver(devpath, &g_rtc_fops, 0666, upper);
+  ret = register_driver(devpath, &g_rtc_fops, 0600, upper);
   if (ret < 0)
     {
       nxmutex_destroy(&upper->lock);

--- a/drivers/timers/timer.c
+++ b/drivers/timers/timer.c
@@ -558,7 +558,7 @@ FAR void *timer_register(FAR const char *path,
 
   /* Register the timer device */
 
-  ret = register_driver(path, &g_timerops, 0666, upper);
+  ret = register_driver(path, &g_timerops, 0600, upper);
   if (ret < 0)
     {
       tmrerr("ERROR: register_driver failed: %d\n", ret);

--- a/drivers/timers/watchdog.c
+++ b/drivers/timers/watchdog.c
@@ -840,7 +840,7 @@ FAR void *watchdog_register(FAR const char *path,
 
   /* Register the watchdog timer device */
 
-  ret = register_driver(path, &g_wdogops, 0666, upper);
+  ret = register_driver(path, &g_wdogops, 0600, upper);
   if (ret < 0)
     {
       wderr("register_driver failed: %d\n", ret);

--- a/drivers/usbdev/cdcncm.c
+++ b/drivers/usbdev/cdcncm.c
@@ -3022,7 +3022,7 @@ static int cdcmbim_classobject(int minor,
       index = self->ncmdriver.dev.netdev.d_ifindex;
 #endif
       snprintf(devname, sizeof(devname), CDC_MBIM_DEVFORMAT, index);
-      ret = register_driver(devname, &g_usbdevfops, 0666, self);
+      ret = register_driver(devname, &g_usbdevfops, 0600, self);
       if (ret < 0)
         {
           nerr("register_driver failed. ret: %d\n", ret);

--- a/drivers/usbdev/uvc.c
+++ b/drivers/usbdev/uvc.c
@@ -1521,7 +1521,7 @@ int usbdev_uvc_classobject(int minor,
 
   /* Register the character device */
 
-  ret = register_driver(USBUVC_CHARDEV_PATH, &g_uvc_fops, 0666, priv);
+  ret = register_driver(USBUVC_CHARDEV_PATH, &g_uvc_fops, 0600, priv);
   if (ret < 0)
     {
       uerr("register_driver failed: %d\n", ret);

--- a/drivers/usbhost/usbhost_cdcmbim.c
+++ b/drivers/usbhost/usbhost_cdcmbim.c
@@ -1581,7 +1581,7 @@ static inline int usbhost_devinit(FAR struct usbhost_cdcmbim_s *priv)
 
       uinfo("Register character driver\n");
       usbhost_mkdevname(priv, devname);
-      ret = register_driver(devname, &g_cdcwdm_fops, 0666, priv);
+      ret = register_driver(devname, &g_cdcwdm_fops, 0600, priv);
     }
 
   if (priv->intin)

--- a/drivers/usbhost/usbhost_hidkbd.c
+++ b/drivers/usbhost/usbhost_hidkbd.c
@@ -1991,7 +1991,7 @@ static inline int usbhost_devinit(FAR struct usbhost_state_s *priv)
 
   uinfo("Register driver\n");
   usbhost_mkdevname(priv, devname);
-  ret = register_driver(devname, &g_hidkbd_fops, 0666, priv);
+  ret = register_driver(devname, &g_hidkbd_fops, 0600, priv);
 
   /* We now have to be concerned about asynchronous modification of crefs
    * because the driver has been registered.

--- a/drivers/usbhost/usbhost_hidmouse.c
+++ b/drivers/usbhost/usbhost_hidmouse.c
@@ -1633,7 +1633,7 @@ static inline int usbhost_devinit(FAR struct usbhost_state_s *priv)
 
   uinfo("Register driver\n");
   usbhost_mkdevname(priv, devname);
-  ret = register_driver(devname, &g_hidmouse_fops, 0666, priv);
+  ret = register_driver(devname, &g_hidmouse_fops, 0600, priv);
 
   /* We now have to be concerned about asynchronous modification of crefs
    * because the driver has been registered.

--- a/drivers/usbhost/usbhost_xboxcontroller.c
+++ b/drivers/usbhost/usbhost_xboxcontroller.c
@@ -1355,7 +1355,7 @@ static inline int usbhost_devinit(FAR struct usbhost_state_s *priv)
 
   uinfo("Register block driver\n");
   usbhost_mkdevname(priv, devname);
-  ret = register_driver(devname, &g_xboxcontroller_fops, 0666, priv);
+  ret = register_driver(devname, &g_xboxcontroller_fops, 0600, priv);
 
   /* Check if we successfully initialized. We now have to be concerned
    * about asynchronous modification of crefs because the block

--- a/drivers/usbmisc/fusb301.c
+++ b/drivers/usbmisc/fusb301.c
@@ -787,7 +787,7 @@ int fusb301_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_fusb301ops, 0666, priv);
+  ret = register_driver(devpath, &g_fusb301ops, 0600, priv);
   if (ret < 0)
     {
       fusb301_err("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/usbmisc/fusb302.c
+++ b/drivers/usbmisc/fusb302.c
@@ -1920,7 +1920,7 @@ int fusb302_register(FAR const char *devpath,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_fusb302ops, 0666, priv);
+  ret = register_driver(devpath, &g_fusb302ops, 0600, priv);
   if (ret < 0)
     {
       fusb302_err("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/usbmisc/fusb303.c
+++ b/drivers/usbmisc/fusb303.c
@@ -975,7 +975,7 @@ int fusb303_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_fusb303ops, 0666, priv);
+  ret = register_driver(devpath, &g_fusb303ops, 0600, priv);
   if (ret < 0)
     {
       fusb303_err("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/usbmisc/stusb4500.c
+++ b/drivers/usbmisc/stusb4500.c
@@ -601,7 +601,7 @@ int stusb4500_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_stusb4500ops, 0666, priv);
+  ret = register_driver(devpath, &g_stusb4500ops, 0600, priv);
   if (ret < 0)
     {
       stusb4500_err("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/usrsock/usrsock_dev.c
+++ b/drivers/usrsock/usrsock_dev.c
@@ -523,7 +523,7 @@ int usrsock_request(FAR struct iovec *iov, unsigned int iovcnt)
 
 void usrsock_register(void)
 {
-  register_driver("/dev/usrsock", &g_usrsockdevops, 0666,
+  register_driver("/dev/usrsock", &g_usrsockdevops, 0600,
                   &g_usrsockdev);
 }
 

--- a/drivers/video/fb.c
+++ b/drivers/video/fb.c
@@ -2017,7 +2017,7 @@ int fb_register_device(int display, int plane,
       snprintf(devname, sizeof(devname), "/dev/fb%d.%d", display, plane);
     }
 
-  ret = register_driver(devname, &g_fb_fops, 0666, fb);
+  ret = register_driver(devname, &g_fb_fops, 0600, fb);
 
   if (ret < 0)
     {

--- a/drivers/video/mipidsi/mipi_dsi_device_driver.c
+++ b/drivers/video/mipidsi/mipi_dsi_device_driver.c
@@ -224,7 +224,7 @@ int mipi_dsi_device_driver_register(FAR struct mipi_dsi_device *device)
   snprintf(devpath, sizeof(devpath), MIPI_DSI_DEVNAME_FMT, host->bus,
            device->channel, device->name);
 
-  ret = register_driver(devpath, &g_dsi_dev_fops, 0666, priv);
+  ret = register_driver(devpath, &g_dsi_dev_fops, 0600, priv);
   if (ret < 0)
     {
       nxmutex_destroy(&priv->lock);

--- a/drivers/video/mipidsi/mipi_dsi_host_driver.c
+++ b/drivers/video/mipidsi/mipi_dsi_host_driver.c
@@ -195,7 +195,7 @@ int mipi_dsi_host_driver_register(FAR struct mipi_dsi_host *host)
 #endif
 
       snprintf(name, sizeof(name), MIPI_DSI_HOSTNAME_FMT, host->bus);
-      ret = register_driver(name, &g_dsi_host_fops, 0666, priv);
+      ret = register_driver(name, &g_dsi_host_fops, 0600, priv);
       if (ret < 0)
         {
 #ifndef CONFIG_DISABLE_PSEUDOFS_OPERATIONS

--- a/drivers/video/v4l2_core.c
+++ b/drivers/video/v4l2_core.c
@@ -560,7 +560,7 @@ int video_register(FAR const char *devpath, FAR struct v4l2_s *v4l2)
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_v4l2_fops, 0666, v4l2);
+  ret = register_driver(devpath, &g_v4l2_fops, 0600, v4l2);
   if (ret < 0)
     {
       verr("Failed to register driver: %d\n", ret);

--- a/drivers/virtio/virtio-rng.c
+++ b/drivers/virtio/virtio-rng.c
@@ -249,7 +249,7 @@ static int virtio_rng_probe(FAR struct virtio_device *vdev)
 #endif
     }
 
-  ret = register_driver(priv->name, &g_virtio_rng_ops, 0444, priv);
+  ret = register_driver(priv->name, &g_virtio_rng_ops, 0400, priv);
   if (ret < 0)
     {
       vrterr("Register NuttX driver failed, ret=%d\n", ret);
@@ -257,7 +257,7 @@ static int virtio_rng_probe(FAR struct virtio_device *vdev)
     }
 
 #ifdef CONFIG_DEV_URANDOM
-  ret = register_driver(priv->uname, &g_virtio_rng_ops, 0444, priv);
+  ret = register_driver(priv->uname, &g_virtio_rng_ops, 0400, priv);
   if (ret < 0)
     {
       vrterr("Register NuttX driver failed, ret=%d\n", ret);

--- a/drivers/virtio/virtio-rpmb.c
+++ b/drivers/virtio/virtio-rpmb.c
@@ -261,7 +261,7 @@ static int virtio_rpmb_probe(FAR struct virtio_device *vdev)
       goto err_with_priv;
     }
 
-  ret = register_driver(VIRTIO_RPMB_DEVNAME, &g_virtio_rpmb_ops, 0666,
+  ret = register_driver(VIRTIO_RPMB_DEVNAME, &g_virtio_rpmb_ops, 0600,
                         priv);
   if (ret < 0)
     {

--- a/drivers/wireless/cc1101.c
+++ b/drivers/wireless/cc1101.c
@@ -1740,7 +1740,7 @@ int cc1101_register(FAR const char *path, FAR struct cc1101_dev_s *dev)
       return -ENODEV;
     }
 
-  return register_driver(path, &g_cc1101ops, 0666, dev);
+  return register_driver(path, &g_cc1101ops, 0600, dev);
 }
 
 /****************************************************************************

--- a/drivers/wireless/gs2200m.c
+++ b/drivers/wireless/gs2200m.c
@@ -3519,7 +3519,7 @@ FAR void *gs2200m_register(FAR const char *devpath,
       goto errout;
     }
 
-  ret = register_driver(devpath, &g_gs2200m_fops, 0666, dev);
+  ret = register_driver(devpath, &g_gs2200m_fops, 0600, dev);
   if (ret < 0)
     {
       wlerr("Failed to register driver: %d\n", ret);

--- a/drivers/wireless/lpwan/rn2xx3/rn2xx3.c
+++ b/drivers/wireless/lpwan/rn2xx3/rn2xx3.c
@@ -1913,7 +1913,7 @@ int rn2xx3_register(FAR const char *devpath, FAR const char *uartpath)
 
   /* Register driver */
 
-  err = register_driver(devpath, &g_rn2xx3fops, 0666, priv);
+  err = register_driver(devpath, &g_rn2xx3fops, 0600, priv);
   if (err < 0)
     {
       wlerr("Failed to register RN2xx3 driver: %d\n", err);

--- a/drivers/wireless/lpwan/sx126x/sx126x.c
+++ b/drivers/wireless/lpwan/sx126x/sx126x.c
@@ -1402,6 +1402,6 @@ void sx126x_register(FAR struct spi_dev_s *spi,
 
   sx126x_attachirq0(dev, sx126x_irq0handler, dev);
 
-  (void)register_driver(path, &sx126x_ops, 0666,
+  (void)register_driver(path, &sx126x_ops, 0600,
                         dev);
 }

--- a/drivers/wireless/lpwan/sx127x/sx127x.c
+++ b/drivers/wireless/lpwan/sx127x/sx127x.c
@@ -4720,7 +4720,7 @@ int sx127x_register(FAR struct spi_dev_s *spi,
 
   wlinfo("Registering " SX127X_DEV_NAME "\n");
 
-  ret = register_driver(SX127X_DEV_NAME, &g_sx127x_fops, 0666, dev);
+  ret = register_driver(SX127X_DEV_NAME, &g_sx127x_fops, 0600, dev);
   if (ret < 0)
     {
       wlerr("ERROR: register_driver() failed: %d\n", ret);

--- a/drivers/wireless/nrf24l01.c
+++ b/drivers/wireless/nrf24l01.c
@@ -1582,7 +1582,7 @@ int nrf24l01_register(FAR struct spi_dev_s *spi,
 
   wlinfo("Registering " DEV_NAME "\n");
 
-  ret = register_driver(DEV_NAME, &g_nrf24l01_fops, 0666, dev);
+  ret = register_driver(DEV_NAME, &g_nrf24l01_fops, 0600, dev);
   if (ret < 0)
     {
       wlerr("ERROR: register_driver() failed: %d\n", ret);

--- a/fs/mount/fs_automount.c
+++ b/fs/mount/fs_automount.c
@@ -858,7 +858,7 @@ FAR void *automount_initialize(FAR const struct automount_lower_s *lower)
   snprintf(devpath, PATH_MAX,
            CONFIG_FS_AUTOMOUNTER_VFS_PATH "%s", lower->mountpoint);
 
-  ret = register_driver(devpath, &g_automount_fops, 0444, priv);
+  ret = register_driver(devpath, &g_automount_fops, 0400, priv);
   lib_put_pathbuffer(devpath);
   if (ret < 0)
     {

--- a/graphics/nxterm/nxterm_register.c
+++ b/graphics/nxterm/nxterm_register.c
@@ -139,7 +139,7 @@ FAR struct nxterm_state_s *
   /* Register the driver */
 
   snprintf(devname, sizeof(devname), NX_DEVNAME_FORMAT, minor);
-  ret = register_driver(devname, &g_nxterm_drvrops, 0666, priv);
+  ret = register_driver(devname, &g_nxterm_drvrops, 0600, priv);
   if (ret < 0)
     {
       gerr("ERROR: Failed to register %s\n", devname);

--- a/wireless/ieee802154/mac802154_device.c
+++ b/wireless/ieee802154/mac802154_device.c
@@ -865,7 +865,7 @@ int mac802154dev_register(MACHANDLE mac, int minor)
 
   /* Register the mac character driver */
 
-  ret = register_driver(devname, &g_mac802154dev_fops, 0666, dev);
+  ret = register_driver(devname, &g_mac802154dev_fops, 0600, dev);
   if (ret < 0)
     {
       wlerr("ERROR: register_driver failed: %d\n", ret);


### PR DESCRIPTION
drivers/: Multiple Drivers Are Registered With World Writable Part 2

## Summary

Permissions (Part 2/3)

# Description:

In kernel builds, any unprivileged process running on the NuttX device can open /dev/efuse and attempt to read/write fuse content. Reading the fuses may provide valuable information to an attacker controlling the user process. The write operation, in extreme cases where the fuse blocks are not locked, may brick the device.

DISCLAIMER: I tried to be strict with the settings, better to relax them later if it's needed.

This is part of https://github.com/apache/nuttx/issues/19410

## Impact

See https://github.com/apache/nuttx/issues/19410

## Testing

Compiles ok.