### PR TITLE
video: fix EDID standard timing decode

### DIFF
--- a/video/videomode/edid_parse.c
+++ b/video/videomode/edid_parse.c
@@ -125,6 +125,7 @@ static bool edid_std_timing(FAR const uint8_t *stdtim,
   unsigned x;
   unsigned y;
   unsigned f;
+  uint8_t info;
 
   if ((stdtim[0] == 1 && stdtim[1] == 1) ||
       (stdtim[0] == 0 && stdtim[1] == 0) ||
@@ -133,8 +134,9 @@ static bool edid_std_timing(FAR const uint8_t *stdtim,
       return false;
     }
 
-  x = stdtim[EDID_STDTIMING_XRES_OFFSET];
-  switch (x & EDID_STDTIMING_ASPECT_MASK)
+  x = (stdtim[EDID_STDTIMING_XRES_OFFSET] + 31) * 8;
+  info = stdtim[EDID_STDTIMING_INFO_OFFSET];
+  switch (info & EDID_STDTIMING_ASPECT_MASK)
     {
     case EDID_STDTIMING_ASPECT_16_10:
       y = x * 10 / 16;
@@ -154,7 +156,7 @@ static bool edid_std_timing(FAR const uint8_t *stdtim,
       break;
     }
 
-  f = stdtim[EDID_STDTIMING_INFO_OFFSET];
+  f = (info & ~EDID_STDTIMING_ASPECT_MASK) + 60;
 
   /* First try to lookup the mode as a DMT timing */
 
@@ -499,7 +501,7 @@ int edid_parse(FAR const uint8_t *data, FAR struct edid_info_s *edid)
   edid->edid_features         = data[EDID_DISPLAY_FEATURES_OFFSET];
 
   edid->edid_chroma.ec_redx   = EDID_CHROMA_RED_X(data);
-  edid->edid_chroma.ec_redy   = EDID_CHROMA_RED_X(data);
+  edid->edid_chroma.ec_redy   = EDID_CHROMA_RED_Y(data);
   edid->edid_chroma.ec_greenx = EDID_CHROMA_GREEN_X(data);
   edid->edid_chroma.ec_greeny = EDID_CHROMA_GREEN_Y(data);
   edid->edid_chroma.ec_bluex  = EDID_CHROMA_BLUE_X(data);


### PR DESCRIPTION
Fix two EDID parsing bugs in `video/videomode/edid_parse.c`.

## Summary

The parser misdecoded EDID standard timing entries and used the wrong chromaticity macro for `edid_chroma.ec_redy`.

`include/nuttx/video/edid.h` defines the standard timing fields as:

```c
#define EDID_STDTIMING_XRES_OFFSET        (0)       /* Byte 0: X resolution, divided by 8, less 31 */
#  define EDID_STDTIMING_ASPECT_SHIFT     (6)       /* Bits 6-7: Image aspect ratio */
#  define EDID_STDTIMING_VFREQ_SHIFT      (0)       /* Bits 0-5: Vertical frequency, less 60 */
#define EDID_STDTIMING_INFO_OFFSET        (1)       /* Byte 1: Image Aspect Ratio / Vertical Frequency */
```

and the chromaticity macros are defined separately:

```c
#define EDID_CHROMA_RED_X(p) \
  (_CHROMA(p, EDID_CHROMA_RG_LOW_OFFSET, EDID_CHROMA_RG_LOW_RED_X_SHIFT, \
           EDID_CHROMA_REDX_OFFSET))
#define EDID_CHROMA_RED_Y(p) \
  (_CHROMA(p, EDID_CHROMA_RG_LOW_OFFSET, EDID_CHROMA_RG_LOW_RED_Y_SHIFT, \
           EDID_CHROMA_REDY_OFFSET))
```

The implementation was reading those fields as if they were literal values and used `RED_X` for `ec_redy`.

## Impact

This is a correctness fix for `CONFIG_VIDEO_EDID`. It can affect mode selection and chromaticity data, but does not change ABI or build configuration.

## Testing

Tested on a local Linux x86_64 build host in this workspace.

- `sim:ostest` build with `CONFIG_VIDEO=y` and `CONFIG_VIDEO_EDID=y`
- local regression harness against a checksum-valid EDID block
- `checkpatch.sh -f video/videomode/edid_parse.c`
- `git diff --check`
