### PR TITLE
fs/vfs: Add ioctldir for volume ioctls via the mountpoint directory.

### DIFF
--- a/Documentation/components/filesystem/index.rst
+++ b/Documentation/components/filesystem/index.rst
@@ -502,10 +502,43 @@ belonging to a unified interface:
 
   This works like ``sync()`` but instead of the file, it syncs the entire
   filesystem's metadata.
-  
+
   :param FAR struct inode * mountpt: Mount point inode of the file system.
   :returns: Status of syncing file system metadata operation.
   :retval OK (0): Success.
+  :retval < 0: Error.
+
+.. c:function:: int ioctldir(FAR struct inode *mountpt, FAR struct fs_dirent_s *dir, int cmd, unsigned long arg)
+
+  Carries out an ioctl command issued on a descriptor for the mountpoint
+  directory rather than on a file inside the volume. It takes the same
+  ``(mountpt, dir)`` pair as the other directory operations. Typical commands
+  act on the volume as a whole rather than on any one open file, such as
+  ``FIOC_REFORMAT``, ``FIOC_OPTIMIZE`` or ``FIOC_INTEGRITY``.
+
+  The command reaches this method when it is issued on a descriptor for the
+  mountpoint directory, which the caller obtains with
+  ``open(mountpoint, O_RDONLY | O_DIRECTORY)``. No file inside the volume
+  needs to be open, which matters for commands that a file system refuses to
+  perform while one is.
+
+  The method is consulted before the VFS acts on the command, so it must
+  answer ``-ENOTTY`` for anything it does not recognize; the VFS then applies
+  its own handling.
+
+  This method is optional. A file system that leaves it ``NULL`` behaves as
+  before: the VFS answers ``-ENOTTY`` for any command on a directory
+  descriptor that it does not handle itself.
+
+  :param FAR struct inode * mountpt: Mount point inode of the file system.
+  :param FAR struct fs_dirent_s * dir: The open mountpoint directory the
+    command was issued on.
+  :param int cmd: The command to carry out, as defined in
+    ``include/nuttx/fs/ioctl.h``.
+  :param unsigned long arg: Additional argument, if the command requires one.
+  :returns: Status of the ioctl operation.
+  :retval OK (0): Success.
+  :retval -ENOTTY: The file system does not recognize the command.
   :retval < 0: Error.
 
 

--- a/Documentation/components/filesystem/nxffs.rst
+++ b/Documentation/components/filesystem/nxffs.rst
@@ -143,6 +143,18 @@ The file system supports to ioctls:
   file system will increase the amount of wear on the FLASH if you use this
   frequently!
 
+Both act on the volume rather than on any one file, so issue them on a
+descriptor for the mountpoint directory::
+
+    int fd = open("/mnt/nxffs", O_RDONLY | O_DIRECTORY);
+    ioctl(fd, FIOC_REFORMAT, 0);
+    close(fd);
+
+``FIOC_REFORMAT`` in particular is only reachable this way.  It refuses to
+run while any file on the volume is open, so issuing it on a descriptor for
+a file *inside* the volume can never succeed -- that descriptor is itself
+such a file, and the request returns ``-EBUSY``.
+
 Things to Do
 ============
 

--- a/fs/nxffs/nxffs.h
+++ b/fs/nxffs/nxffs.h
@@ -1094,6 +1094,8 @@ ssize_t nxffs_read(FAR struct file *filep, FAR char *buffer, size_t buflen);
 ssize_t nxffs_write(FAR struct file *filep, FAR const char *buffer,
                     size_t buflen);
 int nxffs_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
+int nxffs_ioctldir(FAR struct inode *mountpt, FAR struct fs_dirent_s *dir,
+                   int cmd, unsigned long arg);
 
 int nxffs_dup(FAR const struct file *oldp, FAR struct file *newp);
 int nxffs_fstat(FAR const struct file *filep, FAR struct stat *buf);

--- a/fs/nxffs/nxffs_initialize.c
+++ b/fs/nxffs/nxffs_initialize.c
@@ -86,7 +86,9 @@ const struct mountpt_operations g_nxffs_operations =
   NULL,              /* rmdir -- no directories */
   NULL,              /* rename -- cannot rename in place if name is longer */
   nxffs_stat,        /* stat */
-  NULL               /* chstat */
+  NULL,              /* chstat */
+  NULL,              /* syncfs */
+  nxffs_ioctldir     /* ioctldir */
 };
 
 /****************************************************************************

--- a/fs/nxffs/nxffs_ioctl.c
+++ b/fs/nxffs/nxffs_ioctl.c
@@ -38,32 +38,22 @@
 #include "nxffs.h"
 
 /****************************************************************************
- * Public Functions
+ * Private Functions
  ****************************************************************************/
 
 /****************************************************************************
- * Name: nxffs_ioctl
+ * Name: nxffs_volume_cmd
  *
  * Description:
- *   Standard mountpoint ioctl method.
+ *   Carry out an ioctl against the volume.  Shared by the per-file and the
+ *   per-volume entry points, which differ only in how they name the volume.
  *
  ****************************************************************************/
 
-int nxffs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
+static int nxffs_volume_cmd(FAR struct nxffs_volume_s *volume, int cmd,
+                            unsigned long arg)
 {
-  FAR struct nxffs_volume_s *volume;
   int ret;
-
-  finfo("cmd: %d arg: %08lx\n", cmd, arg);
-
-  /* Sanity checks */
-
-  DEBUGASSERT(filep->f_priv != NULL);
-
-  /* Recover the file system state from the open file */
-
-  volume = filep->f_inode->i_private;
-  DEBUGASSERT(volume != NULL);
 
   /* Get exclusive access to the volume.  Note that the volume lock
    * protects the open file list.
@@ -73,7 +63,7 @@ int nxffs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
   if (ret < 0)
     {
       ferr("ERROR: nxmutex_lock failed: %d\n", ret);
-      goto errout;
+      return ret;
     }
 
   /* Only a reformat and optimize commands are supported */
@@ -113,6 +103,62 @@ int nxffs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 
 errout_with_lock:
   nxmutex_unlock(&volume->lock);
-errout:
   return ret;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: nxffs_ioctl
+ *
+ * Description:
+ *   Standard mountpoint ioctl method.
+ *
+ ****************************************************************************/
+
+int nxffs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
+{
+  FAR struct nxffs_volume_s *volume;
+
+  finfo("cmd: %d arg: %08lx\n", cmd, arg);
+
+  /* Sanity checks */
+
+  DEBUGASSERT(filep->f_priv != NULL);
+
+  /* Recover the file system state from the open file */
+
+  volume = filep->f_inode->i_private;
+  DEBUGASSERT(volume != NULL);
+
+  return nxffs_volume_cmd(volume, cmd, arg);
+}
+
+/****************************************************************************
+ * Name: nxffs_ioctldir
+ *
+ * Description:
+ *   ioctl method for a descriptor on the mountpoint directory.
+ *   FIOC_REFORMAT is only reachable this way: it refuses to run while any
+ *   file on the volume is open, and the per-file method is itself such a
+ *   file.  The open directory is not needed -- the volume is recovered from
+ *   the mountpoint inode -- so dir is unused.
+ *
+ ****************************************************************************/
+
+int nxffs_ioctldir(FAR struct inode *mountpt, FAR struct fs_dirent_s *dir,
+                   int cmd, unsigned long arg)
+{
+  FAR struct nxffs_volume_s *volume;
+
+  UNUSED(dir);
+
+  finfo("cmd: %d arg: %08lx\n", cmd, arg);
+
+  volume = mountpt->i_private;
+  DEBUGASSERT(volume != NULL);
+
+  return nxffs_volume_cmd(volume, cmd, arg);
 }

--- a/fs/vfs/fs_dir.c
+++ b/fs/vfs/fs_dir.c
@@ -556,15 +556,34 @@ static off_t dir_seek(FAR struct file *filep, off_t offset, int whence)
 static int dir_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
 {
   FAR struct fs_dirent_s *dir = filep->f_priv;
-  int ret = OK;
+  int ret = -ENOTTY;
 
-  if (cmd == FIOC_FILEPATH)
+#ifndef CONFIG_DISABLE_MOUNTPOINT
+  /* If this directory belongs to a mounted volume whose file system offers
+   * volume-wide commands, give it the first chance:  it is the one route to
+   * them that does not require an unrelated file to be open.  Anything the
+   * file system does not recognize falls through to the VFS defaults.
+   */
+
+  if (INODE_IS_MOUNTPT(dir->fd_root) &&
+      dir->fd_root->u.i_mops != NULL &&
+      dir->fd_root->u.i_mops->ioctldir != NULL)
     {
-      strlcpy((FAR char *)(uintptr_t)arg, dir->fd_path, PATH_MAX);
+      ret = dir->fd_root->u.i_mops->ioctldir(dir->fd_root, dir, cmd, arg);
     }
-  else if (cmd != BIOC_FLUSH)
+#endif
+
+  if (ret == -ENOTTY)
     {
-      ret = -ENOTTY;
+      if (cmd == FIOC_FILEPATH)
+        {
+          strlcpy((FAR char *)(uintptr_t)arg, dir->fd_path, PATH_MAX);
+          ret = OK;
+        }
+      else if (cmd == BIOC_FLUSH)
+        {
+          ret = OK;
+        }
     }
 
   return ret;

--- a/include/nuttx/fs/fs.h
+++ b/include/nuttx/fs/fs.h
@@ -360,6 +360,33 @@ struct mountpt_operations
   CODE int     (*chstat)(FAR struct inode *mountpt, FAR const char *relpath,
                          FAR const struct stat *buf, int flags);
   CODE int     (*syncfs)(FAR struct inode *mountpt);
+
+  /* ioctl issued on a descriptor for the mountpoint directory rather than
+   * on a file inside the volume.  It belongs with the directory operations
+   * above -- it takes the same (mountpt, dir) pair as opendir/readdir -- but
+   * is placed here at the end so the positional initialisers every file
+   * system uses stay unchanged; a file system that does not implement it
+   * simply leaves the slot NULL.
+   *
+   * Commands such as FIOC_REFORMAT, FIOC_OPTIMIZE and FIOC_INTEGRITY act on
+   * the volume, not on any one file, but the only route to a file system
+   * has historically been the per-file ioctl method.  That forces a caller
+   * to open an unrelated file just to name the volume, and a file system
+   * whose volume operation is incompatible with an open file then cannot
+   * implement the command at all.
+   *
+   * A file system that has such commands implements this method; the ioctl
+   * arrives with the mountpoint inode and the open directory, and no open
+   * file in sight.  It is consulted before the VFS acts on the command, so
+   * it must answer -ENOTTY for anything it does not recognise; the VFS then
+   * applies its own handling.  Leaving it NULL keeps the previous behaviour,
+   * in which the VFS answers -ENOTTY for any command it does not handle
+   * itself.
+   */
+
+  CODE int     (*ioctldir)(FAR struct inode *mountpt,
+                           FAR struct fs_dirent_s *dir,
+                           int cmd, unsigned long arg);
 };
 #endif /* CONFIG_DISABLE_MOUNTPOINT */
 


### PR DESCRIPTION
## Summary

Some ioctl commands act on a volume rather than on a file — `FIOC_REFORMAT`,
`FIOC_OPTIMIZE`, `FIOC_INTEGRITY`, `FIOC_DUMP`. The only route into a file
system, though, has been the per-file `ioctl` method, so a caller has to open
an unrelated file just to name the volume it means.

**For NXFFS that is not merely awkward, it is a dead end.** `nxffs_ioctl()`
refuses `FIOC_REFORMAT` while any file on the volume is open:

```c
/* We cannot reformat the volume if there are any open inodes */

if (volume->ofiles)
  {
    ferr("ERROR: Open files\n");
    ret = -EBUSY;
    goto errout_with_lock;
  }
```

and `nxffs_open()` puts every opened file on exactly that list:

```c
ofile->flink   = volume->ofiles;
volume->ofiles = ofile;
```

The descriptor used to issue the command is itself an open file on the
volume, so the check can never pass. `FIOC_REFORMAT` is documented,
implemented, and impossible to invoke.

This adds an optional `ioctldir` method to `struct mountpt_operations`,
reached by issuing the ioctl on a descriptor for the mountpoint directory:

```c
int fd = open("/mnt/nxffs", O_RDONLY | O_DIRECTORY);
ioctl(fd, FIOC_REFORMAT, 0);
close(fd);
```

```c
CODE int (*ioctldir)(FAR struct inode *mountpt,
                     FAR struct fs_dirent_s *dir,
                     int cmd, unsigned long arg);
```

The method takes the same `(mountpt, dir)` pair as `opendir`/`readdir`/
`rewinddir`, so it reads as a member of the directory-operations family; a
file system recovers the volume from the mountpoint inode and may ignore
`dir` (NXFFS does). It is placed at the **end** of the structure rather than
beside the other directory operations on purpose — see Impact.

`dir_ioctl()` forwards any command it does not handle itself to that method,
when the directory belongs to a mounted volume and the file system supplies
one. NXFFS implements it, which is what makes its `FIOC_REFORMAT` reachable.

**Why a new method rather than reusing `ioctl`.** The obvious alternative —
have `dir_ioctl()` call the existing per-file method — is not safe. That
method takes a `struct file`, and the implementations dereference
`filep->f_priv` after asserting on it:

```
fs/fat/fs_fat32.c:1733          DEBUGASSERT(filep->f_priv != NULL);
fs/romfs/fs_romfs.c:597         DEBUGASSERT(filep->f_priv != NULL);
fs/tmpfs/fs_tmpfs.c:2007        DEBUGASSERT(filep->f_priv != NULL);
fs/spiffs/src/spiffs_vfs.c:945  DEBUGASSERT(filep->f_priv != NULL);
```

A directory descriptor has no open file behind it, so forwarding into those
would assert or fault. A separate entry point keeps that contract intact and
makes support explicit rather than assumed.

| File | Change |
|---|---|
| `include/nuttx/fs/fs.h` | `ioctldir` added to `struct mountpt_operations` |
| `fs/vfs/fs_dir.c` | `dir_ioctl()` forwards unhandled commands to it |
| `fs/nxffs/nxffs_ioctl.c` | shared implementation; per-file and per-directory entry points |
| `fs/nxffs/nxffs_initialize.c` | registers the method |
| `fs/nxffs/nxffs.h` | declaration |
| `Documentation/components/filesystem/index.rst` | documents the new VFS method |
| `Documentation/components/filesystem/nxffs.rst` | documents how to reach the two ioctls, and why `FIOC_REFORMAT` needs this route |

## Impact

**Users:** additive. A new way to reach volume-wide ioctls; nothing that
works today changes. NXFFS keeps its per-file path, and both entry points
share one implementation. `FIOC_REFORMAT` on NXFFS becomes usable for the
first time.

**File systems:** the new member is appended at the **end** of
`struct mountpt_operations`, so the positional initialisers every file
system uses are unchanged — several already stop short of the end of the
structure today and continue to compile untouched. A file system that leaves
it `NULL` behaves exactly as before: the VFS answers `-ENOTTY` for any
command on a directory descriptor it does not handle itself.

Although `ioctldir` belongs conceptually with the directory operations
(`opendir`…`rewinddir`), it is placed at the end rather than beside them
precisely for this reason: all 21 in-tree filesystems initialise
`mountpt_operations` positionally, so a member inserted mid-structure would
force every one of them to add a `NULL` slot for a method it does not
implement. Appending keeps the change to the single filesystem that uses it.

**Build / hardware / security:** no build system changes, no hardware
dependency, no new configuration options. No change to any syscall
signature or user-visible ABI.

**Documentation:** updated in this PR, both the VFS method reference and the
NXFFS page.

**Compatibility:** no behavioural change for any existing caller. The
forwarding only happens for commands that previously returned `-ENOTTY`.

## Testing

**Host:** macOS 15 (Darwin 25.5.0), Apple silicon.
**Target:** `sim:nxffs` (simulator).

A test was written that exercises both routes on one volume: create a file,
issue `FIOC_REFORMAT` through a descriptor on that file, then through a
descriptor on the mountpoint directory, then issue an unrecognised command
on the directory to confirm it is still refused.

On `master` — the directory route does not exist, so the command is
unreachable by any means:

```
via file fd:      ret=-1 errno=16 (EBUSY, as expected)
via directory fd: ret=-1 errno=25
bogus cmd on dir: ret=-1 errno=25
```

With this change, same test, same configuration:

```
via file fd:      ret=-1 errno=16 (EBUSY, as expected)
via directory fd: ret=0 errno=0 (reformatted)
bogus cmd on dir: ret=-1 errno=25
```

The first line is unchanged, confirming the per-file path still behaves as
it always did. The second shows the command now succeeds. The third confirms
an unrecognised command on a directory descriptor is still refused with
`-ENOTTY`, so the forwarding did not turn `dir_ioctl()` into a catch-all.

The existing NXFFS test (`CONFIG_TESTING_NXFFS`, 100 loops of fill/delete/
verify against the simulated MTD) was run on `sim:nxffs` and passes
unchanged.

`tools/checkpatch.sh -f` passes on every changed file.

## Follow-up, not in this PR

SPIFFS implements `FIOC_INTEGRITY`, `FIOC_REFORMAT`, `FIOC_OPTIMIZE` and
`FIOC_DUMP` with the same shape and can adopt the method the same way. It is
left out here to keep the change reviewable, and because NXFFS is the case
where the command is currently unreachable rather than merely awkward.

