### PR TITLE
WDOG: Output status on read

### DIFF
--- a/Documentation/components/drivers/character/timers/watchdog.rst
+++ b/Documentation/components/drivers/character/timers/watchdog.rst
@@ -120,6 +120,18 @@ a parameter (where x is the timer number):
 
   nsh> wdog -i /dev/watchdogx
 
+Additionally, the watchdog driver can be read by using standard commands such as ``cat``.
+It will emit relevant information about the watchdog and its current status, including the
+flags bitset, timeout and timeleft from the current slice as milliseconds:
+
+.. code-block:: console
+
+  nsh> cat /dev/watchdogx
+  Status     :
+  flags      : 0x00000000
+  timeout    : 30000
+  timeleft   : 9889
+
 Application Level Interface
 ----------------------------
 

--- a/drivers/timers/watchdog.c
+++ b/drivers/timers/watchdog.c
@@ -34,6 +34,7 @@
 #include <fcntl.h>
 #include <assert.h>
 #include <errno.h>
+#include <stdio.h>
 #include <nuttx/debug.h>
 
 #include <nuttx/fs/fs.h>
@@ -552,16 +553,62 @@ errout:
  * Name: wdog_read
  *
  * Description:
- *   A dummy read method.  This is provided only to satisfy the VFS layer.
+ *   Return the current status of the watchdog timer. Mimics what an `ioctl`
+ *   with `WDIOC_GETSTATUS` would do. This is useful for userspace to get the
+ *   current status of the watchdog timer by just reading from the device.
+ *
+ * Returns:
+ *   The number of bytes read on success, or a negated errno value on failure
  *
  ****************************************************************************/
 
 static ssize_t wdog_read(FAR struct file *filep, FAR char *buffer,
                          size_t buflen)
 {
-  /* Return zero -- usually meaning end-of-file */
+  /* simulate a "get status" on the userspace */
 
-  return 0;
+  ssize_t ret;
+  FAR struct watchdog_status_s status;
+
+  /* the f_pos is not used along this driver.
+   * Use it as a marker to know if the status has been read already.
+   */
+
+  if (filep->f_pos)
+    {
+      filep->f_pos = 0;
+      return 0;
+    }
+
+  ret = wdog_ioctl(filep, WDIOC_GETSTATUS, (uintptr_t)&status);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  /* Copy the watchdog status into the user buffer */
+
+  ret = snprintf(
+          buffer,
+          buflen,
+          "Status       :\n"
+          "  flags      : 0x%08" PRIx32 "\n"
+          "  timeout    : %" PRId32 "\n"
+          "  timeleft   : %" PRId32 "\n",
+          status.flags, status.timeout, status.timeleft
+        );
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  if (ret >= buflen)
+    {
+      return -ENOSPC;
+    }
+
+  filep->f_pos++;
+  return ret;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Currently, the `read` function of the watchdog device is dummy and does nothing. Although this is fine, it's not useful at all from a userspace perspective, where you may want to check the current WDOG status.

A wrapper around the `ioctl` `WDIOC_GETSTATUS` has been added as the `read` function for the WDOG.

## Impact

This should help debugging and developers with watchdog-enabled systems

## Testing

The testing in this case is quite straightforward: `cat /dev/watchdog0`, whose output was:

```
nsh> cat /dev/watchdog0
Status       :
  flags      : 0x00000000
  timeout    : 30000
  timeleft   : 2947
```
