### PR TITLE
arch/sim: Track sim_head dependencies

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -57,7 +57,8 @@ NUTTX = $(call CONVERT_PATH,$(TOPDIR)$(DELIM)nuttx$(EXEEXT))
 # there are a fews that must be included because they
 # are called only from the host OS-specific logic(HOSTOBJS)
 
-LINKOBJS = sim_head$(OBJEXT)
+LINKSRCS = sim_head.c
+LINKOBJS = $(LINKSRCS:.c=$(OBJEXT))
 REQUIREDOBJS = $(LINKOBJS) sim_doirq$(OBJEXT)
 ifeq ($(CONFIG_SIM_NETUSRSOCK),y)
   REQUIREDOBJS += sim_usrsock$(OBJEXT)
@@ -346,7 +347,7 @@ NUTTXOBJS = $(AOBJS) $(COBJS)
 HOSTOBJS = $(HOSTCOBJS) $(HOSTMOBJS)
 HEADOBJ = $(HEADSRC:.c=$(OBJEXT))
 
-SRCS = $(ASRCS) $(CSRCS) $(HOSTSRCS) $(HOSTMSRCS)
+SRCS = $(ASRCS) $(CSRCS) $(HOSTSRCS) $(HOSTMSRCS) $(LINKSRCS)
 OBJS = $(AOBJS) $(COBJS) $(HOSTOBJS)
 
 $(foreach lib,$(notdir $(wildcard $(APPDIR)$(DELIM)staging$(DELIM)*$(LIBEXT))), \
@@ -529,7 +530,8 @@ export_startup: sim_head.o $(HOSTOBJS) nuttx-names.dat
 
 # Dependencies
 
-makedepfile: $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds) $(HOSTSRCS:.c=.ddh)
+makedepfile: $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds) \
+             $(HOSTSRCS:.c=.ddh) $(LINKSRCS:.c=.ddc)
 	$(call CATFILE, Make.dep, $^)
 	$(call DELFILE, $^)
 
@@ -565,7 +567,8 @@ distclean:: clean
 	$(Q) if [ -e board/Makefile ]; then \
 		$(MAKE) -C board distclean ; \
 	fi
-	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds) $(HOSTSRCS:.c=.ddh))
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds) \
+	                   $(HOSTSRCS:.c=.ddh) $(LINKSRCS:.c=.ddc))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 	$(call DELFILE, config.h)


### PR DESCRIPTION
## Summary

Track `sim_head.c` as a separate link source and include it in the simulator
Make dependency generation and cleanup lists.

`sim_head.o` is linked separately from `libarch`, so `sim_head.c` was not in
`CSRCS`. It was also absent from `SRCS` and `makedepfile`, leaving the object
without entries in `Make.dep`. Configuration or header changes therefore did
not rebuild it during an incremental build.

The source remains outside `CSRCS`, preserving the existing link behavior.

Fixes #2211. The `up_head.c` name in that issue has since been renamed to
`sim_head.c`.

## Impact

Make-based simulator builds now rebuild `sim_head.o` when its configuration
or included headers change. This prevents stale simulator startup logic after
incremental configuration changes.

There are no API, hardware, documentation, security, or compatibility
changes.

## Testing

Build host:

- Ubuntu 20.04.6 LTS, x86_64
- GCC 10.5.0

Target:

- `sim:nsh`

On current `master`, changing from `CONFIG_ALLSYMS=n` to
`CONFIG_ALLSYMS=y` and rebuilding left `sim_head.o` unchanged:

```text
CONFIG_ALLSYMS=y
make_exit=0
before=1785117234
after=1785117234
```

The stale object did not contain `allsyms_relocate()`, even though the final
image contained the generated `g_allsyms` table.

With this change:

```text
sim_head.o: sim/sim_head.c /usr/include/stdc-predef.h ...
CONFIG_ALLSYMS=y
make_exit=0
before=1785117701
after=1785117720
CC: sim/sim_head.c
```

Both the rebuilt object and final image contain the expected relocation
function:

```text
0000000000000000 t allsyms_relocate
0000000040002672 t allsyms_relocate
```

The simulator also started successfully:

```text
NuttShell (NSH) NuttX-13.0.0
nsh> uname -a
NuttX 13.0.0 44299ddfcf-dirty Jul 27 2026 10:01:57 sim sim
```

Additional checks:

- `./tools/checkpatch.sh -f arch/sim/src/Makefile`
- `git diff --check`
- `make distclean`, including removal of a generated `sim_head.ddc`
