### PR TITLE
drivers/eeprom: I2C EEPROM Read/Write Kernel Operations Crash

### DIFF
--- a/fs/vfs/fs_read.c
+++ b/fs/vfs/fs_read.c
@@ -178,15 +178,13 @@ ssize_t file_readv(FAR struct file *filep,
 
   /* Are all iov_base accessible? */
 
-#if !defined(CONFIG_BUILD_KERNEL) || CONFIG_ARCH_TEXT_VBASE != 0
   for (ret = 0; ret < iovcnt; ret++)
     {
-      if (iov[ret].iov_base == NULL && iov[ret].iov_len != 0)
+      if (iov[ret].iov_base == NULL)
         {
           return -EFAULT;
         }
     }
-#endif
 
   ret = -EBADF;
 


### PR DESCRIPTION
## Summary

Stops kernel from crashing when a user land process calls the driver with a
NULL buffer. Full details in the issue: https://github.com/apache/nuttx/issues/19473

While this fixes the issue with a typical NULL pointer, fundamentally this will be
addressed with the implementation of access_ok().

https://man7.org/linux/man-pages/man2/access.2.html

## Impact

If user passes NULL as buffer, the driver may crash. This is problematic for NuttX
protected and kernel builds.

## Testing

Builds ok.