### PR TITLE
drivers/video: zero message on MIPI DSI driver

### DIFF
--- a/drivers/video/mipidsi/mipi_dsi_device.c
+++ b/drivers/video/mipidsi/mipi_dsi_device.c
@@ -422,10 +422,10 @@ ssize_t mipi_dsi_dcs_write_buffer(FAR struct mipi_dsi_device *device,
 {
   struct mipi_dsi_msg msg;
 
+  memset(&msg, 0, sizeof(msg));
   msg.channel = device->channel;
   msg.tx_buf = data;
   msg.tx_len = len;
-  msg.flags = 0;
 
   switch (len)
     {


### PR DESCRIPTION
## Summary

- drivers/video: zero message on MIPI DSI driver
Use memset to clear the msg struct before using on mipi_dsi_dcs_write_buffer.

## Impact
Fixes a bug on MIPI DSI usage where `msg` struct would be filled with garbage values.
This uses memset to set the struct to 0 before using.

## Testing

No specific testing available, but solved issues on a `esp32p4-tab5` board MIPI DSI implementation.
