### PR TITLE
sched/backtrace: fix cross-CPU buffer access under addrenv

### DIFF
--- a/sched/sched/sched_backtrace.c
+++ b/sched/sched/sched_backtrace.c
@@ -28,15 +28,36 @@
 #include <nuttx/sched.h>
 #include <nuttx/init.h>
 
+#include <sys/param.h>
+
+#include <string.h>
+
 #include "sched.h"
 
 #ifdef CONFIG_ARCH_HAVE_BACKTRACE
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#if defined(CONFIG_SMP) && defined(CONFIG_ARCH_ADDRENV)
+
+/* Depth of the scratch buffer used to relay a remote backtrace back to
+ * the caller, since the caller's own buffer may not be mapped in the
+ * address environment active on the target CPU.  Requests larger than
+ * this are serviced over multiple round trips.
+ */
+
+#define BACKTRACE_SCRATCH_DEPTH 32
+
+#endif
 
 /****************************************************************************
  * Private Types
  ****************************************************************************/
 
 #ifdef CONFIG_SMP
+
 struct backtrace_arg_s
 {
   pid_t pid;
@@ -105,6 +126,11 @@ int sched_backtrace(pid_t tid, FAR void **buffer, int size, int skip)
   FAR struct tcb_s *tcb = this_task();
   int ret = 0;
 
+  if (size <= 0 || buffer == NULL)
+    {
+      return 0;
+    }
+
   if (tcb->pid == tid)
     {
       ret = up_backtrace(tcb, buffer, size, skip);
@@ -121,25 +147,88 @@ int sched_backtrace(pid_t tid, FAR void **buffer, int size, int skip)
               tcb->task_state == TSTATE_TASK_RUNNING)
             {
               struct backtrace_arg_s arg;
+              bool need_restore;
+#ifdef CONFIG_ARCH_ADDRENV
+              FAR void *scratch[BACKTRACE_SCRATCH_DEPTH];
+#endif
 
               if ((tcb->flags & TCB_FLAG_CPU_LOCKED) != 0)
                 {
-                  arg.pid = tcb->pid;
-                  arg.need_restore = false;
+                  need_restore = false;
                 }
               else
                 {
-                  arg.pid = tcb->pid;
-                  arg.need_restore = true;
+                  need_restore = true;
                   tcb->flags |= TCB_FLAG_CPU_LOCKED;
                 }
 
+              arg.pid = tcb->pid;
+
+#ifdef CONFIG_ARCH_ADDRENV
+              arg.buffer = scratch;
+
+              while (ret < size)
+                {
+                  arg.size = MIN(size - ret, BACKTRACE_SCRATCH_DEPTH);
+                  arg.skip = skip + ret;
+
+                  /* If this round's request covers all remaining
+                   * frames (i.e. it was not capped by the scratch
+                   * buffer), there is nothing left to loop for
+                   * afterwards, so it is safe to have it release the
+                   * pin as well and skip the data-less round below.
+                   */
+
+                  arg.need_restore = need_restore &&
+                                      arg.size == size - ret;
+
+                  if (nxsched_smp_call_single(tcb->cpu,
+                                              sched_backtrace_handler,
+                                              &arg) < 0)
+                    {
+                      break;
+                    }
+
+                  if (arg.need_restore)
+                    {
+                      need_restore = false;
+                    }
+
+                  memcpy(&buffer[ret], scratch,
+                         arg.stacksize * sizeof(FAR void *));
+                  ret += arg.stacksize;
+
+                  if (arg.stacksize < arg.size)
+                    {
+                      /* Reached the bottom of the target's stack. */
+
+                      break;
+                    }
+                }
+
+              /* The loop above may have exited without a round
+               * releasing the pin (e.g. it broke out on reaching the
+               * bottom of the stack before a "guaranteed last round"
+               * occurred).  Send one more, data-less round purely to
+               * release it.
+               */
+
+              if (need_restore)
+                {
+                  arg.size = 0;
+                  arg.need_restore = true;
+                  nxsched_smp_call_single(tcb->cpu, sched_backtrace_handler,
+                                          &arg);
+                }
+#else
+              arg.need_restore = need_restore;
               arg.buffer = buffer;
               arg.size = size;
               arg.skip = skip;
               ret = nxsched_smp_call_single(tcb->cpu,
                                             sched_backtrace_handler,
                                             &arg) < 0 ? 0 : arg.stacksize;
+#endif
             }
           else
 #endif


### PR DESCRIPTION
## Summary

On SMP kernel-mode builds with per-task address environments (`CONFIG_BUILD_KERNEL` + `CONFIG_SMP` + `CONFIG_ARCH_ADDRENV`), backtracing a task running on another CPU sends an IPI whose handler wrote the backtrace straight into the caller's buffer pointer. That pointer is only valid under the caller's own address environment, not the target CPU's, so the remote write could land on unmapped or wrong memory. The handler now fills a small on-stack scratch buffer instead, and the caller copies it into the real buffer once control is back on its own CPU.

## Impact

Only affects `CONFIG_SMP` && `CONFIG_ARCH_ADDRENV` builds (e.g. `rv-virt:ksmp64`). Other SMP builds without `CONFIG_ARCH_ADDRENV` and non-SMP builds are unchanged.

## Testing

Tested on `rv-virt:ksmp64` (CONFIG_BUILD_KERNEL + CONFIG_SMP + CONFIG_ARCH_ADDRENV).

Before fix:

```
NuttShell (NSH) NuttX-13.0.0
nsh> ps
  TID   PID  PPID CPU PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK    USED FILLED COMMAND
    0     0     0   0   0 FIFO     Kthread   - Assigned           0000000000000000 0003024 0001360  44.9%  CPU0 IDLE
    1     0     0   1   0 FIFO     Kthread   - Running            0000000000000000 0003024 0001280  42.3%  CPU1 IDLE
    2     0     0   2   0 FIFO     Kthread   - Running            0000000000000000 0003024 0000760  25.1%  CPU2 IDLE
    3     0     0   3   0 FIFO     Kthread   - Running            0000000000000000 0003024 0000760  25.1%  CPU3 IDLE
    4     0     0 --- 100 RR       Kthread   - Waiting  Semaphore 0000000000000000 0001936 0000912  47.1%  lpwork 0x80400188 0x80400210
    6     6     0   0 100 RR       Task      - Running            0000000000000000 0002976 0002256  75.8%  /system/bin/init
nsh> dumpstack 0
[    8.240000] [CPU0] sched_dumpstack: backtrace| 0: 0xdeadbeefdeadbeef 0xdeadbeefdeadbeef 0xdeadbeefdeadbeef 0xdeadbeefdeadbeef 0xdeadbeefdeadbeef 0xdeadbeefdeadbeef 0xdeadbeefdeadbeef 0xdeadbeefdeadbeef
[    8.250000] [CPU0] sched_dumpstack: backtrace| 0: 0xdeadbeefdeadbeef 0xdeadbeefdeadbeef 0xdeadbeefdeadbeef 0xdeadbeefdeadbeef 0xdeadbeefdeadbeef 0xdeadbeefdeadbeef 0xdeadbeefdeadbeef
nsh> dumpstack 0
[    9.910000] [CPU1] sched_dumpstack: backtrace| 0: 0x000000008020e3da 0x000000008040c440 0x0000000080200b30 0x000000008020004a
nsh> dumpstack 1
[   12.020000] [CPU1] sched_dumpstack: backtrace| 1: 0x000000008020e3da 0x000000008040ce10 0x00000000802011c2 0x0000000080200b36 0x000000008020004a
nsh> dumpstack 1
[   14.690000] [CPU1] riscv_exception: EXCEPTION: Store/AMO page fault. MCAUSE: 000000000000000f, EPC: 000000008021e9e0, MTVAL: 00000000c0202a30
[   14.690000] [CPU1] riscv_fault_handler: PANIC!!! Exception = 000000000000000f
[   14.700000] [CPU1] dump_assert_info: Current Version: NuttX  13.0.0 2f73fe2267-dirty Jul 19 2026 17:53:49 risc-v
[   14.700000] [CPU1] dump_assert_info: Assertion failed panic: at file: :0 task(CPU1): CPU1 IDLE process: Kernel 0x80202448
```

After fix:

```
NuttShell (NSH) NuttX-13.0.0
nsh> ps
  TID   PID  PPID CPU PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK    USED FILLED COMMAND
    0     0     0   0   0 FIFO     Kthread   - Assigned           0000000000000000 0003024 0001360  44.9%  CPU0 IDLE
    1     0     0   1   0 FIFO     Kthread   - Running            0000000000000000 0003024 0001184  39.1%  CPU1 IDLE
    2     0     0   2   0 FIFO     Kthread   - Running            0000000000000000 0003024 0001280  42.3%  CPU2 IDLE
    3     0     0   3   0 FIFO     Kthread   - Running            0000000000000000 0003024 0000760  25.1%  CPU3 IDLE
    4     0     0 --- 100 RR       Kthread   - Waiting  Semaphore 0000000000000000 0001936 0000912  47.1%  lpwork 0x80400188 0x80400210
    6     6     0   0 100 RR       Task      - Running            0000000000000000 0002976 0002256  75.8%  /system/bin/init
nsh> dumpstack 0 10
[    4.160000] [CPU0] sched_dumpstack: backtrace| 0: 0x0000000080219886 0x00000000802038b0 0x0000000080201c92 0x0000000080202584 0x00000000802010a4 0x0000000080200ba6 0x00000000802001fe 0x000000008020e3dc
[    4.170000] [CPU0] sched_dumpstack: backtrace| 0: 0x0000000080202344 0x0000000080200b30 0x000000008020004a
[    4.170000] [CPU0] sched_dumpstack: backtrace| 1: 0x0000000080219886 0x00000000802038b0 0x0000000080201c92 0x0000000080202584 0x00000000802010a4 0x0000000080200ba6 0x00000000802001fe 0x000000008020e3dc
[    4.170000] [CPU0] sched_dumpstack: backtrace| 1: 0x0000000080202468 0x00000000802011c2 0x0000000080200b36 0x000000008020004a
[    4.170000] [CPU0] sched_dumpstack: backtrace| 2: 0x0000000080219886 0x00000000802038b0 0x0000000080201c92 0x0000000080202584 0x00000000802010a4 0x0000000080200ba6 0x00000000802001fe 0x000000008020e3dc
[    4.180000] [CPU0] sched_dumpstack: backtrace| 2: 0x0000000080202468 0x00000000802011c2 0x0000000080200b36 0x000000008020004a
[    4.180000] [CPU0] sched_dumpstack: backtrace| 3: 0x0000000080219886 0x00000000802038b0 0x0000000080201c92 0x0000000080202584 0x00000000802010a4 0x0000000080200ba6 0x00000000802001fe 0x000000008020e3dc
[    4.180000] [CPU0] sched_dumpstack: backtrace| 3: 0x0000000080202468 0x00000000802011c2 0x0000000080200b36 0x000000008020004a
[    4.190000] [CPU0] sched_dumpstack: backtrace| 4: 0x000000008020e276 0x0000000080219b38 0x000000008020ad40 0x000000008020ad64 0x0000000080204ce4 0x0000000080204540
[    4.190000] [CPU0] sched_dumpstack: backtrace| 6: 0x000000008020e276 0x000000008021a38c 0x000000008021ac46 0x00000000802195dc 0x0000000080219618 0x000000008020a8c6 0x0000000080200e6c 0x00000000802001aa
[    4.200000] [CPU0] sched_dumpstack: backtrace| 6: 0x00000000c000b4dc 0x00000000c0004c36 0x00000000c0002248 0x00000000c00031ec 0x00000000c00032c0 0x00000000c0001c7e 0x00000000c0001a94 0x00000000c00000f2
[    4.210000] [CPU0] sched_dumpstack: backtrace| 6: 0x00000000c00000ae
[    4.210000] [CPU0] sched_dumpstack: backtrace| 7: 0x00000000802198e4 0x000000008020a454 0x0000000080200e6c 0x00000000802001aa 0x00000000c0001df4 0x00000000c0000106 0x00000000c0000080 0x00000000c0000036
```

Regression-tested on `rv-virt:smp` (CONFIG_SMP without CONFIG_ARCH_ADDRENV), unaffected code path:

```
NuttShell (NSH) NuttX-13.0.0
nsh> ps
  TID   PID  PPID CPU PRI POLICY   TYPE    NPX STATE    EVENT       STACK    USED FILLED COMMAND
    0     0     0   0   0 FIFO     Kthread   - Assigned           0002016 0000748  37.1%  CPU0 IDLE
    1     0     0   1   0 FIFO     Kthread   - Running            0002016 0000860  42.6%  CPU1 IDLE
    2     0     0   2   0 FIFO     Kthread   - Running            0002016 0000484  24.0%  CPU2 IDLE
    3     0     0   3   0 FIFO     Kthread   - Running            0002016 0000484  24.0%  CPU3 IDLE
    4     0     0   4   0 FIFO     Kthread   - Running            0002016 0000484  24.0%  CPU4 IDLE
    5     0     0   5   0 FIFO     Kthread   - Running            0002016 0000484  24.0%  CPU5 IDLE
    6     0     0   6   0 FIFO     Kthread   - Running            0002016 0000484  24.0%  CPU6 IDLE
    7     0     0   7   0 FIFO     Kthread   - Running            0002016 0000484  24.0%  CPU7 IDLE
    9     9     0   0 100 RR       Task      - Running            0001976 0001976 100.0%! nsh_main
nsh> dumpstack 0 10
[CPU0] backtrace| 0: 0x80011ca0 0x80003496 0x80001fa2 0x80002602 0x800016d8 0x80001638 0x8000019a 0x8000a75a
[CPU0] backtrace| 0: 0x8002ee10 0x800015c8 0x80000048 0x8000a75a 0x8002ee10 0x800015c8 0x80000048
[CPU0] backtrace| 1: 0x80011ca0 0x80003496 0x80001fa2 0x80002602 0x800016d8 0x80001638 0x8000019a 0x8000a75a
[CPU0] backtrace| 1: 0x8002f470 0x80001798 0x800015cc 0x80000048 0x8000a75a 0x8002f470 0x80001798 0x800015cc
[CPU0] backtrace| 1: 0x80000048
[CPU0] backtrace| 2: 0x80011ca0 0x80003496 0x80001fa2 0x80002602 0x800016d8 0x80001638 0x8000019a 0x8000a75a
[CPU0] backtrace| 2: 0x8002fc70 0x80001798 0x800015cc 0x80000048 0x8000a75a 0x8002fc70 0x80001798 0x800015cc
[CPU0] backtrace| 2: 0x80000048
[CPU0] backtrace| 3: 0x80011ca0 0x80003496 0x80001fa2 0x80002602 0x800016d8 0x80001638 0x8000019a 0x8000a75a
[CPU0] backtrace| 3: 0x80030470 0x80001798 0x800015cc 0x80000048 0x8000a75a 0x80030470 0x80001798 0x800015cc
[CPU0] backtrace| 3: 0x80000048
[CPU0] backtrace| 4: 0x80011ca0 0x80003496 0x80001fa2 0x80002602 0x800016d8 0x80001638 0x8000019a 0x8000a75a
[CPU0] backtrace| 4: 0x80030c70 0x80001798 0x800015cc 0x80000048 0x8000a75a 0x80030c70 0x80001798 0x800015cc
[CPU0] backtrace| 4: 0x80000048
[CPU0] backtrace| 5: 0x80011ca0 0x80003496 0x80001fa2 0x80002602 0x800016d8 0x80001638 0x8000019a 0x8000a75a
[CPU0] backtrace| 5: 0x80031470 0x80001798 0x800015cc 0x80000048 0x8000a75a 0x80031470 0x80001798 0x800015cc
[CPU0] backtrace| 5: 0x80000048
[CPU0] backtrace| 6: 0x80011ca0 0x80003496 0x80001fa2 0x80002602 0x800016d8 0x80001638 0x8000019a 0x8000a75a
[CPU0] backtrace| 6: 0x80031c70 0x80001798 0x800015cc 0x80000048 0x8000a75a 0x80031c70 0x80001798 0x800015cc
[CPU0] backtrace| 6: 0x80000048
[CPU0] backtrace| 7: 0x80011ca0 0x80003496 0x80001fa2 0x80002602 0x800016d8 0x80001638 0x8000019a 0x8000a75a
[CPU0] backtrace| 7: 0x80032470 0x80001798 0x800015cc 0x80000048 0x8000a75a 0x80032470 0x80001798 0x800015cc
[CPU0] backtrace| 7: 0x80000048
[CPU0] backtrace| 9: 0x8000a6fe 0x80011f34 0x800083e4 0x80011b7e 0x80011b92 0x8000b82e 0x8000adce 0x8000b5ca
[CPU0] backtrace| 9: 0x8000b61e 0x8000a9e0 0x8000a80c 0x8000a7c8 0x8000827a 0x80003ebe
[CPU0] backtrace|10: 0x80011cf4 0x800081de 0x8001548e 0x8000827a 0x80003ebe
```

## Note on BACKTRACE_SCRATCH_DEPTH

The relay buffer is a fixed 32-entry array on the caller's stack, so requests deeper than 32 frames get silently truncated. We picked this over a multi-round IPI design because the multi-round version was noticeably more complex for little practical benefit. `sched_dumpstack()` stays well under 32 by chunking its own calls at 16 frames each, but `CONFIG_LIBC_MUTEX_BACKTRACE` (used for remote lock-holder backtraces) is a user-configurable depth with no upper bound, so a large enough value there would hit the truncation.