### PR TITLE
arch/risc-v: optimize riscv backtrace

### DIFF
--- a/arch/risc-v/src/common/riscv_backtrace.c
+++ b/arch/risc-v/src/common/riscv_backtrace.c
@@ -25,10 +25,84 @@
  ****************************************************************************/
 
 #include <nuttx/config.h>
+#include <stdbool.h>
 #include <nuttx/arch.h>
 #include <nuttx/addrenv.h>
+#include <nuttx/compiler.h>
 #include "sched/sched.h"
 #include "riscv_internal.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Maximum number of independent starting points up_backtrace() can splice
+ * together.  Current worst case: the main fp chain (possibly starting on
+ * the interrupt or kernel stack) plus the xcp.sregs splice used to reach
+ * the user call site of a task that is mid-syscall.
+ */
+
+#define BACKTRACE_MAX_SEGMENTS 2
+
+/* Upper bound on how many candidate ranges a single segment can
+ * register: interrupt stack, kernel stack, user stack.
+ */
+
+#define BACKTRACE_MAX_RANGES 3
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/* One candidate stack range a segment's fp chain may be walking. */
+
+struct backtrace_range_s
+{
+  uintptr_t *base;
+  uintptr_t *limit;
+#ifdef CONFIG_ARCH_ADDRENV
+  struct addrenv_s *addrenv;
+#endif
+};
+
+/* One independent fp/ra starting point for backtrace_segments() to walk,
+ * together with every stack range its chain may legitimately be found on.
+ */
+
+struct backtrace_segment_s
+{
+  uintptr_t *fp;
+  uintptr_t *ra;
+  struct backtrace_range_s ranges[BACKTRACE_MAX_RANGES];
+  int nranges;
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static struct backtrace_segment_s *
+backtrace_new_segment(struct backtrace_segment_s *segments,
+                      int *nsegments, uintptr_t *fp, uintptr_t *ra);
+static void backtrace_add_range(struct backtrace_segment_s *segment,
+                                uintptr_t *base, uintptr_t *limit
+#ifdef CONFIG_ARCH_ADDRENV
+                                , struct addrenv_s *addrenv
+#endif
+                                );
+
+/* BACKTRACE_ADD_RANGE() drops the trailing addrenv argument when
+ * CONFIG_ARCH_ADDRENV is not configured, so call sites never need their own
+ * #ifdef.
+ */
+
+#ifdef CONFIG_ARCH_ADDRENV
+#  define BACKTRACE_ADD_RANGE(segment, base, limit, addrenv) \
+          backtrace_add_range(segment, base, limit, addrenv)
+#else
+#  define BACKTRACE_ADD_RANGE(segment, base, limit, addrenv) \
+          backtrace_add_range(segment, base, limit)
+#endif
 
 /****************************************************************************
  * Private Functions
@@ -42,7 +116,7 @@
  *
  ****************************************************************************/
 
-static inline uintptr_t getfp(void)
+static always_inline_function uintptr_t getfp(void)
 {
   register uintptr_t fp;
 
@@ -56,6 +130,61 @@ static inline uintptr_t getfp(void)
 }
 
 /****************************************************************************
+ * Name: backtrace_add_range
+ *
+ * Description:
+ *  Append one candidate stack range to a segment.
+ *
+ ****************************************************************************/
+
+static void backtrace_add_range(struct backtrace_segment_s *segment,
+                                uintptr_t *base, uintptr_t *limit
+#ifdef CONFIG_ARCH_ADDRENV
+                                , struct addrenv_s *addrenv
+#endif
+                                )
+{
+  struct backtrace_range_s *range;
+
+  DEBUGASSERT(segment->nranges < BACKTRACE_MAX_RANGES);
+  range = &segment->ranges[segment->nranges++];
+
+  range->base  = base;
+  range->limit = limit;
+#ifdef CONFIG_ARCH_ADDRENV
+  range->addrenv = addrenv;
+#endif
+}
+
+/****************************************************************************
+ * Name: backtrace_new_segment
+ *
+ * Description:
+ *  Allocate the next free segment slot and initialize its fp/ra starting
+ *  point.
+ *
+ * Returned Value:
+ *  A pointer to the newly allocated segment, ready for BACKTRACE_ADD_RANGE()
+ *  calls.
+ *
+ ****************************************************************************/
+
+static struct backtrace_segment_s *
+backtrace_new_segment(struct backtrace_segment_s *segments,
+                      int *nsegments, uintptr_t *fp, uintptr_t *ra)
+{
+  struct backtrace_segment_s *segment;
+
+  segment = &segments[(*nsegments)++];
+
+  segment->fp = fp;
+  segment->ra = ra;
+  segment->nranges = 0;
+
+  return segment;
+}
+
+/****************************************************************************
  * Name: backtrace
  *
  * Description:
@@ -63,29 +192,23 @@ static inline uintptr_t getfp(void)
  *
  ****************************************************************************/
 
-nosanitize_address
+nosanitize_address noinline_function
 static int backtrace(uintptr_t *base, uintptr_t *limit,
                      uintptr_t *fp, uintptr_t *ra,
-                     void **buffer, int size, int *skip
+                     void **buffer, int size, int *skip,
+                     uintptr_t **bridge
 #ifdef CONFIG_ARCH_ADDRENV
-                     , FAR struct addrenv_s *addrenv
+                     , struct addrenv_s *addrenv
 #endif
                      )
 {
   int i = 0;
   uintptr_t *next_fp;
-#if CONFIG_ARCH_INTERRUPTSTACK > 15
-  int cpu = up_cpu_index();
-  uintptr_t *intstack_limit =
-    (uintptr_t *)((uintptr_t)g_intstacktop -
-                  (CONFIG_ARCH_INTERRUPTSTACK * cpu));
-
-  uintptr_t *intstack_base =
-    (uintptr_t *)((uintptr_t)intstack_limit - CONFIG_ARCH_INTERRUPTSTACK);
-#endif
 #ifdef CONFIG_ARCH_ADDRENV
-  FAR struct addrenv_s *oldenv;
+  struct addrenv_s *oldenv;
 #endif
+
+  *bridge = NULL;
 
   if (ra)
     {
@@ -95,18 +218,19 @@ static int backtrace(uintptr_t *base, uintptr_t *limit,
         }
     }
 
-  for (; i < size; fp = next_fp)
+  for (; i < size && fp != NULL; fp = next_fp)
     {
-      if ((fp > limit || fp < base)
-#if CONFIG_ARCH_INTERRUPTSTACK > 15
-          && (fp > intstack_limit || fp < intstack_base)
-#endif
-         )
+      if (fp > limit || fp < base)
         {
+          /* fp is outside [base, limit].  Report it back through
+           * *bridge and stop; the caller decides what to do with it.
+           */
+
+          *bridge = fp;
           break;
         }
 
-      /* fp/fp-1/fp-2 are addresses in the *target* tcb's stack.  If that
+      /* fp-1/fp-2 are addresses in the *target* tcb's stack.  If that
        * tcb has its own address environment, switch to it only for these
        * two dereferences.  buffer belongs to the caller, not the target,
        * and must always be written using the caller's own address
@@ -145,6 +269,89 @@ static int backtrace(uintptr_t *base, uintptr_t *limit,
 }
 
 /****************************************************************************
+ * Name: backtrace_walk_segment
+ *
+ * Description:
+ *  Walk one segment's fp chain, switching to the next candidate range
+ *  whenever backtrace() bridges out of the one it was given.  Ranges are
+ *  only ever crossed outward (e.g. interrupt stack -> kernel stack -> user
+ *  stack, never backwards), so the search for the next range picks up from
+ *  where the previous one left off instead of rescanning from the start.
+ *
+ ****************************************************************************/
+
+static int backtrace_walk_segment(struct backtrace_segment_s *segment,
+                                  void **buffer, int size, int *skip)
+{
+  uintptr_t *fp = segment->fp;
+  uintptr_t *ra = segment->ra;
+  uintptr_t *bridge;
+  int total = 0;
+  int ir = 0;
+
+  for (; ; )
+    {
+      for (; ir < segment->nranges; ir++)
+        {
+          if (fp <= segment->ranges[ir].limit &&
+              fp >= segment->ranges[ir].base)
+            {
+              break;
+            }
+        }
+
+      if (ir == segment->nranges)
+        {
+          break;
+        }
+
+      total += backtrace(segment->ranges[ir].base, segment->ranges[ir].limit,
+                         fp, ra, &buffer[total], size - total, skip,
+                         &bridge
+#ifdef CONFIG_ARCH_ADDRENV
+                         , segment->ranges[ir].addrenv
+#endif
+                         );
+
+      if (bridge == NULL || total >= size)
+        {
+          break;
+        }
+
+      fp = bridge;
+      ra = NULL;
+    }
+
+  return total;
+}
+
+/****************************************************************************
+ * Name: backtrace_segments
+ *
+ * Description:
+ *  Walk a short list of stack segments in order, carrying over into the
+ *  next one whenever the current segment stops producing frames before
+ *  the buffer is full.
+ *
+ ****************************************************************************/
+
+static int backtrace_segments(struct backtrace_segment_s *segments,
+                              int nsegments, void **buffer, int size,
+                              int *skip)
+{
+  int ret = 0;
+  int i;
+
+  for (i = 0; i < nsegments && ret < size; i++)
+    {
+      ret += backtrace_walk_segment(&segments[i], &buffer[ret],
+                                    size - ret, skip);
+    }
+
+  return ret;
+}
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -161,6 +368,12 @@ static int backtrace(uintptr_t *base, uintptr_t *limit,
  *  larger than size, then the addresses corresponding to the size most
  *  recent function calls are returned; to obtain the complete backtrace,
  *  make sure that buffer and size are large enough.
+ *
+ *  A task that is (or was, at the last trap) mid-syscall has its call
+ *  chain split across two stacks: the kernel stack (from the trap that
+ *  entered the syscall up to the ecall itself) and, continuing from
+ *  there, the user stack (the application code that issued the ecall).
+ *  Both segments are walked and spliced together into one buffer.
  *
  * Input Parameters:
  *   tcb    - Address of the task's TCB
@@ -184,100 +397,103 @@ static int backtrace(uintptr_t *base, uintptr_t *limit,
 int up_backtrace(struct tcb_s *tcb, void **buffer, int size, int skip)
 {
   struct tcb_s *rtcb = running_task();
-  int ret;
+  struct backtrace_segment_s segments[BACKTRACE_MAX_SEGMENTS];
+  struct backtrace_segment_s *segment;
+  uintptr_t *ubase;
+  uintptr_t *ulimit;
+  bool self = (tcb == NULL || tcb == rtcb);
+  int nsegments = 0;
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
+  int cpu;
+  uintptr_t *ilimit;
+  uintptr_t *ibase;
+#endif
+#ifdef CONFIG_LIB_SYSCALL
+  bool insyscall;
+#endif
 
   if (size <= 0 || !buffer)
     {
       return 0;
     }
 
-  if (tcb == NULL || tcb == rtcb)
+  if (self)
     {
-      if (up_interrupt_context())
-        {
-          ret = backtrace(rtcb->stack_base_ptr,
-                          (uintptr_t *)((uintptr_t)rtcb->stack_base_ptr +
-                                        rtcb->adj_stack_size),
-                          (void *)getfp(), NULL, buffer, size, &skip
-#ifdef CONFIG_ARCH_ADDRENV
-                          , NULL
-#endif
-                          );
-          if (ret < size)
-            {
-              ret += backtrace(rtcb->stack_base_ptr, (uintptr_t *)
-                               ((uintptr_t)rtcb->stack_base_ptr +
-                                rtcb->adj_stack_size),
-                               running_regs()[REG_FP],
-                               running_regs()[REG_EPC],
-                               &buffer[ret], size - ret, &skip
-#ifdef CONFIG_ARCH_ADDRENV
-                               , NULL
-#endif
-                               );
-            }
-        }
-      else
-        {
-#ifdef CONFIG_ARCH_KERNEL_STACK
-          if ((rtcb->flags & TCB_FLAG_SYSCALL) != 0)
-            {
-              ret = backtrace(rtcb->stack_base_ptr, (uintptr_t *)
-                              ((uintptr_t)rtcb->stack_base_ptr +
-                               rtcb->adj_stack_size),
-                              (void *)rtcb->xcp.sregs[REG_FP],
-                              (void *)rtcb->xcp.sregs[REG_EPC],
-                              buffer, size, &skip
-#ifdef CONFIG_ARCH_ADDRENV
-                              , NULL
-#endif
-                              );
-            }
-          else
-#endif
-            {
-              ret = backtrace(rtcb->stack_base_ptr, (uintptr_t *)
-                              ((uintptr_t)rtcb->stack_base_ptr +
-                               rtcb->adj_stack_size),
-                              (void *)getfp(), NULL, buffer, size, &skip
-#ifdef CONFIG_ARCH_ADDRENV
-                              , NULL
-#endif
-                              );
-            }
-        }
-    }
-  else
-    {
-#ifdef CONFIG_ARCH_KERNEL_STACK
-      if ((tcb->flags & TCB_FLAG_SYSCALL) != 0)
-        {
-          ret = backtrace(tcb->stack_base_ptr,
-                          (uintptr_t *)((uintptr_t)tcb->stack_base_ptr +
-                                        tcb->adj_stack_size),
-                          (void *)tcb->xcp.sregs[REG_FP],
-                          (void *)tcb->xcp.sregs[REG_EPC],
-                          buffer, size, &skip
-#ifdef CONFIG_ARCH_ADDRENV
-                          , tcb->addrenv_own
-#endif
-                          );
-        }
-      else
-#endif
-        {
-          ret = backtrace(tcb->stack_base_ptr,
-                          (uintptr_t *)((uintptr_t)tcb->stack_base_ptr +
-                                        tcb->adj_stack_size),
-                          (void *)tcb->xcp.regs[REG_FP],
-                          (void *)tcb->xcp.regs[REG_EPC],
-                          buffer, size, &skip
-#ifdef CONFIG_ARCH_ADDRENV
-                          , tcb->addrenv_own
-#endif
-                          );
-        }
+      tcb = rtcb;
     }
 
-  return ret;
+  ubase  = tcb->stack_base_ptr;
+  ulimit = (uintptr_t *)((uintptr_t)tcb->stack_base_ptr +
+                         tcb->adj_stack_size);
+
+#ifdef CONFIG_LIB_SYSCALL
+  insyscall = (tcb->flags & TCB_FLAG_SYSCALL) != 0;
+#endif
+
+  /* The main fp chain may start on (and naturally unwind through) any
+   * stack the tcb was last executing on, innermost first: the interrupt
+   * stack, then the kernel stack, then finally the user stack.  Every
+   * range it could legitimately cross into is listed up front instead of
+   * picking just one ahead of time, since the trap entry copies the
+   * pre-trap fp/ra into each synthetic frame, letting the chain unwind
+   * straight through a trap boundary onto the next stack out.
+   */
+
+  segment = backtrace_new_segment(segments, &nsegments,
+                                  self ? (uintptr_t *)getfp() :
+                                  (uintptr_t *)tcb->xcp.regs[REG_FP],
+                                  self ? NULL :
+                                  (uintptr_t *)tcb->xcp.regs[REG_EPC]);
+
+#if CONFIG_ARCH_INTERRUPTSTACK > 15
+  if (self)
+    {
+      /* Only a self chain can genuinely start on the interrupt stack: it
+       * is per-CPU scratch space, reused on every dispatch, so a snapshot
+       * taken from a not-running tcb can never legitimately point into
+       * it.
+       */
+
+      cpu = up_cpu_index();
+      ilimit = (uintptr_t *)((uintptr_t)g_intstacktop -
+                             (CONFIG_ARCH_INTERRUPTSTACK * cpu));
+      ibase = (uintptr_t *)((uintptr_t)ilimit - CONFIG_ARCH_INTERRUPTSTACK);
+
+      BACKTRACE_ADD_RANGE(segment, ibase, ilimit, NULL);
+    }
+#endif
+
+#if defined(CONFIG_ARCH_KERNEL_STACK) && defined(CONFIG_ARCH_ADDRENV)
+  if (tcb->xcp.kstack != NULL)
+    {
+      BACKTRACE_ADD_RANGE(segment, tcb->xcp.kstack,
+                         (uintptr_t *)((uintptr_t)tcb->xcp.kstack +
+                                       ARCH_KERNEL_STACKSIZE), NULL);
+    }
+#endif
+
+  BACKTRACE_ADD_RANGE(segment, ubase, ulimit,
+                      self ? NULL : tcb->addrenv_own);
+
+#ifdef CONFIG_LIB_SYSCALL
+  /* The main chain above stops at the nearest ecall boundary --
+   * dispatch_syscall()'s own call frame has no relation to the user fp
+   * chain, so there is nothing for it to unwind into.  xcp.sregs is
+   * stable (written once by dispatch_syscall(), never by reserved
+   * syscalls) and gives the real user call site, so splice it in as an
+   * independent starting point.
+   */
+
+  if (insyscall)
+    {
+      segment = backtrace_new_segment(segments, &nsegments,
+                                      (uintptr_t *)tcb->xcp.sregs[REG_FP],
+                                      (uintptr_t *)tcb->xcp.sregs[REG_EPC]);
+
+      BACKTRACE_ADD_RANGE(segment, ubase, ulimit,
+                          self ? NULL : tcb->addrenv_own);
+    }
+#endif
+
+  return backtrace_segments(segments, nsegments, buffer, size, &skip);
 }

--- a/arch/risc-v/src/common/riscv_exception.c
+++ b/arch/risc-v/src/common/riscv_exception.c
@@ -119,6 +119,10 @@ static void riscv_fault_handler(uintreg_t cause, void *regs)
       _alert("Segmentation fault in %s (PID %d: %s)\n", get_task_name(ptcb),
              tcb->pid, get_task_name(tcb));
 
+#ifdef CONFIG_SCHED_BACKTRACE
+      sched_dumpstack(tcb->pid);
+#endif
+
       tcb->flags |= TCB_FLAG_FORCED_CANCEL;
 
       /* Return to _exit function in privileged mode with argument SIGSEGV */

--- a/arch/risc-v/src/common/riscv_idle.c
+++ b/arch/risc-v/src/common/riscv_idle.c
@@ -71,7 +71,18 @@ void up_idle(void)
    * sleep in a reduced power mode until an interrupt occurs to save power
    */
 
-  asm("WFI");
+  /* up_idle() never calls another function, so with frame pointers
+   * enabled the compiler has no need to spill ra and skips it, leaving
+   * its slot in the fp-chain holding whatever was on the stack before.
+   * Clobbering "ra" forces it to be spilled/reloaded around WFI so the
+   * fp-chain backtrace sched_backtrace() relies on can find it.
+   */
+
+#if defined(CONFIG_FRAME_POINTER) && defined(CONFIG_SCHED_BACKTRACE)
+  asm volatile ("WFI" : : : "ra");
+#else
+  asm volatile ("WFI");
+#endif
 
 #endif
 }


### PR DESCRIPTION
## Summary

risc-v's `up_backtrace()` currently has the following problems:

1. Under `CONFIG_BUILD_KERNEL`, `dumpstack` on a user task only dumps its user stack, never its kernel stack.
2. Under `CONFIG_BUILD_FLAT`/`CONFIG_BUILD_PROTECTED`, backtrace output contains duplicate frames.
3. The existing implementation piles up branches, macros, and conditionals to handle the various combinations, which makes the code hard to follow and makes it increasingly difficult to keep fixing bugs or adding support for new scenarios on top of the existing structure.

Problem 1 was already noted in https://github.com/apache/nuttx/pull/19439, but never actually fixed in code. Problem 2 is caused by an implementation bug that dumps the same range of the user stack twice.

This change reworks `up_backtrace()` around a table of stack ranges (interrupt stack / kernel stack / user stack) that a given fp chain may legitimately cross into, walked by one shared procedure that switches ranges as needed, instead of hand-writing a separate branch with one or two hardcoded ranges per scenario.

### Problem 1 repro

`rv-virt:knsh`, `dumpstack` on a user task only shows frames on the user stack (tid 2/3/4 partially only show kernel-stack addresses `0xc0...`, missing the corresponding user-stack frames):

```
NuttShell (NSH) NuttX-13.0.0
nsh> dumpstack 0 10
[3951369912320000.001000] sched_dumpstack: backtrace| 0: 0x8020cf92 0x80608730 0x802011d6 0x8020004a
[3977139716096000.001000] sched_dumpstack: backtrace| 1: 0x8020cafc 0x80218ffa 0x80208cfc 0x80208d20 0x8020312c 0x80202a94
[3990024617984000.001000] sched_dumpstack: backtrace| 3: 0xc000c478 0xc000561e 0xc0002d4e 0xc0003cbc 0xc0003d5c 0xc0002722 0xc0002542 0xc0000b4a
[4002909519872000.001000] sched_dumpstack: backtrace| 3: 0xc0000b08
[4011499454464000.001000] sched_dumpstack: backtrace| 4: 0xc000289a 0xc0000b44 0xc0000aca 0xc0000a8c
```

### Problem 2 repro

`rv-virt:nsh`, `mb 0xdeadbeef 1` faults on an invalid address, and the backtrace for nsh_main (tid 2) itself contains duplicate frames. This happens any time `up_backtrace()` tries to backtrace self from `up_interrupt_context()`.

```
NuttShell (NSH) NuttX-13.0.0
nsh> ps
  TID   PID  PPID PRI POLICY   TYPE    NPX STATE    EVENT     SIGMASK            STACK    USED FILLED COMMAND
    0     0     0   0 FIFO     Kthread   - Ready              0000000000000000 0002016 0000668  33.1%  Idle_Task
    2     2     0 100 RR       Task      - Running            0000000000000000 0001984 0001984 100.0%! nsh_main
nsh> mb 0xdeadbeef 1
riscv_exception: EXCEPTION: Load access fault. MCAUSE: 00000005, EPC: 8000b450, MTVAL: deadbeef
riscv_fault_handler: PANIC!!! Exception = 00000005
dump_assert_info: Current Version: NuttX  13.0.0 2f73fe2267-dirty Jul 20 2026 09:26:46 risc-v
dump_assert_info: Assertion failed panic: at file: :0 task: nsh_main process: nsh_main 0x80008ce2
up_dump_register: EPC: 8000b450
......
stack_dump: 0x80039160: 00000000 00000000 80039180 80002288 00000000 00000000 00000000 00000000
stack_dump: 0x80039180: 00000000 00000000 00000000 00000000 00000000 00000000 00000000 00000000
sched_dumpstack: backtrace| 2: 0x80025234 0x80018dc8 0x80015590 0x80008566 0x80001918 0x8000156a 0x8000150c 0x80000186
sched_dumpstack: backtrace| 2: 0x8000b450 0x8000b3b6 0x8000973a 0x8000a490 0x8000a530 0x80008f42 0x80008d62 0x80008d1e
sched_dumpstack: backtrace| 2: 0x80006248 0x80002288 0x8000b450 0x8000b3b6 0x8000973a 0x8000a490 0x8000a530 0x80008f42
sched_dumpstack: backtrace| 2: 0x80008d62 0x80008d1e 0x80006248 0x80002288
dump_tasks:    PID GROUP PRI POLICY   TYPE    NPX STATE   EVENT      SIGMASK          STACKBASE  STACKSIZE      USED   FILLED    COMMAND
dump_tasks:   ----   --- --- -------- ------- --- ------- ---------- ---------------- 0x80034380      2048      1100    53.7%    irq
dump_task:       0     0   0 FIFO     Kthread -   Ready              0000000000000000 0x80037180      2016       668    33.1%    Idle_Task
dump_task:       2     2 100 RR       Task    -   Running            0000000000000000 0x800389c0      1984      1984   100.0%!   nsh_main
sched_dumpstack: backtrace| 0: 0x80008bc0 0x80037950 0x800014a0 0x80000048
sched_dumpstack: backtrace| 2: 0x80025234 0x80018dc8 0x800151d8 0x80015960 0x80015624 0x80008566 0x80001918 0x8000156a
sched_dumpstack: backtrace| 2: 0x8000150c 0x80000186 0x8000b450 0x8000b3b6 0x8000973a 0x8000a490 0x8000a530 0x80008f42
sched_dumpstack: backtrace| 2: 0x80008d62 0x80008d1e 0x80006248 0x80002288 0x8000b450 0x8000b3b6 0x8000973a 0x8000a490
sched_dumpstack: backtrace| 2: 0x8000a530 0x80008f42 0x80008d62 0x80008d1e 0x80006248 0x80002288
```

The duplicated part (`0x8000b450 0x8000b3b6 0x8000973a 0x8000a490 0x8000a530 0x80008f42 0x80008d62 0x80008d1e 0x80006248 0x80002288`) resolved via addr2line:

```
huang@ubuntu:~/workspace/nuttx-fork/nuttx$ riscv64-unknown-elf-addr2line -f -i -e nuttx 0x8000b450 0x8000b3b6 0x8000973a 0x8000a490 0x8000a530 0x80008f42 0x80008d62 0x80008d1e 0x80006248 0x80002288
cmd_mb
/home/huang/workspace/nuttx-fork/apps/nshlib/nsh_dbgcmds.c:150
nsh_command
/home/huang/workspace/nuttx-fork/apps/nshlib/nsh_command.c:1321
nsh_execute
/home/huang/workspace/nuttx-fork/apps/nshlib/nsh_parse.c:759
nsh_parse_command
/home/huang/workspace/nuttx-fork/apps/nshlib/nsh_parse.c:2911
nsh_parse
/home/huang/workspace/nuttx-fork/apps/nshlib/nsh_parse.c:3116
nsh_session
/home/huang/workspace/nuttx-fork/apps/nshlib/nsh_session.c:249
nsh_consolemain
/home/huang/workspace/nuttx-fork/apps/nshlib/nsh_consolemain.c:81
nsh_main
/home/huang/workspace/nuttx-fork/apps/system/nsh/nsh_main.c:82
nxtask_startup
/home/huang/workspace/nuttx-fork/nuttx/libs/libc/sched/task_startup.c:72 (discriminator 1)
nxtask_start
/home/huang/workspace/nuttx-fork/nuttx/sched/task/task_start.c:72
```

The same duplication reproduces under `rv-virt:pnsh` as well.

Along the way, several related but independent issues were found and fixed and are tracked as separate PRs: https://github.com/apache/nuttx/pull/19439, https://github.com/apache/nuttx/pull/19468, https://github.com/apache/nuttx/pull/19471, https://github.com/apache/nuttx/pull/19479, https://github.com/apache/nuttx/pull/19487.

This PR also picks up two small, related fixes/improvements along the way:

1. `up_idle()` is a leaf function that doesn't spill `ra`, which produced garbage frames at the tail of a backtrace that unwound through it.
2. Under `CONFIG_BUILD_KERNEL`, when a user app is killed due to a fault, its backtrace is now dumped proactively to help with debugging.

Since these two are small in scope, the rest of this description focuses on the `up_backtrace()` fix/rework described above.

## Impact

Only affects `up_backtrace()` in `arch/risc-v/src/common/riscv_backtrace.c`. Fixes the missing-kernel-stack-frames bug under `CONFIG_BUILD_KERNEL` and the duplicate-frame bug under `CONFIG_BUILD_FLAT`/`CONFIG_BUILD_PROTECTED` described above, and replaces the previous scenario-specific hardcoded branches with a general multi-range registration + relay walk. Behavior for already-covered scenarios should stay equivalent or become more complete (recovering previously missing frames); no new Kconfig options or API changes.

## Testing

Only one SiFive U74 risc-v SoC is available as real hardware, so most of the verification below is on QEMU.

Config dimensions covered:

1. rv32 / rv64
2. BUILD_FLAT / BUILD_PROTECTED / BUILD_KERNEL
3. no-smp / smp
4. CONFIG_ARCH_INTERRUPTSTACK > 15 / < 15

The full cross product is 2 * 3 * 2 * 2 = 24 combinations, too many to cover individually. Testing mainly relied on the existing nsh/pnsh/knsh/smp/ksmp64 configs, with `CONFIG_ARCH_INTERRUPTSTACK` toggled manually to cover the remaining combination. These configs cover the combinations of interest:

| Config          | Arch | Build mode | SMP | INTERRUPTSTACK > 15 | KERNEL_STACK + ADDRENV | LIBC_SYSCALL |
|------------------|------|------------|-----|----------------------|------------------------|--------------|
| nsh              | RV32 | FLAT       | N   | Y                    | N                      | N            |
| pnsh             | RV32 | PROTECTED  | N   | Y                    | N                      | Y            |
| knsh             | RV32 | KERNEL     | N   | Y                    | Y                      | Y            |
| smp              | RV64 | FLAT       | Y   | Y                    | N                      | N            |
| ksmp64           | RV64 | KERNEL     | Y   | Y                    | Y                      | Y            |
| nsh (no intstack)  | RV32 | FLAT       | N   | N                    | N                      | N            |
| pnsh (no intstack) | RV32 | PROTECTED  | N   | N                    | N                      | Y            |
| knsh (no intstack) | RV32 | KERNEL     | N   | N                    | Y                      | Y            |

Scenarios covered (the most complex case involves interrupt stack + kernel stack + user stack together; there's also an independent dimension of backtracing self vs. a different task, where cross-task backtracing under BUILD_KERNEL additionally has to cross address spaces):

1. ostest
2. dumpstack (application) on self / another task
3. `mb` on an invalid address triggering a panic with backtrace output
4. backtrace from an interrupt handler that preempted a kernel thread
5. backtrace from an interrupt handler that preempted a user thread running in user mode
6. backtrace from an interrupt handler that preempted a user thread that had trapped into the kernel via a syscall
7. NULL pointer access inside an interrupt handler that preempted a kernel thread, triggering a panic with backtrace output
8. NULL pointer access inside an interrupt handler that preempted a user thread running in user mode, triggering a panic with backtrace output
9. NULL pointer access inside an interrupt handler that preempted a user thread that had trapped into the kernel via a syscall, triggering a panic with backtrace output
10. a user thread trapping into the kernel and accessing a NULL pointer, triggering a panic with backtrace output

Notes:

- Under BUILD_FLAT/BUILD_PROTECTED, scenarios 4/5/6 are treated as a single case, since these build modes don't distinguish user stack from kernel stack; likewise for 7/8/9. Scenario 10 only applies to BUILD_KERNEL.
- Under SMP, interrupt-handler scenarios only test backtracing self (cross-CPU backtracing from interrupt context isn't recommended).

Test matrix and results (`-` means not applicable for that config):

| Config             | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10 |
|--------------------|---|---|---|---|---|---|---|---|---|----|
| nsh                | Y | Y | Y | Y |   |   | Y |   |   | -  |
| pnsh               | Y | Y | Y | Y |   |   | Y |   |   | -  |
| knsh               | Y | Y | Y | Y | Y | Y | Y | Y | Y | Y  |
| smp                | Y | Y | Y | Y |   |   | Y |   |   | -  |
| ksmp64             | Y | Y | Y | Y | Y | Y | Y | Y | Y | Y  |
| nsh (no intstack)  | Y | Y | Y | Y |   |   | Y |   |   | -  |
| pnsh (no intstack) | Y | Y | Y | Y |   |   | Y |   |   | -  |
| knsh (no intstack) | Y | Y | Y | Y | Y | Y | Y | Y | Y | Y  |

All the above test cases have been covered, and the backtrace output matched expectations in every case.