### PR TITLE
arch/risc-v/espressif: Add CMake ULP support

### DIFF
--- a/Documentation/platforms/risc-v/esp32c6/index.rst
+++ b/Documentation/platforms/risc-v/esp32c6/index.rst
@@ -256,14 +256,6 @@ Or for a single invocation::
 
 .. _esp32c6_debug:
 
-CMake limitations
-^^^^^^^^^^^^^^^^^^
-
-The following is **not** supported when building with CMake yet; use the Make-based build instead:
-
-* **ULP / LP core** — Low-power coprocessor support (``CONFIG_ESPRESSIF_USE_LP_CORE``) is
-  not wired up for CMake (ULP/LP integration is TODO).
-
 Debugging
 =========
 
@@ -835,13 +827,14 @@ using build system has some dependencies on example side.
 Both methods requires ``CONFIG_ESPRESSIF_USE_LP_CORE`` variable to enable ULP core
 and it can be set using ``make menuconfig`` or ``kconfig-tweak`` commands.
 
-Additionally, a Makefile needs to be provided to specify the ULP application name,
+Additionally, a Makefile or CMake file must be provided to specify the ULP application name,
 source path of the ULP application, and either the binary (for prebuilt) or the source files (for internal build).
-This Makefile must include the ULP makefile after the variable set process on ``arch/risc-v/src/common/espressif/esp_ulp.mk`` integration script.
-For more information please refer to :ref:`ulp example Makefile. <ulp_makefile>`
+This file must include either ULP makefile after the variable set process on ``arch/risc-v/src/common/espressif/esp_ulp.mk``
+or ``arch/risc-v/src/common/espressif/esp_ulp.cmake`` integration script depending on build system preference.
+For more information please refer to :ref:`ulp example Makefile. <ulp_makefile>` or :ref:`ulp example CMake. <ulp_cmake>`
 
-Makefile Variables for ULP Core Build:
---------------------------------------
+Makefile/CMake Variables for ULP Core Build:
+--------------------------------------------
 
 - ``ULP_APP_NAME``: Sets name for the ULP application. This variable also be used as prefix (e.g. ULP application bin variable name)
 - ``ULP_APP_FOLDER``: Specifies the directory containing the ULP application's source codes.
@@ -856,12 +849,12 @@ Here is an Makefile example when using prebuilt binary for ULP core:
 
    ULP_APP_NAME = esp_ulp
    ULP_APP_FOLDER = $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)$(CHIP_SERIES)
-   ULP_APP_BIN = $(TOPDIR)$(DELIM)Documentation$(DELIM)platforms$(DELIM)$(CONFIG_ARCH)$(DELIM)$(CONFIG_ARCH_CHIP)$(DELIM)boards$(DELIM)$(CONFIG_ARCH_BOARD)$(DELIM)ulp_riscv_blink.bin
+   ULP_APP_BIN = $(TOPDIR)$(DELIM)Documentation$(DELIM)platforms$(DELIM)$(CONFIG_ARCH)$(DELIM)$(CONFIG_ARCH_CHIP)$(DELIM)boards$(DELIM)$(CONFIG_ARCH_BOARD)$(DELIM)ulp_blink.bin
 
    include $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)common$(DELIM)espressif$(DELIM)esp_ulp.mk
 
 
-Here is an example for enabling ULP and using the prebuilt test binary for ULP core::
+Here is an example for enabling ULP and using the prebuilt test binary for ULP core using make build system::
 
     make distclean
     ./tools/configure.sh esp32c6-devkitc:nsh
@@ -869,6 +862,26 @@ Here is an example for enabling ULP and using the prebuilt test binary for ULP c
     kconfig-tweak -e CONFIG_ESPRESSIF_ULP_USE_TEST_BIN
     make olddefconfig
     make -j
+
+Here is an CMake file example when using prebuilt binary for ULP core:
+
+.. code-block:: cmake
+
+   set(ULP_APP_USE_TEST_BIN TRUE)
+   set(ULP_APP_NAME esp_ulp)
+   set(ULP_APP_FOLDER ${NUTTX_CHIP_ABS_DIR})
+   set(ULP_APP_BIN ${NUTTX_DIR}/Documentation/platforms/risc-v/${CONFIG_ARCH_CHIP}/boards/${CONFIG_ARCH_BOARD}/ulp_blink.bin)
+
+   include(${NUTTX_DIR}/arch/risc-v/src/common/espressif/esp_ulp.cmake)
+
+
+Here is an example for enabling ULP and using the prebuilt test binary for ULP core using CMake build system::
+
+    cmake -B build -DBOARD_CONFIG=esp32c6-devkitc:nsh -GNinja
+    kconfig-tweak --file build/.config -e CONFIG_ESPRESSIF_USE_LP_CORE
+    kconfig-tweak --file build/.config -e CONFIG_ESPRESSIF_ULP_USE_TEST_BIN
+    cmake --build build -t olddefconfig
+    cmake --build build
 
 Creating an ULP LP-Core Application
 -----------------------------------
@@ -878,7 +891,7 @@ To use NuttX's internal build system to compile the bare-metal LP binary, check 
 First, create a folder for the ULP source and header files into your NuttX example.
 This folder is just for ULP project and it is an independent project. Therefore, the NuttX example guide should not be followed
 for ULP example (folder location is irrelevant. It can be the same of the `nuttx-apps` repository, for instance).
-To include the ULP folder in the build system, don't forget to include the ULP Makefile in the NuttX example Makefile. Lastly, configuration variables
+To include the ULP folder in the build system, don't forget to include the ULP Makefile or Cmake integration in the NuttX example build file. Lastly, configuration variables
 needed to enable ULP core instructions can be found above.
 
 NuttX's internal functions or POSIX calls are not supported.
@@ -929,12 +942,36 @@ this example will demonstrate how to add ULP code into a custom application:
    ├── nuttx/
    └── apps/
    └── ulp_example/
+       └── CMakeLists.txt
        └── Makefile
        └── Kconfig
        └── ulp_example.c
        └── ulp/
+           └── CMakeLists.txt
            └── Makefile
            └── ulp_main.c
+
+
+- Contents in CMakeLists.txt:
+
+.. code-block:: cmake
+
+   include(ulp/CMakeLists.txt)
+   nuttx_add_application(
+      NAME
+      ${CONFIG_EXAMPLES_ULP_EXAMPLE_PROGNAME}
+      PRIORITY
+      ${SCHED_PRIORITY_DEFAULT}
+      STACKSIZE
+      ${CONFIG_DEFAULT_TASK_STACKSIZE}
+      MODULE
+      ${CONFIG_EXAMPLES_ULP_EXAMPLE}
+      INCLUDE_DIRECTORIES
+      ${CMAKE_CURRENT_BINARY_DIR}
+      SRCS
+      ulp_example.c
+      DEPENDS
+      ${_ulp_example_deps})
 
 
 - Contents in Makefile:
@@ -995,6 +1032,19 @@ this example will demonstrate how to add ULP code into a custom application:
       return 0;
     }
 
+.. _ulp_cmake:
+
+- Contents in ulp/CMakeLists.txt:
+
+.. code-block:: cmake
+
+    set(_ulp_example_deps)
+    set(ULP_APP_NAME ulp_example)
+    set(ULP_APP_FOLDER ${CMAKE_CURRENT_LIST_DIR}/ulp)
+    set(ULP_APP_C_SRCS ulp_main.c)
+    include(${NUTTX_DIR}/arch/risc-v/src/common/espressif/esp_ulp.cmake)
+    list(APPEND _ulp_example_deps ulp_example_ulp_bin)
+
 .. _ulp_makefile:
 
 - Contents in ulp/Makefile:
@@ -1036,7 +1086,7 @@ this example will demonstrate how to add ULP code into a custom application:
        return 0;
     }
 
-- Command to build::
+- Command to build using make build system::
 
     make distclean
     ./tools/configure.sh esp32c6-devkitc:nsh
@@ -1047,6 +1097,16 @@ this example will demonstrate how to add ULP code into a custom application:
     make olddefconfig
     make -j
 
+- Command to build using CMake build system::
+
+    cmake -B build -DBOARD_CONFIG=esp32c6-devkitc:nsh -GNinja
+    kconfig-tweak --file build/.config -e CONFIG_ESPRESSIF_GPIO_IRQ
+    kconfig-tweak --file build/.config -e CONFIG_DEV_GPIO
+    kconfig-tweak --file build/.config -e CONFIG_ESPRESSIF_USE_LP_CORE
+    kconfig-tweak --file build/.config -e CONFIG_EXAMPLES_ULP_EXAMPLE
+    cmake --build build -t olddefconfig
+    cmake --build build
+
 Here is an example of a single ULP application. However, support is not limited to just
 one application. Multiple ULP applications are also supported.
 By following the same guideline, multiple ULP applications can be created and loaded using ``write`` POSIX call.
@@ -1056,7 +1116,7 @@ build multiple ULP applications; it does not affect the ability to load multiple
 
 ULP binary can be included in NuttX application by adding
 ``#include "ulp/ulp/ulp_code.h"`` line. Then, the ULP binary is accessible by using the ULP application
-prefix (defined by the ``ULP_APP_NAME`` variable in the ULP application Makefile) with the ``bin`` keyword to
+prefix (defined by the ``ULP_APP_NAME`` variable in the ULP application Makefile or CMake file) with the ``bin`` keyword to
 access the binary data (e.g., if ``ULP_APP_NAME`` is ``ulp_test``, the binary variable will be ``ulp_test_bin``)
 and ``bin_len`` keyword to access its length (e.g., ``ulp_test_bin_len`` for ``ULP_APP_NAME`` is ``ulp_test``).
 
@@ -1065,8 +1125,8 @@ Accessing the ULP LP-Core Program Variables
 
 Global symbols defined in the ULP application are available to the HP core through a shared memory region. To read or write ULP variables,
 direct reading/writing to such memory positions are not allowed. POSIX calls are needed instead. To access the ULP variable through the HP core,
-consider that its name is defined by the ULP application prefix (defined by the ``ULP_APP_NAME`` variable in the ULP application Makefile) + the ULP application variable.
-For example if HP core tries to access a ULP application variable named ``result`` and ``ULP_APP_NAME`` in the ULP application Makefile set as ``ulp_app``, required name for
+consider that its name is defined by the ULP application prefix (defined by the ``ULP_APP_NAME`` variable in the ULP Makefile or CMake integration) + the ULP application variable.
+For example if HP core tries to access a ULP application variable named ``result`` and ``ULP_APP_NAME`` in the ULP application build file set as ``ulp_app``, required name for
 that variable will be ``ulp_app_result``.
 ``FIONREAD`` or ``FIONWRITE`` ioctl calls are, then, performed with the address of a ``struct symtab_s`` previously defined with the name of the variable to be read or written.
 

--- a/Documentation/platforms/risc-v/esp32p4/index.rst
+++ b/Documentation/platforms/risc-v/esp32p4/index.rst
@@ -193,15 +193,6 @@ Or for a single invocation::
 
   $ ESPTOOL_PORT=/dev/ttyUSB0 cmake --build build -t flash
 
-CMake limitations
-^^^^^^^^^^^^^^^^^^
-
-The following is **not** supported when building with CMake yet; use the Make-based build instead:
-
-* **ULP / LP core** — Low-power coprocessor support (``CONFIG_ESPRESSIF_USE_LP_CORE``) is
-  not wired up for CMake (ULP/LP integration is TODO).
-
-
 .. _esp32p4_debug:
 
 Debugging
@@ -464,13 +455,14 @@ using build system has some dependencies on example side.
 Both methods requires ``CONFIG_ESPRESSIF_USE_LP_CORE`` variable to enable ULP core
 and it can be set using ``make menuconfig`` or ``kconfig-tweak`` commands.
 
-Additionally, a Makefile needs to be provided to specify the ULP application name,
+Additionally, a Makefile or CMake file must be provided to specify the ULP application name,
 source path of the ULP application, and either the binary (for prebuilt) or the source files (for internal build).
-This Makefile must include the ULP makefile after the variable set process on ``arch/risc-v/src/common/espressif/esp_ulp.mk`` integration script.
-For more information please refer to :ref:`ulp example Makefile. <ulp_makefile>`
+This file must include either ULP makefile after the variable set process on ``arch/risc-v/src/common/espressif/esp_ulp.mk``
+or ``arch/risc-v/src/common/espressif/esp_ulp.cmake`` integration script depending on build system preference.
+For more information please refer to :ref:`ulp example Makefile. <ulp_makefile>` or :ref:`ulp example CMake. <ulp_cmake>`
 
-Makefile Variables for ULP Core Build:
---------------------------------------
+Makefile/CMake Variables for ULP Core Build:
+--------------------------------------------
 
 - ``ULP_APP_NAME``: Sets name for the ULP application. This variable also be used as prefix (e.g. ULP application bin variable name)
 - ``ULP_APP_FOLDER``: Specifies the directory containing the ULP application's source codes.
@@ -485,12 +477,12 @@ Here is an Makefile example when using prebuilt binary for ULP core:
 
    ULP_APP_NAME = esp_ulp
    ULP_APP_FOLDER = $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)$(CHIP_SERIES)
-   ULP_APP_BIN = $(TOPDIR)$(DELIM)Documentation$(DELIM)platforms$(DELIM)$(CONFIG_ARCH)$(DELIM)$(CONFIG_ARCH_CHIP)$(DELIM)boards$(DELIM)$(CONFIG_ARCH_BOARD)$(DELIM)ulp_riscv_blink.bin
+   ULP_APP_BIN = $(TOPDIR)$(DELIM)Documentation$(DELIM)platforms$(DELIM)$(CONFIG_ARCH)$(DELIM)$(CONFIG_ARCH_CHIP)$(DELIM)boards$(DELIM)$(CONFIG_ARCH_BOARD)$(DELIM)ulp_blink.bin
 
    include $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)common$(DELIM)espressif$(DELIM)esp_ulp.mk
 
 
-Here is an example for enabling ULP and using the prebuilt test binary for ULP core::
+Here is an example for enabling ULP and using the prebuilt test binary for ULP core using make build system::
 
     make distclean
     ./tools/configure.sh esp32p4-function-ev-board:nsh
@@ -498,6 +490,26 @@ Here is an example for enabling ULP and using the prebuilt test binary for ULP c
     kconfig-tweak -e CONFIG_ESPRESSIF_ULP_USE_TEST_BIN
     make olddefconfig
     make -j
+
+Here is an CMake file example when using prebuilt binary for ULP core:
+
+.. code-block:: cmake
+
+   set(ULP_APP_USE_TEST_BIN TRUE)
+   set(ULP_APP_NAME esp_ulp)
+   set(ULP_APP_FOLDER ${NUTTX_CHIP_ABS_DIR})
+   set(ULP_APP_BIN ${NUTTX_DIR}/Documentation/platforms/risc-v/${CONFIG_ARCH_CHIP}/boards/${CONFIG_ARCH_BOARD}/ulp_blink.bin)
+
+   include(${NUTTX_DIR}/arch/risc-v/src/common/espressif/esp_ulp.cmake)
+
+
+Here is an example for enabling ULP and using the prebuilt test binary for ULP core using CMake build system::
+
+    cmake -B build -DBOARD_CONFIG=esp32p4-function-ev-board:nsh -GNinja
+    kconfig-tweak --file build/.config -e CONFIG_ESPRESSIF_USE_LP_CORE
+    kconfig-tweak --file build/.config -e CONFIG_ESPRESSIF_ULP_USE_TEST_BIN
+    cmake --build build -t olddefconfig
+    cmake --build build
 
 Creating an ULP LP-Core Application
 -----------------------------------
@@ -507,7 +519,7 @@ To use NuttX's internal build system to compile the bare-metal LP binary, check 
 First, create a folder for the ULP source and header files into your NuttX example.
 This folder is just for ULP project and it is an independent project. Therefore, the NuttX example guide should not be followed
 for ULP example (folder location is irrelevant. It can be the same of the `nuttx-apps` repository, for instance).
-To include the ULP folder in the build system, don't forget to include the ULP Makefile in the NuttX example Makefile. Lastly, configuration variables
+To include the ULP folder in the build system, don't forget to include the ULP Makefile or Cmake integration in the NuttX example build file. Lastly, configuration variables
 needed to enable ULP core instructions can be found above.
 
 NuttX's internal functions or POSIX calls are not supported.
@@ -558,12 +570,36 @@ this example will demonstrate how to add ULP code into a custom application:
    ├── nuttx/
    └── apps/
    └── ulp_example/
+       └── CMakeLists.txt
        └── Makefile
        └── Kconfig
        └── ulp_example.c
        └── ulp/
+           └── CMakeLists.txt
            └── Makefile
            └── ulp_main.c
+
+
+- Contents in CMakeLists.txt:
+
+.. code-block:: cmake
+
+   include(ulp/CMakeLists.txt)
+   nuttx_add_application(
+      NAME
+      ${CONFIG_EXAMPLES_ULP_EXAMPLE_PROGNAME}
+      PRIORITY
+      ${SCHED_PRIORITY_DEFAULT}
+      STACKSIZE
+      ${CONFIG_DEFAULT_TASK_STACKSIZE}
+      MODULE
+      ${CONFIG_EXAMPLES_ULP_EXAMPLE}
+      INCLUDE_DIRECTORIES
+      ${CMAKE_CURRENT_BINARY_DIR}
+      SRCS
+      ulp_example.c
+      DEPENDS
+      ${_ulp_example_deps})
 
 
 - Contents in Makefile:
@@ -624,6 +660,19 @@ this example will demonstrate how to add ULP code into a custom application:
       return 0;
     }
 
+.. _ulp_cmake:
+
+- Contents in ulp/CMakeLists.txt:
+
+.. code-block:: cmake
+
+    set(_ulp_example_deps)
+    set(ULP_APP_NAME ulp_example)
+    set(ULP_APP_FOLDER ${CMAKE_CURRENT_LIST_DIR}/ulp)
+    set(ULP_APP_C_SRCS ulp_main.c)
+    include(${NUTTX_DIR}/arch/risc-v/src/common/espressif/esp_ulp.cmake)
+    list(APPEND _ulp_example_deps ulp_example_ulp_bin)
+
 .. _ulp_makefile:
 
 - Contents in ulp/Makefile:
@@ -665,7 +714,7 @@ this example will demonstrate how to add ULP code into a custom application:
        return 0;
     }
 
-- Command to build::
+- Command to build using make build system::
 
     make distclean
     ./tools/configure.sh esp32p4-function-ev-board:nsh
@@ -676,6 +725,16 @@ this example will demonstrate how to add ULP code into a custom application:
     make olddefconfig
     make -j
 
+- Command to build using CMake build system::
+
+    cmake -B build -DBOARD_CONFIG=esp32p4-function-ev-board:nsh -GNinja
+    kconfig-tweak --file build/.config -e CONFIG_ESPRESSIF_GPIO_IRQ
+    kconfig-tweak --file build/.config -e CONFIG_DEV_GPIO
+    kconfig-tweak --file build/.config -e CONFIG_ESPRESSIF_USE_LP_CORE
+    kconfig-tweak --file build/.config -e CONFIG_EXAMPLES_ULP_EXAMPLE
+    cmake --build build -t olddefconfig
+    cmake --build build
+
 Here is an example of a single ULP application. However, support is not limited to just
 one application. Multiple ULP applications are also supported.
 By following the same guideline, multiple ULP applications can be created and loaded using ``write`` POSIX call.
@@ -685,7 +744,7 @@ build multiple ULP applications; it does not affect the ability to load multiple
 
 ULP binary can be included in NuttX application by adding
 ``#include "ulp/ulp/ulp_code.h"`` line. Then, the ULP binary is accessible by using the ULP application
-prefix (defined by the ``ULP_APP_NAME`` variable in the ULP application Makefile) with the ``bin`` keyword to
+prefix (defined by the ``ULP_APP_NAME`` variable in the ULP application Makefile or CMake file) with the ``bin`` keyword to
 access the binary data (e.g., if ``ULP_APP_NAME`` is ``ulp_test``, the binary variable will be ``ulp_test_bin``)
 and ``bin_len`` keyword to access its length (e.g., ``ulp_test_bin_len`` for ``ULP_APP_NAME`` is ``ulp_test``).
 
@@ -714,8 +773,8 @@ Global Symbols
 
 Global symbols defined in the ULP application are available to the HP core through a shared memory region. To read or write ULP variables,
 direct reading/writing to such memory positions are not allowed. POSIX calls are needed instead. To access the ULP variable through the HP core,
-consider that its name is defined by the ULP application prefix (defined by the ``ULP_APP_NAME`` variable in the ULP application Makefile) + the ULP application variable.
-For example if HP core tries to access a ULP application variable named ``result`` and ``ULP_APP_NAME`` in the ULP application Makefile set as ``ulp_app``, required name for
+consider that its name is defined by the ULP application prefix (defined by the ``ULP_APP_NAME`` variable in the ULP Makefile or CMake integration) + the ULP application variable.
+For example if HP core tries to access a ULP application variable named ``result`` and ``ULP_APP_NAME`` in the ULP application build file set as ``ulp_app``, required name for
 that variable will be ``ulp_app_result``.
 ``FIONREAD`` or ``FIONWRITE`` ioctl calls are, then, performed with the address of a ``struct symtab_s`` previously defined with the name of the variable to be read or written.
 

--- a/arch/risc-v/src/common/espressif/CMakeLists.txt
+++ b/arch/risc-v/src/common/espressif/CMakeLists.txt
@@ -199,10 +199,10 @@ if(CONFIG_COMP)
 endif()
 
 if(CONFIG_ESPRESSIF_USE_LP_CORE)
-  message(
-    WARNING
-      "LP Core is not supported on CMake. Use Make to build the image instead.")
+  list(APPEND SRCS esp_ulp.c)
 endif()
+
+# if(CONFIG_ESPRESSIF_LP_MAILBOX) list(APPEND SRCS esp_lp_mailbox.c) endif()
 
 if(CONFIG_PM)
   if(NOT CONFIG_ARCH_CUSTOM_PMINIT)
@@ -469,14 +469,6 @@ add_custom_target(
   VERBATIM)
 
 # ##############################################################################
-# ULP Support (TODO)
-# ##############################################################################
-
-if(CONFIG_ESPRESSIF_USE_LP_CORE)
-  list(APPEND ESP_CLEAN_FILES ${CMAKE_CURRENT_SOURCE_DIR}/../chip/ulp)
-endif()
-
-# ##############################################################################
 # Clean hook - replicate Make.defs distclean behavior
 # ##############################################################################
 
@@ -484,6 +476,15 @@ set(ESP_CLEAN_FILES
     ${NUTTX_DIR}/arch/${CONFIG_ARCH}/include/${CONFIG_ARCH_CHIP}/gpio_sig_map.h
     ${NUTTX_DIR}/arch/${CONFIG_ARCH}/include/${CONFIG_ARCH_CHIP}/irq.h
     ${NUTTX_DIR}/vefuse.bin)
+
+if(CONFIG_ESPRESSIF_USE_LP_CORE)
+  list(
+    APPEND
+    ESP_CLEAN_FILES
+    ${NUTTX_CHIP_ABS_DIR}/ulp
+    ${NUTTX_DIR}/boards/${CONFIG_ARCH}/${CHIP_SERIES}/common/scripts/ulp_aliases.ld
+  )
+endif()
 
 set_property(
   DIRECTORY ${CMAKE_SOURCE_DIR}

--- a/arch/risc-v/src/common/espressif/esp_ulp.cmake
+++ b/arch/risc-v/src/common/espressif/esp_ulp.cmake
@@ -1,0 +1,494 @@
+# ##############################################################################
+# arch/risc-v/src/common/espressif/esp_ulp.cmake
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+if(CONFIG_ESPRESSIF_USE_LP_CORE)
+
+  # ############################################################################
+  # Path variables for ULP build
+  # ############################################################################
+
+  if(NOT CHIP_SERIES)
+    string(REPLACE "\"" "" CHIP_SERIES "${CONFIG_ESPRESSIF_CHIP_SERIES}")
+  endif()
+
+  set(ARCH_SRCDIR ${NUTTX_DIR}/arch/${CONFIG_ARCH}/src)
+  set(CHIP_DIR ${NUTTX_CHIP_ABS_DIR})
+  set(ULP_ARCH_FOLDER ${CHIP_DIR}/ulp)
+  set(ULP_FOLDER ${ULP_APP_FOLDER}/ulp)
+
+  if(NOT ULP_APP_NAME)
+    set(ULP_APP_NAME ${ULP_APP_FOLDER})
+  endif()
+
+  string(MAKE_C_IDENTIFIER "${ULP_APP_NAME}" _ulp_app_id)
+  set(ULP_BIN_TARGET ${_ulp_app_id}_ulp_bin)
+  set(ULP_PREPARE_TARGET ${_ulp_app_id}_ulp_prepare)
+  set(ULP_FIRMWARE_TARGET ${_ulp_app_id}_ulp_firmware)
+
+  if(DEFINED NUTTX_BOARD_DIR)
+    set(ULP_BOARD_SCRIPTS_DIR ${NUTTX_BOARD_DIR}/../common/scripts)
+  else()
+    set(ULP_BOARD_SCRIPTS_DIR
+        ${NUTTX_DIR}/boards/${CONFIG_ARCH}/${CHIP_SERIES}/common/scripts)
+  endif()
+  get_filename_component(ULP_BOARD_SCRIPTS_DIR ${ULP_BOARD_SCRIPTS_DIR}
+                         ABSOLUTE)
+
+  set(ULP_CODE_HEADER ${ULP_FOLDER}/ulp_code.h)
+  set(ULP_VAR_MAP_HEADER ${ULP_ARCH_FOLDER}/ulp_var_map.h)
+  set(ULP_VARS_HEADER ${ULP_ARCH_FOLDER}/ulp_vars.h)
+  set(ULP_ALIASES_LD ${ULP_BOARD_SCRIPTS_DIR}/ulp_aliases.ld)
+  set(ULP_MAIN_HEADER ${ULP_FOLDER}/ulp_main.h)
+  set(ULP_MAIN_LD ${ULP_FOLDER}/ulp_main.ld)
+  set(ULP_LOCKFILE ${ULP_VAR_MAP_HEADER}.lock)
+  set(ULP_PREFIX ${ULP_APP_NAME}_)
+  set(ULP_BASE 0)
+
+  if(NOT ESP_HAL_3RDPARTY_REPO)
+    get_filename_component(
+      ESP_HAL_3RDPARTY_REPO
+      "${CMAKE_BINARY_DIR}/arch/${CONFIG_ARCH}/src/common/espressif/esp-hal-3rdparty"
+      REALPATH)
+  endif()
+
+  set(HAL ${ESP_HAL_3RDPARTY_REPO})
+
+  set(ULP_LPCORE_SECTIONS_LD
+      ${ULP_BOARD_SCRIPTS_DIR}/${CHIP_SERIES}_lpcore_sections.ld)
+  set(ULP_SECTIONS_LD ${ULP_FOLDER}/ulp_sections.ld)
+  set(ULP_MAPGEN_TOOL ${HAL}/components/ulp/esp32ulp_mapgen.py)
+
+  find_program(XXD_PROGRAM xxd REQUIRED)
+  find_package(Python3 REQUIRED COMPONENTS Interpreter)
+  get_filename_component(_ulp_toolchain_bin ${CMAKE_OBJCOPY} DIRECTORY)
+  find_program(ULP_READELF readelf HINTS ${_ulp_toolchain_bin} REQUIRED)
+
+  # ############################################################################
+  # Include paths
+  # ############################################################################
+
+  set(ULP_INCLUDE_DIRS
+      ${HAL}
+      ${ULP_ARCH_FOLDER}
+      ${HAL}/components/esp_common/include
+      ${HAL}/components/esp_hal_ana_conv/include
+      ${HAL}/components/esp_hal_ana_conv/${CHIP_SERIES}/include
+      ${HAL}/components/esp_hal_clock/include
+      ${HAL}/components/esp_hal_clock/${CHIP_SERIES}/include
+      ${HAL}/components/esp_hal_gpio/include
+      ${HAL}/components/esp_hal_gpio/${CHIP_SERIES}/include
+      ${HAL}/components/esp_hal_gpspi/include
+      ${HAL}/components/esp_hal_gpspi/${CHIP_SERIES}/include
+      ${HAL}/components/esp_hal_i2c/include
+      ${HAL}/components/esp_hal_i2c/${CHIP_SERIES}/include
+      ${HAL}/components/esp_hal_pmu/include
+      ${HAL}/components/esp_hal_pmu/${CHIP_SERIES}/include
+      ${HAL}/components/esp_hal_rtc_timer/include
+      ${HAL}/components/esp_hal_rtc_timer/${CHIP_SERIES}/include
+      ${HAL}/components/esp_hal_uart/include
+      ${HAL}/components/esp_hal_uart/${CHIP_SERIES}/include
+      ${HAL}/components/esp_hw_support/include
+      ${HAL}/components/esp_hw_support/port/${CHIP_SERIES}/include
+      ${HAL}/components/esp_hw_support/port/${CHIP_SERIES}/private_include
+      ${HAL}/components/esp_rom
+      ${HAL}/components/esp_rom/include
+      ${HAL}/components/esp_rom/${CHIP_SERIES}
+      ${HAL}/components/esp_rom/${CHIP_SERIES}/include
+      ${HAL}/components/esp_rom/${CHIP_SERIES}/include/${CHIP_SERIES}
+      ${HAL}/components/hal/include
+      ${HAL}/components/hal/platform_port/include
+      ${HAL}/components/log
+      ${HAL}/components/log/include
+      ${HAL}/components/riscv/include
+      ${HAL}/components/soc
+      ${HAL}/components/soc/include
+      ${HAL}/components/soc/${CHIP_SERIES}
+      ${HAL}/components/soc/${CHIP_SERIES}/include
+      ${HAL}/components/hal/${CHIP_SERIES}/include
+      ${HAL}/components/soc/${CHIP_SERIES}/register
+      ${HAL}/components/soc/${CHIP_SERIES}/register/soc
+      ${HAL}/components/ulp
+      ${HAL}/components/ulp/ulp_common
+      ${HAL}/components/ulp/ulp_common/include
+      ${HAL}/components/ulp/lp_core
+      ${HAL}/components/ulp/lp_core/lp_core
+      ${HAL}/components/ulp/lp_core/include
+      ${HAL}/components/ulp/lp_core/shared
+      ${HAL}/components/ulp/lp_core/lp_core/include
+      ${HAL}/components/ulp/lp_core/shared/include
+      ${HAL}/components/upper_hal_uart/include
+      ${HAL}/nuttx/include
+      ${HAL}/nuttx/${CHIP_SERIES}/include
+      ${HAL}/nuttx/src/components/esp_driver_uart/include)
+
+  if(CONFIG_ARCH_CHIP_ESP32P4)
+    if(NOT CONFIG_ESP32P4_SELECTS_REV_LESS_V3)
+      list(APPEND ULP_INCLUDE_DIRS
+           ${HAL}/components/soc/${CHIP_SERIES}/register/hw_ver3
+           ${HAL}/components/soc/${CHIP_SERIES}/register/soc/)
+    else()
+      list(APPEND ULP_INCLUDE_DIRS
+           ${HAL}/components/soc/${CHIP_SERIES}/register/hw_ver1
+           ${HAL}/components/soc/${CHIP_SERIES}/register/soc/)
+    endif()
+    list(
+      APPEND
+      ULP_INCLUDE_DIRS
+      ${HAL}/components/esp_adc/include
+      ${HAL}/components/esp_adc/${CHIP_SERIES}/include
+      ${HAL}/components/esp_hal_i2s/include
+      ${HAL}/components/esp_hal_i2s/${CHIP_SERIES}/include
+      ${HAL}/components/esp_hal_touch_sens/include
+      ${HAL}/components/esp_hal_touch_sens/${CHIP_SERIES}/include
+      ${HAL}/components/esp_system/ld
+      ${HAL}/components/upper_hal_i2s/include)
+  endif()
+
+  # ############################################################################
+  # Linker scripts
+  # ############################################################################
+
+  set(ULP_LDSCRIPTS
+      -T${HAL}/components/soc/${CHIP_SERIES}/ld/${CHIP_SERIES}.peripherals.ld
+      -T${ULP_SECTIONS_LD})
+
+  if(CONFIG_ARCH_CHIP_ESP32P4)
+    list(
+      APPEND
+      ULP_LDSCRIPTS
+      -T${HAL}/components/esp_rom/${CHIP_SERIES}/ld/${CHIP_SERIES}lp.rom.ld
+      -T${HAL}/components/esp_rom/${CHIP_SERIES}/ld/${CHIP_SERIES}lp.rom.newlib.ld
+      -T${HAL}/components/esp_rom/${CHIP_SERIES}/ld/${CHIP_SERIES}lp.rom.version.ld
+      -T${HAL}/components/esp_rom/${CHIP_SERIES}/ld/${CHIP_SERIES}lp.rom.api.ld)
+  endif()
+
+  # ############################################################################
+  # HAL / LP-core sources
+  # ############################################################################
+
+  set(ULP_ASOURCES
+      ${HAL}/components/ulp/lp_core/lp_core/port/${CHIP_SERIES}/vector_table.S
+      ${HAL}/components/ulp/lp_core/lp_core/start.S
+      ${HAL}/components/ulp/lp_core/lp_core/vector.S)
+
+  set(ULP_CSOURCES
+      ${HAL}/components/ulp/lp_core/lp_core/lp_core_spi.c
+      ${HAL}/components/ulp/lp_core/shared/ulp_lp_core_memory_shared.c
+      ${HAL}/components/ulp/lp_core/shared/ulp_lp_core_lp_uart_shared.c
+      ${HAL}/components/ulp/lp_core/shared/ulp_lp_core_lp_timer_shared.c
+      ${HAL}/components/esp_hal_uart/uart_hal_iram.c
+      ${HAL}/components/esp_hal_uart/uart_hal.c
+      ${HAL}/components/ulp/lp_core/lp_core/lp_core_i2c.c
+      ${HAL}/components/ulp/lp_core/lp_core/lp_core_startup.c
+      ${HAL}/components/ulp/lp_core/lp_core/lp_core_utils.c
+      ${HAL}/components/ulp/lp_core/lp_core/lp_core_uart.c
+      ${HAL}/components/ulp/lp_core/lp_core/lp_core_print.c
+      ${HAL}/components/ulp/lp_core/lp_core/lp_core_panic.c
+      ${HAL}/components/ulp/lp_core/lp_core/lp_core_interrupt.c
+      ${HAL}/components/ulp/lp_core/lp_core/lp_core_ubsan.c
+      ${HAL}/components/ulp/lp_core/shared/ulp_lp_core_lp_adc_shared.c
+      ${HAL}/components/ulp/lp_core/shared/ulp_lp_core_lp_vad_shared.c
+      ${HAL}/components/ulp/lp_core/shared/ulp_lp_core_critical_section_shared.c
+  )
+
+  if(CONFIG_ARCH_CHIP_ESP32P4)
+    list(
+      APPEND ULP_CSOURCES ${HAL}/components/ulp/lp_core/lp_core/lp_core_touch.c
+      ${HAL}/components/ulp/lp_core/lp_core/port/lp_core_mailbox_impl_hw.c
+      ${HAL}/components/ulp/lp_core/lp_core/lp_core_mailbox.c)
+  endif()
+
+  # ############################################################################
+  # Shared chip-level stubs
+  # ############################################################################
+
+  if(NOT TARGET esp_ulp_shared_stubs)
+    set(_ESP_ULP_BASH_WRITE_VAR_MAP_INIT
+        [=[printf '%s\n' '#include "nuttx/symtab.h"' '#include "ulp/ulp_vars.h"' '' 'struct ulp_var_map_s' '{' '  struct symtab_s sym;' '  size_t size;' '};' '' 'struct ulp_var_map_s ulp_var_map[] =' '{ };' > "@ULP_VAR_MAP_HEADER@"]=]
+    )
+    string(REPLACE "@ULP_VAR_MAP_HEADER@" "${ULP_VAR_MAP_HEADER}"
+                   _ESP_ULP_BASH_WRITE_VAR_MAP_INIT
+                   "${_ESP_ULP_BASH_WRITE_VAR_MAP_INIT}")
+
+    add_custom_command(
+      OUTPUT ${ULP_VARS_HEADER} ${ULP_VAR_MAP_HEADER} ${ULP_ALIASES_LD}
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${ULP_ARCH_FOLDER}
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${ULP_BOARD_SCRIPTS_DIR}
+      COMMAND ${CMAKE_COMMAND} -E touch ${ULP_VARS_HEADER}
+      COMMAND ${CMAKE_COMMAND} -E touch ${ULP_ALIASES_LD}
+      COMMAND bash -c "${_ESP_ULP_BASH_WRITE_VAR_MAP_INIT}"
+      COMMENT "Creating shared ULP stub files"
+      VERBATIM)
+
+    add_custom_target(esp_ulp_shared_stubs DEPENDS ${ULP_VARS_HEADER})
+    add_dependencies(arch esp_ulp_shared_stubs)
+  endif()
+
+  # ############################################################################
+  # Compiler / linker flags
+  # ############################################################################
+
+  set(ULP_COMPILE_OPTS -Os -ggdb -march=rv32imac_zicsr_zifencei -mdiv
+                       -fdata-sections -ffunction-sections)
+  set(ULP_ASM_OPTS -Os -ggdb -march=rv32imac_zicsr_zifencei -x
+                   assembler-with-cpp -D__ASSEMBLER__)
+  set(ULP_LINK_OPTS
+      -march=rv32imac_zicsr_zifencei --specs=nano.specs --specs=nosys.specs
+      -nostartfiles -Wl,--no-warn-rwx-segments -Wl,--gc-sections)
+
+  if(CONFIG_DEBUG_SYMBOLS)
+    set(ULP_COMPILE_OPTS -O0 -ggdb -march=rv32imac_zicsr_zifencei -mdiv
+                         -fdata-sections -ffunction-sections)
+    set(ULP_ASM_OPTS -O0 -ggdb -march=rv32imac_zicsr_zifencei -x
+                     assembler-with-cpp -D__ASSEMBLER__)
+    if(CONFIG_ESPRESSIF_ULP_ENABLE_UBSAN)
+      list(APPEND ULP_COMPILE_OPTS -fno-sanitize=shift-base
+           -fsanitize=undefined)
+      list(APPEND ULP_ASM_OPTS -fno-sanitize=shift-base -fsanitize=undefined)
+    endif()
+  endif()
+
+  foreach(_ulp_inc ${ULP_INCLUDE_DIRS})
+    list(APPEND ULP_INCLUDE_FLAGS -I${_ulp_inc})
+  endforeach()
+
+  # ############################################################################
+  # Build
+  # ############################################################################
+
+  if(DEFINED ULP_APP_BIN AND ULP_APP_BIN MATCHES "\\.bin$")
+    set(ULP_BIN_FILE_PATH ${ULP_APP_BIN})
+
+    if(NOT EXISTS "${ULP_BIN_FILE_PATH}")
+      message(FATAL_ERROR "ULP prebuilt binary not found: ${ULP_BIN_FILE_PATH}")
+    endif()
+
+    add_custom_command(
+      OUTPUT ${ULP_CODE_HEADER}
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${ULP_FOLDER}
+      COMMAND ${XXD_PROGRAM} -i ${ULP_BIN_FILE_PATH} ${ULP_CODE_HEADER}
+      COMMAND
+        sed -i
+        "s/unsigned char[^[]*\\[[^]]*\\]/unsigned char ${ULP_APP_NAME}_bin[]/g"
+        ${ULP_CODE_HEADER}
+      COMMAND
+        sed -i "s/unsigned int[^=]* =/unsigned int ${ULP_APP_NAME}_bin_len =/g"
+        ${ULP_CODE_HEADER}
+      DEPENDS ${ULP_BIN_FILE_PATH} ${ULP_VAR_MAP_HEADER}
+      COMMENT "Converting ULP prebuilt binary into header file"
+      VERBATIM)
+  else()
+    if(NOT ULP_APP_C_SRCS AND NOT ULP_APP_ASM_SRCS)
+      message(
+        FATAL_ERROR
+          "ULP source build requires ULP_APP_C_SRCS and/or ULP_APP_ASM_SRCS")
+    endif()
+
+    set(ULP_BIN_FILE ${ULP_FOLDER}/ulp.bin)
+    set(ULP_BIN_FILE_PATH ${ULP_BIN_FILE})
+    set(ULP_ELF_FILE ${ULP_FOLDER}/ulp.elf)
+    set(ULP_MAP_FILE ${ULP_FOLDER}/ulp.map)
+    set(ULP_SYM_FILE ${ULP_FOLDER}/ulp.sym)
+    set(ULP_NUTTX_CONFIG_COPY ${ULP_FOLDER}/nuttx/config.h)
+
+    foreach(_ulp_csrc ${ULP_APP_C_SRCS})
+      list(APPEND ULP_APP_C_SOURCES ${ULP_APP_FOLDER}/${_ulp_csrc})
+    endforeach()
+
+    foreach(_ulp_asrc ${ULP_APP_ASM_SRCS})
+      list(APPEND ULP_APP_ASM_SOURCES ${ULP_APP_FOLDER}/${_ulp_asrc})
+    endforeach()
+
+    if(ULP_APP_INCLUDES)
+      foreach(_ulp_incl ${ULP_APP_INCLUDES})
+        get_filename_component(_ulp_incl_dir ${_ulp_incl} DIRECTORY)
+        list(APPEND ULP_APP_INCLUDE_DIRS ${_ulp_incl_dir})
+      endforeach()
+      list(REMOVE_DUPLICATES ULP_APP_INCLUDE_DIRS)
+      list(APPEND ULP_INCLUDE_DIRS ${ULP_APP_INCLUDE_DIRS})
+      set(ULP_INCLUDE_FLAGS)
+      foreach(_ulp_inc ${ULP_INCLUDE_DIRS})
+        list(APPEND ULP_INCLUDE_FLAGS -I${_ulp_inc})
+      endforeach()
+    endif()
+
+    list(APPEND ULP_INCLUDE_DIRS ${ULP_FOLDER})
+    list(APPEND ULP_INCLUDE_FLAGS -I${ULP_FOLDER})
+    list(APPEND ULP_CSOURCES ${ULP_APP_C_SOURCES})
+    list(APPEND ULP_ASOURCES ${ULP_APP_ASM_SOURCES})
+
+    if(NOT EXISTS ${ULP_LPCORE_SECTIONS_LD})
+      message(
+        FATAL_ERROR "ULP linker template not found: ${ULP_LPCORE_SECTIONS_LD}")
+    endif()
+
+    add_custom_command(
+      OUTPUT ${ULP_NUTTX_CONFIG_COPY}
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${ULP_FOLDER}/nuttx
+      COMMAND
+        ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/include/nuttx/config.h
+        ${ULP_NUTTX_CONFIG_COPY}
+      DEPENDS nuttx_context ${ULP_VAR_MAP_HEADER}
+      COMMENT "Copying nuttx/config.h for ULP build"
+      VERBATIM)
+
+    add_custom_command(
+      OUTPUT ${ULP_SECTIONS_LD}
+      COMMAND ${CMAKE_C_COMPILER} ${ULP_INCLUDE_FLAGS} -E -P -xc -o
+              ${ULP_SECTIONS_LD} ${ULP_LPCORE_SECTIONS_LD}
+      DEPENDS ${ULP_NUTTX_CONFIG_COPY} ${ULP_LPCORE_SECTIONS_LD}
+      COMMENT "Preprocessing ULP linker sections"
+      VERBATIM)
+
+    add_custom_target(${ULP_PREPARE_TARGET} DEPENDS ${ULP_NUTTX_CONFIG_COPY}
+                                                    ${ULP_SECTIONS_LD})
+
+    add_library(${ULP_FIRMWARE_TARGET} OBJECT ${ULP_CSOURCES} ${ULP_ASOURCES})
+    add_dependencies(${ULP_FIRMWARE_TARGET} ${ULP_PREPARE_TARGET})
+    if(TARGET copy_esp3rdparty_headers)
+      add_dependencies(${ULP_FIRMWARE_TARGET} copy_esp3rdparty_headers)
+    endif()
+
+    set_source_files_properties(
+      ${ULP_CSOURCES} ${ULP_ASOURCES} PROPERTIES OBJECT_DEPENDS
+                                                 "${ULP_NUTTX_CONFIG_COPY}")
+
+    target_include_directories(${ULP_FIRMWARE_TARGET}
+                               PRIVATE ${ULP_INCLUDE_DIRS})
+    target_compile_definitions(${ULP_FIRMWARE_TARGET} PRIVATE IS_ULP_COCPU)
+    target_compile_options(
+      ${ULP_FIRMWARE_TARGET}
+      PRIVATE ${ULP_COMPILE_OPTS}
+              -include
+              ${HAL}/nuttx/${CHIP_SERIES}/include/sdkconfig.h
+              -Wno-shadow
+              -Wno-undef
+              -Wno-unused-variable
+              -Wno-strict-prototypes
+              -Wno-deprecated-declarations
+              $<$<COMPILE_LANGUAGE:ASM>:${ULP_ASM_OPTS}>)
+
+    add_custom_command(
+      OUTPUT ${ULP_ELF_FILE}
+      COMMAND
+        ${CMAKE_C_COMPILER} ${ULP_LINK_OPTS} ${ULP_LDSCRIPTS} -Xlinker
+        -Map=${ULP_MAP_FILE} "$<TARGET_OBJECTS:${ULP_FIRMWARE_TARGET}>" -o
+        ${ULP_ELF_FILE}
+      COMMAND_EXPAND_LISTS
+      DEPENDS ${ULP_FIRMWARE_TARGET} ${ULP_SECTIONS_LD}
+      COMMENT "Linking ULP firmware"
+      VERBATIM)
+
+    set(_ulp_postprocess_aliases
+        [=[grep -E '^[[:space:]]*[a-zA-Z_][a-zA-Z0-9_]*[[:space:]]*=[[:space:]]*[0x]*[0-9a-fA-F]+;' "@ULP_MAIN_LD@" | while IFS= read -r line; do var_name=$(echo "$line" | sed -E 's/^[[:space:]]*([a-zA-Z_][a-zA-Z0-9_]*).*/\1/'); existing_line=$(grep -E "^[[:space:]]*${var_name}[[:space:]]*=" "@ULP_ALIASES_LD@" 2>/dev/null || true); if [ -n "$existing_line" ]; then if [ "$existing_line" != "$line" ]; then sed -i "/${existing_line}/c\\${line}" "@ULP_ALIASES_LD@"; fi; else echo "$line" >> "@ULP_ALIASES_LD@"; fi; done]=]
+    )
+    string(REPLACE "@ULP_MAIN_LD@" "${ULP_MAIN_LD}" _ulp_postprocess_aliases
+                   "${_ulp_postprocess_aliases}")
+    string(REPLACE "@ULP_ALIASES_LD@" "${ULP_ALIASES_LD}"
+                   _ulp_postprocess_aliases "${_ulp_postprocess_aliases}")
+
+    set(_ulp_postprocess_var_map
+        [=[if ! grep -q "struct ulp_var_map_s ulp_var_map" "@ULP_VAR_MAP_HEADER@"; then printf '%s\n' '#include "nuttx/symtab.h"' '#include "ulp/ulp_vars.h"' '' 'struct ulp_var_map_s' '{' '  struct symtab_s sym;' '  size_t size;' '};' '' 'struct ulp_var_map_s ulp_var_map[] =' '{ };' > "@ULP_VAR_MAP_HEADER@"; fi; sed -i "/@ULP_PREFIX@/d" "@ULP_VAR_MAP_HEADER@"; flock -x "@ULP_LOCKFILE@" -c 'grep "@ULP_PREFIX@" "@ULP_MAIN_HEADER@" | while IFS= read -r line; do var=$(echo "$line" | grep -oP "@ULP_PREFIX@\w+(?=[;\[])" ); if [ -n "$var" ]; then size=$(echo "$line" | grep -oP "\[\d+\]" | grep -oP "\d+"); if [ -n "$size" ]; then size=$(( size * 4 )); else size=4; fi; sed -i "s/ };//" "@ULP_VAR_MAP_HEADER@"; echo -ne "  { .sym.sym_name = \"${var}\", .sym.sym_value = &${var}, .size = ${size}},\n };" >> "@ULP_VAR_MAP_HEADER@"; fi; done']=]
+    )
+    string(REPLACE "@ULP_VAR_MAP_HEADER@" "${ULP_VAR_MAP_HEADER}"
+                   _ulp_postprocess_var_map "${_ulp_postprocess_var_map}")
+    string(REPLACE "@ULP_LOCKFILE@" "${ULP_LOCKFILE}" _ulp_postprocess_var_map
+                   "${_ulp_postprocess_var_map}")
+    string(REPLACE "@ULP_MAIN_HEADER@" "${ULP_MAIN_HEADER}"
+                   _ulp_postprocess_var_map "${_ulp_postprocess_var_map}")
+    string(REPLACE "@ULP_PREFIX@" "${ULP_PREFIX}" _ulp_postprocess_var_map
+                   "${_ulp_postprocess_var_map}")
+
+    add_custom_command(
+      OUTPUT ${ULP_CODE_HEADER} ${ULP_BIN_FILE} ${ULP_SYM_FILE}
+             ${ULP_MAIN_HEADER} ${ULP_MAIN_LD}
+      COMMAND ${CMAKE_COMMAND} -E make_directory ${ULP_FOLDER}
+      COMMAND ${CMAKE_OBJCOPY} -O binary ${ULP_ELF_FILE} ${ULP_BIN_FILE}
+      COMMAND ${ULP_READELF} -sW ${ULP_ELF_FILE} > ${ULP_SYM_FILE}
+      COMMAND ${Python3_EXECUTABLE} ${ULP_MAPGEN_TOOL} -s ${ULP_SYM_FILE} -o
+              ${ULP_FOLDER}/ulp_main --base ${ULP_BASE} --prefix ${ULP_PREFIX}
+      COMMAND bash -c "${_ulp_postprocess_aliases}"
+      COMMAND sed -i "/${ULP_PREFIX}/d" ${ULP_VARS_HEADER}
+      COMMAND
+        bash -c
+        "grep \"extern uint32_t\" \"${ULP_MAIN_HEADER}\" >> \"${ULP_VARS_HEADER}\""
+      COMMAND bash -c "${_ulp_postprocess_var_map}"
+      COMMAND ${XXD_PROGRAM} -i ${ULP_BIN_FILE_PATH} ${ULP_CODE_HEADER}
+      COMMAND
+        sed -i
+        "s/unsigned char[^[]*\\[[^]]*\\]/unsigned char ${ULP_APP_NAME}_bin[]/g"
+        ${ULP_CODE_HEADER}
+      COMMAND
+        sed -i "s/unsigned int[^=]* =/unsigned int ${ULP_APP_NAME}_bin_len =/g"
+        ${ULP_CODE_HEADER}
+      DEPENDS ${ULP_ELF_FILE} ${ULP_VAR_MAP_HEADER}
+      COMMENT "Generating ULP binary, symbol map, and headers"
+      VERBATIM)
+  endif()
+
+  add_custom_target(${ULP_BIN_TARGET} DEPENDS ${ULP_CODE_HEADER})
+  if(TARGET ${ULP_PREPARE_TARGET})
+    add_dependencies(${ULP_BIN_TARGET} ${ULP_PREPARE_TARGET})
+  endif()
+  add_dependencies(board ${ULP_BIN_TARGET})
+  add_dependencies(arch ${ULP_BIN_TARGET})
+
+  set_property(GLOBAL APPEND PROPERTY ESP_ULP_BIN_TARGETS ${ULP_BIN_TARGET})
+
+  function(_esp_ulp_add_nuttx_link_deps)
+    get_property(_esp_ulp_bins GLOBAL PROPERTY ESP_ULP_BIN_TARGETS)
+    if(NOT _esp_ulp_bins)
+      return()
+    endif()
+
+    foreach(_esp_ulp_bin_target ${_esp_ulp_bins})
+      if(TARGET ${_esp_ulp_bin_target})
+        add_dependencies(nuttx ${_esp_ulp_bin_target})
+        if(TARGET ldscript_tmp_ulp_aliases.ld)
+          add_dependencies(ldscript_tmp_ulp_aliases.ld ${_esp_ulp_bin_target})
+        endif()
+      endif()
+    endforeach()
+
+    if(TARGET ldscript_tmp_ulp_aliases.ld AND TARGET esp_ulp_shared_stubs)
+      add_dependencies(ldscript_tmp_ulp_aliases.ld esp_ulp_shared_stubs)
+    endif()
+  endfunction()
+
+  get_property(_esp_ulp_defer GLOBAL PROPERTY ESP_ULP_LINK_DEFER_REGISTERED)
+  if(NOT _esp_ulp_defer)
+    set_property(GLOBAL PROPERTY ESP_ULP_LINK_DEFER_REGISTERED TRUE)
+    cmake_language(DEFER DIRECTORY ${CMAKE_SOURCE_DIR} CALL
+                   _esp_ulp_add_nuttx_link_deps)
+  endif()
+
+  # ############################################################################
+  # Clean hook
+  # ############################################################################
+
+  set_property(
+    DIRECTORY ${CMAKE_SOURCE_DIR}
+    APPEND
+    PROPERTY ADDITIONAL_CLEAN_FILES ${ULP_FOLDER} ${ULP_ARCH_FOLDER}
+             ${ULP_ALIASES_LD} ${ULP_ARCH_FOLDER}/.ulp_shared_stubs_stamp)
+
+endif()

--- a/arch/risc-v/src/common/espressif/ulp.cmake
+++ b/arch/risc-v/src/common/espressif/ulp.cmake
@@ -1,0 +1,31 @@
+# ##############################################################################
+# arch/risc-v/src/common/espressif/ulp.cmake
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+set(ULP_APP_USE_TEST_BIN TRUE)
+
+set(ULP_APP_NAME esp_ulp)
+set(ULP_APP_FOLDER ${NUTTX_CHIP_ABS_DIR})
+set(ULP_APP_BIN
+    ${NUTTX_DIR}/Documentation/platforms/risc-v/${CONFIG_ARCH_CHIP}/boards/${CONFIG_ARCH_BOARD}/ulp_blink.bin
+)
+
+include(${NUTTX_DIR}/arch/risc-v/src/common/espressif/esp_ulp.cmake)

--- a/arch/risc-v/src/esp32c6/hal_esp32c6.cmake
+++ b/arch/risc-v/src/esp32c6/hal_esp32c6.cmake
@@ -199,8 +199,11 @@ set(_esp32c6_rom_ld_files
     ${ESP_SOC_LD_DIR}/${CHIP_SERIES}.peripherals.ld)
 
 if(CONFIG_ESPRESSIF_USE_LP_CORE)
-  list(APPEND _esp32c6_rom_ld_files
-       ${NUTTX_DIR}/arch/${CONFIG_ARCH}/src/board/scripts/ulp_aliases.ld)
+  list(
+    APPEND
+    _esp32c6_rom_ld_files
+    ${NUTTX_DIR}/boards/${CONFIG_ARCH}/${CHIP_SERIES}/common/scripts/ulp_aliases.ld
+  )
 endif()
 
 if(CONFIG_ESPRESSIF_SPI_FLASH_USE_ROM_CODE)

--- a/arch/risc-v/src/esp32h2/hal_esp32h2.cmake
+++ b/arch/risc-v/src/esp32h2/hal_esp32h2.cmake
@@ -197,11 +197,6 @@ set(_esp32h2_rom_ld_files
     ${ESP_RISCV_LD_DIR}/rom.api.ld
     ${ESP_SOC_LD_DIR}/${CHIP_SERIES}.peripherals.ld)
 
-if(CONFIG_ESPRESSIF_USE_LP_CORE)
-  list(APPEND _esp32h2_rom_ld_files
-       ${NUTTX_DIR}/arch/${CONFIG_ARCH}/src/board/scripts/ulp_aliases.ld)
-endif()
-
 if(CONFIG_ESPRESSIF_SPI_FLASH_USE_ROM_CODE)
   list(APPEND _esp32h2_rom_ld_files
        ${ESP_ROM_LD_DIR}/${CHIP_SERIES}.rom.spiflash.ld)

--- a/arch/risc-v/src/esp32p4/hal_esp32p4.cmake
+++ b/arch/risc-v/src/esp32p4/hal_esp32p4.cmake
@@ -225,10 +225,12 @@ list(
   ${ESP_SOC_LD_DIR}/${CHIP_SERIES}.peripherals.ld
   ${ESP_RISCV_LD_DIR}/rom.api.ld)
 
-# Review the path below when ULP core is implemented on CMake
 if(CONFIG_ESPRESSIF_USE_LP_CORE)
-  list(APPEND _esp32p4_rom_ld_files
-       ${TOPDIR}/arch/${CONFIG_ARCH}/src/board/scripts/ulp_aliases.ld)
+  list(
+    APPEND
+    _esp32p4_rom_ld_files
+    ${NUTTX_DIR}/boards/${CONFIG_ARCH}/${CHIP_SERIES}/common/scripts/ulp_aliases.ld
+  )
 endif()
 
 # Add these files to the GLOBAL PROPERTY LD_SCRIPT

--- a/boards/risc-v/esp32c6/common/src/CMakeLists.txt
+++ b/boards/risc-v/esp32c6/common/src/CMakeLists.txt
@@ -112,6 +112,10 @@ if(CONFIG_ARCH_BOARD_COMMON)
     target_link_libraries(board PRIVATE romfs_etc)
   endif()
 
+  if(CONFIG_ESPRESSIF_ULP_USE_TEST_BIN)
+    include(${NUTTX_DIR}/arch/risc-v/src/common/espressif/ulp.cmake)
+  endif()
+
 endif()
 
 target_sources(board PRIVATE ${SRCS})

--- a/boards/risc-v/esp32p4/common/src/CMakeLists.txt
+++ b/boards/risc-v/esp32p4/common/src/CMakeLists.txt
@@ -76,6 +76,10 @@ if(CONFIG_ARCH_BOARD_COMMON)
     list(APPEND SRCS esp_board_pcnt.c)
   endif()
 
+  if(CONFIG_ESPRESSIF_ULP_USE_TEST_BIN)
+    include(${NUTTX_DIR}/arch/risc-v/src/common/espressif/ulp.cmake)
+  endif()
+
 endif()
 
 target_sources(board PRIVATE ${SRCS})


### PR DESCRIPTION
## Summary

<!-- This field should contain a summary of the changes. It will be pre-filled with the commit's message and descriptions. Adjust it accordingly -->

* Docs/platforms/risc-v: Add CMake ULP build system docs

Add CMake ULP build system docs for esp32[-c6|-p4]

* boards/risc-v/espressif: Add CMake ULP board support

Add CMake ULP board support for esp32[-c6|-p4]

* arch/risc-v/espressif: Add CMake ULP support

Add CMake support for ULP build

## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: Yes, users can build ULP app with using CMake build system
<!-- Does it impact user's applications? How? -->

Impact on build: Yes, ULP application can be built with CMake
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: Yes, ULP can be built with using CMake
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: Yes, related docs added
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: No
<!-- Does it impact NuttX's security? -->

Impact on compatibility: No
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

## Testing
<!-- Please provide all the testing procedure. Consider that upstream reviewers should be able to reproduce the same testing performed internally -->

`esp32c6-devkitc:ulp` and `esp32p4-function-ev-board:ulp` configs used to test.

### Building
<!-- Provide how to build the test for each SoC being tested -->

ULP processor can be used with 2 ways:
- Using Pre-Built binary
- Using NuttX ULP build system for Espressif

#### Using Pre-Built binary

These commands can be used for pre-built binary example

```
cmake -B build -DBOARD_CONFIG=esp32c6-devkitc:ulp -GNinja && cmake --build build && ESPTOOL_PORT=/dev/ttyUSB0 cmake --build build -t flash
```

Feature included a pre-built binary which is a blink example. After these commands it will include `.bin` file under `boards/risc-v/esp32c6/common/etc/` and GPIO0 will blink after flashing.


#### Using NuttX ULP build system for Espressif

```
.
└── nuttxspace/
    ├── nuttx
    └── apps/
        └── external/
            ├── ...
            └── ulp_test/
                ├── Kconfig
                ├── CMakeLists.txt
                ├── ulp_test_main.c
                └── ulp/
                    ├── CMakeLists.txt
                    └── ulp_blink.c
```

Contents of the files:


- Kconfig:
```
config ULP_TEST_APP
	bool "ULP test app"
	default n
```

- CMakeLists.txt:
```
   include(ulp/CMakeLists.txt)
   nuttx_add_application(
      NAME
      ${CONFIG_EXAMPLES_ULP_EXAMPLE_PROGNAME}
      PRIORITY
      ${SCHED_PRIORITY_DEFAULT}
      STACKSIZE
      ${CONFIG_DEFAULT_TASK_STACKSIZE}
      MODULE
      ${CONFIG_EXAMPLES_ULP_EXAMPLE}
      INCLUDE_DIRECTORIES
      ${CMAKE_CURRENT_BINARY_DIR}
      SRCS
      ulp_example.c
      DEPENDS
      ${_ulp_example_deps})
```

- ulp_test_main.c:

```
#include <nuttx/config.h>
#include <fcntl.h>
#include <inttypes.h>
#include <stdio.h>
#include <nuttx/fs/ioctl.h>
#include <sys/ioctl.h>
#include "ulp/ulp/ulp_main.h"
#include "ulp/ulp/ulp_code.h"
#include "nuttx/symtab.h"

#define PIN 0

int main(int argc, char *argv[])
{
  int fd;
  uint32_t read_result;
  struct symtab_s sym =
  {
    .sym_name = "ulp_blink_gpio_level_previous",
    .sym_value = &read_result,
  };

  fd = open("/dev/ulp", O_WRONLY);
  if (fd < 0)
    {
      printf("Failed to open ULP: %d\n", errno);
      return -1;
    }
  int ret = write(fd, ulp_blink_bin, ulp_blink_bin_len);
  if (ret != OK)
    {
      printf("Write failed \n");
      return ERROR;
    }
  ioctl(fd, FIONREAD, &sym);

  /* Chaging LP GPIO status from a variable on HP core */

  printf("First GPIO level: %ld\n", read_result);
  printf("Expected GPIO level: %ld\n", !read_result);
  read_result = !read_result;
  ioctl(fd, FIONWRITE, &sym);
  return OK;

}
```

- ulp/CMakeLists.txt:
```
    set(_ulp_example_deps)
    set(ULP_APP_NAME ulp_example)
    set(ULP_APP_FOLDER ${CMAKE_CURRENT_LIST_DIR}/ulp)
    set(ULP_APP_C_SRCS ulp_main.c)
    include(${NUTTX_DIR}/arch/risc-v/src/common/espressif/esp_ulp.cmake)
    list(APPEND _ulp_example_deps ulp_example_ulp_bin)
```

- ulp/ulp_blink.c
```
#include <stdint.h>
#include <stdbool.h>
#include "ulp_lp_core_gpio.h"

#define GPIO_PIN 0

#define nop()   __asm__ __volatile__ ("nop")

bool gpio_level_previous = true;

int main(void)
{
    while (1)
        {
            ulp_lp_core_gpio_set_level(GPIO_PIN, gpio_level_previous);

            /* Delay */

            for (int i = 0; i < 10000; i++)
                {
                    nop();
                }
        }

    /* ulp_lp_core_halt() is called automatically when main exits */

    return 0;
}
```

Command to build ULP example:

```
cmake -B build -DBOARD_CONFIG=esp32c6-devkitc:nsh -GNinja && kconfig-tweak --file build/.config -e CONFIG_ESPRESSIF_GPIO_IRQ && kconfig-tweak --file build/.config -e CONFIG_DEV_GPIO && kconfig-tweak --file build/.config -e CONFIG_ESPRESSIF_USE_LP_CORE && kconfig-tweak --file build/.config -e CONFIG_EXAMPLES_ULP_EXAMPLE && cmake --build build -t olddefconfig && cmake --build build && ESPTOOL_PORT=/dev/ttyUSB0 cmake --build build -t flash
```

### Running
<!-- Provide how to run the test for each SoC being tested -->

Test bin will start to run at startup. Logic analyzer connected to GPIO0. For ULP example `ulp_test` command used to run.

### Results
<!-- Provide tests' results and runtime logs -->

Blink will start on startup

For ULP example:

```
nsh> ulp_blink
First GPIO level: 1
Expected GPIO level: 0
Pin status: 1
Pin status: 0
Cheking done. Exiting.
nsh> 
```