### PR TITLE
usbmsc: fix composite-mode class requests and BOT short-response handling

### DIFF
--- a/drivers/usbdev/usbmsc.c
+++ b/drivers/usbdev/usbmsc.c
@@ -741,7 +741,7 @@ static int usbmsc_setup(FAR struct usbdevclass_driver_s *driver,
             if (ctrl->type == USB_REQ_RECIPIENT_INTERFACE)
               {
                 if (priv->config == USBMSC_CONFIGID &&
-                    index == USBMSC_INTERFACEID &&
+                    index == priv->devinfo.ifnobase &&
                     value == USBMSC_ALTINTERFACEID)
                   {
                     /* Signal to instantiate the interface change */
@@ -764,7 +764,7 @@ static int usbmsc_setup(FAR struct usbdevclass_driver_s *driver,
             if (ctrl->type == (USB_DIR_IN | USB_REQ_RECIPIENT_INTERFACE) &&
                 priv->config == USBMSC_CONFIGIDNONE)
               {
-                if (index != USBMSC_INTERFACEID)
+                if (index != priv->devinfo.ifnobase)
                   {
                     ret = -EDOM;
                   }
@@ -805,7 +805,7 @@ static int usbmsc_setup(FAR struct usbdevclass_driver_s *driver,
               {
                 /* Only one interface is supported */
 
-                if (index != USBMSC_INTERFACEID)
+                if (index != priv->devinfo.ifnobase)
                   {
                     usbtrace(TRACE_CLSERROR(USBMSC_TRACEERR_MSRESETNDX),
                              index);
@@ -836,7 +836,7 @@ static int usbmsc_setup(FAR struct usbdevclass_driver_s *driver,
               {
                 /* Only one interface is supported */
 
-                if (index != USBMSC_INTERFACEID)
+                if (index != priv->devinfo.ifnobase)
                   {
                     usbtrace(TRACE_CLSERROR(USBMSC_TRACEERR_GETMAXLUNNDX),
                              index);
@@ -1280,7 +1280,6 @@ void usbmsc_rdcomplete(FAR struct usbdev_ep_s *ep,
 
 void usbmsc_deferredresponse(FAR struct usbmsc_dev_s *priv, bool failed)
 {
-#ifndef CONFIG_USBMSC_COMPOSITE
   FAR struct usbdev_s *dev;
   FAR struct usbdev_req_s *ctrlreq;
   int ret;
@@ -1322,7 +1321,6 @@ void usbmsc_deferredresponse(FAR struct usbmsc_dev_s *priv, bool failed)
       usbtrace(TRACE_CLSERROR(USBMSC_TRACEERR_DEFERREDRESPSTALLED), 0);
       EP_STALL(dev->ep0);
     }
-#endif
 }
 
 /****************************************************************************

--- a/drivers/usbdev/usbmsc_scsi.c
+++ b/drivers/usbdev/usbmsc_scsi.c
@@ -2614,6 +2614,8 @@ static int usbmsc_cmdfinishstate(FAR struct usbmsc_dev_s *priv)
     case USBMSC_FLAGS_DIRDEVICE2HOST:
       if (priv->cbwlen > 0)
         {
+          bool terminated = false;
+
           /* On most commands (the exception is outgoing, write commands),
            * the data has not yet been sent.
            */
@@ -2645,11 +2647,35 @@ static int usbmsc_cmdfinishstate(FAR struct usbmsc_dev_s *priv)
                   usbtrace(TRACE_CLSERROR(USBMSC_TRACEERR_CMDFINISHSUBMIT),
                            (uint16_t)-ret);
                 }
+              else
+                {
+                  /* The request was submitted with USBDEV_REQFLAGS_NULLPKT,
+                   * so the transfer ends with a short packet (or a ZLP if
+                   * the response length is an exact multiple of the packet
+                   * size).  Either way the host's Data-In phase terminates
+                   * cleanly when this request completes.
+                   */
+
+                  terminated = true;
+                }
              }
 
-          /* Stall the BULK In endpoint if there is a residue */
+          /* If there is a residue, the host expected more data than we
+           * sent.  If the data phase was already terminated by a short
+           * packet (or ZLP), nothing more is needed: the host's transfer
+           * has completed and the residue is reported in the CSW
+           * (dCSWDataResidue).  Stalling here as well is permitted by BOT
+           * (USB MSC BOT 6.7.2), but it is gratuitous and some hosts
+           * (macOS) respond with a full Bulk-Only reset sequence to any
+           * bulk-IN halt during device probing, which costs seconds per
+           * command or aborts the probe entirely.
+           *
+           * Only halt the endpoint when nothing terminated the data
+           * phase - otherwise the host would mistake the following CSW
+           * for transfer data.
+           */
 
-          if (priv->residue > 0)
+          if (priv->residue > 0 && !terminated)
             {
 #ifndef CONFIG_USBMSC_NOT_STALL_BULKEP
               usbtrace(TRACE_CLSERROR(USBMSC_TRACEERR_CMDFINISHRESIDUE),
@@ -2975,8 +3001,20 @@ int usbmsc_scsi_main(int argc, FAR char *argv[])
            * response
            */
 
+#ifdef CONFIG_USBMSC_COMPOSITE
+          /* In composite mode the composite driver itself responds to
+           * SETCONFIGURATION (see composite_ep0submit); only the deferred
+           * responses to MSRESET and SETINTERFACE are owed by this class.
+           * Submitting a second response for SETCONFIGURATION would corrupt
+           * the EP0 state.
+           */
+
+          if ((eventset & (USBMSC_EVENT_RESET |
+                           USBMSC_EVENT_IFCHANGE)) != 0)
+#else
           if ((eventset & (USBMSC_EVENT_RESET | USBMSC_EVENT_CFGCHANGE |
                            USBMSC_EVENT_IFCHANGE)) != 0)
+#endif
             {
               usbmsc_deferredresponse(priv, false);
             }


### PR DESCRIPTION
# PR 2 — usbmsc: fix composite-mode class requests and Hi>Di stall behavior

Branch: `usbmsc-composite-bot-fixes` (worktree `~/nuttxspace/wt-pr-usbmsc`)
Base: apache/nuttx master (1b6f918c3f)
References: #19435 (bugs 1-3 of that report)

## Summary

Three usbmsc defects that together prevent macOS from ever mounting a
composite USBMSC function (and degrade any host that probes with allocation
lengths larger than the response). Linux is mostly unaffected because its
probe sequence and recovery timing never exercise these paths — which is why
they survived so long.

## The three fixes

1. **wIndex checked against a compile-time constant instead of the assigned
   interface number.** `usbmsc_setup()` compared the class-request `wIndex`
   with `USBMSC_INTERFACEID` (= `CONFIG_USBMSC_IFNOBASE` + 0 = 0) instead of
   the composite-assigned `priv->devinfo.ifnobase`. In composite mode the MSC
   interface is nonzero, so GET MAX LUN, Bulk-Only Mass Storage Reset, and
   GET/SET INTERFACE failed the check and stalled EP0 (macOS then read a
   garbage LUN count — "Max LUNs reported as 28" — off the stalled transfer
   and probed phantom LUNs). Standalone MSC is unaffected (ifnobase == 0).
   Four call sites fixed.

2. **`usbmsc_deferredresponse()` is a no-op in composite mode** — its whole
   body was inside `#ifndef CONFIG_USBMSC_COMPOSITE`, so the deferred EP0
   status stage for MSRESET/SETINTERFACE was never sent and the host's
   Bulk-Only reset timed out. (Unreachable before fix 1: MSRESET used to
   stall at the wrong-interface check.) The body is now compiled in composite
   mode too; the worker's deferred response for SETCONFIGURATION is
   suppressed there, because the composite driver answers that request itself
   and a duplicate ZLP corrupts EP0.

3. **Gratuitous bulk-IN stall on Hi>Di residue.** `usbmsc_cmdfinishstate()`
   stalled bulk-IN whenever a device-to-host command left a residue, even
   when the response had already been sent and terminated by a short packet
   (or ZLP). The stall is BOT-legal (USB MSC BOT 6.7.2) but pointless — the
   short packet already ended the data phase and the residue is reported in
   `dCSWDataResidue` — and macOS answers any bulk-IN halt during probing with
   a full Bulk-Only reset sequence (macOS probes MODE SENSE(6) with
   allocation lengths exceeding the response; Linux's probe does not). Only
   halt the endpoint when nothing terminated the data phase.

## Validation

- **RP2350 (Raspberry Pi Pico 2 W) hardware, composite CDC-ACM + CDC-NCM +
  USBMSC (MSC at interface 4), Linux host with usbmon + raw-usbfs traces:**
  - GET MAX LUN: EP0 stall (`-EPIPE`) before → 1 byte (1 LUN) after.
  - MSRESET: `ETIMEDOUT` before → completes 10/10 after, including MSRESET
    arriving mid-command with an immediate bus reset after it.
  - MODE SENSE(6) alloc=0xC0: short data then CSW-read stall + clear-halt
    before → short data then immediate CSW with `dCSWDataResidue=0xB0` and
    zero bulk-IN stalls across the exact-length suite after.
  - No regressions: FAT volume mounts/full-reads, NCM + ACM unaffected, warm
    reboots clean.
  - End-to-end: macOS now mounts the volume (together with the companion DCD
    fixes in the separate rp2040/rp23xx PR).
- **Build-tested** on `raspberrypi-pico:composite` (composite MSC) and
  `pimoroni-pico-2-plus:usbmsc` (standalone MSC — exercises the unchanged
  `#ifndef CONFIG_USBMSC_COMPOSITE` paths).

Full host traces and the failure chronology are in #19435.

## Impact

Every composite configuration containing USBMSC where the MSC interface
number is nonzero (i.e. essentially all of them). Standalone MSC behavior is
unchanged except fix 3 (fewer gratuitous stalls; hosts see a CSW with
residue instead of stall/clear-halt/retry).

## AI disclosure

This investigation and the fixes were performed by an AI agent (Claude Code),
operated and directed by the submitter, and reviewed by the submitter before
posting.
