### PR TITLE
tools/Zig.defs: Fix Zig builds on sim:x86_64

### DIFF
--- a/tools/Zig.defs
+++ b/tools/Zig.defs
@@ -36,7 +36,13 @@ else ifeq ($(CONFIG_ARCH_RISCV),y)
   ZIGFLAGS += -mcmodel=medium
 
 else 
-  ZIGFLAGS := -target $(LLVM_ARCHTYPE)-freestanding-$(LLVM_ABITYPE)
+  ifeq ($(LLVM_ABITYPE),sysv)
+    ZIG_ABITYPE := gnu
+  else
+    ZIG_ABITYPE := $(LLVM_ABITYPE)
+  endif
+
+  ZIGFLAGS := -target $(LLVM_ARCHTYPE)-freestanding-$(ZIG_ABITYPE)
 endif
 
 # Convert cortex-xxx/sifive-exx to cortex_xxx/sifive_exx
@@ -44,3 +50,5 @@ endif
 ifneq ($(LLVM_CPUTYPE),)
 ZIGFLAGS += -mcpu $(subst -,_,$(LLVM_CPUTYPE))
 endif
+
+ZIGFLAGS += -fcompiler-rt


### PR DESCRIPTION
## Summary

Building a Zig-based application (`CONFIG_EXAMPLES_HELLO_ZIG`, `CONFIG_EXAMPLES_LEDS_ZIG`) on the sim board fails with Zig 0.13.0. The generated target triple uses `LLVM_ABITYPE := sysv`, producing `x86_64-freestanding-sysv`. Zig does not recognize `sysv` as a valid ABI, causing the build to fail before any Zig source is compiled.

After correcting the target triple, the build fails again at link time because `__zig_probe_stack` is undefined.

## Impact

Introduce `ZIG_ABITYPE`, a Zig-specific mapping from `sysv` to `gnu`, used only when constructing the Zig target triple. `LLVM_ABITYPE` remains unchanged, so the existing behavior for the other toolchains is preserved.

Also add `-fcompiler-rt` to `ZIGFLAGS` so Zig includes the required compiler runtime during linking and resolves the missing `__zig_probe_stack` symbol.

## Issues

Fixes #19475

## Testing

Host: WSL2 Ubuntu 24.04 x86_64

Configuration: `sim:nsh`

Enabled `CONFIG_EXAMPLES_HELLO_ZIG`.

Before this change, the build failed while parsing the generated target triple. After correcting the target triple, the build failed because `__zig_probe_stack` was undefined.

After applying this change, the project built successfully.

Verified the application from NSH:

```text
nsh> hello_zig
[sim]: Hello, Zig!
```
