### PR TITLE
binfmt/elf: treat nx_priority == 0 as "use the default"

### DIFF
--- a/binfmt/elf.c
+++ b/binfmt/elf.c
@@ -184,8 +184,19 @@ static int elf_loadbinary(FAR struct binary_s *binp,
       binp->stacksize = CONFIG_ELF_STACKSIZE;
     }
 
+  /* A zero nx_priority means "use the default", not "priority zero".  That
+   * is how apps/Application.mk encodes PRIORITY = SCHED_PRIORITY_DEFAULT:
+   *
+   *   SYM_PRIORITY = $(if $(filter SCHED_PRIORITY_DEFAULT,\
+   *                       $(PRIORITY_$@)),0,$(PRIORITY_$@))
+   *
+   * Taking it literally gives the task the idle task's priority, so it is
+   * queued behind the idle task and never runs -- the program loads, reports
+   * no error, and simply never executes an instruction.
+   */
+
   ret = libelf_findsymbol(&loadinfo, "nx_priority", &sym);
-  if (ret == 0)
+  if (ret == 0 && sym.st_value != 0)
     {
       binp->priority = sym.st_value;
     }


### PR DESCRIPTION
## Summary

`apps/Application.mk` stamps each program's configured priority into its ELF as
an absolute `nx_priority` symbol, and encodes `PRIORITY = SCHED_PRIORITY_DEFAULT`
as **zero**:

```make
$(PROGLIST): SYM_PRIORITY = $(if $(filter SCHED_PRIORITY_DEFAULT,$(PRIORITY_$@)),0,$(PRIORITY_$@))
$(PROGLIST): MODLDFLAGS += $(if $(PRIORITY_$@),--defsym nx_priority=$(SYM_PRIORITY))
```

`elf_loadbinary()` takes that literally:

```c
ret = libelf_findsymbol(&loadinfo, "nx_priority", &sym);
if (ret == 0)
  {
    binp->priority = sym.st_value;   /* 0 means "default", not priority 0 */
  }
```

so any program whose `Makefile` declares `PRIORITY = SCHED_PRIORITY_DEFAULT` —
`testing/ostest` among them — is created at priority 0. That ties with the idle
task, the new task is queued *behind* it, and it never runs.

The failure gives nothing to go on: the loader reports success, `binfmt_dumpmodule`
looks normal, the task appears in the task list as READY-TO-RUN, and the program
never executes an instruction. There is no error message anywhere.

This changes the zero to mean what `Application.mk` intends by it.

## Impact

Affects any configuration that loads ELF programs (`CONFIG_ELF`) and runs an
application whose `Makefile` uses `PRIORITY = SCHED_PRIORITY_DEFAULT`. Those
programs currently never run; with this change they are created at
`SCHED_PRIORITY_DEFAULT` as intended.

No impact on programs that specify a numeric priority — those already worked and
are unchanged. No API, ABI, build-system or configuration change. Architecture
independent.

## Testing

**Host:** macOS 15 (darwin 25.5.0), `xtensa-esp32s3-elf-gcc` 12.2.

**Target:** ESP32-S3-DevKitC-1 with an ESP32-S3-WROOM-2 (N32R8V) module, running a
`CONFIG_BUILD_KERNEL` configuration where `/system/bin/init` (NSH) and the test
programs are separate ELF files in a ROMFS, loaded by `binfmt/elf`.

**Which programs are affected, confirmed by what each binary asks for:**

```
$ xtensa-esp32s3-elf-nm bin/ostest   | grep nx_priority
00000000 A nx_priority          <- PRIORITY = SCHED_PRIORITY_DEFAULT
$ xtensa-esp32s3-elf-nm bin/init     | grep nx_priority
00000064 A nx_priority          <- CONFIG_SYSTEM_NSH_PRIORITY=100
$ xtensa-esp32s3-elf-nm bin/getprime | grep nx_priority
00000032 A nx_priority          <- CONFIG_TESTING_GETPRIME_PRIORITY=50
```

**Before.** `ostest` loads and then produces no output at all; the shell never
returns. Programs with numeric priorities are unaffected and run normally.

```
nsh> /system/bin/ostest
load_absmodule: Successfully loaded module /system/bin/ostest
binfmt_dumpmodule:   entrypt:   0x42c0000c
binfmt_dumpmodule:   stacksize: 8192
exec_module: Executing /system/bin/ostest
exec_module: Initialize the user heap (heapsize=1048576)
<nothing further>
```

Halted over JTAG (OpenOCD + `xtensa-esp32s3-elf-gdb`) and walked the scheduler
state, sampled four times ~12 s apart — stable, not a transient:

```
running=Idle_Task  [0:Idle_Task st=3] [1:lpwork st=5] [3:/system/bin/init st=6] [4:/system/bin/ostest st=2]
```

state 3 = `TSTATE_TASK_RUNNING`, 2 = `TSTATE_TASK_READYTORUN`. Walking
`g_readytorun` shows why:

```
===== g_readytorun list =====
  Idle_Task pid=0 prio=0 state=3
  /system/bin/ostest pid=4 prio=0 state=2
```

`ostest` is correctly enqueued, at priority 0, behind the idle task.

**After.** Same board, same image apart from this patch:

```
nsh> /system/bin/ostest
...
user_main: Exiting
ostest_main: Exiting with status 0
nsh> free
      total       used       free    maxused    maxfree  nused  nfree name
     379640      18744     360896     105648     353800     79      4 Kmem
    4194304    1245184    2949120               2949120               Page
```

`ostest` runs to completion with status 0, and the page pool returns to its
baseline.

**Regression check on the same target**, all unchanged by this patch: `getprime`
(priority 50) runs and reports the same result and timing; NSH (priority 100)
starts and remains interactive; `ps` shows no zombies after repeated runs.

`./tools/checkpatch.sh -f binfmt/elf.c` passes.


## Second reproduction: RISC-V, and it is an assert rather than a hang

The same bug reproduces on `rv-virt:knsh64` under QEMU, on unmodified `master`
(`216edd74db`) with no other patches applied. This needs no hardware and no
JTAG, so it is a much cheaper reproduction than the one above.

**Host:** macOS 15 (darwin 25.5.0), xPack `riscv-none-elf-gcc` 14.2.0-3 — the
version `tools/ci/platforms/darwin.sh` pins. **Target:** `rv-virt:knsh64`
(`CONFIG_BUILD_KERNEL` + `CONFIG_ARCH_ADDRENV`), NSH and the test programs as
separate ELFs loaded by `binfmt/elf` over hostfs.

Worth flagging for reviewers, because the symptom is not the one described
above: `knsh64` has `CONFIG_DEBUG_ASSERTIONS=y`, so the priority-0 task never
survives long enough to be mis-queued behind the idle task. It trips the
priority sanity check in `nxsched_add_prioritized()` while
`exec_module()` → `nxtask_activate()` is still enqueueing it:

```c
/* sched/sched/sched.h */
static inline_function bool nxsched_add_prioritized(FAR struct tcb_s *tcb,
                                                    DSEG dq_queue_t *list)
{
  uint8_t sched_priority = tcb->sched_priority;
  ...
  DEBUGASSERT(sched_priority >= SCHED_PRIORITY_MIN);
```

**Before**, on `master`:

```
NuttShell (NSH) NuttX-13.0.0
nsh> ostest
[    7.964000] dump_assert_info: Current Version: NuttX  13.0.0 216edd74db risc-v
[    7.964000] dump_assert_info: Assertion failed : at file: sched/sched/sched.h:466 task: /system/bin/init process: /system/bin/init
```

So the two symptoms are the same defect seen through different lenses: with
assertions off the task is silently queued behind idle and never runs; with
assertions on it never reaches a ready list at all. Either way the priority-0
task is the cause, and the give-away is the same in both — the loader reports
success and the program produces no output.

Same evidence from the binaries on this target:

```
$ riscv-none-elf-readelf -sW bin/ostest   | grep nx_priority
    17: 0000000000000000     0 NOTYPE  GLOBAL DEFAULT  ABS nx_priority
$ riscv-none-elf-readelf -sW bin/init     | grep nx_priority
    39: 0000000000000064     0 NOTYPE  GLOBAL DEFAULT  ABS nx_priority
$ riscv-none-elf-readelf -sW bin/getprime | grep nx_priority
    12: 0000000000000032     0 NOTYPE  GLOBAL DEFAULT  ABS nx_priority
```

**After**, same config with this patch — `ostest` launches and the whole suite
runs to completion, with no assertion, exception or `ERROR` line anywhere in
the output:

```
nsh> ostest
...
user_main: Exiting
ostest_main: Exiting with status 0
```

**Regression check on this target**, unchanged by the patch: `hello`
(priority 100) prints normally, and `getprime` (priority 50) reports the same
result and effectively the same timing before and after (`found 1230 primes`,
58 ms → 59 ms). Binaries carrying a numeric `nx_priority` are unaffected, as
expected.

Reproduce with:

```sh
./tools/configure.sh rv-virt:knsh64 && make olddefconfig && make -j
make export && cd ../apps
./tools/mkimport.sh -z -x ../nuttx/nuttx-export-*.tar.gz && make import && cd ../nuttx
qemu-system-riscv64 -semihosting -M virt,aclint=on -cpu rv64 -smp 1 \
  -kernel ./nuttx -nographic
```

Note `knsh64` sets `CONFIG_ARCH_USE_S_MODE=y`, so OpenSBI is required — do not
pass the `-bios none` that the rv-virt documentation otherwise suggests.
