### PR TITLE
drivers/: Multiple Drivers Are Registered With World Writable Part 3

### DIFF
--- a/drivers/misc/goldfish_pipe.c
+++ b/drivers/misc/goldfish_pipe.c
@@ -681,7 +681,7 @@ int goldfish_pipe_register(FAR void *base, int irq)
   /* Register the pipe device */
 
   return register_driver("/dev/goldfish_pipe",
-                         &g_goldfish_pipe_fops, 0666, dev);
+                         &g_goldfish_pipe_fops, 0600, dev);
 
 out:
   kmm_free(dev);

--- a/drivers/misc/rpmsgblk.c
+++ b/drivers/misc/rpmsgblk.c
@@ -1307,7 +1307,7 @@ int rpmsgblk_register(FAR const char *remotecpu, FAR const char *remotepath,
       localpath = remotepath;
     }
 
-  ret = register_blockdriver(localpath, &dev->blk, 0750, dev);
+  ret = register_blockdriver(localpath, &dev->blk, 0600, dev);
   if (ret < 0)
     {
       ferr("ERROR: register driver failed, ret=%d\n", ret);

--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -4407,7 +4407,7 @@ static int mmcsd_probe(FAR struct mmcsd_state_s *priv)
                 {
                   snprintf(devname, sizeof(devname), "/dev/mmcsd%d%s",
                            priv->minor, g_partname[i]);
-                  register_blockdriver(devname, &g_bops, 0660,
+                  register_blockdriver(devname, &g_bops, 0600,
                                        &priv->part[i]);
                 }
             }

--- a/drivers/mtd/dhara.c
+++ b/drivers/mtd/dhara.c
@@ -754,7 +754,7 @@ int dhara_initialize_by_path(FAR const char *path,
    * DHARA_MTDBLOCK device structure
    */
 
-  ret = register_blockdriver(path, &g_dhara_bops, 0660, dev);
+  ret = register_blockdriver(path, &g_dhara_bops, 0600, dev);
   if (ret < 0)
     {
       ferr("register_blockdriver failed: %d\n", ret);

--- a/drivers/mtd/nvblk.c
+++ b/drivers/mtd/nvblk.c
@@ -542,7 +542,7 @@ int nvblk_initialize(FAR const char *path,
    * NVBLK_MTDBLOCK device structure
    */
 
-  ret = register_blockdriver(path, &g_nvblk_bops, 0660, dev);
+  ret = register_blockdriver(path, &g_nvblk_bops, 0600, dev);
   if (ret < 0)
     {
       ferr("register_blockdriver failed: %d\n", ret);

--- a/drivers/pipes/pipe.c
+++ b/drivers/pipes/pipe.c
@@ -149,7 +149,7 @@ static int pipe_register(size_t bufsize, int flags,
 
   /* Register the pipe device */
 
-  ret = register_pipedriver(devname, &g_pipe_fops, 0666, (FAR void *)dev);
+  ret = register_pipedriver(devname, &g_pipe_fops, 0600, (FAR void *)dev);
   if (ret != 0)
     {
       pipecommon_freedev(dev);

--- a/drivers/sensors/ina3221.c
+++ b/drivers/sensors/ina3221.c
@@ -393,7 +393,7 @@ int ina3221_register(FAR const char *devpath, FAR struct i2c_master_s *i2c,
 
   /* Register the character driver */
 
-  ret = register_driver(devpath, &g_ina3221fops, 0666, priv);
+  ret = register_driver(devpath, &g_ina3221fops, 0600, priv);
   if (ret < 0)
     {
       snerr("ERROR: Failed to register driver: %d\n", ret);

--- a/drivers/serial/uart_hostfs.c
+++ b/drivers/serial/uart_hostfs.c
@@ -131,7 +131,7 @@ static int uart_hostfs_setup(FAR struct uart_dev_s *dev)
   FAR struct uart_hostfs_priv_s *priv = dev->priv;
 
   priv->fd = host_open(CONFIG_UART_HOSTFS_DEVPATH, O_RDWR | O_NONBLOCK,
-                       0666);
+                       0600);
   return priv->fd;
 }
 

--- a/drivers/usbdev/usbdev_fs.c
+++ b/drivers/usbdev/usbdev_fs.c
@@ -1244,7 +1244,7 @@ static void usbdev_fs_register_driver(FAR void *arg)
     {
       snprintf(devname, sizeof(devname), "%s/ep%d",
                devinfo->name, i);
-      ret = register_driver(devname, &g_usbdev_fs_fops, 0666, &fs->eps[i]);
+      ret = register_driver(devname, &g_usbdev_fs_fops, 0600, &fs->eps[i]);
       if (ret < 0)
         {
           uerr("Failed to register driver:%s, ret:%d\n", devname, ret);

--- a/drivers/video/max7456.c
+++ b/drivers/video/max7456.c
@@ -1662,7 +1662,7 @@ int max7456_register(FAR const char *path, FAR struct mx7_config_s *config)
 
   for (n = 0; ret >= 0 && n < NODE_MAP_LEN; n++)
     {
-      ret = add_interface(path, node_map[n].path, &g_mx7_fops, 0666, dev);
+      ret = add_interface(path, node_map[n].path, &g_mx7_fops, 0600, dev);
     }
 
 #if defined(DEBUG)
@@ -1675,7 +1675,7 @@ int max7456_register(FAR const char *path, FAR struct mx7_config_s *config)
   for (n = 0; ret >= 0 && n < REG_NAME_MAP_LEN; n++)
     {
       ret = add_interface(path, reg_name_map[n].path, &g_mx7_debug_fops,
-                          0666, dev);
+                          0600, dev);
     }
 #endif
 

--- a/drivers/virtio/virtio-blk.c
+++ b/drivers/virtio/virtio-blk.c
@@ -596,7 +596,7 @@ static int virtio_blk_probe(FAR struct virtio_device *vdev)
   /* Register block driver */
 
   snprintf(priv->name, NAME_MAX, "/dev/virtblk%d", g_virtio_blk_idx);
-  ret = register_blockdriver(priv->name, &g_virtio_blk_bops, 0660, priv);
+  ret = register_blockdriver(priv->name, &g_virtio_blk_bops, 0600, priv);
   if (ret < 0)
     {
       vrterr("Register block driver failed, ret=%d\n", ret);


### PR DESCRIPTION
## Summary

Permissions (Part 3/3)

## Description:

In kernel builds, any unprivileged process running on the NuttX device can open /dev/efuse and attempt to read/write fuse content. Reading the fuses may provide valuable information to an attacker controlling the user process. The write operation, in extreme cases where the fuse blocks are not locked, may brick the device.

DISCLAIMER: I tried to be strict with the settings, better to relax them later if it's needed.

This is part of https://github.com/apache/nuttx/issues/19410

## Impact

See https://github.com/apache/nuttx/issues/19410

## Testing

Compiles ok.