### PR TITLE
cmake: Omit default priority ELF symbol.

### DIFF
--- a/cmake/nuttx_add_application.cmake
+++ b/cmake/nuttx_add_application.cmake
@@ -153,10 +153,7 @@ function(nuttx_add_application)
           set(SYMBOL_STACKSIZE $<$<NOT:$<BOOL:${USE_LINKER}>>:-Wl,>--defsym
                                nx_stacksize=${STACKSIZE})
         endif()
-        if(PRIORITY)
-          if(PRIORITY STREQUAL "SCHED_PRIORITY_DEFAULT")
-            set(PRIORITY "0")
-          endif()
+        if(PRIORITY AND NOT PRIORITY STREQUAL "SCHED_PRIORITY_DEFAULT")
           set(SYMBOL_PRIORITY $<$<NOT:$<BOOL:${USE_LINKER}>>:-Wl,>--defsym
                               nx_priority=${PRIORITY})
         endif()


### PR DESCRIPTION
## Summary

`nuttx_add_application()` translates `SCHED_PRIORITY_DEFAULT` into a zero-valued `nx_priority` linker symbol for CMake-built ELF applications. Priority zero is invalid for a runnable application task; on assertion-enabled targets, launching such an application triggers the scheduler priority assertion.

Do not emit `nx_priority` when an application selects `SCHED_PRIORITY_DEFAULT`. The ELF loader already uses its scheduler default when the symbol is absent. Explicit numeric priorities continue to be emitted unchanged.

This is the CMake companion to [apache/nuttx-apps#3667](https://github.com/apache/nuttx-apps/pull/3667), which makes the corresponding correction for Make-built application ELFs. Together they replace the need for the broader ELF-loader workaround proposed in apache/nuttx#19537.

## Impact

- **Feature/API/ABI:** No new feature or API/ABI change.
- **Users:** No user action required. CMake-built applications using `SCHED_PRIORITY_DEFAULT` receive the existing scheduler default instead of an invalid priority-zero ELF attribute.
- **Build:** CMake kernel/loadable-ELF link metadata changes only. Applications with explicit numeric priorities are unchanged.
- **Hardware/architecture:** None; the CMake helper is architecture-independent.
- **Documentation:** No update required; behavior now matches the existing ELF-loader default semantics.
- **Security:** No security impact.
- **Compatibility:** Improves compatibility with the loader's default-priority behavior. It does not alter explicitly configured numeric priorities.

## Testing

Host: Fedora Linux x86_64; CMake 4.3.0; Ninja 1.13.2; xPack `riscv-none-elf-gcc` 14.2.0.

Target configuration: `rv-virt:knsh64` (RISC-V 64-bit kernel ELF build).

Commands:

```console
cmake -S nuttx -B cmake-knsh64 -G Ninja -DBOARD_CONFIG=rv-virt:knsh64
ninja -C cmake-knsh64 -t commands ELF_ostest
ninja -C cmake-knsh64 -t commands ELF_getprime
./tools/checkpatch.sh -f cmake/nuttx_add_application.cmake
```

After this change, the generated `ostest` link command contains no `nx_priority` definition:

```console
riscv-none-elf-ld ... -o .../bin_debug/ostest
```

The explicit numeric-priority regression check is retained:

```console
riscv-none-elf-ld ... --defsym nx_priority=50 ... -o .../bin_debug/getprime
```

A generated-build-tree search found no `--defsym nx_priority=0`. `./tools/checkpatch.sh -f cmake/nuttx_add_application.cmake` and `git diff --check` pass.

The full CMake/Ninja `rv-virt:knsh64` build could not complete on this host because CMake invokes this xPack toolchain's `riscv-none-elf-ld` with its default 32-bit emulation while the target objects are 64-bit:

```text
target emulation `elf64-littleriscv' does not match `elf32-littleriscv'
```

This is unrelated to the priority change. No physical-hardware runtime validation is available in this workspace, so this PR is marked draft pending that validation.

## PR verification self-check

- [x] This PR introduces one focused CMake build-system correction.
- [x] All required description fields are updated.
- [x] The commit follows the Contributing Guidelines, including `Assisted-by` and human sign-off trailers.
- [x] This PR is a work in progress pending hardware build/runtime validation.
- [x] This PR is ready for review and can be safely merged.
