### PR TITLE
lib/math32: Avoid __uint128_t casts for LDC ImportC

### DIFF
--- a/include/nuttx/lib/math32.h
+++ b/include/nuttx/lib/math32.h
@@ -495,7 +495,8 @@ static inline_function uint64_t invdiv_umulh64(uint64_t a, uint64_t b)
    * the inline assembly.
    */
 
-  __uint128_t res128 = (__uint128_t)a * b;
+  __uint128_t a128 = a;
+  __uint128_t res128 = a128 * b;
   return res128 >> 64;
 #endif
 }
@@ -542,7 +543,8 @@ void invdiv_init_param64(uint64_t d, FAR invdiv_param64_t *param)
 
   param->mult = q[0] + 1;
 #else
-  param->mult  = ((__uint128_t)1 << 64) * t / d + 1;
+  __uint128_t one128 = 1;
+  param->mult = (one128 << 64) * t / d + 1;
 #endif
   param->shift = l - 1;
 }


### PR DESCRIPTION
## Summary

Building the `hello_d` example with LDC ImportC fails because ImportC does not correctly handle direct `__uint128_t` C-style casts such as `(__uint128_t)a` and `(__uint128_t)1` used in `include/nuttx/lib/math32.h`.

These expressions compile successfully with the existing implementation, but ImportC fails while parsing them, preventing the D example from building.

Rewrite the affected expressions to initialize `__uint128_t` variables first and then perform the arithmetic. This preserves the existing behavior while allowing the code to compile successfully with LDC ImportC.

## Impact

Rewrite the two direct `__uint128_t` cast expressions in `math32.h` to use initialized `__uint128_t` variables before the arithmetic operations.

The computation remains unchanged while avoiding the current ImportC parser limitation.

## Testing

**Host:** WSL2 Ubuntu 24.04 x86_64

**Configuration:** `sim:nsh`

Enabled `CONFIG_EXAMPLES_HELLO_D`.

Before this change, the build failed while compiling `include/nuttx/lib/math32.h` with LDC ImportC.

After applying this change, the project built successfully.

Verified the application from NSH:

```text
nsh> hello_d
Hello World, [skylake]!
hello_d_main: Saying hello from the dynamically constructed instance
HelloWorld: mSecret=1630678024
DHelloWorld.HelloWorld: CONSTRUCTION FAILED!
Constructor
hello_d_main: Saying hello from the instance constructed on the stack
HelloWorld: mSecret=42
DHelloWorld.HelloWorld: Hello, World!!
Destructor
```