### PR TITLE
drivers/usbdev/cdcncm: send TX immediately instead of after a tick-quantized delay

### DIFF
--- a/drivers/usbdev/cdcncm.c
+++ b/drivers/usbdev/cdcncm.c
@@ -1302,8 +1302,13 @@ static int cdcncm_send(FAR struct netdev_lowerhalf_s *dev, FAR netpkt_t *pkt)
     }
   else
     {
-      work_queue(ETHWORK, &self->delaywork, cdcncm_transmit_work, self,
-                 MSEC2TICK(CDCNCM_DGRAM_COMBINE_PERIOD));
+      /* Defer to the work thread with zero delay.  A non-zero delay is
+       * rounded up to a full tick (10ms at 100Hz), which dominated the
+       * USB-NIC round-trip; delay 0 wakes the worker immediately while
+       * still coalescing datagrams appended in the same TX burst.
+       */
+
+      work_queue(ETHWORK, &self->delaywork, cdcncm_transmit_work, self, 0);
     }
 
   return OK;


### PR DESCRIPTION
## Summary

`cdcncm_send()` defers each transmit to the work queue with a coalescing delay of
`MSEC2TICK(CDCNCM_DGRAM_COMBINE_PERIOD)`, where `CDCNCM_DGRAM_COMBINE_PERIOD` is `1` (ms).
`MSEC2TICK()` quantizes to the system tick and rounds **up**, so on the default 100 Hz
tick (`CONFIG_USEC_PER_TICK=10000`) a "1 ms" delay becomes a full 10 ms tick — 10–20 ms
of real dead time once tick phase is included. As a result the reply to every
single-datagram exchange (ICMP echo, TCP ACK, a one-MSS HTTP segment) is parked in the
work queue for ~10–20 ms before `EP_SUBMIT`, which dominates the CDC-NCM round-trip time.

Because the coalescing window only ever batches datagrams that the network stack appends
within the *same* synchronous TX burst (which are already queued before the worker runs),
a non-zero inter-burst delay adds latency without providing any batching benefit in the
common one-datagram-at-a-time case. This change fires the transmit worker immediately
(delay `0`); within-burst coalescing is preserved.

## Impact

Measured on a Raspberry Pi Pico 2 W (RP2350) acting as a USB-NIC (CDC-NCM), default
100 Hz tick:

| | Before | After |
|---|---|---|
| Ping RTT (avg) | 21.7 ms | 2.8 ms |
| HTTP GET of a 257 KB gzip page | 5.79 s | 0.92 s |
| Throughput | 44.5 KB/s | 279 KB/s |

The RTT drop is the direct effect; the throughput gain follows because, without TCP write
buffers, the stack sends one segment per round trip, so throughput is `~MSS / RTT`.

## Testing

Validated on hardware (RP2350 / Pico 2 W, CDC-NCM over USB FS to a Linux host): ping RTT
and HTTP download measured before/after as above; served content verified byte-identical
(sha256) after the change. Not yet exercised on other platforms; the reasoning is
tick-rate-general (any board at the default 100 Hz tick is affected).

---

*Disclosure: this change was prepared with the assistance of an AI agent (Anthropic's
Claude, via Claude Code). The root cause, fix, and on-hardware measurements were
reviewed by a human maintainer before submission.*
