### PR TITLE
arch/arm: set PSPLIM to top of TLS region to protect it from overflow

### DIFF
--- a/arch/arm/src/armv8-m/arm_initialstate.c
+++ b/arch/arm/src/armv8-m/arm_initialstate.c
@@ -31,6 +31,7 @@
 #include <string.h>
 
 #include <nuttx/arch.h>
+#include <tls/tls.h>
 #include <arch/armv8-m/nvicpri.h>
 
 #include "arm_internal.h"
@@ -106,9 +107,13 @@ void up_initial_state(struct tcb_s *tcb)
 #endif
 
 #ifdef CONFIG_ARMV8M_STACKCHECK_HARDWARE
-  /* Save the stack limit value, will be used in context switch. */
+  /* Save the stack limit (restored on context switch) at the top of the
+   * TLS region. The stack grows downward and TLS occupies the bottom of
+   * the allocation, so an overflow faults here before it clobbers TLS
+   * data instead of silently corrupting it first.
+   */
 
-  xcp->regs[REG_SPLIM]   = (uint32_t)tcb->stack_alloc_ptr;
+  xcp->regs[REG_SPLIM]   = (uint32_t)tcb->stack_alloc_ptr + tls_info_size();
 #endif
 
   /* Save the task entry point (stripping off the thumb bit) */


### PR DESCRIPTION
## Summary

A crash was observed when running `ps`: a BusFault in nxtask_argvstr
dereferencing tl_argv, because a thread's stack overflow had silently
corrupted the TLS region where tl_argv resides.

On ARMv8-M with CONFIG_ARMV8M_STACKCHECK_HARDWARE, PSPLIM was set to
stack_alloc_ptr -- the bottom of the stack allocation where TLS begins.
The stack grows downward, and TLS occupies [stack_alloc_ptr,
stack_alloc_ptr + tls_info_size()), so an overflow crossed into TLS and
clobbered tl_argv before SP ever reached the limit. The overflow went
undetected and only surfaced later as an unrelated BusFault in code
that read the corrupted TLS data (such as ps iterating the task list).

Set the limit to stack_alloc_ptr + tls_info_size() -- the top of the
TLS region and the usable stack base -- so an overflow faults at the
TLS boundary, before any TLS byte is touched. Include <tls/tls.h> for
the tls_info_size() macro, which is the value sched reserves for the
TLS region via up_stack_frame().

## Impact

 Behavior change only for overflowing threads -- a thread
  that previously overflowed silently into TLS now triggers an immediate
  Stack Overflow fault at the offending function. Well-behaved threads
  are unaffected; usable stack size is unchanged (TLS already occupied
  those bytes).

## Testing

Built on the upstream nuttx tree (Ubuntu, arm-none-eabi-gcc 13.2.1) for
stm32l562e-dk:nsh (Cortex-M33, ARMv8-M). The change is under
#ifdef CONFIG_ARMV8M_STACKCHECK_HARDWARE, which is off by default, so it
must be enabled to exercise the code:
```bash
  $ make distclean
  $ tools/configure.sh -l stm32l562e-dk:nsh
  $ sed -i 's|^# CONFIG_ARMV8M_STACKCHECK_HARDWARE is not set|CONFIG_ARMV8M_STACKCHECK_HARDWARE=y|' .config
  $ make olddefconfig
  $ make -j20
  LD: nuttx
  Memory region         Used Size  Region Size  %age Used
             flash:      190832 B      1015 KB     18.36%
              sram:        9704 B       192 KB      4.94%
  CP: nuttx.bin
  $ ls -la nuttx nuttx.bin
  -rwxrwxr-x 1 mi mi 2124048 Jul 20 17:37 nuttx
  -rwxrwxr-x 1 mi mi  190832 Jul 20 17:37 nuttx.bin
```

This makes a stack overflow fault at its source, so on hardware the
offending task is surfaced immediately and the root cause (insufficient
stack) is fixed by enlarging the stack -- caught proactively, rather
than only appearing later as a delayed BusFault in ps when it reads the
corrupted TLS.