### PR TITLE
libc/time: Fix POSIX timezone string parsing

### DIFF
--- a/libs/libc/time/lib_localtime.c
+++ b/libs/libc/time/lib_localtime.c
@@ -2751,8 +2751,8 @@ static int zoneinit(FAR const char *name)
       int err;
 
       err = tzload(name, g_lcl_ptr, TRUE);
-      if (err != 0 && name != NULL && name[0] == ':' &&
-          tzparse(name, g_lcl_ptr, NULL) != 0)
+      if (err != 0 && name != NULL && name[0] != ':' &&
+          tzparse(name, g_lcl_ptr, NULL) == 0)
         {
           err = 0;
         }


### PR DESCRIPTION
## Summary

- fall back to parsing a POSIX TZ string when loading a zoneinfo file fails
- keep the leading-colon form as file-only, as required by the existing semantics

This addresses the POSIX timezone parsing part of #19446. The reported ROMFS
archive build error is not changed here because it did not reproduce on the
current master branch.

## Root cause

The conditions around `tzparse()` were inverted. The fallback was attempted
only for names beginning with `:`, and a parse failure was treated as success.
As a result, ordinary POSIX TZ strings such as `ART3` and `JST-9` fell back to
UTC instead of applying their offsets.

## Validation

Tested with `sim:nsh` using:

```text
CONFIG_LIBC_LOCALTIME=y
CONFIG_LIBC_TZDIR="/etc/zoneinfo"
# CONFIG_LIBC_ZONEINFO is not set
```

The simulator was rebuilt from `make distclean` before both runs.

Observed before this change:

```text
TZ=UTC0   08:03:19
TZ=ART3   08:03:36
TZ=JST-9  08:03:56
TZ=:ART3  08:04:06
```

Observed after this change:

```text
TZ=UTC0   08:09:52
TZ=ART3   05:10:05
TZ=JST-9  17:10:18
TZ=:ART3  08:10:24
```

`ART3` now applies UTC-3, `JST-9` applies UTC+9, and `:ART3` remains
file-only and falls back to UTC when that file is unavailable.

Additional checks:

- `make -j$(nproc)`
- `tools/checkpatch.sh -f libs/libc/time/lib_localtime.c`
