### PR TITLE
libs/libbuiltin/compiler-rt: skip unsupported Arm VFP builtins asm

### DIFF
--- a/libs/libbuiltin/compiler-rt/CMakeLists.txt
+++ b/libs/libbuiltin/compiler-rt/CMakeLists.txt
@@ -114,6 +114,45 @@ if(CONFIG_BUILTIN_COMPILER_RT)
     list(REMOVE_ITEM RT_BUILTINS_SRCS ${x86_80_BIT_SOURCES})
   endif()
 
+  # The Arm builtins ship hand-written VFP assembly whose FPU requirements the
+  # globs above ignore, so assemble only the files the configured FPU supports
+  # (upstream compiler-rt selects them conditionally).  chkstk.S and chkstk2.S
+  # are Windows/MinGW-only stack probes; every *vfp.S needs a hardware FPU; and
+  # the double-precision *df*vfp.S routines additionally need a double-precision
+  # FPU.  Without this, single-precision-FPU targets such as Cortex-M33
+  # (fpv5-sp-d16) fail with "selected FPU does not support instruction".  See
+  # apache/nuttx#17386.
+  if(CONFIG_ARCH_ARM)
+    set(RT_BUILTINS_ARM_EXCLUDE ${BUILTINS_DIR}/arm/chkstk.S
+                                ${BUILTINS_DIR}/arm/chkstk2.S)
+    if(NOT CONFIG_ARCH_FPU)
+      file(GLOB RT_BUILTINS_ARM_VFP ${BUILTINS_DIR}/arm/*vfp.S)
+      list(APPEND RT_BUILTINS_ARM_EXCLUDE ${RT_BUILTINS_ARM_VFP})
+    elseif(NOT CONFIG_ARCH_DPFPU)
+      list(
+        APPEND
+        RT_BUILTINS_ARM_EXCLUDE
+        ${BUILTINS_DIR}/arm/adddf3vfp.S
+        ${BUILTINS_DIR}/arm/divdf3vfp.S
+        ${BUILTINS_DIR}/arm/eqdf2vfp.S
+        ${BUILTINS_DIR}/arm/extendsfdf2vfp.S
+        ${BUILTINS_DIR}/arm/fixdfsivfp.S
+        ${BUILTINS_DIR}/arm/fixunsdfsivfp.S
+        ${BUILTINS_DIR}/arm/floatsidfvfp.S
+        ${BUILTINS_DIR}/arm/floatunssidfvfp.S
+        ${BUILTINS_DIR}/arm/gedf2vfp.S
+        ${BUILTINS_DIR}/arm/gtdf2vfp.S
+        ${BUILTINS_DIR}/arm/ledf2vfp.S
+        ${BUILTINS_DIR}/arm/ltdf2vfp.S
+        ${BUILTINS_DIR}/arm/muldf3vfp.S
+        ${BUILTINS_DIR}/arm/nedf2vfp.S
+        ${BUILTINS_DIR}/arm/subdf3vfp.S
+        ${BUILTINS_DIR}/arm/truncdfsf2vfp.S
+        ${BUILTINS_DIR}/arm/unorddf2vfp.S)
+    endif()
+    list(REMOVE_ITEM RT_BUILTINS_SRCS ${RT_BUILTINS_ARM_EXCLUDE})
+  endif()
+
   if(NOT CONFIG_COVERAGE_NONE)
     target_compile_options(rt.builtins PRIVATE -fno-profile-instr-generate
                                                -fno-coverage-mapping)

--- a/libs/libbuiltin/compiler-rt/Make.defs
+++ b/libs/libbuiltin/compiler-rt/Make.defs
@@ -108,6 +108,33 @@ ifeq ($(CONFIG_ARCH_X86_64),)
   CSRCS := $(filter-out $(x86_80_BIT_SOURCES), $(CSRCS))
 endif
 
+# The Arm builtins ship hand-written VFP assembly whose FPU requirements the
+# wildcard glob above ignores.  Upstream compiler-rt selects these files
+# conditionally, so assemble only the ones the configured FPU supports;
+# otherwise single-precision-FPU targets (e.g. Cortex-M33, fpv5-sp-d16) fail
+# with "selected FPU does not support instruction".  See apache/nuttx#17386.
+#   - chkstk.S / chkstk2.S are Windows/MinGW-only stack probes;
+#   - every *vfp.S needs a hardware FPU;
+#   - the double-precision *df*vfp.S routines additionally need a
+#     double-precision FPU.
+
+ifeq ($(CONFIG_ARCH_ARM),y)
+  COMPILER_RT_ARM_EXCLUDE := chkstk.S chkstk2.S
+ifneq ($(CONFIG_ARCH_FPU),y)
+  COMPILER_RT_ARM_EXCLUDE += $(notdir \
+    $(wildcard compiler-rt/compiler-rt/lib/builtins/arm/*vfp.S))
+else ifneq ($(CONFIG_ARCH_DPFPU),y)
+  COMPILER_RT_ARM_EXCLUDE += adddf3vfp.S divdf3vfp.S eqdf2vfp.S extendsfdf2vfp.S
+  COMPILER_RT_ARM_EXCLUDE += fixdfsivfp.S fixunsdfsivfp.S floatsidfvfp.S
+  COMPILER_RT_ARM_EXCLUDE += floatunssidfvfp.S gedf2vfp.S gtdf2vfp.S ledf2vfp.S
+  COMPILER_RT_ARM_EXCLUDE += ltdf2vfp.S muldf3vfp.S nedf2vfp.S subdf3vfp.S
+  COMPILER_RT_ARM_EXCLUDE += truncdfsf2vfp.S unorddf2vfp.S
+endif
+  ASRCS := $(filter-out $(addprefix \
+    compiler-rt/compiler-rt/lib/builtins/arm/, $(COMPILER_RT_ARM_EXCLUDE)), \
+    $(ASRCS))
+endif
+
 endif
 
 ################# Profile Library #################


### PR DESCRIPTION
## Summary

`libs/libbuiltin/compiler-rt` globs **every** `arm/*.S` source into the builtins
library (`$(wildcard .../arm/*.S)` in `Make.defs`, `file(GLOB ...)` in
`CMakeLists.txt`). Several of those hand-written VFP assembly files require FPU
features the selected target may not have. Upstream compiler-rt selects them
conditionally in its own CMake logic; NuttX did not, so enabling
`BUILTIN_COMPILER_RT` on a single-precision-FPU Arm target (e.g. Cortex-M33 with
`-mfpu=fpv5-sp-d16`, as on the Raspberry Pi Pico 2 / RP2350) breaks the build
with assembler errors such as:

```
compiler-rt/lib/builtins/arm/adddf3vfp.S:24: Error: selected FPU does not support instruction -- `vadd.f64 d6,d6,d7'
compiler-rt/lib/builtins/arm/chkstk.S:29:   Error: instruction not supported in Thumb16 mode -- `subs r5,r5,#4096'
```

This filters the Arm `.S` source list to match the configured FPU, in both the
Makefile and CMake builds:

- `chkstk.S` / `chkstk2.S` are Windows/MinGW-only stack probes — always dropped;
- with no hardware FPU (`!CONFIG_ARCH_FPU`), every `arm/*vfp.S` is dropped;
- with a single-precision FPU (`!CONFIG_ARCH_DPFPU`), the double-precision
  `*df*vfp.S` routines are dropped.

The excluded set mirrors upstream compiler-rt's own conditional selection.

Fixes #17386.

## Impact

- Fixes the build for `CONFIG_BUILTIN_COMPILER_RT=y` on single-precision-FPU and
  soft-float Arm targets (previously failed to link/assemble).
- No behavioural change for targets with a double-precision FPU or for
  non-Arm architectures: those targets keep the same source set (the double-
  precision `*df*vfp.S` files are only removed when `CONFIG_ARCH_DPFPU` is unset,
  and the whole block is guarded by `CONFIG_ARCH_ARM`).
- Build system only; no runtime code, API, or documentation changes.

## Testing

Host: Ubuntu 24.04 (x86_64), `arm-none-eabi-gcc` 14.2.rel1 (matching the
toolchain in the original report), compiler-rt 17.0.1 (NuttX default
`LIB_COMPILER_RT_VERSION`).

Reproduced the failure by assembling every `arm/*.S` builtin with the Cortex-M33
single-precision flags from the issue
(`-march=armv8-m.main+dsp -mtune=cortex-m33 -mfpu=fpv5-sp-d16 -mfloat-abi=softfp -mthumb -mcmse`):

```
[RESULT] total=86  FAIL=18  PASS=68
FAILING: adddf3vfp.S chkstk.S divdf3vfp.S eqdf2vfp.S extendsfdf2vfp.S
         fixdfsivfp.S fixunsdfsivfp.S floatsidfvfp.S floatunssidfvfp.S
         gedf2vfp.S gtdf2vfp.S ledf2vfp.S ltdf2vfp.S muldf3vfp.S nedf2vfp.S
         subdf3vfp.S truncdfsf2vfp.S unorddf2vfp.S
```

Applying this patch's exclusion set (17 double-precision `*df*vfp.S` files +
`chkstk.S`) and re-assembling the remainder:

```
[POST-FIX] assembled=68  remaining_failures=0
```

`negdf2vfp.S` and the single-precision `*sf*vfp.S` routines are correctly
retained (they assemble under a single-precision FPU). Verified the Make filter
logic independently: for a single-precision target it removes exactly the DP-VFP
and `chkstk` files while keeping `negdf2vfp.S`, `addsf3vfp.S`, and `.c` sources.

`./tools/checkpatch.sh -f` passes on both changed files (including
`cmake-format`).
