### PR TITLE
rp2040/rp23xx: preserve SIE_CTRL.PULLUP_EN in usbdev_register

### DIFF
--- a/arch/arm/src/rp2040/rp2040_usbdev.c
+++ b/arch/arm/src/rp2040/rp2040_usbdev.c
@@ -2184,8 +2184,17 @@ int usbdev_register(struct usbdevclass_driver_s *driver)
 
   /* Enable interrupt */
 
-  putreg32(RP2040_USBCTRL_REGS_SIE_CTRL_EP0_INT_1BUF,
-           RP2040_USBCTRL_REGS_SIE_CTRL);
+  /* Use setbits, NOT putreg32: CLASS_BIND above ends with DEV_CONNECT
+   * (composite_bind/cdcacm_bind), which sets SIE_CTRL.PULLUP_EN.  A
+   * wholesale write here clobbers that pull-up microseconds after it was
+   * asserted; enumeration then only succeeds if the host happened to
+   * latch the short pull-up blip and issues a bus reset (whose handler
+   * re-arms the pull-up).  A cold-plugged host port misses the blip and
+   * the device stays disconnected forever.
+   */
+
+  setbits_reg32(RP2040_USBCTRL_REGS_SIE_CTRL_EP0_INT_1BUF,
+                RP2040_USBCTRL_REGS_SIE_CTRL);
   putreg32(RP2040_USBCTRL_REGS_INTR_BUFF_STATUS |
            RP2040_USBCTRL_REGS_INTR_BUS_RESET |
            RP2040_USBCTRL_REGS_INTR_SETUP_REQ,

--- a/arch/arm/src/rp23xx/rp23xx_usbdev.c
+++ b/arch/arm/src/rp23xx/rp23xx_usbdev.c
@@ -2176,8 +2176,17 @@ int usbdev_register(struct usbdevclass_driver_s *driver)
 
   /* Enable interrupt */
 
-  putreg32(RP23XX_USBCTRL_REGS_SIE_CTRL_EP0_INT_1BUF,
-           RP23XX_USBCTRL_REGS_SIE_CTRL);
+  /* Use setbits, NOT putreg32: CLASS_BIND above ends with DEV_CONNECT
+   * (composite_bind/cdcacm_bind), which sets SIE_CTRL.PULLUP_EN.  A
+   * wholesale write here clobbers that pull-up microseconds after it was
+   * asserted; enumeration then only succeeds if the host happened to
+   * latch the short pull-up blip and issues a bus reset (whose handler
+   * re-arms the pull-up).  A cold-plugged host port misses the blip and
+   * the device stays disconnected forever.
+   */
+
+  setbits_reg32(RP23XX_USBCTRL_REGS_SIE_CTRL_EP0_INT_1BUF,
+                RP23XX_USBCTRL_REGS_SIE_CTRL);
   putreg32(RP23XX_USBCTRL_REGS_INTR_BUFF_STATUS |
            RP23XX_USBCTRL_REGS_INTR_BUS_RESET |
            RP23XX_USBCTRL_REGS_INTR_SETUP_REQ,


### PR DESCRIPTION
# PR 1 — rp2040/rp23xx: preserve SIE_CTRL.PULLUP_EN in usbdev_register

Branch: `rp2040-rp23xx-pullup-en` (worktree `~/nuttxspace/wt-pr-pullup`)
Base: apache/nuttx master (1b6f918c3f)
Closes: #19434

## Summary

`usbdev_register()` in both `rp2040_usbdev.c` and `rp23xx_usbdev.c` clobbers
`SIE_CTRL.PULLUP_EN` immediately after the class driver asserted it, so a
cold-plugged device may never enumerate at all. One-line fix per chip: use
`setbits_reg32` instead of a wholesale `putreg32` when enabling EP0_INT_1BUF.

## Root cause

`CLASS_BIND` (composite_bind/cdcacm_bind) ends with `DEV_CONNECT`, which sets
`SIE_CTRL.PULLUP_EN`. Microseconds later `usbdev_register()` executes
`putreg32(EP0_INT_1BUF, SIE_CTRL)`, wiping the pull-up. Enumeration then only
succeeds if the host latched the microsecond pull-up blip and issued a bus
reset — the BUS_RESET handler re-arms the pull-up via
`CLASS_DISCONNECT -> DEV_CONNECT`. A warm host port catches the blip; a
cold-plugged port is still in attach debounce, misses it, and `PULLUP_EN`
stays 0 forever: total USB silence while NuttX runs normally underneath.
This presents as an intermittent, image/timing-dependent "cold boot brick".

Full investigation record (register dumps of the bricked state, breadcrumb
trace of the strip + host-blip rescue, A/B image data) is in #19434.

## Validation

- **RP2350 (Raspberry Pi Pico 2 W), hardware:** an image that failed 0/10
  dmesg-verified cold plugs enumerated 10/10 after the fix; a second board
  that had never enumerated anything was recovered by the fix on first boot.
  Bricked-state diagnosis confirmed on live silicon: `SIE_CTRL = 0x20000000`
  (EP0_INT_1BUF only, PULLUP_EN=0) with all classes registered and software
  believing it was connected.
- **RP2040:** identical code, identical fix; build-tested
  (raspberrypi-pico:usbnsh) — no RP2040 hardware validation performed, but
  the RP2350 validation exercised the same logic.

## Impact

Any RP2040/RP23XX USB device application that is cold-plugged (or powered on
while attached to an already-powered host port that is slow to notice the
blip). No behavior change other than the pull-up surviving registration.

## AI disclosure

This investigation and fix were performed by an AI agent (Claude Code),
operated and directed by the submitter, and reviewed by the submitter before
posting.
