### PR TITLE
arch/arm/stm32h7: fix MDIO RDA field in c22 write

### DIFF
--- a/arch/arm/src/stm32h7/stm32_mdio.c
+++ b/arch/arm/src/stm32h7/stm32_mdio.c
@@ -179,7 +179,7 @@ static int stm32_c22_write(struct mdio_lowerhalf_s *dev, uint8_t phydev,
 
   regval |= (((uint32_t)phydev << ETH_MACMDIOAR_PA_SHIFT) &
             ETH_MACMDIOAR_PA_MASK);
-  regval |= (((uint32_t)phydev << ETH_MACMDIOAR_RDA_SHIFT) &
+  regval |= (((uint32_t)regaddr << ETH_MACMDIOAR_RDA_SHIFT) &
             ETH_MACMDIOAR_RDA_MASK);
   regval |= (ETH_MACMDIOAR_MB | ETH_MACMDIOAR_GOC_WRITE);
 


### PR DESCRIPTION
## Summary

Finally I've managed to get some time to submit the changes discussed in [16999](https://github.com/apache/nuttx/pull/16999#discussion_r3428427437).

During mdio bus development I've overlooked some implementation details:

1. I've copy-pasted existing code that used the wrong register. basically this PR swaps `phydev` with `regaddr `
2. @ppisa already addressed the other mdio bus issue, embedding the `mdio_lowerhalf_s` instance in `stm32_mdio_lowerhalf_s`

@zkkkk12 Please have an look. Also check the changes added by @ppisa 

## Testing

```console
NuttShell (NSH) NuttX-13.0.0
nsh> ?
help usage:  help [-v] [<cmd>]

    .           cd          exit        mkfatfs     rmdir       true
    [           cp          expr        mkrd        route       truncate
    ?           cmp         false       mount       set         uname
    addroute    dirname     fdinfo      mv          kill        umount
    alias       delroute    free        nslookup    pkill       unset
    unalias     df          help        pidof       sleep       uptime
    arp         dmesg       hexdump     printf      usleep      watch
    basename    echo        ifconfig    ps          source      wget
    break       env         ls          pwd         test        xd
    cat         exec        mkdir       rm          time        wait

Builtin Apps:
    dd         nsh        ping       renew      sh         telnetd
nsh> ifconfig
eth0    Link encap:Ethernet HWaddr 12:8a:41:a8:2a:93 at RUNNING mtu 1486
        inet addr:192.168.88.249 DRaddr:192.168.88.1 Mask:255.255.255.0

lo      Link encap:Local Loopback at RUNNING mtu 1518
        inet addr:127.0.0.1 DRaddr:127.0.0.1 Mask:255.0.0.0

             IPv4   TCP   UDP  ICMP
Received     0004  0000  0004  0000
Dropped      0000  0000  0000  0000
  IPv4        VHL: 0000   Frg: 0000
  Checksum   0000  0000  0000  ----
  TCP         ACK: 0000   SYN: 0000
              RST: 0000  0000
  Type       0000  ----  ----  0000
Sent         0004  0000  0004  0000
  Rexmit     ----  0000  ----  ----
```

```console
nsh> ping -c3 8.8.8.8
PING 8.8.8.8 56 bytes of data
56 bytes from 8.8.8.8: icmp_seq=0 time=30.0 ms
56 bytes from 8.8.8.8: icmp_seq=1 time=20.0 ms
56 bytes from 8.8.8.8: icmp_seq=2 time=20.0 ms
3 packets transmitted, 3 received, 0% packet loss, time 3030 ms
rtt min/avg/max/mdev = 20.000/23.333/30.000/4.715 ms
```
