### PR TITLE
tools/uncrustify: Update uncrustify for better support

### DIFF
--- a/tools/uncrustify.cfg
+++ b/tools/uncrustify.cfg
@@ -26,7 +26,6 @@ nl_after_func_proto           = 1        # One \n after function prototype
 nl_after_func_proto_group     = 2        # Two \n after last prototype
 nl_after_func_body            = 2        # was 1. One \n after function body
 nl_after_func_body_class      = 1        # One \n after '}' of a single line function body
-nl_after_multiline_comment    = true     # Newline after multiline comment
 nl_before_block_comment       = 2        # Two \n before block comment
 nl_before_c_comment           = 2        # was 1. At least line space before C comment
 nl_before_cpp_comment         = 1        #At least line space before C++ comment
@@ -38,8 +37,8 @@ nl_after_access_spec          = 1        # One \n after 'private:', 'public:', .
 nl_comment_func_def           = 2        # Two \n between function def and function comment.
 nl_after_try_catch_finally    = 2        # Two \n after a try-catch-finally block
 nl_around_cs_property         = 0        # No change in number of newlines before/after a property, indexer or event decl.
-eat_blanks_after_open_brace   = false    # May be a comment. Remove blank lines after '{'
-eat_blanks_before_close_brace = false    # May be a comment. Remove blank lines after '}'
+eat_blanks_after_open_brace   = true     # May be a comment. Remove blank lines after '{'
+eat_blanks_before_close_brace = true     # May be a comment. Remove blank lines after '}'
 nl_remove_extra_newlines      = 1        # was 2. Remove all newlines not specified by config
 nl_before_return              = false    # No newline before return
 nl_after_return               = false    # No newline after return statement`
@@ -55,7 +54,7 @@ nl_while_brace                = add      # "while \n () {" vs "while () {"
 nl_switch_brace               = add      # "switch \n () {" vs "switch () {"
 nl_brace_while                = add      # "} \n while" vs "} while"
 nl_brace_else                 = add      # "} \n else" vs "} else"
-nl_func_var_def_blk           = 1
+nl_var_def_blk_end_func_top   = 1
 nl_fcall_brace                = add      # "list_for_each() \n {" vs "list_for_each() {"
 nl_fdef_brace                 = add      # "int foo() {" vs "int foo()\n{"
 nl_before_case                = true     # Newline before 'case' statement
@@ -68,7 +67,7 @@ mod_full_brace_do             = add      # "do { a--; } while ();" vs "do a--; w
 mod_full_brace_for            = add      # "for () { a--; }" vs "for () a--;"
 mod_full_brace_function       = add      # Add braces on single-line function definitions. (Pawn)
 mod_full_brace_if             = add      # "if (a) { a--; }" vs "if (a) a--;"
-mod_full_brace_if_chain       = false    # was true  Make all if/elseif/else statements in a chain be braced
+mod_full_brace_if_chain       = 0        # Do not force brace chain on if-else
 mod_full_brace_nl             = 1        # Don't remove if more than 1 newlines
 mod_full_brace_while          = add      # "while (a) { a--; } " vs "while (a) a--;"
 mod_full_brace_using          = add      # Add braces on single-line 'using ()' statement
@@ -140,14 +139,51 @@ align_with_tabs               = false    # Use spaces to align
 align_on_tabstop              = true     # align on tabstops
 align_keep_tabs               = false    # Don't keep non-indenting tabs
 align_enum_equ_span           = 2        # '=' in enum definition
-align_nl_cont                 = true     # Align macros wrapped wht \n
-align_var_def_span            = 2        # Span for aligning variable definitions
-align_var_def_inline          = true     # Align union/struct variable definitions
+align_nl_cont                 = 2        # Align macro continuation lines
+align_var_def_span            = 0        # Span for aligning variable definitions
+align_var_def_inline          = false     # Align union/struct variable definitions
 align_var_def_star_style      = 2        # 2=Dangling
 align_var_def_colon           = true     # Align colons in bit field definitions
-align_assign_span             = 1        # Span for aligning =
+align_assign_span             = 0        # Span for aligning =
 align_struct_init_span        = 3        # align stuff in a structure init '= { }'
 align_right_cmt_span          = 3        # Span for aligning comments that end lines
 align_pp_define_span          = 8        # Span for aligning #define bodies
 align_pp_define_gap           = 2        # Min space define #define variable and value
 indent_brace                  = 2        # Indent brace 2 from level
+
+# No space inside parens: if (a) not if ( a )
+sp_inside_paren               = remove
+sp_inside_fparen              = remove
+
+# No space before comma: foo(a, b) not foo(a , b)
+sp_before_comma               = remove
+
+# Pointer style: type *ptr (space before *, none after)
+sp_before_ptr_star            = add
+sp_after_ptr_star             = remove
+sp_between_ptr_star           = remove
+
+# Remove spaces inside if/for/while parens
+sp_inside_sparen               = remove
+
+# Switch-case indented 2 from switch level
+indent_switch_case            = 2
+
+# Case body indented 2 from case
+indent_case_brace             = 2
+
+# Preprocessor directives NOT indented
+pp_indent                     = remove
+
+# Align function parameters to opening paren when wrapping
+align_func_params             = true
+indent_func_call_param        = true
+
+# One blank line before C comment (NuttX standard says 1, was 2)
+nl_before_c_comment            = 1
+
+# One blank line after function body (NuttX: optional single line, was 2)
+nl_after_func_body             = 1
+
+# Force brace after case colon on new line
+nl_case_colon_brace           = add


### PR DESCRIPTION
## Summary

When porting external projects to NuttX using uncrustify could help to convert "alien code" (maybe we are the aliens) to NuttX coding style.

I decided to do a test: asked an agent to use our uncrustify.cfg and analyze the converted files against our coding style. It confirmed the existing limitations of uncrustify (i.e. there is not instruction to add new line after single line comment, etc). But it improved our uncrustify a lot. Now it is able to fix 95% of an external C file.

These are the limitations that uncrustify cannot be enforced:

1. Block comment asterisks to column 78 — uncrustify can't auto-generate the `*` line fillers for section headers
2. Apache 2.0 license header — requires file header template (uncrustify has `cmt_insert_file_header` but needs template file)
3. Order of groupings (Included Files first, then Pre-processor, etc.) — structural, not formattable
4. `FAR` qualifier — can't auto-add to pointer parameters
5. Header guard #ifndef pattern — can't auto-generate
6. Sentence case in comments — content, not formatting
7. US English spelling — content
8. Two spaces after '.' and ':' in comments — uncrustify doesn't touch comment content

## Impact

It will help users to convert code from other projects to NuttX

## Testing

I tested against the picotts source code that I'm porting to NuttX