### PR TITLE
binfmt: parse application stacksize/priority from ELF symbols

### DIFF
--- a/binfmt/elf.c
+++ b/binfmt/elf.c
@@ -98,6 +98,7 @@ static int elf_loadbinary(FAR struct binary_s *binp,
                           int nexports)
 {
   struct mod_loadinfo_s loadinfo;
+  Elf_Sym sym;
   int ret;
 
   binfo("Loading file: %s\n", filename);
@@ -173,7 +174,57 @@ static int elf_loadbinary(FAR struct binary_s *binp,
 
   /* Return the load information */
 
-  binp->stacksize = CONFIG_ELF_STACKSIZE;
+  ret = libelf_findsymbol(&loadinfo, "nx_stacksize", &sym);
+  if (ret == 0)
+    {
+      binp->stacksize = sym.st_value;
+    }
+  else
+    {
+      binp->stacksize = CONFIG_ELF_STACKSIZE;
+    }
+
+  ret = libelf_findsymbol(&loadinfo, "nx_priority", &sym);
+  if (ret == 0)
+    {
+      binp->priority = sym.st_value;
+    }
+  else
+    {
+      binp->priority = SCHED_PRIORITY_DEFAULT;
+    }
+
+#ifdef CONFIG_SCHED_USER_IDENTITY
+  ret = libelf_findsymbol(&loadinfo, "nx_uid", &sym);
+  if (ret == 0)
+    {
+      binp->uid = sym.st_value;
+    }
+  else
+    {
+      binp->uid = 0;
+    }
+
+  ret = libelf_findsymbol(&loadinfo, "nx_gid", &sym);
+  if (ret == 0)
+    {
+      binp->gid = sym.st_value;
+    }
+  else
+    {
+      binp->gid = 0;
+    }
+
+  ret = libelf_findsymbol(&loadinfo, "nx_mode", &sym);
+  if (ret == 0)
+    {
+      binp->mode = sym.st_value;
+    }
+  else
+    {
+      binp->mode = 0;
+    }
+#endif
 
   /* Add the ELF allocation to the alloc[] only if there is no address
    * environment.  If there is an address environment, it will automatically

--- a/cmake/nuttx_add_application.cmake
+++ b/cmake/nuttx_add_application.cmake
@@ -147,6 +147,31 @@ function(nuttx_add_application)
         if(NOT "${CMAKE_LD}" MATCHES "gcc$")
           set(USE_LINKER True)
         endif()
+        if(STACKSIZE)
+          set(SYMBOL_STACKSIZE $<$<NOT:$<BOOL:${USE_LINKER}>>:-Wl,>--defsym
+                               nx_stacksize=${STACKSIZE})
+        endif()
+        if(PRIORITY)
+          if(PRIORITY STREQUAL "SCHED_PRIORITY_DEFAULT")
+            set(PRIORITY "0")
+          endif()
+          set(SYMBOL_PRIORITY $<$<NOT:$<BOOL:${USE_LINKER}>>:-Wl,>--defsym
+                              nx_priority=${PRIORITY})
+        endif()
+        if(CONFIG_SCHED_USER_IDENTITY)
+          if(UID)
+            set(SYMBOL_UID $<$<NOT:$<BOOL:${USE_LINKER}>>:-Wl,>--defsym
+                           nx_uid=${UID})
+          endif()
+          if(GID)
+            set(SYMBOL_GID $<$<NOT:$<BOOL:${USE_LINKER}>>:-Wl,>--defsym
+                           nx_gid=${GID})
+          endif()
+          if(MODE)
+            set(SYMBOL_MODE $<$<NOT:$<BOOL:${USE_LINKER}>>:-Wl,>--defsym
+                            nx_mode=${MODE})
+          endif()
+        endif()
         add_custom_command(
           TARGET ${TARGET}
           POST_BUILD
@@ -158,7 +183,8 @@ function(nuttx_add_application)
             # add global ELF link option if m&kernel link
             $<$<OR:$<BOOL:${KERNEL_ELF_MODE}>,$<BOOL:${LOADABLE_ELF_MODE}>>:$<TARGET_PROPERTY:nuttx_global,NUTTX_ELF_APP_LINK_OPTIONS>>
             # add local link option last
-            ${LINK_FLAGS}
+            ${LINK_FLAGS} ${SYMBOL_STACKSIZE} ${SYMBOL_PRIORITY} ${SYMBOL_UID}
+            ${SYMBOL_GID} ${SYMBOL_MODE}
             # link startup obj if m&kernel link
             $<$<AND:$<TARGET_EXISTS:STARTUP_OBJS>,$<NOT:$<BOOL:${DYNLIB_ELF_MODE}>>>:$<TARGET_OBJECTS:STARTUP_OBJS>>
             $<$<NOT:$<BOOL:${USE_LINKER}>>:-Wl,>--start-group

--- a/include/nuttx/lib/elf.h
+++ b/include/nuttx/lib/elf.h
@@ -780,4 +780,24 @@ FAR void *libelf_gethandle(FAR const char *name);
 #  define libelf_gethandle(n) NULL
 #endif
 
+/****************************************************************************
+ * Name: libelf_findsymbol
+ *
+ * Description:
+ *   Locate a symbol in the ELF symbol table by its name.
+ *
+ * Input Parameters:
+ *   loadinfo - Load state information containing the symbol table
+ *   name     - The name of the symbol to search for
+ *   sym      - Pointer to store the located symbol's table entry
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int libelf_findsymbol(FAR struct mod_loadinfo_s *loadinfo,
+                      FAR const char *name, FAR Elf_Sym *sym);
+
 #endif /* __INCLUDE_NUTTX_LIB_LIBC_ELF_H */

--- a/libs/libc/elf/elf_symbols.c
+++ b/libs/libc/elf/elf_symbols.c
@@ -640,3 +640,78 @@ void libelf_freesymtab(FAR struct module_s *modp)
       lib_free((FAR void *)symbol);
     }
 }
+
+/****************************************************************************
+ * Name: libelf_findsymbol
+ *
+ * Description:
+ *   Locate a symbol in the ELF symbol table by its name.
+ *
+ * Input Parameters:
+ *   loadinfo - Load state information containing the symbol table
+ *   name     - The name of the symbol to search for
+ *   sym      - Pointer to store the located symbol's table entry
+ *
+ * Returned Value:
+ *   0 (OK) is returned on success and a negated errno is returned on
+ *   failure.
+ *
+ ****************************************************************************/
+
+int libelf_findsymbol(FAR struct mod_loadinfo_s *loadinfo,
+                      FAR const char *name, FAR Elf_Sym *sym)
+{
+  size_t num;
+  int ret;
+  int i;
+
+  if (loadinfo == NULL || name == NULL)
+    {
+      return -EINVAL;
+    }
+
+  if (loadinfo->symtabidx == 0)
+    {
+      ret = libelf_findsymtab(loadinfo);
+      if (ret < 0)
+        {
+          berr("ERROR: Failed to find symbol table\n");
+          return ret;
+        }
+    }
+
+  /* Loop through all symbols in the symbol table */
+
+  num = loadinfo->shdr[loadinfo->symtabidx].sh_size / sizeof(Elf_Sym);
+  for (i = 0; i < num; i++)
+    {
+      /* Read the symbol entry */
+
+      ret = libelf_readsym(loadinfo, i, sym,
+                           &loadinfo->shdr[loadinfo->symtabidx]);
+      if (ret)
+        {
+          berr("ERROR: Failed to read symbol entry\n");
+          return ret;
+        }
+
+      /* Get the symbol name */
+
+      ret = libelf_symname(loadinfo, sym,
+                           loadinfo->shdr[loadinfo->strtabidx].sh_offset);
+      if (ret < 0 && ret != -ESRCH)
+        {
+          berr("ERROR: Failed to get symbol name\n");
+          return ret;
+        }
+
+      /* Compare the symbol name with the given name */
+
+      if (strcmp((FAR const char *)loadinfo->iobuffer, name) == 0)
+        {
+          return ret;
+        }
+    }
+
+  return -ENOENT;
+}

--- a/libs/libc/spawn/lib_psa_init.c
+++ b/libs/libc/spawn/lib_psa_init.c
@@ -75,7 +75,10 @@ int posix_spawnattr_init(posix_spawnattr_t *attr)
       return _SCHED_ERRNO(ret);
     }
 
-  attr->priority            = param.sched_priority;
+  /* attr->priority left at 0: callers that do not set a priority will have
+   * it filled in from the loaded binary (binp->priority) by the binary
+   * loader, or from the parent task by task_spawn().
+   */
 
   /* Set the default scheduler policy to the policy of this task */
 
@@ -104,13 +107,11 @@ int posix_spawnattr_init(posix_spawnattr_t *attr)
   attr->budget.tv_nsec      = param.sched_ss_init_budget.tv_nsec;
 #endif
 
-  /* Default stack size */
-
-  attr->stacksize           = CONFIG_POSIX_SPAWN_DEFAULT_STACKSIZE;
-
-#ifndef CONFIG_BUILD_KERNEL
-  attr->stackaddr           = NULL;
-#endif
+  /* attr->stacksize and attr->stackaddr left at 0 (memset above): callers
+   * that do not set a stack size will have it filled in from the loaded
+   * binary (binp->stacksize) by the binary loader, or from
+   * CONFIG_POSIX_SPAWN_DEFAULT_STACKSIZE by task_spawn().
+   */
 
   return OK;
 }

--- a/sched/task/task_spawn.c
+++ b/sched/task/task_spawn.c
@@ -219,6 +219,26 @@ static int nxtask_spawn_exec(FAR pid_t *pidp, FAR const char *name,
       stacksize = CONFIG_POSIX_SPAWN_DEFAULT_STACKSIZE;
     }
 
+  /* A zero priority/stacksize means "use the default": inherit the parent
+   * task's priority and fall back to CONFIG_POSIX_SPAWN_DEFAULT_STACKSIZE.
+   * This lets posix_spawnattr_init() leave these fields zero so that the
+   * binary loader can supply them from the loaded ELF (binp->priority /
+   * binp->stacksize) instead.
+   */
+
+  if (priority == 0)
+    {
+      struct sched_param param;
+
+      nxsched_get_param(0, &param);
+      priority = param.sched_priority;
+    }
+
+  if (stacksize == 0)
+    {
+      stacksize = CONFIG_POSIX_SPAWN_DEFAULT_STACKSIZE;
+    }
+
   /* Start the task */
 
   pid = nxtask_spawn_create(name, priority, stackaddr,


### PR DESCRIPTION

## Summary

  * Allows an application's configured stack size and priority to be carried
    as absolute ELF symbols (`nx_stacksize`, `nx_priority`, and
    `nx_uid`/`nx_gid`/`nx_mode` under `CONFIG_SCHED_USER_IDENTITY`) and read
    back by the binary loader at exec time, instead of always falling back
    to `CONFIG_ELF_STACKSIZE` / `SCHED_PRIORITY_DEFAULT`.
  * Adds `libelf_findsymbol()` (a name-based symbol lookup over the ELF
    symbol table) in `libs/libc/elf/elf_symbols.c` and declares it in
    `include/nuttx/lib/elf.h`; `binfmt/elf.c` uses it to populate
    `struct binary_s` (`binp->stacksize`/`priority`/`uid`/`gid`/`mode`),
    falling back to the existing defaults when a symbol is absent.
  * `cmake/nuttx_add_application.cmake` emits the `--defsym nx_*` flags at
    link time.
  * `posix_spawnattr_init()` no longer pre-fills `attr->stacksize` and
    `attr->priority` (left at 0); `nxtask_spawn_exec()` fills the parent
    priority and `CONFIG_POSIX_SPAWN_DEFAULT_STACKSIZE` when a caller does
    not set them. This stops the spawnattr defaults from overriding the
    values parsed from the ELF, so the embedded symbols actually drive the
    spawned task.
  * Related NuttX Apps PR: https://github.com/apache/nuttx-apps/pull/3641

## Impact

  * Is new feature added? Is existing feature changed? YES — new feature:
    application attributes are parsed from ELF symbols and used by the
    binary loader.
  * Impact on user (will user need to adapt to change)? NO — the symbols
    are optional; when absent the loader keeps using the existing defaults
    (`CONFIG_ELF_STACKSIZE`, `SCHED_PRIORITY_DEFAULT`).
  * Impact on build (will build process change)? YES (minor) — the ELF app
    link now emits `--defsym nx_stacksize`/`nx_priority` (and `nx_uid`/
    `nx_gid`/`nx_mode` under `CONFIG_SCHED_USER_IDENTITY`); handled in the
    companion apps PR via `Application.mk`.
  * Impact on hardware (will arch(s) / board(s) / driver(s) change)? NO.
  * Impact on documentation (is update required / provided)? NO (not yet).
  * Impact on security (any sort of implications)? NO.
  * Impact on compatibility (backward/forward/interoperability)? NO —
    `posix_spawnattr_init()` callers that relied on the old stacksize/
    priority defaults still get them filled in by `nxtask_spawn_exec()` /
    the binary loader, so observable defaults are unchanged; only apps that
    embed the `nx_*` symbols change behavior (they now honor their own
    configured values).
  * Anything else to consider or add? The `heapsize` attribute from the
    original implementation is intentionally not included (it depends on
    the separate task-heap feature).

## Testing

  I confirm that changes are verified on local setup and works as intended:
  * Build Host(s): Ubuntu, arm-none-eabi-gcc 12.2.1
  * Target(s): `qemu-armv7a:knsh` (CONFIG_BUILD_KERNEL, CONFIG_ELF=y)
  * Build: `./tools/configure.sh qemu-armv7a:knsh && make && make export`
    (apps built separately and mounted via hostfs as `/system`).
  * Run command: `qemu-system-arm -semihosting -M virt -m 1024 -nographic -kernel ./nuttx`

  Testing logs before change (stock upstream/master nuttx; the `getprime`
  app was built with `--defsym nx_stacksize=8192 --defsym nx_priority=50`,
  but the symbol is not consulted, so the task uses the defaults — stack
  4096, priority 100):

  ```
  nsh> getprime 4 &
    TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK    USED FILLED COMMAND
      4     4     3 100 RR       Task      - Waiting  Semaphore 0000000000000000 0004048 0000776  19.1%  getprime 4
  ```

  Testing logs after change (this PR; same `getprime` app — the ELF symbols
  now drive the task: stack ≈ 8192, priority 50):

  ```
  nsh> getprime 4 &
    TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK    USED FILLED COMMAND
      4     4     3  50 RR       Task      - Waiting  Semaphore 0000000000000000 0008144 0000792   9.7%  getprime 4
  ```

  `hello`, `ostest`, and NSH itself continue to load and run; no regression
  observed on `knsh`.

## PR verification Self-Check

  * [X] This PR introduces only one functional change.
  * [X] I have updated all required description fields above.
  * [X] My PR adheres to Contributing Guidelines and Documentation (git commit title and message, coding standard, etc).
  * [ ] My PR is still work in progress (not ready for review).
  * [X] My PR is ready for review and can be safely merged into a codebase.
