### PR TITLE
sim/alsa: Use bundled codec headers.

### DIFF
--- a/arch/sim/src/sim/CMakeLists.txt
+++ b/arch/sim/src/sim/CMakeLists.txt
@@ -137,6 +137,9 @@ if(CONFIG_SIM_SOUND_ALSA)
   list(APPEND SRCS posix/sim_alsa.c)
   list(APPEND SRCS sim_offload.c)
   list(APPEND STDLIBS asound)
+  target_include_directories(
+    arch PRIVATE ${NUTTX_APPS_DIR}/audioutils/lame/lame/include
+                 ${NUTTX_APPS_DIR}/audioutils/libmad/libmad)
 endif()
 
 # host sources ###############################################################

--- a/arch/sim/src/sim/sim_offload.c
+++ b/arch/sim/src/sim/sim_offload.c
@@ -27,7 +27,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/debug.h>
 
-#include <lame/lame.h>
+#include <lame.h>
 #include <mad.h>
 
 #include "sim_offload.h"


### PR DESCRIPTION
## Summary

Fix CMake header integration for the `sim:alsa` audio offload codec implementation.

`sim_offload.c` uses LAME and libmad from the checked-out `nuttx-apps` tree, but the `arch` CMake target did not receive their include directories. It also included LAME as `<lame/lame.h>`, while the bundled public header is `lame/include/lame.h`. The build consequently depended on host-installed codec development headers and failed when they were absent.

This change uses `<lame.h>` and exposes the bundled LAME and libmad include directories only when `CONFIG_SIM_SOUND_ALSA=y`.

Companion Apps PR: https://github.com/apache/nuttx-apps/pull/3666

The companion PR adds the LAME vector translation units that are required at link time when LAME enables x86 SSE2/AVX2 runtime dispatch. Both PRs are required for a complete CMake `sim:alsa` fix.

## Impact

- New feature: **No**.
- User adaptation: **No**.
- Build impact: **Yes**. Makes the CMake `sim:alsa` target use bundled LAME/libmad headers instead of relying on host codec header installation.
- Hardware impact: **No**. The change is limited to the simulator ALSA configuration.
- Documentation impact: **No**.
- Security impact: **No**.
- Compatibility impact: **No**. It corrects the include path for the bundled Apps codecs.
- Dependency: https://github.com/apache/nuttx-apps/pull/3666

## Testing

Verified locally with the companion Apps branch.

- Build host: Fedora Linux 44, x86_64, GCC 16.1.1.
- Target: `sim:alsa`, CMake/Ninja, `CONFIG_SIM_M32=y`.

Before this change, compilation stopped in `sim_offload.c`:

```text
fatal error: lame/lame.h: No such file or directory
```

After this change, with the companion Apps change applied:

```sh
cmake -B build -DBOARD_CONFIG=sim:alsa -DNXTMPDIR=OFF -GNinja
cmake --build build -j4
```

completed successfully and produced `nuttx.tgz`.

Additional verification:

```sh
./tools/checkpatch.sh -f arch/sim/src/sim/sim_offload.c
./tools/checkpatch.sh -f arch/sim/src/sim/CMakeLists.txt
git diff --check
```

All checks completed successfully.

No hardware runtime test applies to this host simulator build.

## PR verification self-check

- [x] This PR introduces one focused functional change.
- [x] All required PR description fields are completed.
- [x] The commit has a descriptive topic/body, `Signed-off-by`, and `Assisted-by` trailer.
- [x] The modified files pass `checkpatch.sh` and `git diff --check`.
- [x] This PR is ready for review.
