### PR TITLE
arch/risc-v/espressif: Fix build errors on CMake ULP build system

### DIFF
--- a/arch/risc-v/src/common/espressif/CMakeLists.txt
+++ b/arch/risc-v/src/common/espressif/CMakeLists.txt
@@ -202,7 +202,9 @@ if(CONFIG_ESPRESSIF_USE_LP_CORE)
   list(APPEND SRCS esp_ulp.c)
 endif()
 
-# if(CONFIG_ESPRESSIF_LP_MAILBOX) list(APPEND SRCS esp_lp_mailbox.c) endif()
+if(CONFIG_ESPRESSIF_LP_MAILBOX)
+  list(APPEND SRCS esp_lp_mailbox.c)
+endif()
 
 if(CONFIG_PM)
   if(NOT CONFIG_ARCH_CUSTOM_PMINIT)

--- a/arch/risc-v/src/common/espressif/esp_ulp.cmake
+++ b/arch/risc-v/src/common/espressif/esp_ulp.cmake
@@ -378,6 +378,7 @@ if(CONFIG_ESPRESSIF_USE_LP_CORE)
     target_compile_options(
       ${ULP_FIRMWARE_TARGET}
       PRIVATE ${ULP_COMPILE_OPTS}
+              -U__NuttX__
               -include
               ${HAL}/nuttx/${CHIP_SERIES}/include/sdkconfig.h
               -Wno-shadow

--- a/arch/risc-v/src/esp32p4/hal_esp32p4.cmake
+++ b/arch/risc-v/src/esp32p4/hal_esp32p4.cmake
@@ -434,6 +434,8 @@ list(
   ${ESP_HAL_3RDPARTY_REPO}/components/ulp/lp_core/lp_core_i2c.c
   ${ESP_HAL_3RDPARTY_REPO}/components/ulp/lp_core/lp_core_spi.c
   ${ESP_HAL_3RDPARTY_REPO}/components/ulp/lp_core/lp_core.c
+  ${ESP_HAL_3RDPARTY_REPO}/components/ulp/lp_core/lp_core_mailbox.c
+  ${ESP_HAL_3RDPARTY_REPO}/components/ulp/lp_core/lp_core_mailbox_impl_hw.c
   ${ESP_HAL_3RDPARTY_REPO}/components/ulp/lp_core/shared/ulp_lp_core_memory_shared.c
   ${ESP_HAL_3RDPARTY_REPO}/components/ulp/lp_core/shared/ulp_lp_core_lp_timer_shared.c
   ${ESP_HAL_3RDPARTY_REPO}/components/upper_hal_ana_cmpr/ana_cmpr.c


### PR DESCRIPTION
## Summary

<!-- This field should contain a summary of the changes. It will be pre-filled with the commit's message and descriptions. Adjust it accordingly -->

* arch/risc-v/espressif: Fix build errors on CMake ULP build system

Fix build errors on ULP usage with CMake (e.g lp_mailbox usage, hal assertions enabled)

## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: Yes, build error fixed
<!-- Does it impact user's applications? How? -->

Impact on build: Yes, ULP build error fixed when using CMake
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: No
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: No
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: No
<!-- Does it impact NuttX's security? -->

Impact on compatibility: No
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

## Testing
<!-- Please provide all the testing procedure. Consider that upstream reviewers should be able to reproduce the same testing performed internally -->

`esp32p4-function-ev-board:ulp` config used to test.

### Building
<!-- Provide how to build the test for each SoC being tested -->


```
.
└── nuttxspace/
    ├── nuttx
    └── apps/
        └── external/
            ├── ...
            └── ulp_test/
                ├── Kconfig
                ├── CMakeLists.txt
                ├── ulp_test_main.c
                └── ulp/
                    ├── CMakeLists.txt
                    └── ulp_blink.c
```

Contents of the files:


- Kconfig:
```
config ULP_TEST_APP
	bool "ULP test app"
	default n
```

- CMakeLists.txt:
```
   include(ulp/CMakeLists.txt)
   nuttx_add_application(
      NAME
      ${CONFIG_EXAMPLES_ULP_EXAMPLE_PROGNAME}
      PRIORITY
      ${SCHED_PRIORITY_DEFAULT}
      STACKSIZE
      ${CONFIG_DEFAULT_TASK_STACKSIZE}
      MODULE
      ${CONFIG_EXAMPLES_ULP_EXAMPLE}
      INCLUDE_DIRECTORIES
      ${CMAKE_CURRENT_BINARY_DIR}
      SRCS
      ulp_example.c
      DEPENDS
      ${_ulp_example_deps})
```

- ulp_test_main.c:

```
#include <nuttx/config.h>
#include <errno.h>
#include <fcntl.h>
#include <inttypes.h>
#include <stdio.h>
#include <unistd.h>

#include <nuttx/fs/ioctl.h>
#include <sys/ioctl.h>

#include "ulp/ulp/ulp_main.h"
#include "ulp/ulp/ulp_code.h"


int main(int argc, char *argv[])
{
  int fd;
  int mailbox;
  uint8_t data = 0;
  int ret = OK;
  int prev_data;

  fd = open("/dev/ulp", O_WRONLY);
  if (fd < 0)
    {
      printf("Failed to open ULP: %d\n", errno);
      return -1;
    }

  write(fd, ulp_mailbox_bin, ulp_mailbox_bin_len);

  mailbox = open("/dev/lp_mailbox", O_RDWR);
  if (mailbox < 0)
    {
      printf("Failed to open LP Mailbox: %d\n", errno);
      return -1;
    }

  /* Waiting for a while to let ULP start to run */

  sleep(3);
  for (int i = 0; i < 2; i++)
    {
      ret = write(mailbox, &data, 1);
      if (ret != 1)
        {
          printf("Failed to send data\n");
          return ERROR;
        }

      prev_data = data;
      ret = read(mailbox, &data, 1);
      if (ret != 1 || (prev_data + 1 != data))
        {
          printf("Failed to read data\n");
          return ERROR;
        }
      else
        {
          printf("Read data: %d\n", data);
        }

      sleep(1);
    }

  printf("All done.\n");
  return OK;
}
```

- ulp/CMakeLists.txt:
```
    set(_ulp_example_deps)
    set(ULP_APP_NAME ulp_example)
    set(ULP_APP_FOLDER ${CMAKE_CURRENT_LIST_DIR}/ulp)
    set(ULP_APP_C_SRCS ulp_main.c)
    include(${NUTTX_DIR}/arch/risc-v/src/common/espressif/esp_ulp.cmake)
    list(APPEND _ulp_example_deps ulp_example_ulp_bin)
```

- ulp/ulp_blink.c
```
#include <stdint.h>
#include "nuttx/config.h"
#include <stdbool.h>
#include <stdint.h>
#include "ulp_lp_core_utils.h"
#include "ulp_lp_core_mailbox.h"

#define nop()   __asm__ __volatile__ ("nop")

static lp_mailbox_t mailbox;

int main(void)
{
  lp_core_mailbox_init(&mailbox, NULL);
  lp_message_t message;
  esp_err_t ret;

  while (1)
    {
      ret = lp_core_mailbox_receive(mailbox, &message, UINT32_MAX);

      if (ret == ESP_OK)
        {
          message = message + 1;
          ret = lp_core_mailbox_send(mailbox, message, UINT32_MAX);
        }

      for (int i = 0; i < 100; i++)
        {
          nop();
        }
    }

  return 0;
}
```

Command to build ULP example:

```
cmake -B build -DBOARD_CONFIG=esp32p4-function-ev-board:ulp -GNinja && kconfig-tweak --file build/.config -e CONFIG_ESPRESSIF_GPIO_IRQ && kconfig-tweak --file build/.config -e CONFIG_DEV_GPIO && kconfig-tweak --file build/.config -e CONFIG_ESPRESSIF_USE_LP_CORE && kconfig-tweak --file build/.config -e CONFIG_EXAMPLES_ULP_EXAMPLE && kconfig-tweak --file build/.config -e CONFIG_ESPRESSIF_LP_MAILBOX && cmake --build build -t olddefconfig && cmake --build build && ESPTOOL_PORT=/dev/ttyUSB0 cmake --build build -t flash
```

### Running
<!-- Provide how to run the test for each SoC being tested -->

`ulp_test` command used to run.

### Results
<!-- Provide tests' results and runtime logs -->

Blink will start on startup

For ULP example:

```
nsh> ls /dev
/dev:
...
 lp_mailbox
...
nsh> custom_app
Read data: 1
Read data: 2
All done.
nsh> 
```
