### PR TITLE
Documentation: add nsh boot command reference

### DIFF
--- a/Documentation/applications/nsh/commands.rst
+++ b/Documentation/applications/nsh/commands.rst
@@ -143,6 +143,23 @@ default gateway.
 removing the preceding path segments and (optionally) removing any
 trailing ``<suffix>``.
 
+.. _cmdboot:
+
+``boot`` Boot an Application Image
+==================================
+
+**Command Syntax**::
+
+  boot [<image path> [<header size>]]
+
+**Synopsis**. Boot a new application firmware image by invoking
+``boardctl(BOARDIOC_BOOT_IMAGE)``. The ``<image path>`` may be
+absolute or relative; relative paths are resolved against the NSH
+current working directory, consistent with ``cp``, ``cat``, and
+``rm``. This command depends on ``CONFIG_BOARDCTL_BOOT_IMAGE``; if
+the boot image cannot be started, ``boardctl()`` returns and an
+error is reported.
+
 .. _cmdbreak:
 
 ``break`` Terminate a Loop

--- a/Documentation/applications/nsh/config.rst
+++ b/Documentation/applications/nsh/config.rst
@@ -35,6 +35,7 @@ Command                Depends on Configuration                    Can Be Disabl
 :ref:`cmdbase64enc`    ``CONFIG_NETUTILS_CODECS`` &&               ``CONFIG_NSH_DISABLE_BASE64ENC``
                        ``CONFIG_CODECS_BASE64``
 :ref:`cmdbasename`     .                                           ``CONFIG_NSH_DISABLE_BASENAME``
+:ref:`cmdboot`         ``CONFIG_BOARDCTL_BOOT_IMAGE``              ``CONFIG_NSH_DISABLE_BOOT``
 :ref:`cmdbreak`        ! ``CONFIG_NSH_DISABLESCRIPT`` &&           .
                        ! ``CONFIG_NSH_DISABLE_LOOPS``  
 :ref:`cmdcat`          ``CONFIG_NSH_DISABLE_CAT``                  .


### PR DESCRIPTION
## Summary

Add `boot` commands.rst section describing its syntax and behavior, including relative image path resolution against the NSH
current working directory, and `boot` command config.rst dependency-table entry mapping `CONFIG_BOARDCTL_BOOT_IMAGE` and `CONFIG_NSH_DISABLE_BOOT`.

Depends on https://github.com/apache/nuttx-apps/pull/3668

## Impact

- Users: None -- documentation only
- Build: None -- no build-system or source change.
- Hardware: None.
- Documentation: Adds the missing boot command reference and config.rst dependency-table entry.
- Security & Compatibility: None.

## Testing

Documentation-only change; no build or runtime behavior affected.