### PR TITLE
arch/sim: register RTC after clock initialization

### DIFF
--- a/arch/sim/src/sim/sim_initialize.c
+++ b/arch/sim/src/sim/sim_initialize.c
@@ -266,6 +266,14 @@ void up_initialize(void)
   sim_init_cmdline();
 #endif
 
+#ifdef CONFIG_RTC_DRIVER
+  /* Register the RTC after clock_initialize() has synchronized system
+   * time.
+   */
+
+  sim_rtc_initialize();
+#endif
+
   /* Register some tty-port to access tty-port on sim platform */
 
   sim_uartinit();

--- a/arch/sim/src/sim/sim_internal.h
+++ b/arch/sim/src/sim/sim_internal.h
@@ -276,6 +276,12 @@ int sim_init_func_call_ipi(int irq);
 void sim_timer_update(void);
 #endif
 
+/* sim_rtc.c ****************************************************************/
+
+#ifdef CONFIG_RTC_DRIVER
+int sim_rtc_initialize(void);
+#endif
+
 /* sim_uart.c ***************************************************************/
 
 void sim_uartinit(void);

--- a/arch/sim/src/sim/sim_rtc.c
+++ b/arch/sim/src/sim/sim_rtc.c
@@ -59,6 +59,7 @@ static struct rtc_lowerhalf_s g_sim_rtc =
   .ops         = &g_sim_rtc_ops,
 };
 
+static struct rtc_lowerhalf_s *g_sim_rtc_lower;
 static int64_t g_sim_delta;
 
 /****************************************************************************
@@ -134,6 +135,28 @@ int up_rtc_initialize(void)
   rtc = rpmsg_rtc_initialize();
   sync = false;
 #endif
+
+  g_sim_rtc_lower = rtc;
   up_rtc_set_lowerhalf(rtc, sync);
-  return rtc_initialize(0, rtc);
+  return OK;
+}
+
+/****************************************************************************
+ * Name: sim_rtc_initialize
+ *
+ * Description:
+ *   Register the SIM RTC driver after the system clock has been initialized.
+ *   This ensures that the /dev/rtc0 inode receives a valid timestamp.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   Zero (OK) on success; a negated errno on failure
+ *
+ ****************************************************************************/
+
+int sim_rtc_initialize(void)
+{
+  return rtc_initialize(0, g_sim_rtc_lower);
 }


### PR DESCRIPTION
## Summary

Registering `/dev/rtc0` from `up_rtc_initialize()` creates its
PseudoFS inode before `clock_inittime()` synchronizes
`CLOCK_REALTIME`. As a result, the inode timestamp is zero and
`ls -l /dev` omits the date for `rtc0`.

Keep the RTC lower-half setup in the early initialization path so it
can still provide the system time. Defer registration of the RTC
character device to `up_initialize()`, after clock initialization has
completed.

Fixes #19504.

## Impact

This change only affects the SIM RTC initialization order. The
`/dev/rtc0` inode now receives a valid creation timestamp. RTC time
synchronization and the RTC driver interface are unchanged.

## Testing

Host:

- Ubuntu 20.04.6 LTS under WSL2, x86_64
- Board configuration: `sim:nsh`

The baseline and fixed builds used identical `.config` files, verified
with `cmp`.

Before this change on `master`:

```text
nsh> ls -l /dev
 crw-------           0 rtc0
nsh> date
Fri, Jul 24 02:24:43 2026
```

After this change:

```text
nsh> ls -l /dev
 crw-------           0 2026-07-24 02:16 rtc0
nsh> date
Fri, Jul 24 02:16:59 2026
```

Additional checks:

- `./tools/checkpatch.sh -f` passes for all modified files.
- `sim:nsh` builds successfully.
- `sim:ostest`, which does not enable RTC support, builds successfully.
