### PR TITLE
cmake: Sanitize NAME for _main symbol generation

### DIFF
--- a/cmake/nuttx_add_application.cmake
+++ b/cmake/nuttx_add_application.cmake
@@ -111,6 +111,8 @@ function(nuttx_add_application)
     return()
   endif()
 
+  string(REPLACE "-" "_" NAME_SYM "${NAME}")
+
   # check if SRCS exist
   if(SRCS)
     file(GLOB SRCS_EXIST ${SRCS})
@@ -257,7 +259,7 @@ function(nuttx_add_application)
         set_property(
           SOURCE ${MAIN_SRC}
           APPEND
-          PROPERTY COMPILE_DEFINITIONS main=${NAME}_main)
+          PROPERTY COMPILE_DEFINITIONS main=${NAME_SYM}_main)
       endif()
     endif()
 
@@ -275,7 +277,7 @@ function(nuttx_add_application)
 
   # store parameters into properties (used during builtin list generation)
 
-  set_target_properties(${TARGET} PROPERTIES APP_MAIN ${NAME}_main)
+  set_target_properties(${TARGET} PROPERTIES APP_MAIN ${NAME_SYM}_main)
   set_target_properties(${TARGET} PROPERTIES APP_NAME ${NAME})
 
   if(PRIORITY)


### PR DESCRIPTION
## Summary

The CMake build generates an internal entry-point symbol by concatenating `NAME` with `_main`. If `NAME` contains `-` (for example, `hello-world`), the generated symbol (`hello-world_main`) is not a valid C identifier, causing the build to fail.

This can be reproduced by setting `CONFIG_EXAMPLES_HELLO_PROGNAME="hello-world"` and rebuilding with CMake.

## Impact

Introduce `NAME_SYM`, a sanitized copy of `NAME` with `-` replaced by `_`, and use it only where an internal C identifier is required.

- Use `NAME_SYM` for the `main=` compile definition.
- Use `NAME_SYM` for the `APP_MAIN` target property used during builtin list generation.
- Keep `NAME` unchanged for the CMake target name, output name, and the `APP_NAME` property so applications continue to be invoked using their configured program name.

The standalone and loadable executable path (`MODULE`/`DYNLIB`/kernel build) does not rename `main()` and therefore does not require any sanitization.

This mirrors the Make-based fix already merged in `apache/nuttx-apps#3647`.

## Issues

Fixes #19447

## Testing

**Host:** WSL2 Ubuntu 24.04 x86_64

**Configuration:** `sim/nsh`

Configured the hello example with a hyphenated program name:

- Set `CONFIG_EXAMPLES_HELLO_PROGNAME="hello-world"`.
- Reconfigured the build with CMake.
- Rebuilt the project.

Before this change, the build failed because `hello-world_main` is not a valid C identifier.

After applying this change, the build completed successfully.

Verified the application from NSH:

```text
nsh> hello-world
Hello, World!!
```

Regression test:

- Changed `CONFIG_EXAMPLES_HELLO_PROGNAME` back to `"hello"`.
- Reconfigured the build with `cmake -S .. -B .`.
- Rebuilt in the same build directory.

Verified the default configuration still works:

```text
nsh> hello
Hello, World!!
```