### PR TITLE
boards/lm3s6965-ek: Disable CONFIG_READLINE_EDIT to fix build

### DIFF
--- a/boards/arm/tiva/lm3s6965-ek/configs/qemu-protected/defconfig
+++ b/boards/arm/tiva/lm3s6965-ek/configs/qemu-protected/defconfig
@@ -6,6 +6,7 @@
 # modifications.
 #
 # CONFIG_NSH_DISABLE_DATE is not set
+# CONFIG_READLINE_EDIT is not set
 CONFIG_ARCH="arm"
 CONFIG_ARCH_BOARD="lm3s6965-ek"
 CONFIG_ARCH_BOARD_LM3S6965EK=y


### PR DESCRIPTION
## Summary

When enabling CONFIG_READLINE_EDIT the CI fails because it reports there is not left space in this device.

## Impact

Fix nuttx-apps CI issue

## Testing

Building correctly.