### PR TITLE
crypto: add CRYPTO_AES_CTR_SSH variant (128-bit big-endian counter)

### DIFF
--- a/crypto/cryptodev.c
+++ b/crypto/cryptodev.c
@@ -232,6 +232,7 @@ static int cryptof_ioctl(FAR struct file *filep,
             case CRYPTO_AES_256_CBC:
             case CRYPTO_AES_CMAC:
             case CRYPTO_AES_CTR:
+            case CRYPTO_AES_CTR_SSH:
             case CRYPTO_AES_XTS:
             case CRYPTO_AES_OFB:
             case CRYPTO_AES_CFB_8:

--- a/crypto/cryptosoft.c
+++ b/crypto/cryptosoft.c
@@ -1619,6 +1619,9 @@ int swcr_newsession(FAR uint32_t *sid, FAR struct cryptoini *cri)
           case CRYPTO_AES_CTR:
             txf = &enc_xform_aes_ctr;
             goto enccommon;
+          case CRYPTO_AES_CTR_SSH:
+            txf = &enc_xform_aes_ctr_ssh;
+            goto enccommon;
           case CRYPTO_AES_XTS:
             txf = &enc_xform_aes_xts;
             goto enccommon;
@@ -1903,6 +1906,7 @@ int swcr_freesession(uint64_t tid)
           case CRYPTO_CAST_CBC:
           case CRYPTO_RIJNDAEL128_CBC:
           case CRYPTO_AES_CTR:
+          case CRYPTO_AES_CTR_SSH:
           case CRYPTO_AES_XTS:
           case CRYPTO_AES_GCM_16:
           case CRYPTO_AES_GMAC:
@@ -2046,6 +2050,7 @@ int swcr_process(struct cryptop *crp)
           case CRYPTO_CAST_CBC:
           case CRYPTO_RIJNDAEL128_CBC:
           case CRYPTO_AES_CTR:
+          case CRYPTO_AES_CTR_SSH:
           case CRYPTO_AES_XTS:
           case CRYPTO_AES_OFB:
           case CRYPTO_AES_CFB_8:
@@ -2442,6 +2447,7 @@ void swcr_init(void)
   algs[CRYPTO_RIPEMD160_HMAC] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_RIJNDAEL128_CBC] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_AES_CTR] = CRYPTO_ALG_FLAG_SUPPORTED;
+  algs[CRYPTO_AES_CTR_SSH] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_AES_XTS] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_AES_GCM_16] = CRYPTO_ALG_FLAG_SUPPORTED;
   algs[CRYPTO_AES_GMAC] = CRYPTO_ALG_FLAG_SUPPORTED;

--- a/crypto/xform.c
+++ b/crypto/xform.c
@@ -108,6 +108,7 @@ int blf_setkey(FAR void *, FAR uint8_t *, int);
 int cast5_setkey(FAR void *, FAR uint8_t *, int);
 int aes_setkey_xform(FAR void *, FAR uint8_t *, int);
 int aes_ctr_setkey(FAR void *, FAR uint8_t *, int);
+int aes_ctr_ssh_setkey(FAR void *, FAR uint8_t *, int);
 int aes_xts_setkey(FAR void *, FAR uint8_t *, int);
 int aes_ofb_setkey(FAR void *, FAR uint8_t *, int);
 int null_setkey(FAR void *, FAR uint8_t *, int);
@@ -132,8 +133,10 @@ void aes_cfb8_decrypt(caddr_t, FAR uint8_t *, size_t);
 void aes_cfb128_decrypt(caddr_t, FAR uint8_t *, size_t);
 
 void aes_ctr_crypt(caddr_t, FAR uint8_t *, size_t);
+void aes_ctr_ssh_crypt(caddr_t, FAR uint8_t *, size_t);
 
 void aes_ctr_reinit(caddr_t, FAR uint8_t *);
+void aes_ctr_ssh_reinit(caddr_t, FAR uint8_t *);
 void aes_xts_reinit(caddr_t, FAR uint8_t *);
 void aes_gcm_reinit(caddr_t, FAR uint8_t *);
 void aes_ofb_reinit(caddr_t, FAR uint8_t *);
@@ -230,6 +233,17 @@ const struct enc_xform enc_xform_aes_ctr =
   aes_ctr_crypt,
   aes_ctr_setkey,
   aes_ctr_reinit
+};
+
+const struct enc_xform enc_xform_aes_ctr_ssh =
+{
+  CRYPTO_AES_CTR_SSH, "AES-CTR-SSH",
+  16, 16, 16, 32,
+  sizeof(struct aes_ctr_ctx),
+  aes_ctr_ssh_crypt,
+  aes_ctr_ssh_crypt,
+  aes_ctr_ssh_setkey,
+  aes_ctr_ssh_reinit
 };
 
 const struct enc_xform enc_xform_aes_gcm =
@@ -695,6 +709,60 @@ int aes_ctr_setkey(FAR void *sched, FAR uint8_t *key, int len)
 
   bcopy(key + len - AESCTR_NONCESIZE, ctx->ac_block, AESCTR_NONCESIZE);
   return 0;
+}
+
+/* SSH AES-CTR (RFC 4344). Unlike the RFC 3686 variant above, the key holds
+ * no embedded nonce and the whole 16-byte IV is the initial counter block,
+ * incremented as a 128-bit big-endian integer. The counter is encrypted
+ * before it is incremented so the first block keystream is E(IV).
+ */
+
+void aes_ctr_ssh_crypt(caddr_t key, FAR uint8_t *data, size_t len)
+{
+  FAR struct aes_ctr_ctx *ctx;
+  uint8_t keystream[AESCTR_BLOCKSIZE];
+  int i;
+
+  ctx = (FAR struct aes_ctr_ctx *)key;
+
+  aes_encrypt(&ctx->ac_key, ctx->ac_block, keystream);
+  for (i = 0; i < AESCTR_BLOCKSIZE; i++)
+    {
+      data[i] ^= keystream[i];
+    }
+
+  /* increment the 128-bit big-endian counter */
+
+  for (i = AESCTR_BLOCKSIZE - 1; i >= 0; i--)
+    {
+      if (++ctx->ac_block[i])
+        {
+          break;
+        }
+    }
+
+  explicit_bzero(keystream, sizeof(keystream));
+}
+
+int aes_ctr_ssh_setkey(FAR void *sched, FAR uint8_t *key, int len)
+{
+  FAR struct aes_ctr_ctx *ctx;
+
+  ctx = (FAR struct aes_ctr_ctx *)sched;
+  if (aes_setkey(&ctx->ac_key, key, len) != 0)
+    {
+      return -1;
+    }
+
+  return 0;
+}
+
+void aes_ctr_ssh_reinit(caddr_t key, FAR uint8_t *iv)
+{
+  FAR struct aes_ctr_ctx *ctx;
+
+  ctx = (FAR struct aes_ctr_ctx *)key;
+  bcopy(iv, ctx->ac_block, AESCTR_BLOCKSIZE);
 }
 
 void aes_xts_reinit(caddr_t key, FAR uint8_t *iv)

--- a/include/crypto/cryptodev.h
+++ b/include/crypto/cryptodev.h
@@ -142,7 +142,8 @@
 #define CRYPTO_SHA2_224_HMAC    41
 #define CRYPTO_CHACHA20         42
 #define CRYPTO_CHACHA20_DJB     43
-#define CRYPTO_ALGORITHM_MAX    43 /* Keep updated */
+#define CRYPTO_AES_CTR_SSH      44
+#define CRYPTO_ALGORITHM_MAX    44 /* Keep updated */
 
 /* Algorithm flags */
 

--- a/include/crypto/xform.h
+++ b/include/crypto/xform.h
@@ -105,6 +105,7 @@ extern const struct enc_xform enc_xform_blf;
 extern const struct enc_xform enc_xform_cast5;
 extern const struct enc_xform enc_xform_aes;
 extern const struct enc_xform enc_xform_aes_ctr;
+extern const struct enc_xform enc_xform_aes_ctr_ssh;
 extern const struct enc_xform enc_xform_aes_gcm;
 extern const struct enc_xform enc_xform_aes_gmac;
 extern const struct enc_xform enc_xform_aes_cmac;


### PR DESCRIPTION
## Summary

Add `CRYPTO_AES_CTR_SSH`, an AES-CTR encryption transform that uses the whole 16-byte IV as the initial counter block and increments it as a 128-bit big-endian integer (RFC 4344), with the first keystream block being `E(IV)`.

The existing `CRYPTO_AES_CTR` is the RFC 3686 profile: the last 4 bytes of the key are a nonce, the IV is 8 bytes and only the low 32 bits of the counter block are incremented. That layout cannot represent SSH's `aes128-ctr`/`aes192-ctr`/`aes256-ctr`, which pass the key as-is (no embedded nonce) and treat the full 16-byte IV as the counter.

This new transform provides the missing primitive so that a follow-up Dropbear port change can offload SSH AES-CTR to `/dev/crypto`.

## Impact

- **Users**: none. No existing algorithm changes behavior; the new transform is only reachable by requesting `CRYPTO_AES_CTR_SSH`.
- **Build**: one new algorithm id (`CRYPTO_ALGORITHM_MAX` bumped), one new `enc_xform` and case labels; no new files, no new config options.
- **Security**: standard AES-CTR keystream, validated against OpenSSL below.

## Testing

Tested on `sim:crypto`, whose software backend (`CRYPTO_CRYPTODEV_SOFTWARE_CRYPTO` + `CRYPTO_SW_AES`) routes the new transform, plus the `/dev/crypto` test suite (`TESTING_CRYPTO`).

**1. Derive the expected ciphertext from a trusted implementation.** SSH AES-CTR is standard AES-CTR, so OpenSSL is used as the oracle for the test vectors (128/192/256-bit keys, plus a counter that carries across byte boundaries — IV ending in `...fffd`). Example for the 128-bit vector:

```console
$ echo -n "Single block msg" > pt.bin
$ openssl enc -aes-128-ctr \
    -K 2b7e151628aed2a6abf7158809cf4f3c \
    -iv f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff -in pt.bin | xxd -p
bfe5b114f4055cd29ebd751ecaf3d283
```

**2. Drive the transform through `/dev/crypto`.** A companion test `apps/testing/drivers/crypto/aesctrssh.c` (enabled with `TESTING_CRYPTO_AES_CTR_SSH`) opens `/dev/crypto`, creates a `CRYPTO_AES_CTR_SSH` session (`CIOCGSESSION`), encrypts each vector with `CIOCCRYPT` and compares the output against the OpenSSL ciphertext from step 1.

**3. Build and run.**

```console
$ ./tools/configure.sh sim:crypto
$ make
$ ./nuttx
nsh> aesctrssh
OK test vector 0    # 128-bit, one block
OK test vector 1    # 128-bit, counter carry + non-block-aligned length
OK test vector 2    # 192-bit
OK test vector 3    # 256-bit
```

**4. Check for regressions.** On the same image the existing RFC 3686 `aesctr`, `aesxts` and `hmac` tests still pass (this change only adds case labels and one transform; no existing case is modified):

```console
nsh> aesctr
OK test vector 0
OK test vector 1
OK test vector 2
OK test vector 3
OK test vector 4
OK test vector 5
OK test vector 6
OK test vector 7
OK test vector 8
nsh> aesxts
OK encrypt test vector 0
OK decrypt test vector 0
OK encrypt test vector 1
OK decrypt test vector 1
OK encrypt test vector 2
OK decrypt test vector 2
OK encrypt test vector 3
OK decrypt test vector 3
OK encrypt test vector 4
OK decrypt test vector 4
OK encrypt test vector 5
OK decrypt test vector 5
OK encrypt test vector 6
OK decrypt test vector 6
OK encrypt test vector 7
OK decrypt test vector 7
OK encrypt test vector 8
OK decrypt test vector 8
```
