### PR TITLE
ci: exclude esp32p5-tab5:python from CI

### DIFF
--- a/tools/ci/testlist/risc-v-03.dat
+++ b/tools/ci/testlist/risc-v-03.dat
@@ -2,3 +2,4 @@
 /risc-v/esp32[d-z]*
 -esp32p4-function-ev-board:python
 -esp32p4-function-ev-board:webpanel
+-esp32p4-tab5:python


### PR DESCRIPTION
*ci: exclude esp32p5-tab5:python from CI

Ignores Python defconfig from esp32p4-tab5 board.
Python builds are excluded due to its long build time.

## Summary

Removes the Python build for `esp32p4-tab5` board due to long build times.

## Testing

Verify CI log build.