### PR TITLE
Documentation: add du command to NSH commands reference

### DIFF
--- a/Documentation/applications/nsh/commands.rst
+++ b/Documentation/applications/nsh/commands.rst
@@ -431,6 +431,47 @@ that in-memory, circular buffer to the NSH console output.
 ``dmesg`` has the side effect of clearing the buffered data so
 that entering ``dmesg`` again will show only newly buffered data.
 
+.. _cmddu:
+
+``du`` Estimate File Space Usage
+================================
+
+**Command Syntax**::
+
+  du [-h] [-s] [-a] [-d N] <path>...
+
+**Synopsis**. Recursively summarize the apparent size of each
+``<path>`` in 1K-blocks, or in human-readable form with ``-h``. If
+no ``<path>`` is given, the current working directory is used. As
+an example::
+
+  nsh> du
+  397449  /data/test/elf
+  71993   /data/test/coredump
+  5       /data/test/log2
+  3251    /data/test/log1
+  472700  /data/test
+  nsh> du -h
+  388.1M  /data/test/elf
+  70.3M   /data/test/coredump
+  4.1K    /data/test/log2
+  3.1M    /data/test/log1
+  461.6M  /data/test
+  nsh>
+
+**Options**
+
+========  ===========================================================
+``-s``    Summary only: print only the total for each ``<path>``.
+``-a``    List all files, not only directories.
+``-d N``  Print at most N directory depth levels.
+``-h``    Human-readable sizes (K/M/G, one decimal; ``B`` below 1K).
+========  ===========================================================
+
+Sizes are apparent sizes (``st_size``), not block usage. ``-h``
+prints one decimal using integer arithmetic and does not require
+float printf support.
+
 .. _cmdecho:
 
 ``echo`` Echo Strings and Variables


### PR DESCRIPTION
## Summary

Add a reference section for the NSH `du` command, covering the -h,
-s, -a, and -d N options, default-to-current-directory behavior,
and an example showing recursive directory output.

Options are rendered as an RST simple table to match the style of
other NSH command sections (ls, umount, uptime). Sizes are noted as
apparent sizes (st_size) and -h as integer-arithmetic, one-decimal
output that needs no float printf support.

The `du` nsh command implementation has been merged https://github.com/apache/nuttx-apps/pull/3656


## Impact

- **Users**: None -- only for documentation.
- **Build**: None.
- **Hardware**: None.
- **Documentation**: Adds the `du` command section to the NSH commands
  reference.
- **Security & Compatibility**: None.

## Testing

Documentation-only change; `du` command test refers to https://github.com/apache/nuttx-apps/pull/3656