### PR TITLE
tools/nxstyle: fix most of the incompatibilities with the coding standard

### DIFF
--- a/audio/audio.c
+++ b/audio/audio.c
@@ -895,6 +895,7 @@ static int audio_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         {
           FAR struct audio_caps_s *caps =
                      (FAR struct audio_caps_s *)((uintptr_t)arg);
+
           DEBUGASSERT(lower->ops->getcaps != NULL);
 
           audinfo("AUDIOIOC_GETCAPS: Device=%d\n", caps->ac_type);
@@ -1342,6 +1343,7 @@ static int audio_poll(FAR struct file *filep,
       /* This is a request to tear down the poll. */
 
       FAR struct pollfd **slot = (FAR struct pollfd **)fds->priv;
+
       *slot = NULL;
       fds->priv = NULL;
     }

--- a/audio/audio_comp.c
+++ b/audio/audio_comp.c
@@ -193,6 +193,7 @@ static int audio_comp_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
           FAR struct audio_caps_s dup = *caps;
 
           int tmp = lower[i]->ops->getcaps(lower[i], type, &dup);
+
           if (tmp == -ENOTTY)
             {
               continue;
@@ -294,6 +295,7 @@ static int audio_comp_shutdown(FAR struct audio_lowerhalf_s *dev)
       if (lower[i]->ops->shutdown)
         {
           int tmp = lower[i]->ops->shutdown(lower[i]);
+
           if (tmp == -ENOTTY)
             {
               continue;
@@ -680,6 +682,7 @@ static int audio_comp_ioctl(FAR struct audio_lowerhalf_s *dev, int cmd,
       if (lower[i]->ops->ioctl)
         {
           int tmp = lower[i]->ops->ioctl(lower[i], cmd, arg);
+
           if (tmp == -ENOTTY)
             {
               continue;

--- a/audio/pcm_decode.c
+++ b/audio/pcm_decode.c
@@ -493,7 +493,7 @@ static void pcm_subsample_configure(FAR struct pcm_decode_s *priv,
        * next audio buffer that we receive.
        */
 
-       priv->subsample = subsample;
+      priv->subsample = subsample;
     }
 }
 #endif
@@ -1089,9 +1089,11 @@ static int pcm_enqueuebuffer(FAR struct audio_lowerhalf_s *dev,
 #ifndef CONFIG_AUDIO_FORMAT_RAW
   ssize_t headersize = pcm_parsewav(priv, &apb->samp[apb->curbyte],
                                     bytesleft);
+
   if (headersize > 0)
     {
       struct audio_caps_s caps;
+
       memset(&caps, 0, sizeof(caps));
 
       /* Configure the lower level for the number of channels, bitrate,

--- a/drivers/audio/audio_dma.c
+++ b/drivers/audio/audio_dma.c
@@ -162,22 +162,22 @@ static int audio_dma_getcaps(struct audio_lowerhalf_s *dev, int type,
 
         if (caps->ac_subtype == AUDIO_TYPE_QUERY)
           {
-              /* We don't decode any formats!  Only something above us in
-               * the audio stream can perform decoding on our behalf.
-               */
+            /* We don't decode any formats!  Only something above us in
+             * the audio stream can perform decoding on our behalf.
+             */
 
-              /* The types of audio units we implement */
+            /* The types of audio units we implement */
 
-              if (audio_dma->playback)
+            if (audio_dma->playback)
               {
                 caps->ac_controls.b[0] = AUDIO_TYPE_OUTPUT;
               }
-              else
+            else
               {
                 caps->ac_controls.b[0] = AUDIO_TYPE_INPUT;
               }
 
-              caps->ac_format.hw = 1 << (AUDIO_FMT_PCM - 1);
+            caps->ac_format.hw = 1 << (AUDIO_FMT_PCM - 1);
           }
 
         caps->ac_controls.b[0] = AUDIO_SUBFMT_END;
@@ -194,11 +194,11 @@ static int audio_dma_getcaps(struct audio_lowerhalf_s *dev, int type,
           {
             /* Report the Sample rates we support */
 
-              caps->ac_controls.hw[0] = AUDIO_SAMP_RATE_DEF_ALL;
+            caps->ac_controls.hw[0] = AUDIO_SAMP_RATE_DEF_ALL;
           }
 
         break;
-   }
+    }
 
   /* Return the length of the audio_caps_s struct for validation of
    * proper Audio device type.
@@ -233,9 +233,14 @@ static int audio_dma_configure(struct audio_lowerhalf_s *dev,
             memset(&cfg, 0, sizeof(struct dma_config_s));
             cfg.direction = DMA_MEM_TO_DEV;
             if (audio_dma->fifo_width)
-              cfg.dst_width = audio_dma->fifo_width;
+              {
+                cfg.dst_width = audio_dma->fifo_width;
+              }
             else
-              cfg.dst_width = caps->ac_controls.b[2] / 8;
+              {
+                cfg.dst_width = caps->ac_controls.b[2] / 8;
+              }
+
             ret = DMA_CONFIG(audio_dma->chan, &cfg);
           }
         break;
@@ -245,9 +250,14 @@ static int audio_dma_configure(struct audio_lowerhalf_s *dev,
             memset(&cfg, 0, sizeof(struct dma_config_s));
             cfg.direction = DMA_DEV_TO_MEM;
             if (audio_dma->fifo_width)
-              cfg.src_width = audio_dma->fifo_width;
+              {
+                cfg.src_width = audio_dma->fifo_width;
+              }
             else
-              cfg.src_width = caps->ac_controls.b[2] / 8;
+              {
+                cfg.src_width = caps->ac_controls.b[2] / 8;
+              }
+
             ret = DMA_CONFIG(audio_dma->chan, &cfg);
           }
         break;
@@ -382,9 +392,13 @@ static int audio_dma_allocbuffer(struct audio_lowerhalf_s *dev,
         }
 
       if (audio_dma->playback)
-        audio_dma->src_addr = up_addrenv_va_to_pa(audio_dma->alloc_addr);
+        {
+          audio_dma->src_addr = up_addrenv_va_to_pa(audio_dma->alloc_addr);
+        }
       else
-        audio_dma->dst_addr = up_addrenv_va_to_pa(audio_dma->alloc_addr);
+        {
+          audio_dma->dst_addr = up_addrenv_va_to_pa(audio_dma->alloc_addr);
+        }
     }
 
   apb = kumm_zalloc(sizeof(struct ap_buffer_s));
@@ -438,8 +452,10 @@ static int audio_dma_enqueuebuffer(struct audio_lowerhalf_s *dev,
   irqstate_t flags;
 
   if (audio_dma->playback)
-    up_clean_dcache((uintptr_t)apb->samp,
-                    (uintptr_t)apb->samp + apb->nbytes);
+    {
+      up_clean_dcache((uintptr_t)apb->samp,
+                      (uintptr_t)apb->samp + apb->nbytes);
+    }
 
   apb->flags |= AUDIO_APB_OUTPUT_ENQUEUED;
 
@@ -525,18 +541,22 @@ static void audio_dma_callback(struct dma_chan_s *chan,
     }
 
   if (!audio_dma->playback)
-    up_invalidate_dcache((uintptr_t)apb->samp,
-                         (uintptr_t)apb->samp + apb->nbytes);
+    {
+      up_invalidate_dcache((uintptr_t)apb->samp,
+                           (uintptr_t)apb->samp + apb->nbytes);
+    }
 
   if ((apb->flags & AUDIO_APB_FINAL) != 0)
-    final = true;
+    {
+      final = true;
+    }
 
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-    audio_dma->dev.upper(audio_dma->dev.priv, AUDIO_CALLBACK_DEQUEUE,
-                         apb, OK, NULL);
+  audio_dma->dev.upper(audio_dma->dev.priv, AUDIO_CALLBACK_DEQUEUE,
+                       apb, OK, NULL);
 #else
-    audio_dma->dev.upper(audio_dma->dev.priv, AUDIO_CALLBACK_DEQUEUE,
-                         apb, OK);
+  audio_dma->dev.upper(audio_dma->dev.priv, AUDIO_CALLBACK_DEQUEUE,
+                       apb, OK);
 #endif
   if (final)
     {
@@ -589,9 +609,13 @@ struct audio_lowerhalf_s *audio_dma_initialize(struct dma_dev_s *dma_dev,
   audio_dma->fifo_width = fifo_width;
 
   if (audio_dma->playback)
-    audio_dma->dst_addr = up_addrenv_va_to_pa((FAR void *)fifo_addr);
+    {
+      audio_dma->dst_addr = up_addrenv_va_to_pa((FAR void *)fifo_addr);
+    }
   else
-    audio_dma->src_addr = up_addrenv_va_to_pa((FAR void *)fifo_addr);
+    {
+      audio_dma->src_addr = up_addrenv_va_to_pa((FAR void *)fifo_addr);
+    }
 
   audio_dma->buffer_size = CONFIG_AUDIO_BUFFER_NUMBYTES;
   audio_dma->buffer_num  = CONFIG_AUDIO_NUM_BUFFERS;

--- a/drivers/audio/audio_fake.c
+++ b/drivers/audio/audio_fake.c
@@ -591,6 +591,7 @@ static int audio_fake_configure(FAR struct audio_lowerhalf_s *dev,
 {
   FAR struct audio_fake_s *priv = (FAR struct audio_fake_s *)dev;
   int ret;
+
   audinfo("ac_type: %d\n", caps->ac_type);
 
   if (priv->mqname[0] == '\0')
@@ -901,6 +902,7 @@ static int audio_fake_pause(FAR struct audio_lowerhalf_s *dev)
 #endif
 {
   FAR struct audio_fake_s *priv = (FAR struct audio_fake_s *)dev;
+
   audinfo("%s pause\n", priv->dev_params->dev_name);
   return OK;
 }
@@ -922,6 +924,7 @@ static int audio_fake_resume(FAR struct audio_lowerhalf_s *dev)
 #endif
 {
   FAR struct audio_fake_s *priv = (FAR struct audio_fake_s *)dev;
+
   audinfo("%s resume\n", priv->dev_params->dev_name);
   return OK;
 }
@@ -1048,6 +1051,7 @@ static int audio_fake_reserve(FAR struct audio_lowerhalf_s *dev)
 #endif
 {
   FAR struct audio_fake_s *priv = (FAR struct audio_fake_s *)dev;
+
   priv->terminate               = false;
   audinfo("%s reserve\n", priv->dev_params->dev_name);
   return OK;

--- a/drivers/audio/audio_i2s.c
+++ b/drivers/audio/audio_i2s.c
@@ -155,27 +155,27 @@ static int audio_i2s_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
 
         if (caps->ac_subtype == AUDIO_TYPE_QUERY)
           {
-              /* We don't decode any formats!  Only something above us in
-               * the audio stream can perform decoding on our behalf.
-               */
+            /* We don't decode any formats!  Only something above us in
+             * the audio stream can perform decoding on our behalf.
+             */
 
-              /* The types of audio units we implement */
+            /* The types of audio units we implement */
 
-              if (audio_i2s->playback)
-                {
-                  caps->ac_controls.b[0] = AUDIO_TYPE_OUTPUT;
-                }
-              else
-                {
-                  caps->ac_controls.b[0] = AUDIO_TYPE_INPUT;
-                }
+            if (audio_i2s->playback)
+              {
+                caps->ac_controls.b[0] = AUDIO_TYPE_OUTPUT;
+              }
+            else
+              {
+                caps->ac_controls.b[0] = AUDIO_TYPE_INPUT;
+              }
 
-              caps->ac_format.hw = 1 << (AUDIO_FMT_PCM - 1);
-              break;
+            caps->ac_format.hw = 1 << (AUDIO_FMT_PCM - 1);
+            break;
           }
 
-         caps->ac_controls.b[0] = AUDIO_SUBFMT_END;
-         break;
+        caps->ac_controls.b[0] = AUDIO_SUBFMT_END;
+        break;
 
         /* Provide capabilities of our OUTPUT unit */
 
@@ -186,11 +186,11 @@ static int audio_i2s_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
           {
             /* Report the Sample rates we support */
 
-              caps->ac_controls.hw[0] = AUDIO_SAMP_RATE_DEF_ALL;
+            caps->ac_controls.hw[0] = AUDIO_SAMP_RATE_DEF_ALL;
 
-              caps->ac_channels = 2;
+            caps->ac_channels = 2;
 
-              break;
+            break;
           }
 
       default:

--- a/drivers/audio/audio_null.c
+++ b/drivers/audio/audio_null.c
@@ -395,6 +395,7 @@ static int null_configure(FAR struct audio_lowerhalf_s *dev,
 #endif
 {
   FAR struct null_dev_s *priv = (FAR struct null_dev_s *)dev;
+
   audinfo("ac_type: %d\n", caps->ac_type);
 
   if (priv->mqname[0] == '\0')
@@ -427,48 +428,48 @@ static int null_configure(FAR struct audio_lowerhalf_s *dev,
 
   switch (caps->ac_type)
     {
-    case AUDIO_TYPE_FEATURE:
-      audinfo("  AUDIO_TYPE_FEATURE\n");
+      case AUDIO_TYPE_FEATURE:
+        audinfo("  AUDIO_TYPE_FEATURE\n");
 
-      /* Process based on Feature Unit */
+        /* Process based on Feature Unit */
 
-      switch (caps->ac_format.hw)
-        {
+        switch (caps->ac_format.hw)
+          {
 #ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
-        case AUDIO_FU_VOLUME:
-          audinfo("    Volume: %d\n", caps->ac_controls.hw[0]);
-          break;
+            case AUDIO_FU_VOLUME:
+              audinfo("    Volume: %d\n", caps->ac_controls.hw[0]);
+              break;
 #endif /* CONFIG_AUDIO_EXCLUDE_VOLUME */
 
 #ifndef CONFIG_AUDIO_EXCLUDE_TONE
-        case AUDIO_FU_BASS:
-          audinfo("    Bass: %d\n", caps->ac_controls.b[0]);
-          break;
+            case AUDIO_FU_BASS:
+              audinfo("    Bass: %d\n", caps->ac_controls.b[0]);
+              break;
 
-        case AUDIO_FU_TREBLE:
-          audinfo("    Treble: %d\n", caps->ac_controls.b[0]);
-          break;
+            case AUDIO_FU_TREBLE:
+              audinfo("    Treble: %d\n", caps->ac_controls.b[0]);
+              break;
 #endif /* CONFIG_AUDIO_EXCLUDE_TONE */
 
-        default:
-          auderr("    ERROR: Unrecognized feature unit\n");
-          break;
-        }
-      break;
+            default:
+              auderr("    ERROR: Unrecognized feature unit\n");
+              break;
+          }
+        break;
 
-    case AUDIO_TYPE_OUTPUT:
-    case AUDIO_TYPE_INPUT:
-      priv->scaler = caps->ac_channels
-                   * caps->ac_controls.hw[0]
-                   * caps->ac_controls.b[2] / 8;
-      audinfo("    Number of channels: %u\n", caps->ac_channels);
-      audinfo("    Sample rate:        %u\n", caps->ac_controls.hw[0]);
-      audinfo("    Sample width:       %u\n", caps->ac_controls.b[2]);
-      break;
+      case AUDIO_TYPE_OUTPUT:
+      case AUDIO_TYPE_INPUT:
+        priv->scaler = caps->ac_channels
+                     * caps->ac_controls.hw[0]
+                     * caps->ac_controls.b[2] / 8;
+        audinfo("    Number of channels: %u\n", caps->ac_channels);
+        audinfo("    Sample rate:        %u\n", caps->ac_controls.hw[0]);
+        audinfo("    Sample width:       %u\n", caps->ac_controls.b[2]);
+        break;
 
-    case AUDIO_TYPE_PROCESSING:
-      audinfo("  AUDIO_TYPE_PROCESSING:\n");
-      break;
+      case AUDIO_TYPE_PROCESSING:
+        audinfo("  AUDIO_TYPE_PROCESSING:\n");
+        break;
     }
 
   audinfo("Return OK\n");
@@ -789,7 +790,7 @@ static int null_ioctl(FAR struct audio_lowerhalf_s *dev, int cmd,
         }
         break;
 
-       /* Report our preferred buffer size and quantity */
+        /* Report our preferred buffer size and quantity */
 
 #ifdef CONFIG_AUDIO_DRIVER_SPECIFIC_BUFFERS
       case AUDIOIOC_GETBUFFERINFO:

--- a/drivers/audio/cs4344.c
+++ b/drivers/audio/cs4344.c
@@ -538,84 +538,85 @@ cs4344_configure(FAR struct audio_lowerhalf_s *dev,
 
   switch (caps->ac_type)
     {
-    case AUDIO_TYPE_FEATURE:
-      audinfo("  AUDIO_TYPE_FEATURE\n");
+      case AUDIO_TYPE_FEATURE:
+        audinfo("  AUDIO_TYPE_FEATURE\n");
 
-      /* Process based on Feature Unit */
+        /* Process based on Feature Unit */
 
-      switch (caps->ac_format.hw)
+        switch (caps->ac_format.hw)
+          {
+            default:
+              auderr("    ERROR: Unrecognized feature unit\n");
+              ret = -ENOTTY;
+              break;
+          }
+        break;
+
+      case AUDIO_TYPE_OUTPUT:
         {
-        default:
-          auderr("    ERROR: Unrecognized feature unit\n");
-          ret = -ENOTTY;
-          break;
+          ret = OK;
+
+          audinfo("  AUDIO_TYPE_OUTPUT:\n");
+          audinfo("    Number of channels: %u\n", caps->ac_channels);
+          audinfo("    Sample rate:        %u\n", caps->ac_controls.hw[0]);
+          audinfo("    Sample width:       %u\n", caps->ac_controls.b[2]);
+
+          /* Verify that all of the requested values are supported */
+
+          if (caps->ac_channels != 1 && caps->ac_channels != 2)
+            {
+              auderr("ERROR: Unsupported number of channels: %d\n",
+                     caps->ac_channels);
+              ret = -ERANGE;
+              break;
+            }
+
+          if (caps->ac_controls.b[2] != 16 && caps->ac_controls.b[2] != 24)
+            {
+              auderr("ERROR: Unsupported bits per sample: %d\n",
+                     caps->ac_controls.b[2]);
+              ret = -ERANGE;
+              break;
+            }
+
+          /* Save the current stream configuration */
+
+          priv->samprate  = caps->ac_controls.hw[0];
+          priv->nchannels = caps->ac_channels;
+          priv->bpsamp    = caps->ac_controls.b[2];
+
+          /* Reconfigure the master clock to support the resulting number
+           * of channels, data width, and sample rate. However, if I2S lower
+           * half doesn't provide support for setting the master clock,
+           * execution goes on and try just to set the data width and sample
+           * rate.
+           */
+
+          ret = cs4344_setmclkfrequency(priv);
+          if (ret != OK)
+            {
+              if (ret != -ENOTTY)
+                {
+                  auderr("ERROR: Unsupported combination of sample rate and"
+                         "data width\n");
+                  break;
+                }
+              else
+                {
+                  audwarn("WARNING: MCLK could not be set on lower half\n");
+                  priv->mclk_freq = 0;
+                  ret = OK;
+                }
+            }
+
+          cs4344_settxchannels(priv);
+          cs4344_setdatawidth(priv);
+          cs4344_setbitrate(priv);
         }
         break;
 
-    case AUDIO_TYPE_OUTPUT:
-      {
-        ret = OK;
-
-        audinfo("  AUDIO_TYPE_OUTPUT:\n");
-        audinfo("    Number of channels: %u\n", caps->ac_channels);
-        audinfo("    Sample rate:        %u\n", caps->ac_controls.hw[0]);
-        audinfo("    Sample width:       %u\n", caps->ac_controls.b[2]);
-
-        /* Verify that all of the requested values are supported */
-
-        if (caps->ac_channels != 1 && caps->ac_channels != 2)
-          {
-            auderr("ERROR: Unsupported number of channels: %d\n",
-                   caps->ac_channels);
-            ret = -ERANGE;
-            break;
-          }
-
-        if (caps->ac_controls.b[2] != 16 && caps->ac_controls.b[2] != 24)
-          {
-            auderr("ERROR: Unsupported bits per sample: %d\n",
-                   caps->ac_controls.b[2]);
-            ret = -ERANGE;
-            break;
-          }
-
-        /* Save the current stream configuration */
-
-        priv->samprate  = caps->ac_controls.hw[0];
-        priv->nchannels = caps->ac_channels;
-        priv->bpsamp    = caps->ac_controls.b[2];
-
-        /* Reconfigure the master clock to support the resulting number of
-         * channels, data width, and sample rate. However, if I2S lower half
-         * doesn't provide support for setting the master clock, execution
-         * goes on and try just to set the data width and sample rate.
-         */
-
-        ret = cs4344_setmclkfrequency(priv);
-        if (ret != OK)
-          {
-            if (ret != -ENOTTY)
-              {
-                auderr("ERROR: Unsupported combination of sample rate and"
-                       "data width\n");
-                break;
-              }
-            else
-              {
-                audwarn("WARNING: MCLK could not be set on lower half\n");
-                priv->mclk_freq = 0;
-                ret = OK;
-              }
-          }
-
-        cs4344_settxchannels(priv);
-        cs4344_setdatawidth(priv);
-        cs4344_setbitrate(priv);
-      }
-      break;
-
-    case AUDIO_TYPE_PROCESSING:
-      break;
+      case AUDIO_TYPE_PROCESSING:
+        break;
     }
 
   return ret;
@@ -1137,7 +1138,7 @@ static int cs4344_ioctl(FAR struct audio_lowerhalf_s *dev, int cmd,
         }
         break;
 
-       /* Report our preferred buffer size and quantity */
+        /* Report our preferred buffer size and quantity */
 
 #ifdef CONFIG_AUDIO_DRIVER_SPECIFIC_BUFFERS
       case AUDIOIOC_GETBUFFERINFO:
@@ -1194,7 +1195,7 @@ static int cs4344_reserve(FAR struct audio_lowerhalf_s *dev)
       /* Initialize the session context */
 
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-     *session           = NULL;
+      *session           = NULL;
 #endif
       priv->inflight    = 0;
       priv->running     = false;

--- a/drivers/audio/cs43l22.c
+++ b/drivers/audio/cs43l22.c
@@ -703,150 +703,154 @@ cs43l22_configure(FAR struct audio_lowerhalf_s *dev,
 
   switch (caps->ac_type)
     {
-    case AUDIO_TYPE_FEATURE:
-      audinfo("  AUDIO_TYPE_FEATURE\n");
+      case AUDIO_TYPE_FEATURE:
+        audinfo("  AUDIO_TYPE_FEATURE\n");
 
-      /* Process based on Feature Unit */
+        /* Process based on Feature Unit */
 
-      switch (caps->ac_format.hw)
-        {
-#ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
-        case AUDIO_FU_VOLUME:
+        switch (caps->ac_format.hw)
           {
-            /* Set the volume */
-
-            uint16_t volume = caps->ac_controls.hw[0];
-            audinfo("    Volume: %d\n", volume);
-
-            if (volume >= 0 && volume <= 1000)
+#ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
+            case AUDIO_FU_VOLUME:
               {
-                /* Scale the volume setting to the range {76..255} */
+                /* Set the volume */
 
-                cs43l22_setvolume(priv, (179 * volume / 1000) + 76,
-                                  priv->mute);
+                uint16_t volume = caps->ac_controls.hw[0];
+
+                audinfo("    Volume: %d\n", volume);
+
+                if (volume >= 0 && volume <= 1000)
+                  {
+                    /* Scale the volume setting to the range {76..255} */
+
+                    cs43l22_setvolume(priv, (179 * volume / 1000) + 76,
+                                      priv->mute);
+                  }
+                else
+                  {
+                    ret = -EDOM;
+                  }
               }
-            else
-              {
-                ret = -EDOM;
-              }
-          }
-          break;
+              break;
 #endif /* CONFIG_AUDIO_EXCLUDE_VOLUME */
 
 #ifndef CONFIG_AUDIO_EXCLUDE_BALANCE
-        case AUDIO_FU_BALANCE:
-          {
-            /* Set the Balance */
-
-            uint16_t balance = caps->ac_controls.hw[0];
-            audinfo("    Balance: %d\n", balance);
-            if (balance >= 0 && balance <= 1000)
+            case AUDIO_FU_BALANCE:
               {
-                /* Scale the volume setting to the range {76..255} */
+                /* Set the Balance */
 
-                cs43l22_setvolume(priv, (179 * priv->volume / 1000) + 76,
-                                  priv->mute);
+                uint16_t balance = caps->ac_controls.hw[0];
+
+                audinfo("    Balance: %d\n", balance);
+                if (balance >= 0 && balance <= 1000)
+                  {
+                    /* Scale the volume setting to the range {76..255} */
+
+                    cs43l22_setvolume(priv, (179 * priv->volume / 1000) + 76,
+                                      priv->mute);
+                  }
+                else
+                  {
+                    ret = -EDOM;
+                  }
               }
-            else
-              {
-                ret = -EDOM;
-              }
-           }
-          break;
+              break;
 #endif /* CONFIG_AUDIO_EXCLUDE_VOLUME */
 
 #ifndef CONFIG_AUDIO_EXCLUDE_TONE
-        case AUDIO_FU_BASS:
-          {
-            /* Set the bass.  The percentage level (0-100) is in the
-             * ac_controls.b[0] parameter.
-             */
-
-            uint8_t bass = caps->ac_controls.b[0];
-            audinfo("    Bass: %d\n", bass);
-
-            if (bass <= 100)
+            case AUDIO_FU_BASS:
               {
-                cs43l22_setbass(priv, bass);
-              }
-            else
-              {
-                ret = -EDOM;
-              }
-          }
-          break;
+                /* Set the bass.  The percentage level (0-100) is in the
+                 * ac_controls.b[0] parameter.
+                 */
 
-        case AUDIO_FU_TREBLE:
-          {
-            /* Set the treble.  The percentage level (0-100) is in the
-             * ac_controls.b[0] parameter.
-             */
+                uint8_t bass = caps->ac_controls.b[0];
 
-            uint8_t treble = caps->ac_controls.b[0];
-            audinfo("    Treble: %d\n", treble);
+                audinfo("    Bass: %d\n", bass);
 
-            if (treble <= 100)
-              {
-                cs43l22_settreble(priv, treble);
+                if (bass <= 100)
+                  {
+                    cs43l22_setbass(priv, bass);
+                  }
+                else
+                  {
+                    ret = -EDOM;
+                  }
               }
-            else
+              break;
+
+            case AUDIO_FU_TREBLE:
               {
-                ret = -EDOM;
+                /* Set the treble.  The percentage level (0-100) is in the
+                 * ac_controls.b[0] parameter.
+                 */
+
+                uint8_t treble = caps->ac_controls.b[0];
+
+                audinfo("    Treble: %d\n", treble);
+
+                if (treble <= 100)
+                  {
+                    cs43l22_settreble(priv, treble);
+                  }
+                else
+                  {
+                    ret = -EDOM;
+                  }
               }
-          }
-          break;
+              break;
 #endif /* CONFIG_AUDIO_EXCLUDE_TONE */
 
-        default:
-          auderr("    ERROR: Unrecognized feature unit\n");
-          ret = -ENOTTY;
-          break;
+            default:
+              auderr("    ERROR: Unrecognized feature unit\n");
+              ret = -ENOTTY;
+              break;
+          }
+        break;
+
+      case AUDIO_TYPE_OUTPUT:
+        {
+          audinfo("  AUDIO_TYPE_OUTPUT:\n");
+          audinfo("    Number of channels: %u\n", caps->ac_channels);
+          audinfo("    Sample rate:        %u\n", caps->ac_controls.hw[0]);
+          audinfo("    Sample width:       %u\n", caps->ac_controls.b[2]);
+
+          /* Verify that all of the requested values are supported */
+
+          ret = -ERANGE;
+          if (caps->ac_channels != 1 && caps->ac_channels != 2)
+            {
+              auderr("ERROR: Unsupported number of channels: %d\n",
+                     caps->ac_channels);
+              break;
+            }
+
+          if (caps->ac_controls.b[2] != 8 && caps->ac_controls.b[2] != 16)
+            {
+              auderr("ERROR: Unsupported bits per sample: %d\n",
+                     caps->ac_controls.b[2]);
+              break;
+            }
+
+          /* Save the current stream configuration */
+
+          priv->samprate  = caps->ac_controls.hw[0];
+          priv->nchannels = caps->ac_channels;
+          priv->bpsamp    = caps->ac_controls.b[2];
+
+          /* Reconfigure the FLL to support the resulting number or channels,
+           * bits per sample, and bitrate.
+           */
+
+          cs43l22_setdatawidth(priv);
+          cs43l22_setbitrate(priv);
+          cs43l22_clock_analysis(&priv->dev, "AUDIO_TYPE_OUTPUT");
+          ret = OK;
         }
         break;
 
-    case AUDIO_TYPE_OUTPUT:
-      {
-        audinfo("  AUDIO_TYPE_OUTPUT:\n");
-        audinfo("    Number of channels: %u\n", caps->ac_channels);
-        audinfo("    Sample rate:        %u\n", caps->ac_controls.hw[0]);
-        audinfo("    Sample width:       %u\n", caps->ac_controls.b[2]);
-
-        /* Verify that all of the requested values are supported */
-
-        ret = -ERANGE;
-        if (caps->ac_channels != 1 && caps->ac_channels != 2)
-          {
-            auderr("ERROR: Unsupported number of channels: %d\n",
-                   caps->ac_channels);
-            break;
-          }
-
-        if (caps->ac_controls.b[2] != 8 && caps->ac_controls.b[2] != 16)
-          {
-            auderr("ERROR: Unsupported bits per sample: %d\n",
-                   caps->ac_controls.b[2]);
-            break;
-          }
-
-        /* Save the current stream configuration */
-
-        priv->samprate  = caps->ac_controls.hw[0];
-        priv->nchannels = caps->ac_channels;
-        priv->bpsamp    = caps->ac_controls.b[2];
-
-        /* Reconfigure the FLL to support the resulting number or channels,
-         * bits per sample, and bitrate.
-         */
-
-        cs43l22_setdatawidth(priv);
-        cs43l22_setbitrate(priv);
-        cs43l22_clock_analysis(&priv->dev, "AUDIO_TYPE_OUTPUT");
-        ret = OK;
-      }
-      break;
-
-    case AUDIO_TYPE_PROCESSING:
-      break;
+      case AUDIO_TYPE_PROCESSING:
+        break;
     }
 
   return ret;
@@ -1391,7 +1395,7 @@ static int cs43l22_ioctl(FAR struct audio_lowerhalf_s *dev, int cmd,
         }
         break;
 
-       /* Report our preferred buffer size and quantity */
+        /* Report our preferred buffer size and quantity */
 
 #ifdef CONFIG_AUDIO_DRIVER_SPECIFIC_BUFFERS
       case AUDIOIOC_GETBUFFERINFO:
@@ -1448,7 +1452,7 @@ static int cs43l22_reserve(FAR struct audio_lowerhalf_s *dev)
       /* Initialize the session context */
 
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-     *session           = NULL;
+      *session           = NULL;
 #endif
       priv->inflight    = 0;
       priv->running     = false;
@@ -1864,12 +1868,12 @@ static void cs43l22_reset(FAR struct cs43l22_dev_s *priv)
 
   /* Configure the FLL and the LRCLK */
 
-    cs43l22_setbitrate(priv);
+  cs43l22_setbitrate(priv);
 
   /* Dump some information and return the device instance */
 
-    cs43l22_dump_registers(&priv->dev, "After configuration");
-    cs43l22_clock_analysis(&priv->dev, "After configuration");
+  cs43l22_dump_registers(&priv->dev, "After configuration");
+  cs43l22_clock_analysis(&priv->dev, "After configuration");
 }
 
 /****************************************************************************

--- a/drivers/audio/es7210.c
+++ b/drivers/audio/es7210.c
@@ -774,6 +774,7 @@ static int es7210_ioctl(FAR struct audio_lowerhalf_s *dev, int cmd,
         {
           FAR struct ap_buffer_info_s *bufinfo =
             (FAR struct ap_buffer_info_s *)arg;
+
           bufinfo->buffer_size = CONFIG_ES7210_BUFFER_SIZE;
           bufinfo->nbuffers    = CONFIG_ES7210_NUM_BUFFERS;
         }
@@ -900,6 +901,7 @@ static void es7210_worker(FAR void *arg)
   for (; ; )
     {
       irqstate_t flags = enter_critical_section();
+
       apb = (FAR struct ap_buffer_s *)dq_remfirst(&priv->doneq);
       leave_critical_section(flags);
 

--- a/drivers/audio/es8311.c
+++ b/drivers/audio/es8311.c
@@ -824,12 +824,12 @@ static int es8311_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
 
         if (caps->ac_subtype == AUDIO_TYPE_QUERY)
           {
-              /* The types of audio units we implement */
+            /* The types of audio units we implement */
 
-              caps->ac_controls.b[0] = AUDIO_TYPE_INPUT |
-                                       AUDIO_TYPE_OUTPUT |
-                                       AUDIO_TYPE_FEATURE;
-              break;
+            caps->ac_controls.b[0] = AUDIO_TYPE_INPUT |
+                                     AUDIO_TYPE_OUTPUT |
+                                     AUDIO_TYPE_FEATURE;
+            break;
           }
 
         caps->ac_controls.b[0] = AUDIO_SUBFMT_END;
@@ -844,16 +844,16 @@ static int es8311_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
 
         if (caps->ac_subtype == AUDIO_TYPE_QUERY)
           {
-              /* Report the Sample rates we support */
+            /* Report the Sample rates we support */
 
-              /* 8kHz is hardware dependent */
+            /* 8kHz is hardware dependent */
 
-              caps->ac_controls.hw[0] =
-                AUDIO_SAMP_RATE_11K | AUDIO_SAMP_RATE_16K |
-                AUDIO_SAMP_RATE_22K | AUDIO_SAMP_RATE_32K |
-                AUDIO_SAMP_RATE_44K | AUDIO_SAMP_RATE_48K;
-              break;
-         }
+            caps->ac_controls.hw[0] =
+              AUDIO_SAMP_RATE_11K | AUDIO_SAMP_RATE_16K |
+              AUDIO_SAMP_RATE_22K | AUDIO_SAMP_RATE_32K |
+              AUDIO_SAMP_RATE_44K | AUDIO_SAMP_RATE_48K;
+            break;
+          }
 
         break;
 
@@ -863,14 +863,14 @@ static int es8311_getcaps(FAR struct audio_lowerhalf_s *dev, int type,
 
         if (caps->ac_subtype == AUDIO_TYPE_QUERY)
           {
-              /* Report supported input sample rates */
+            /* Report supported input sample rates */
 
-              caps->ac_controls.hw[0] =
-                AUDIO_SAMP_RATE_11K | AUDIO_SAMP_RATE_16K |
-                AUDIO_SAMP_RATE_22K | AUDIO_SAMP_RATE_32K |
-                AUDIO_SAMP_RATE_44K | AUDIO_SAMP_RATE_48K;
-              break;
-         }
+            caps->ac_controls.hw[0] =
+              AUDIO_SAMP_RATE_11K | AUDIO_SAMP_RATE_16K |
+              AUDIO_SAMP_RATE_22K | AUDIO_SAMP_RATE_32K |
+              AUDIO_SAMP_RATE_44K | AUDIO_SAMP_RATE_48K;
+            break;
+          }
 
         break;
 
@@ -948,159 +948,162 @@ static int es8311_configure(FAR struct audio_lowerhalf_s *dev,
 
   switch (caps->ac_type)
     {
-    case AUDIO_TYPE_FEATURE:
-      audinfo("  AUDIO_TYPE_FEATURE\n");
+      case AUDIO_TYPE_FEATURE:
+        audinfo("  AUDIO_TYPE_FEATURE\n");
 
-      /* Process based on Feature Unit */
+        /* Process based on Feature Unit */
 
-      switch (caps->ac_format.hw)
-        {
-#ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
-        case AUDIO_FU_VOLUME:
+        switch (caps->ac_format.hw)
           {
-            /* Set the volume */
-
-            uint16_t volume = caps->ac_controls.hw[0];
-            audinfo("    Volume: %d\n", volume);
-
-            if (volume >= 0 && volume <= 1000)
+#ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
+            case AUDIO_FU_VOLUME:
               {
-                es8311_setvolume(priv, priv->audio_mode, volume);
-                break;
-              }
+                /* Set the volume */
 
-            ret = -EDOM;
-          }
-          break;
+                uint16_t volume = caps->ac_controls.hw[0];
+
+                audinfo("    Volume: %d\n", volume);
+
+                if (volume >= 0 && volume <= 1000)
+                  {
+                    es8311_setvolume(priv, priv->audio_mode, volume);
+                    break;
+                  }
+
+                ret = -EDOM;
+              }
+              break;
 #endif /* CONFIG_AUDIO_EXCLUDE_VOLUME */
 
 #ifndef CONFIG_AUDIO_EXCLUDE_MUTE
-        case AUDIO_FU_MUTE:
-          {
-            /* Mute/Unmute */
+            case AUDIO_FU_MUTE:
+              {
+                /* Mute/Unmute */
 
-            bool mute = (bool)caps->ac_controls.hw[0];
-            audinfo("    Mute: %d\n", mute);
+                bool mute = (bool)caps->ac_controls.hw[0];
 
-            es8311_setmute(priv, ES_MODULE_DAC, mute);
-          }
-          break;
+                audinfo("    Mute: %d\n", mute);
+
+                es8311_setmute(priv, ES_MODULE_DAC, mute);
+              }
+              break;
 #endif /* CONFIG_AUDIO_EXCLUDE_MUTE */
 
-        case AUDIO_FU_INP_GAIN:
-          {
-            /* Set the mic gain */
+            case AUDIO_FU_INP_GAIN:
+              {
+                /* Set the mic gain */
 
-            uint32_t mic_gain = caps->ac_controls.hw[0];
-            audinfo("    Mic gain: %" PRIu32 "\n", mic_gain);
+                uint32_t mic_gain = caps->ac_controls.hw[0];
 
-            es8311_setmicgain(priv, mic_gain);
+                audinfo("    Mic gain: %" PRIu32 "\n", mic_gain);
+
+                es8311_setmicgain(priv, mic_gain);
+              }
+              break;
+
+            default:
+              auderr("    Unrecognized feature unit\n");
+              ret = -ENOTTY;
+              break;
           }
-          break;
+        break;
 
-        default:
-          auderr("    Unrecognized feature unit\n");
-          ret = -ENOTTY;
-          break;
+      case AUDIO_TYPE_OUTPUT:
+        {
+          audinfo("  AUDIO_TYPE_OUTPUT:\n");
+          audinfo("    Number of channels: %u\n", caps->ac_channels);
+          audinfo("    Sample rate:        %u\n", caps->ac_controls.hw[0]);
+          audinfo("    Sample width:       %u\n", caps->ac_controls.b[2]);
+
+          /* Verify that all of the requested values are supported */
+
+          ret = -ERANGE;
+
+          /* The codec can take stereo audio and play only one channel */
+
+          if (caps->ac_channels != 1 && caps->ac_channels != 2)
+            {
+              auderr("Unsupported number of channels: %d\n",
+                     caps->ac_channels);
+              break;
+            }
+
+          if (caps->ac_controls.b[2] != 16 &&
+              caps->ac_controls.b[2] != 24 &&
+              caps->ac_controls.b[2] != 32)
+            {
+              auderr("Unsupported bits per sample: %d\n",
+                     caps->ac_controls.b[2]);
+              break;
+            }
+
+          es8311_audio_output(priv);
+          es8311_reset(priv);
+
+          /* Save the current stream configuration */
+
+          priv->samprate  = caps->ac_controls.hw[0];
+          priv->bpsamp    = caps->ac_controls.b[2];
+
+          ret = es8311_setsamplerate(priv) == -ENOTTY ? OK : ret;
+          if (ret < 0)
+            {
+              break;
+            }
+
+          ret = es8311_setbitspersample(priv) == -ENOTTY ? OK : ret;
         }
         break;
 
-    case AUDIO_TYPE_OUTPUT:
-      {
-        audinfo("  AUDIO_TYPE_OUTPUT:\n");
-        audinfo("    Number of channels: %u\n", caps->ac_channels);
-        audinfo("    Sample rate:        %u\n", caps->ac_controls.hw[0]);
-        audinfo("    Sample width:       %u\n", caps->ac_controls.b[2]);
+      case AUDIO_TYPE_INPUT:
+        {
+          audinfo("  AUDIO_TYPE_INPUT:\n");
+          audinfo("    Number of channels: %u\n", caps->ac_channels);
+          audinfo("    Sample rate:        %u\n", caps->ac_controls.hw[0]);
+          audinfo("    Sample width:       %u\n", caps->ac_controls.b[2]);
 
-        /* Verify that all of the requested values are supported */
+          /* Verify that all of the requested values are supported */
 
-        ret = -ERANGE;
+          ret = -ERANGE;
 
-        /* The codec can take stereo audio and play only one channel */
+          /* The codec can take stereo audio and play only one channel */
 
-        if (caps->ac_channels != 1 && caps->ac_channels != 2)
-          {
-            auderr("Unsupported number of channels: %d\n",
-                   caps->ac_channels);
-            break;
-          }
+          if (caps->ac_channels != 1 && caps->ac_channels != 2)
+            {
+              auderr("Unsupported number of channels: %d\n",
+                     caps->ac_channels);
+              break;
+            }
 
-        if (caps->ac_controls.b[2] != 16 &&
-            caps->ac_controls.b[2] != 24 &&
-            caps->ac_controls.b[2] != 32)
-          {
-            auderr("Unsupported bits per sample: %d\n",
-                   caps->ac_controls.b[2]);
-            break;
-          }
+          if (caps->ac_controls.b[2] != 16 &&
+              caps->ac_controls.b[2] != 24 &&
+              caps->ac_controls.b[2] != 32)
+            {
+              auderr("Unsupported bits per sample: %d\n",
+                     caps->ac_controls.b[2]);
+              break;
+            }
 
-        es8311_audio_output(priv);
-        es8311_reset(priv);
+          es8311_audio_input(priv);
+          es8311_reset(priv);
 
-        /* Save the current stream configuration */
+          /* Save the current stream configuration */
 
-        priv->samprate  = caps->ac_controls.hw[0];
-        priv->bpsamp    = caps->ac_controls.b[2];
+          priv->samprate  = caps->ac_controls.hw[0];
+          priv->bpsamp    = caps->ac_controls.b[2];
 
-        ret = es8311_setsamplerate(priv) == -ENOTTY ? OK : ret;
-        if (ret < 0)
-          {
-            break;
-          }
+          ret = es8311_setsamplerate(priv) == -ENOTTY ? OK : ret;
+          if (ret != OK)
+            {
+              break;
+            }
 
-        ret = es8311_setbitspersample(priv) == -ENOTTY ? OK : ret;
-      }
-      break;
+          ret = es8311_setbitspersample(priv) == -ENOTTY ? OK : ret;
+        }
+        break;
 
-    case AUDIO_TYPE_INPUT:
-      {
-        audinfo("  AUDIO_TYPE_INPUT:\n");
-        audinfo("    Number of channels: %u\n", caps->ac_channels);
-        audinfo("    Sample rate:        %u\n", caps->ac_controls.hw[0]);
-        audinfo("    Sample width:       %u\n", caps->ac_controls.b[2]);
-
-        /* Verify that all of the requested values are supported */
-
-        ret = -ERANGE;
-
-        /* The codec can take stereo audio and play only one channel */
-
-        if (caps->ac_channels != 1 && caps->ac_channels != 2)
-          {
-            auderr("Unsupported number of channels: %d\n",
-                   caps->ac_channels);
-            break;
-          }
-
-        if (caps->ac_controls.b[2] != 16 &&
-            caps->ac_controls.b[2] != 24 &&
-            caps->ac_controls.b[2] != 32)
-          {
-            auderr("Unsupported bits per sample: %d\n",
-                   caps->ac_controls.b[2]);
-            break;
-          }
-
-        es8311_audio_input(priv);
-        es8311_reset(priv);
-
-        /* Save the current stream configuration */
-
-        priv->samprate  = caps->ac_controls.hw[0];
-        priv->bpsamp    = caps->ac_controls.b[2];
-
-        ret = es8311_setsamplerate(priv) == -ENOTTY ? OK : ret;
-        if (ret != OK)
-          {
-            break;
-          }
-
-        ret = es8311_setbitspersample(priv) == -ENOTTY ? OK : ret;
-      }
-      break;
-
-    case AUDIO_TYPE_PROCESSING:
-      break;
+      case AUDIO_TYPE_PROCESSING:
+        break;
     }
 
   return ret;
@@ -1865,7 +1868,7 @@ static int es8311_reserve(FAR struct audio_lowerhalf_s *dev)
       /* Initialize the session context */
 
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-     *session           = NULL;
+      *session           = NULL;
 #endif /* CONFIG_AUDIO_MULTI_SESSION */
       priv->inflight    = 0;
       priv->running     = false;

--- a/drivers/audio/es8388.c
+++ b/drivers/audio/es8388.c
@@ -938,172 +938,177 @@ static int es8388_configure(FAR struct audio_lowerhalf_s *dev,
 
   switch (caps->ac_type)
     {
-    case AUDIO_TYPE_FEATURE:
-      audinfo("  AUDIO_TYPE_FEATURE\n");
+      case AUDIO_TYPE_FEATURE:
+        audinfo("  AUDIO_TYPE_FEATURE\n");
 
-      /* Process based on Feature Unit */
+        /* Process based on Feature Unit */
 
-      switch (caps->ac_format.hw)
-        {
-#ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
-        case AUDIO_FU_VOLUME:
+        switch (caps->ac_format.hw)
           {
-            /* Set the volume */
-
-            uint16_t volume = caps->ac_controls.hw[0];
-            audinfo("    Volume: %d\n", volume);
-
-            if (volume >= 0 && volume <= 1000)
+#ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
+            case AUDIO_FU_VOLUME:
               {
-                es8388_setvolume(priv, priv->audio_mode, volume);
+                /* Set the volume */
+
+                uint16_t volume = caps->ac_controls.hw[0];
+
+                audinfo("    Volume: %d\n", volume);
+
+                if (volume >= 0 && volume <= 1000)
+                  {
+                    es8388_setvolume(priv, priv->audio_mode, volume);
+                  }
+                else
+                  {
+                    ret = -EDOM;
+                  }
               }
-            else
-              {
-                ret = -EDOM;
-              }
-          }
-          break;
+              break;
 #endif /* CONFIG_AUDIO_EXCLUDE_VOLUME */
 
 #ifndef CONFIG_AUDIO_EXCLUDE_MUTE
-        case AUDIO_FU_MUTE:
-          {
-            /* Mute/Unmute */
+            case AUDIO_FU_MUTE:
+              {
+                /* Mute/Unmute */
 
-            bool mute = (bool)caps->ac_controls.hw[0];
-            audinfo("    Mute: %d\n", mute);
+                bool mute = (bool)caps->ac_controls.hw[0];
 
-            es8388_setmute(priv, ES_MODULE_DAC, mute);
-          }
-          break;
+                audinfo("    Mute: %d\n", mute);
+
+                es8388_setmute(priv, ES_MODULE_DAC, mute);
+              }
+              break;
 #endif /* CONFIG_AUDIO_EXCLUDE_MUTE */
 
 #ifndef CONFIG_AUDIO_EXCLUDE_BALANCE
-        case AUDIO_FU_BALANCE:
-          {
-            /* Set the Balance */
+            case AUDIO_FU_BALANCE:
+              {
+                /* Set the Balance */
 
-            uint16_t balance = caps->ac_controls.hw[0];
-            audinfo("    Balance: %d\n", balance);
-            if (balance >= 0 && balance <= 1000)
-              {
-                priv->balance = balance;
-                es8388_setvolume(priv, priv->audio_mode, priv->volume_out);
+                uint16_t balance = caps->ac_controls.hw[0];
+
+                audinfo("    Balance: %d\n", balance);
+                if (balance >= 0 && balance <= 1000)
+                  {
+                    priv->balance = balance;
+                    es8388_setvolume(priv, priv->audio_mode,
+                                     priv->volume_out);
+                  }
+                else
+                  {
+                    ret = -EDOM;
+                  }
               }
-            else
-              {
-                ret = -EDOM;
-              }
-          }
-          break;
+              break;
 #endif /* CONFIG_AUDIO_EXCLUDE_BALANCE */
 
-        case AUDIO_FU_INP_GAIN:
-          {
-            /* Set the mic gain */
+            case AUDIO_FU_INP_GAIN:
+              {
+                /* Set the mic gain */
 
-            uint32_t mic_gain = caps->ac_controls.hw[0];
-            audinfo("    Mic gain: %" PRIu32 "\n", mic_gain);
+                uint32_t mic_gain = caps->ac_controls.hw[0];
 
-            es8388_setmicgain(priv, mic_gain);
+                audinfo("    Mic gain: %" PRIu32 "\n", mic_gain);
+
+                es8388_setmicgain(priv, mic_gain);
+              }
+              break;
+
+            default:
+              auderr("    Unrecognized feature unit\n");
+              ret = -ENOTTY;
+              break;
           }
-          break;
+        break;
 
-        default:
-          auderr("    Unrecognized feature unit\n");
-          ret = -ENOTTY;
-          break;
+      case AUDIO_TYPE_OUTPUT:
+        {
+          audinfo("  AUDIO_TYPE_OUTPUT:\n");
+          audinfo("    Number of channels: %u\n", caps->ac_channels);
+          audinfo("    Sample rate:        %u\n", caps->ac_controls.hw[0]);
+          audinfo("    Sample width:       %u\n", caps->ac_controls.b[2]);
+
+          /* Verify that all of the requested values are supported */
+
+          ret = -ERANGE;
+          if (caps->ac_channels != 1 && caps->ac_channels != 2)
+            {
+              auderr("Unsupported number of channels: %d\n",
+                     caps->ac_channels);
+              break;
+            }
+
+          if (caps->ac_controls.b[2] != 16 &&
+              caps->ac_controls.b[2] != 18 &&
+              caps->ac_controls.b[2] != 20 &&
+              caps->ac_controls.b[2] != 24 &&
+              caps->ac_controls.b[2] != 32)
+            {
+              auderr("Unsupported bits per sample: %d\n",
+                     caps->ac_controls.b[2]);
+              break;
+            }
+
+          /* Save the current stream configuration */
+
+          priv->samprate  = caps->ac_controls.hw[0];
+          priv->nchannels = caps->ac_channels;
+          priv->bpsamp    = caps->ac_controls.b[2];
+
+          es8388_audio_output(priv);
+          es8388_reset(priv);
+          es8388_setsamplerate(priv);
+          es8388_setbitspersample(priv);
+
+          ret = OK;
         }
         break;
 
-    case AUDIO_TYPE_OUTPUT:
-      {
-        audinfo("  AUDIO_TYPE_OUTPUT:\n");
-        audinfo("    Number of channels: %u\n", caps->ac_channels);
-        audinfo("    Sample rate:        %u\n", caps->ac_controls.hw[0]);
-        audinfo("    Sample width:       %u\n", caps->ac_controls.b[2]);
+      case AUDIO_TYPE_INPUT:
+        {
+          audinfo("  AUDIO_TYPE_INPUT:\n");
+          audinfo("    Number of channels: %u\n", caps->ac_channels);
+          audinfo("    Sample rate:        %u\n", caps->ac_controls.hw[0]);
+          audinfo("    Sample width:       %u\n", caps->ac_controls.b[2]);
 
-        /* Verify that all of the requested values are supported */
+          /* Verify that all of the requested values are supported */
 
-        ret = -ERANGE;
-        if (caps->ac_channels != 1 && caps->ac_channels != 2)
-          {
-            auderr("Unsupported number of channels: %d\n",
-                   caps->ac_channels);
-            break;
-          }
+          ret = -ERANGE;
+          if (caps->ac_channels != 1 && caps->ac_channels != 2)
+            {
+              auderr("Unsupported number of channels: %d\n",
+                     caps->ac_channels);
+              break;
+            }
 
-        if (caps->ac_controls.b[2] != 16 &&
-            caps->ac_controls.b[2] != 18 &&
-            caps->ac_controls.b[2] != 20 &&
-            caps->ac_controls.b[2] != 24 &&
-            caps->ac_controls.b[2] != 32)
-          {
-            auderr("Unsupported bits per sample: %d\n",
-                   caps->ac_controls.b[2]);
-            break;
-          }
+          if (caps->ac_controls.b[2] != 16 &&
+              caps->ac_controls.b[2] != 18 &&
+              caps->ac_controls.b[2] != 20 &&
+              caps->ac_controls.b[2] != 24 &&
+              caps->ac_controls.b[2] != 32)
+            {
+              auderr("Unsupported bits per sample: %d\n",
+                     caps->ac_controls.b[2]);
+              break;
+            }
 
-        /* Save the current stream configuration */
+          /* Save the current stream configuration */
 
-        priv->samprate  = caps->ac_controls.hw[0];
-        priv->nchannels = caps->ac_channels;
-        priv->bpsamp    = caps->ac_controls.b[2];
+          priv->samprate  = caps->ac_controls.hw[0];
+          priv->nchannels = caps->ac_channels;
+          priv->bpsamp    = caps->ac_controls.b[2];
 
-        es8388_audio_output(priv);
-        es8388_reset(priv);
-        es8388_setsamplerate(priv);
-        es8388_setbitspersample(priv);
+          es8388_audio_input(priv);
+          es8388_reset(priv);
+          es8388_setsamplerate(priv);
+          es8388_setbitspersample(priv);
 
-        ret = OK;
-      }
-      break;
+          ret = OK;
+        }
+        break;
 
-        case AUDIO_TYPE_INPUT:
-      {
-        audinfo("  AUDIO_TYPE_INPUT:\n");
-        audinfo("    Number of channels: %u\n", caps->ac_channels);
-        audinfo("    Sample rate:        %u\n", caps->ac_controls.hw[0]);
-        audinfo("    Sample width:       %u\n", caps->ac_controls.b[2]);
-
-        /* Verify that all of the requested values are supported */
-
-        ret = -ERANGE;
-        if (caps->ac_channels != 1 && caps->ac_channels != 2)
-          {
-            auderr("Unsupported number of channels: %d\n",
-                   caps->ac_channels);
-            break;
-          }
-
-        if (caps->ac_controls.b[2] != 16 &&
-            caps->ac_controls.b[2] != 18 &&
-            caps->ac_controls.b[2] != 20 &&
-            caps->ac_controls.b[2] != 24 &&
-            caps->ac_controls.b[2] != 32)
-          {
-            auderr("Unsupported bits per sample: %d\n",
-                   caps->ac_controls.b[2]);
-            break;
-          }
-
-        /* Save the current stream configuration */
-
-        priv->samprate  = caps->ac_controls.hw[0];
-        priv->nchannels = caps->ac_channels;
-        priv->bpsamp    = caps->ac_controls.b[2];
-
-        es8388_audio_input(priv);
-        es8388_reset(priv);
-        es8388_setsamplerate(priv);
-        es8388_setbitspersample(priv);
-
-        ret = OK;
-      }
-      break;
-
-    case AUDIO_TYPE_PROCESSING:
-      break;
+      case AUDIO_TYPE_PROCESSING:
+        break;
     }
 
   return ret;
@@ -1938,7 +1943,7 @@ static int es8388_reserve(FAR struct audio_lowerhalf_s *dev)
       /* Initialize the session context */
 
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-     *session           = NULL;
+      *session           = NULL;
 #endif
       priv->inflight    = 0;
       priv->running     = false;

--- a/drivers/audio/tone.c
+++ b/drivers/audio/tone.c
@@ -217,23 +217,23 @@ static uint32_t note_duration(FAR uint32_t *silence, uint32_t note_length,
   note_period = whole_note_period / note_length;
 
   switch (g_note_mode)
-  {
-    case MODE_NORMAL:
-      *silence = note_period / 8;
-      break;
+    {
+      case MODE_NORMAL:
+        *silence = note_period / 8;
+        break;
 
-    case MODE_STACCATO:
-      *silence = note_period / 4;
-      break;
+      case MODE_STACCATO:
+        *silence = note_period / 4;
+        break;
 
-    case MODE_LEGATO:
-      *silence = 0;
-      break;
+      case MODE_LEGATO:
+        *silence = 0;
+        break;
 
-    default:
-      auderr("Mode undefined!\n");
-      break;
-  }
+      default:
+        auderr("Mode undefined!\n");
+        break;
+    }
 
   note_period -= *silence;
   dot_extension = note_period / 2;
@@ -417,210 +417,210 @@ static void next_note(FAR struct tone_upperhalf_s *upper)
 
       switch (c)
         {
-          uint8_t nt;
+            uint8_t nt;
 
-          /* Select note length */
+            /* Select note length */
 
-        case 'L':
-          g_note_length = next_number();
-          if (g_note_length < 1)
-            {
-              auderr("note length too short!\n");
-              goto tune_error;
-            }
-          break;
+          case 'L':
+            g_note_length = next_number();
+            if (g_note_length < 1)
+              {
+                auderr("note length too short!\n");
+                goto tune_error;
+              }
+            break;
 
-          /* Select octave */
+            /* Select octave */
 
-        case 'O':
-          g_octave = next_number();
-          if (g_octave > 6)
-            {
-              g_octave = 6;
-            }
-          break;
+          case 'O':
+            g_octave = next_number();
+            if (g_octave > 6)
+              {
+                g_octave = 6;
+              }
+            break;
 
-          /* Decrease octave */
+            /* Decrease octave */
 
-        case '<':
-          if (g_octave > 0)
-            {
-              g_octave--;
-            }
-          break;
+          case '<':
+            if (g_octave > 0)
+              {
+                g_octave--;
+              }
+            break;
 
-          /* Increase octave */
+            /* Increase octave */
 
-        case '>':
-          if (g_octave < 6)
-            {
-              g_octave++;
-            }
-          break;
+          case '>':
+            if (g_octave < 6)
+              {
+                g_octave++;
+              }
+            break;
 
-          /* Select inter-note gap */
+            /* Select inter-note gap */
 
-        case 'M':
-          c = next_char();
+          case 'M':
+            c = next_char();
 
-          if (c == 0)
-            {
-              auderr("no character after M!\n");
-              goto tune_error;
-            }
+            if (c == 0)
+              {
+                auderr("no character after M!\n");
+                goto tune_error;
+              }
 
-          g_next++;
+            g_next++;
 
-          switch (c)
-            {
-            case 'N':
-              g_note_mode = MODE_NORMAL;
-              break;
+            switch (c)
+              {
+                case 'N':
+                  g_note_mode = MODE_NORMAL;
+                  break;
 
-            case 'L':
-              g_note_mode = MODE_LEGATO;
-              break;
+                case 'L':
+                  g_note_mode = MODE_LEGATO;
+                  break;
 
-            case 'S':
-              g_note_mode = MODE_STACCATO;
-              break;
+                case 'S':
+                  g_note_mode = MODE_STACCATO;
+                  break;
 
-            case 'F':
-              g_repeat = false;
-              break;
+                case 'F':
+                  g_repeat = false;
+                  break;
 
-            case 'B':
-              g_repeat = true;
-              break;
+                case 'B':
+                  g_repeat = true;
+                  break;
 
-            default:
-              auderr("unknown symbol: %c!\n", c);
-              goto tune_error;
-              break;
-            }
+                default:
+                  auderr("unknown symbol: %c!\n", c);
+                  goto tune_error;
+                  break;
+              }
 
-          /* Pause for a note length */
+            /* Pause for a note length */
 
-        case 'P':
+          case 'P':
 
-          stop_note(upper);
+            stop_note(upper);
 
-          duration = rest_duration(next_number(), next_dots());
+            duration = rest_duration(next_number(), next_dots());
 
-          /* Setup the time duration */
+            /* Setup the time duration */
 
-          sec = duration / USEC_PER_SEC;
-          nsec = ((duration) - (sec * USEC_PER_SEC)) * NSEC_PER_USEC;
+            sec = duration / USEC_PER_SEC;
+            nsec = ((duration) - (sec * USEC_PER_SEC)) * NSEC_PER_USEC;
 
-          ts.tv_sec = sec;
-          ts.tv_nsec = nsec;
+            ts.tv_sec = sec;
+            ts.tv_nsec = nsec;
 
-          ONESHOT_START(upper->oneshot, &ts);
-          return;
+            ONESHOT_START(upper->oneshot, &ts);
+            return;
 
-          /* Change tempo */
+            /* Change tempo */
 
-        case 'T':
-          nt = next_number();
+          case 'T':
+            nt = next_number();
 
-          if ((nt >= 32) && (nt <= 255))
-            {
-              g_tempo = nt;
-            }
-          else
-            {
-              auderr("T is out of range 32-255!\n");
-              goto tune_error;
-            }
-          break;
+            if ((nt >= 32) && (nt <= 255))
+              {
+                g_tempo = nt;
+              }
+            else
+              {
+                auderr("T is out of range 32-255!\n");
+                goto tune_error;
+              }
+            break;
 
-          /* Play an arbitrary note */
+            /* Play an arbitrary note */
 
-        case 'N':
-          note = next_number();
-          if (note > 84)
-            {
-              auderr("Note higher than 84!\n");
-              goto tune_error;
-            }
+          case 'N':
+            note = next_number();
+            if (note > 84)
+              {
+                auderr("Note higher than 84!\n");
+                goto tune_error;
+              }
 
-          /* This is a rest - pause for the current note length */
+            /* This is a rest - pause for the current note length */
 
-          if (note == 0)
-            {
-              duration = rest_duration(g_note_length, next_dots());
+            if (note == 0)
+              {
+                duration = rest_duration(g_note_length, next_dots());
 
-              /* Setup the time duration */
+                /* Setup the time duration */
 
-              sec = duration / USEC_PER_SEC;
-              nsec = ((duration) - (sec * USEC_PER_SEC)) * NSEC_PER_USEC;
+                sec = duration / USEC_PER_SEC;
+                nsec = ((duration) - (sec * USEC_PER_SEC)) * NSEC_PER_USEC;
 
-              ts.tv_sec = sec;
-              ts.tv_nsec = nsec;
+                ts.tv_sec = sec;
+                ts.tv_nsec = nsec;
 
-              ONESHOT_START(upper->oneshot, &ts);
+                ONESHOT_START(upper->oneshot, &ts);
 
-              return;
-            }
-          break;
+                return;
+              }
+            break;
 
-          /* Play a note in the current octave */
+            /* Play a note in the current octave */
 
-        case 'A':
-        case 'B':
-        case 'C':
-        case 'D':
-        case 'E':
-        case 'F':
-        case 'G':
-          note = g_note_tab[c - 'A'] + (g_octave * 12) + 1;
+          case 'A':
+          case 'B':
+          case 'C':
+          case 'D':
+          case 'E':
+          case 'F':
+          case 'G':
+            note = g_note_tab[c - 'A'] + (g_octave * 12) + 1;
 
-          c = next_char();
+            c = next_char();
 
-          switch (c)
-            {
-              /* Up a semitone */
+            switch (c)
+              {
+                /* Up a semitone */
 
-            case '#':
-            case '+':
-              if (note < 84)
-                {
-                  note++;
-                }
+                case '#':
+                case '+':
+                  if (note < 84)
+                    {
+                      note++;
+                    }
 
-              g_next++;
-              break;
+                  g_next++;
+                  break;
 
-              /* Down a semitone */
+                /* Down a semitone */
 
-            case '-':
-              if (note > 1)
-                {
-                  note--;
-                }
+                case '-':
+                  if (note > 1)
+                    {
+                      note--;
+                    }
 
-              g_next++;
-              break;
+                  g_next++;
+                  break;
 
-              /* No next char here is OK */
+                /* No next char here is OK */
 
-            default:
-              break;
-            }
+                default:
+                  break;
+              }
 
-          /* Shorthand length notation */
+            /* Shorthand length notation */
 
-          note_length = next_number();
+            note_length = next_number();
 
-          if (note_length == 0)
-            {
-              note_length = g_note_length;
-            }
+            if (note_length == 0)
+              {
+                note_length = g_note_length;
+              }
 
-          break;
+            break;
 
-        default:
-          goto tune_error;
+          default:
+            goto tune_error;
         }
     }
 

--- a/drivers/audio/vs1053.c
+++ b/drivers/audio/vs1053.c
@@ -1402,8 +1402,7 @@ static void *vs1053_workerthread(pthread_addr_t pvarg)
       /* Get the next buffer from the queue */
 
       while ((apb = (FAR struct ap_buffer_s *)dq_remfirst(&dev->apbq))
-               != NULL)
-        ;
+               != NULL);
     }
 
   nxmutex_unlock(&dev->apbq_lock);
@@ -1727,7 +1726,7 @@ static int vs1053_ioctl(FAR struct audio_lowerhalf_s *lower, int cmd,
         vs1053_hardreset((FAR struct vs1053_struct_s *)lower);
         break;
 
-       /* Report our preferred buffer size and quantity */
+        /* Report our preferred buffer size and quantity */
 
 #ifdef CONFIG_AUDIO_DRIVER_SPECIFIC_BUFFERS
       case AUDIOIOC_GETBUFFERINFO:

--- a/drivers/audio/wm8776.c
+++ b/drivers/audio/wm8776.c
@@ -158,6 +158,10 @@ static const struct audio_ops_s g_audioops =
 };
 
 /****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
  * Name: wm8776_writereg
  *
  * Description:
@@ -364,81 +368,82 @@ static int wm8776_configure(FAR struct audio_lowerhalf_s *dev,
 
   switch (caps->ac_type)
     {
-    case AUDIO_TYPE_FEATURE:
-      audinfo("  AUDIO_TYPE_FEATURE\n");
+      case AUDIO_TYPE_FEATURE:
+        audinfo("  AUDIO_TYPE_FEATURE\n");
 
-      /* Process based on Feature Unit */
+        /* Process based on Feature Unit */
 
-      switch (caps->ac_format.hw)
-        {
-#ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
-        case AUDIO_FU_VOLUME:
+        switch (caps->ac_format.hw)
           {
-            /* Set the volume */
-
-            uint16_t volume = caps->ac_controls.hw[0];
-            audinfo("    Volume: %d\n", volume);
-
-            if (volume >= 0 && volume <= 1000)
+#ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
+            case AUDIO_FU_VOLUME:
               {
-                /* Scale the volume setting to the range {0x2f .. 0x79} */
+                /* Set the volume */
 
-                wm8776_setvolume(priv, (0x4a * volume / 1000) + 0x2f,
-                                 priv->mute);
+                uint16_t volume = caps->ac_controls.hw[0];
+
+                audinfo("    Volume: %d\n", volume);
+
+                if (volume >= 0 && volume <= 1000)
+                  {
+                    /* Scale the volume setting to the range {0x2f .. 0x79} */
+
+                    wm8776_setvolume(priv, (0x4a * volume / 1000) + 0x2f,
+                                     priv->mute);
+                  }
+                else
+                  {
+                    ret = -EDOM;
+                  }
               }
-            else
-              {
-                ret = -EDOM;
-              }
-          }
-          break;
+              break;
 #endif /* CONFIG_AUDIO_EXCLUDE_VOLUME */
 
-        default:
-          auderr("    ERROR: Unrecognized feature unit\n");
-          ret = -ENOTTY;
-          break;
+            default:
+              auderr("    ERROR: Unrecognized feature unit\n");
+              ret = -ENOTTY;
+              break;
+          }
+        break;
+
+      case AUDIO_TYPE_OUTPUT:
+        {
+          audinfo("  AUDIO_TYPE_OUTPUT:\n");
+          audinfo("    Number of channels: %u\n", caps->ac_channels);
+          audinfo("    Sample rate:        %u\n", caps->ac_controls.hw[0]);
+          audinfo("    Sample width:       %u\n", caps->ac_controls.b[2]);
+
+          /* Verify that all of the requested values are supported */
+
+          ret = -ERANGE;
+          if (caps->ac_channels != 1 && caps->ac_channels != 2)
+            {
+              auderr("ERROR: Unsupported number of channels: %d\n",
+                     caps->ac_channels);
+              break;
+            }
+
+          if (caps->ac_controls.b[2] != 8 && caps->ac_controls.b[2] != 16)
+            {
+              auderr("ERROR: Unsupported bits per sample: %d\n",
+                     caps->ac_controls.b[2]);
+              break;
+            }
+
+          /* Save the current stream configuration */
+
+          priv->samprate  = caps->ac_controls.hw[0];
+          priv->nchannels = caps->ac_channels;
+          priv->bpsamp    = caps->ac_controls.b[2];
+
+          /* TODO : channels, bits per sample, bitrate */
+
+          ret = OK;
         }
         break;
 
-    case AUDIO_TYPE_OUTPUT:
-      {
-        audinfo("  AUDIO_TYPE_OUTPUT:\n");
-        audinfo("    Number of channels: %u\n", caps->ac_channels);
-        audinfo("    Sample rate:        %u\n", caps->ac_controls.hw[0]);
-        audinfo("    Sample width:       %u\n", caps->ac_controls.b[2]);
-
-        /* Verify that all of the requested values are supported */
-
-        ret = -ERANGE;
-        if (caps->ac_channels != 1 && caps->ac_channels != 2)
-          {
-            auderr("ERROR: Unsupported number of channels: %d\n",
-                   caps->ac_channels);
-            break;
-          }
-
-        if (caps->ac_controls.b[2] != 8 && caps->ac_controls.b[2] != 16)
-          {
-            auderr("ERROR: Unsupported bits per sample: %d\n",
-                   caps->ac_controls.b[2]);
-            break;
-          }
-
-        /* Save the current stream configuration */
-
-        priv->samprate  = caps->ac_controls.hw[0];
-        priv->nchannels = caps->ac_channels;
-        priv->bpsamp    = caps->ac_controls.b[2];
-
-        /* TODO : channels, bits per sample, bitrate */
-
-        ret = OK;
-      }
-      break;
-
-    case AUDIO_TYPE_PROCESSING:
-      break;
+      case AUDIO_TYPE_PROCESSING:
+        break;
     }
 
   return ret;
@@ -941,7 +946,7 @@ static int wm8776_ioctl(FAR struct audio_lowerhalf_s *dev, int cmd,
         }
         break;
 
-       /* Report our preferred buffer size and quantity */
+        /* Report our preferred buffer size and quantity */
 
 #ifdef CONFIG_AUDIO_DRIVER_SPECIFIC_BUFFERS
       case AUDIOIOC_GETBUFFERINFO:
@@ -997,7 +1002,7 @@ static int wm8776_reserve(FAR struct audio_lowerhalf_s *dev)
       /* Initialize the session context */
 
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-     *session           = NULL;
+      *session           = NULL;
 #endif
       priv->inflight    = 0;
       priv->running     = false;

--- a/drivers/audio/wm8904.c
+++ b/drivers/audio/wm8904.c
@@ -923,7 +923,7 @@ static void wm8904_setbitrate(FAR struct wm8904_dev_s *priv)
   retries = 5;
   do
     {
-       nxsched_usleep(5 * 5000);
+      nxsched_usleep(5 * 5000);
     }
   while ((wm8904_readreg(priv, WM8904_INT_STATUS) &
          WM8904_FLL_LOCK_INT) != 0 ||
@@ -1139,154 +1139,160 @@ static int wm8904_configure(FAR struct audio_lowerhalf_s *dev,
 
   switch (caps->ac_type)
     {
-    case AUDIO_TYPE_FEATURE:
-      audinfo("  AUDIO_TYPE_FEATURE\n");
+      case AUDIO_TYPE_FEATURE:
+        audinfo("  AUDIO_TYPE_FEATURE\n");
 
-      /* Process based on Feature Unit */
+        /* Process based on Feature Unit */
 
-      switch (caps->ac_format.hw)
-        {
-#ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
-        case AUDIO_FU_VOLUME:
+        switch (caps->ac_format.hw)
           {
-            /* Set the volume */
-
-            uint16_t volume = caps->ac_controls.hw[0];
-            audinfo("    Volume: %d\n", volume);
-
-            if (volume >= 0 && volume <= 1000)
+#ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
+            case AUDIO_FU_VOLUME:
               {
-                /* Scale the volume setting to the range {0.. 63} */
+                /* Set the volume */
 
-                wm8904_setvolume(priv, (63 * volume / 1000), priv->mute);
+                uint16_t volume = caps->ac_controls.hw[0];
+
+                audinfo("    Volume: %d\n", volume);
+
+                if (volume >= 0 && volume <= 1000)
+                  {
+                    /* Scale the volume setting to the range {0.. 63} */
+
+                    wm8904_setvolume(priv, (63 * volume / 1000), priv->mute);
+                  }
+                else
+                  {
+                    ret = -EDOM;
+                  }
               }
-            else
-              {
-                ret = -EDOM;
-              }
-           }
-          break;
+              break;
 #endif /* CONFIG_AUDIO_EXCLUDE_VOLUME */
 
 #ifndef CONFIG_AUDIO_EXCLUDE_BALANCE
-        case AUDIO_FU_BALANCE:
-          {
-            /* Set the balance.  The percentage level * 10 (0-1000) is in the
-             * ac_controls.b[0] parameter.
-             */
-
-            uint16_t balance = caps->ac_controls.hw[0];
-            audinfo("    Balance: %d\n", balance);
-
-            if (balance >= 0 && balance <= 1000)
+            case AUDIO_FU_BALANCE:
               {
-                /* Scale the balance setting to the range {0..(b16ONE - 1)} */
+                /* Set the balance.  The percentage level * 10 (0-1000)
+                 * is in the ac_controls.b[0] parameter.
+                 */
 
-                priv->balance = (balance * (b16ONE - 1)) / 1000;
-                wm8904_setvolume(priv, priv->volume, priv->mute);
+                uint16_t balance = caps->ac_controls.hw[0];
+
+                audinfo("    Balance: %d\n", balance);
+
+                if (balance >= 0 && balance <= 1000)
+                  {
+                    /* Scale the balance setting to the range
+                     * {0..(b16ONE - 1)}
+                     */
+
+                    priv->balance = (balance * (b16ONE - 1)) / 1000;
+                    wm8904_setvolume(priv, priv->volume, priv->mute);
+                  }
+                else
+                  {
+                    ret = -EDOM;
+                  }
               }
-            else
-              {
-                ret = -EDOM;
-              }
-           }
-          break;
+              break;
 #endif /* CONFIG_AUDIO_EXCLUDE_BALANCE */
 
 #ifndef CONFIG_AUDIO_EXCLUDE_TONE
-        case AUDIO_FU_BASS:
-          {
-            /* Set the bass.  The percentage level (0-100) is in the
-             * ac_controls.b[0] parameter.
-             */
-
-            uint8_t bass = caps->ac_controls.b[0];
-            audinfo("    Bass: %d\n", bass);
-
-            if (bass <= 100)
+            case AUDIO_FU_BASS:
               {
-                wm8904_setbass(priv, bass);
-              }
-            else
-              {
-                ret = -EDOM;
-              }
-          }
-          break;
+                /* Set the bass.  The percentage level (0-100) is in the
+                 * ac_controls.b[0] parameter.
+                 */
 
-        case AUDIO_FU_TREBLE:
-          {
-            /* Set the treble.  The percentage level (0-100) is in the
-             * ac_controls.b[0] parameter.
-             */
+                uint8_t bass = caps->ac_controls.b[0];
 
-            uint8_t treble = caps->ac_controls.b[0];
-            audinfo("    Treble: %d\n", treble);
+                audinfo("    Bass: %d\n", bass);
 
-            if (treble <= 100)
-              {
-                wm8904_settreble(priv, treble);
+                if (bass <= 100)
+                  {
+                    wm8904_setbass(priv, bass);
+                  }
+                else
+                  {
+                    ret = -EDOM;
+                  }
               }
-            else
+              break;
+
+            case AUDIO_FU_TREBLE:
               {
-                ret = -EDOM;
+                /* Set the treble.  The percentage level (0-100) is in the
+                 * ac_controls.b[0] parameter.
+                 */
+
+                uint8_t treble = caps->ac_controls.b[0];
+
+                audinfo("    Treble: %d\n", treble);
+
+                if (treble <= 100)
+                  {
+                    wm8904_settreble(priv, treble);
+                  }
+                else
+                  {
+                    ret = -EDOM;
+                  }
               }
-          }
-          break;
+              break;
 #endif /* CONFIG_AUDIO_EXCLUDE_TONE */
 
-        default:
-          auderr("    ERROR: Unrecognized feature unit\n");
-          ret = -ENOTTY;
-          break;
+            default:
+              auderr("    ERROR: Unrecognized feature unit\n");
+              ret = -ENOTTY;
+              break;
+          }
+        break;
+
+      case AUDIO_TYPE_OUTPUT:
+        {
+          audinfo("  AUDIO_TYPE_OUTPUT:\n");
+          audinfo("    Number of channels: %u\n", caps->ac_channels);
+          audinfo("    Sample rate:        %u\n", caps->ac_controls.hw[0]);
+          audinfo("    Sample width:       %u\n", caps->ac_controls.b[2]);
+
+          /* Verify that all of the requested values are supported */
+
+          ret = -ERANGE;
+          if (caps->ac_channels != 1 && caps->ac_channels != 2)
+            {
+              auderr("ERROR: Unsupported number of channels: %d\n",
+                     caps->ac_channels);
+              break;
+            }
+
+          if (caps->ac_controls.b[2] != 8 && caps->ac_controls.b[2] != 16)
+            {
+              auderr("ERROR: Unsupported bits per sample: %d\n",
+                     caps->ac_controls.b[2]);
+              break;
+            }
+
+          /* Save the current stream configuration */
+
+          priv->samprate  = caps->ac_controls.hw[0];
+          priv->nchannels = caps->ac_channels;
+          priv->bpsamp    = caps->ac_controls.b[2];
+
+          /* Reconfigure the FLL to support the resulting number or channels,
+           * bits per sample, and bitrate.
+           */
+
+          wm8904_setdatawidth(priv);
+          wm8904_setbitrate(priv);
+          wm8904_writereg(priv, WM8904_DUMMY, 0x55aa);
+
+          wm8904_clock_analysis(&priv->dev, "AUDIO_TYPE_OUTPUT");
+          ret = OK;
         }
         break;
 
-    case AUDIO_TYPE_OUTPUT:
-      {
-        audinfo("  AUDIO_TYPE_OUTPUT:\n");
-        audinfo("    Number of channels: %u\n", caps->ac_channels);
-        audinfo("    Sample rate:        %u\n", caps->ac_controls.hw[0]);
-        audinfo("    Sample width:       %u\n", caps->ac_controls.b[2]);
-
-        /* Verify that all of the requested values are supported */
-
-        ret = -ERANGE;
-        if (caps->ac_channels != 1 && caps->ac_channels != 2)
-          {
-            auderr("ERROR: Unsupported number of channels: %d\n",
-                   caps->ac_channels);
-            break;
-          }
-
-        if (caps->ac_controls.b[2] != 8 && caps->ac_controls.b[2] != 16)
-          {
-            auderr("ERROR: Unsupported bits per sample: %d\n",
-                   caps->ac_controls.b[2]);
-            break;
-          }
-
-        /* Save the current stream configuration */
-
-        priv->samprate  = caps->ac_controls.hw[0];
-        priv->nchannels = caps->ac_channels;
-        priv->bpsamp    = caps->ac_controls.b[2];
-
-        /* Reconfigure the FLL to support the resulting number or channels,
-         * bits per sample, and bitrate.
-         */
-
-        wm8904_setdatawidth(priv);
-        wm8904_setbitrate(priv);
-        wm8904_writereg(priv, WM8904_DUMMY, 0x55aa);
-
-        wm8904_clock_analysis(&priv->dev, "AUDIO_TYPE_OUTPUT");
-        ret = OK;
-      }
-      break;
-
-    case AUDIO_TYPE_PROCESSING:
-      break;
+      case AUDIO_TYPE_PROCESSING:
+        break;
     }
 
   return ret;
@@ -1824,7 +1830,7 @@ static int wm8904_ioctl(FAR struct audio_lowerhalf_s *dev, int cmd,
         }
         break;
 
-       /* Report our preferred buffer size and quantity */
+        /* Report our preferred buffer size and quantity */
 
 #ifdef CONFIG_AUDIO_DRIVER_SPECIFIC_BUFFERS
       case AUDIOIOC_GETBUFFERINFO:
@@ -1880,7 +1886,7 @@ static int wm8904_reserve(FAR struct audio_lowerhalf_s *dev)
       /* Initialize the session context */
 
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-     *session           = NULL;
+      *session           = NULL;
 #endif
       priv->inflight    = 0;
       priv->running     = false;

--- a/drivers/audio/wm8994.c
+++ b/drivers/audio/wm8994.c
@@ -215,7 +215,9 @@ static const struct audio_ops_s g_audioops =
   wm8994_release        /* release        */
 };
 
-/* Private Functions */
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
 
 /* Name: wm8994_readreg
  *
@@ -269,16 +271,17 @@ uint16_t wm8994_readreg(FAR struct wm8994_dev_s *priv, uint16_t regaddr)
            */
 
           if (retries < MAX_RETRIES)
-          {
-            audwarn("WARNING: I2C_TRANSFER failed: %d ... Resetting\n", ret);
+            {
+              audwarn("WARNING: I2C_TRANSFER failed: %d ... Resetting\n",
+                      ret);
 
-            ret = I2C_RESET(priv->i2c);
+              ret = I2C_RESET(priv->i2c);
               if (ret < 0)
-              {
-                auderr("ERROR: I2C_RESET failed: %d\n", ret);
-                break;
-              }
-          }
+                {
+                  auderr("ERROR: I2C_RESET failed: %d\n", ret);
+                  break;
+                }
+            }
 #else
           auderr("ERROR: I2C_TRANSFER failed: %d\n", ret);
 #endif
@@ -394,48 +397,48 @@ static void wm8994_setsamplefreq(FAR struct wm8994_dev_s *priv)
 
   switch (priv->samprate)
     {
-    case 8000:
-      regval = WM8994_AIF1_SR_8K;
-      break;
-    case 11025:
-      regval = WM8994_AIF1_SR_11K;
-      break;
-    case 12000:
-      regval = WM8994_AIF1_SR_12K;
-      break;
-    case 16000:
-      regval = WM8994_AIF1_SR_16K;
-      break;
-    case 22050:
-      regval = WM8994_AIF1_SR_22K;
-      break;
-    case 24000:
-      regval = WM8994_AIF1_SR_24K;
-      break;
-    case 32000:
-      regval = WM8994_AIF1_SR_32K;
-      break;
-    case 44100:
-      regval = WM8994_AIF1_SR_44K;
-      break;
-    case 48000:
-      regval = WM8994_AIF1_SR_48K;
-      break;
+      case 8000:
+        regval = WM8994_AIF1_SR_8K;
+        break;
+      case 11025:
+        regval = WM8994_AIF1_SR_11K;
+        break;
+      case 12000:
+        regval = WM8994_AIF1_SR_12K;
+        break;
+      case 16000:
+        regval = WM8994_AIF1_SR_16K;
+        break;
+      case 22050:
+        regval = WM8994_AIF1_SR_22K;
+        break;
+      case 24000:
+        regval = WM8994_AIF1_SR_24K;
+        break;
+      case 32000:
+        regval = WM8994_AIF1_SR_32K;
+        break;
+      case 44100:
+        regval = WM8994_AIF1_SR_44K;
+        break;
+      case 48000:
+        regval = WM8994_AIF1_SR_48K;
+        break;
 
-      /* If these frequencies should be added, the sample rate
-       * would need to be changed to 32 bit throughout the code
-       */
+        /* If these frequencies should be added, the sample rate
+         * would need to be changed to 32 bit throughout the code
+         */
 
 #if 0
-    case 88200:
-      regval = WM8994_AIF1_SR_88K;
-      break;
-    case 96000:
-      regval = WM8994_AIF1_SR_96K;
-      break;
+      case 88200:
+        regval = WM8994_AIF1_SR_88K;
+        break;
+      case 96000:
+        regval = WM8994_AIF1_SR_96K;
+        break;
 #endif
-    default:
-      regval = WM8994_AIF1_SR_11K; /* 11025 as default */
+      default:
+        regval = WM8994_AIF1_SR_11K; /* 11025 as default */
     }
 
   /* AIF1CLK / fs ratio = 256 */
@@ -530,6 +533,7 @@ static void wm8994_setvolume(FAR struct wm8994_dev_s *priv, uint16_t volume,
     {
       regval |= WM8994_HPOUT1L_MUTE_N_NO;
     }
+
   wm8994_writereg(priv, WM8994_LEFT_OUTPUT_VOL, regval);
   wm8994_writereg(priv, WM8994_SPEAKER_VOL_LEFT, regval);
 
@@ -538,6 +542,7 @@ static void wm8994_setvolume(FAR struct wm8994_dev_s *priv, uint16_t volume,
     {
       regval |= WM8994_HPOUT1R_MUTE_N_NO;
     }
+
   wm8994_writereg(priv, WM8994_RIGHT_OUTPUT_VOL, regval);
   wm8994_writereg(priv, WM8994_SPEAKER_VOL_RIGHT, regval);
 
@@ -837,153 +842,157 @@ static int wm8994_configure(FAR struct audio_lowerhalf_s *dev,
 
   switch (caps->ac_type)
     {
-    case AUDIO_TYPE_FEATURE:
-      audinfo("  AUDIO_TYPE_FEATURE\n");
+      case AUDIO_TYPE_FEATURE:
+        audinfo("  AUDIO_TYPE_FEATURE\n");
 
-      /* Process based on Feature Unit */
+        /* Process based on Feature Unit */
 
-      switch (caps->ac_format.hw)
-        {
-#ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
-        case AUDIO_FU_VOLUME:
+        switch (caps->ac_format.hw)
           {
-            /* Set the volume */
-
-            uint16_t volume = caps->ac_controls.hw[0];
-            audinfo("    Volume: %d\n", volume);
-
-            if (volume >= 0 && volume <= 1000)
+#ifndef CONFIG_AUDIO_EXCLUDE_VOLUME
+            case AUDIO_FU_VOLUME:
               {
-                /* Scale the volume setting to the range {0.. 63} */
+                /* Set the volume */
 
-                wm8994_setvolume(priv, (63 * volume / 1000), priv->mute);
+                uint16_t volume = caps->ac_controls.hw[0];
+
+                audinfo("    Volume: %d\n", volume);
+
+                if (volume >= 0 && volume <= 1000)
+                  {
+                    /* Scale the volume setting to the range {0.. 63} */
+
+                    wm8994_setvolume(priv, (63 * volume / 1000), priv->mute);
+                  }
+                else
+                  {
+                    ret = -EDOM;
+                  }
               }
-            else
-              {
-                ret = -EDOM;
-              }
-          }
-          break;
+              break;
 #endif /* CONFIG_AUDIO_EXCLUDE_VOLUME */
 
 #ifndef CONFIG_AUDIO_EXCLUDE_BALANCE
-        case AUDIO_FU_BALANCE:
-          {
-            /* Set the balance.  The percentage level (0-100) is in the
-             * ac_controls.b[0] parameter.
-             */
-
-            uint16_t balance = caps->ac_controls.hw[0];
-            audinfo("    Balance: %d\n", balance);
-
-            if (balance >= 0 && balance <= 1000)
+            case AUDIO_FU_BALANCE:
               {
-                /* Scale the volume setting to the range {0.. 63} */
+                /* Set the balance.  The percentage level (0-100) is in the
+                 * ac_controls.b[0] parameter.
+                 */
 
-                priv->balance = (balance * (b16ONE - 1)) / 1000;
-                wm8994_setvolume(priv, priv->volume, priv->mute);
+                uint16_t balance = caps->ac_controls.hw[0];
+
+                audinfo("    Balance: %d\n", balance);
+
+                if (balance >= 0 && balance <= 1000)
+                  {
+                    /* Scale the volume setting to the range {0.. 63} */
+
+                    priv->balance = (balance * (b16ONE - 1)) / 1000;
+                    wm8994_setvolume(priv, priv->volume, priv->mute);
+                  }
+                else
+                  {
+                    ret = -EDOM;
+                  }
               }
-            else
-              {
-                ret = -EDOM;
-              }
-          }
-          break;
+              break;
 #endif /* CONFIG_AUDIO_EXCLUDE_BALANCE */
 
 #ifndef CONFIG_AUDIO_EXCLUDE_TONE
-        case AUDIO_FU_BASS:
-          {
-            /* Set the bass.  The percentage level (0-100) is in the
-             * ac_controls.b[0] parameter.
-             */
-
-            uint8_t bass = caps->ac_controls.b[0];
-            audinfo("    Bass: %d\n", bass);
-
-            if (bass <= 100)
+            case AUDIO_FU_BASS:
               {
-                wm8994_setbass(priv, bass);
-              }
-            else
-              {
-                ret = -EDOM;
-              }
-          }
-          break;
+                /* Set the bass.  The percentage level (0-100) is in the
+                 * ac_controls.b[0] parameter.
+                 */
 
-        case AUDIO_FU_TREBLE:
-          {
-            /* Set the treble.  The percentage level (0-100) is in the
-             * ac_controls.b[0] parameter.
-             */
+                uint8_t bass = caps->ac_controls.b[0];
 
-            uint8_t treble = caps->ac_controls.b[0];
-            audinfo("    Treble: %d\n", treble);
+                audinfo("    Bass: %d\n", bass);
 
-            if (treble <= 100)
-              {
-                wm8994_settreble(priv, treble);
+                if (bass <= 100)
+                  {
+                    wm8994_setbass(priv, bass);
+                  }
+                else
+                  {
+                    ret = -EDOM;
+                  }
               }
-            else
+              break;
+
+            case AUDIO_FU_TREBLE:
               {
-                ret = -EDOM;
+                /* Set the treble.  The percentage level (0-100) is in the
+                 * ac_controls.b[0] parameter.
+                 */
+
+                uint8_t treble = caps->ac_controls.b[0];
+
+                audinfo("    Treble: %d\n", treble);
+
+                if (treble <= 100)
+                  {
+                    wm8994_settreble(priv, treble);
+                  }
+                else
+                  {
+                    ret = -EDOM;
+                  }
               }
-          }
-          break;
+              break;
 #endif /* CONFIG_AUDIO_EXCLUDE_TONE */
 
-        default:
-          auderr("    ERROR: Unrecognized feature unit\n");
-          ret = -ENOTTY;
-          break;
+            default:
+              auderr("    ERROR: Unrecognized feature unit\n");
+              ret = -ENOTTY;
+              break;
+          }
+        break;
+
+      case AUDIO_TYPE_OUTPUT:
+        {
+          audinfo("  AUDIO_TYPE_OUTPUT:\n");
+          audinfo("    Number of channels: %u\n", caps->ac_channels);
+          audinfo("    Sample rate:        %u\n", caps->ac_controls.hw[0]);
+          audinfo("    Sample width:       %u\n", caps->ac_controls.b[2]);
+
+          /* Verify that all of the requested values are supported */
+
+          ret = -ERANGE;
+          if (caps->ac_channels != 1 && caps->ac_channels != 2)
+            {
+              auderr("ERROR: Unsupported number of channels: %d\n",
+                     caps->ac_channels);
+              break;
+            }
+
+          if (caps->ac_controls.b[2] != 8 && caps->ac_controls.b[2] != 16)
+            {
+              auderr("ERROR: Unsupported bits per sample: %d\n",
+                     caps->ac_controls.b[2]);
+              break;
+            }
+
+          /* Save the current stream configuration */
+
+          priv->samprate  = caps->ac_controls.hw[0];
+          priv->nchannels = caps->ac_channels;
+          priv->bpsamp    = caps->ac_controls.b[2];
+
+          /* Reconfigure the FLL to support the resulting number or channels,
+           * bits per sample, and bitrate.
+           */
+
+          wm8994_setdatawidth(priv);
+          wm8994_setbitrate(priv);
+
+          wm8994_clock_analysis(&priv->dev, "AUDIO_TYPE_OUTPUT");
+          ret = OK;
         }
         break;
 
-    case AUDIO_TYPE_OUTPUT:
-      {
-        audinfo("  AUDIO_TYPE_OUTPUT:\n");
-        audinfo("    Number of channels: %u\n", caps->ac_channels);
-        audinfo("    Sample rate:        %u\n", caps->ac_controls.hw[0]);
-        audinfo("    Sample width:       %u\n", caps->ac_controls.b[2]);
-
-        /* Verify that all of the requested values are supported */
-
-        ret = -ERANGE;
-        if (caps->ac_channels != 1 && caps->ac_channels != 2)
-          {
-            auderr("ERROR: Unsupported number of channels: %d\n",
-                   caps->ac_channels);
-            break;
-          }
-
-        if (caps->ac_controls.b[2] != 8 && caps->ac_controls.b[2] != 16)
-          {
-            auderr("ERROR: Unsupported bits per sample: %d\n",
-                   caps->ac_controls.b[2]);
-            break;
-          }
-
-        /* Save the current stream configuration */
-
-        priv->samprate  = caps->ac_controls.hw[0];
-        priv->nchannels = caps->ac_channels;
-        priv->bpsamp    = caps->ac_controls.b[2];
-
-        /* Reconfigure the FLL to support the resulting number or channels,
-         * bits per sample, and bitrate.
-         */
-
-        wm8994_setdatawidth(priv);
-        wm8994_setbitrate(priv);
-
-        wm8994_clock_analysis(&priv->dev, "AUDIO_TYPE_OUTPUT");
-        ret = OK;
-      }
-      break;
-
-    case AUDIO_TYPE_PROCESSING:
-      break;
+      case AUDIO_TYPE_PROCESSING:
+        break;
     }
 
   return ret;
@@ -1507,7 +1516,7 @@ static int wm8994_ioctl(FAR struct audio_lowerhalf_s *dev, int cmd,
         }
         break;
 
-       /* Report our preferred buffer size and quantity */
+        /* Report our preferred buffer size and quantity */
 
 #ifdef CONFIG_AUDIO_DRIVER_SPECIFIC_BUFFERS
       case AUDIOIOC_GETBUFFERINFO:
@@ -1557,7 +1566,7 @@ static int wm8994_reserve(FAR struct audio_lowerhalf_s *dev)
       /* Initialize the session context */
 
 #ifdef CONFIG_AUDIO_MULTI_SESSION
-     *session           = NULL;
+      *session           = NULL;
 #endif
       priv->inflight    = 0;
       priv->running     = false;
@@ -1902,7 +1911,7 @@ static void wm8994_audio_output(FAR struct wm8994_dev_s *priv)
    *
    * Currently the DAC1 is used and configured for AIF1 Timeslot 0
    * DAC2 and AIF1 Timeslot 1 remain unused
-  */
+   */
 
   /* Enable DAC1 (Left), Enable DAC1 (Right)
    * Enable AIF1DAC1L (Left) input path (AIF1, TS0)
@@ -2138,6 +2147,7 @@ static void wm8994_audio_output(FAR struct wm8994_dev_s *priv)
       regval |= WM8994_SPKLVOL_ENA |
                 WM8994_SPKRVOL_ENA;
     }
+
   wm8994_writereg(priv, WM8994_PM3, regval);
 
   /* Enable DC Servo and trigger start-up mode on left and right channels */
@@ -2334,9 +2344,13 @@ static void wm8994_hw_reset(FAR struct wm8994_dev_s *priv)
   wm8994_writereg(priv, WM8994_ANTI_POP2, regval);
 
   if (WM8994_DEFAULT_INPUT_DEVICE > 0)
-    regval = 0x0013;
+    {
+      regval = 0x0013;
+    }
   else
-    regval = 0x0003;
+    {
+      regval = 0x0003;
+    }
 
   /* 0x01 = 0x0013 */
 
@@ -2348,7 +2362,7 @@ static void wm8994_hw_reset(FAR struct wm8994_dev_s *priv)
   wm8994_audio_output(priv);
   {
     switch (WM8994_DEFAULT_OUTPUT_DEVICE)
-    {
+      {
         case WM8994_OUTPUT_DEVICE_SPEAKER:
 
           /* regval = 0x0c0c */
@@ -2412,21 +2426,21 @@ static void wm8994_hw_reset(FAR struct wm8994_dev_s *priv)
         case WM8994_OUTPUT_DEVICE_BOTH:
           if (WM8994_DEFAULT_INPUT_DEVICE ==
               WM8994_INPUT_DEVICE_DIGITAL_MIC1_MIC2)
-          {
-            wm8994_writereg(priv, 0x005, 0x0303 | 0x0c0c);
-            wm8994_writereg(priv, 0x601, 0x0003);
-            wm8994_writereg(priv, 0x602, 0x0003);
-            wm8994_writereg(priv, 0x604, 0x0003);
-            wm8994_writereg(priv, 0x605, 0x0003);
-          }
+            {
+              wm8994_writereg(priv, 0x005, 0x0303 | 0x0c0c);
+              wm8994_writereg(priv, 0x601, 0x0003);
+              wm8994_writereg(priv, 0x602, 0x0003);
+              wm8994_writereg(priv, 0x604, 0x0003);
+              wm8994_writereg(priv, 0x605, 0x0003);
+            }
           else
-          {
-            wm8994_writereg(priv, 0x005, 0x0303 | 0x0c0c);
-            wm8994_writereg(priv, 0x601, 0x0001);
-            wm8994_writereg(priv, 0x602, 0x0001);
-            wm8994_writereg(priv, 0x604, 0x0002);
-            wm8994_writereg(priv, 0x605, 0x0002);
-          }
+            {
+              wm8994_writereg(priv, 0x005, 0x0303 | 0x0c0c);
+              wm8994_writereg(priv, 0x601, 0x0001);
+              wm8994_writereg(priv, 0x602, 0x0001);
+              wm8994_writereg(priv, 0x604, 0x0002);
+              wm8994_writereg(priv, 0x605, 0x0002);
+            }
 
           break;
         case WM8994_OUTPUT_DEVICE_AUTO:
@@ -2438,132 +2452,136 @@ static void wm8994_hw_reset(FAR struct wm8994_dev_s *priv)
           break;
         default:
           break;
-    }
+      }
   }
 
   /* Configure the WM8994 hardware as an audio input device */
 
   wm8994_audio_input(priv);
   switch (WM8994_DEFAULT_INPUT_DEVICE)
-  {
-    case WM8994_INPUT_DEVICE_DIGITAL_MICROPHONE_2:
-      wm8994_writereg(priv, 0x004, 0x0c30);
-      wm8994_writereg(priv, 0x450, 0x00db);
-      wm8994_writereg(priv, 0x002, 0x6000);
-      wm8994_writereg(priv, 0x608, 0x0002);
-      wm8994_writereg(priv, 0x700, 0x000b);
-      break;
-  case WM8994_INPUT_DEVICE_INPUT_LINE_1:
-      wm8994_writereg(priv, 0x028, 0x0011);
-      wm8994_writereg(priv, 0x029, 0x0035);
-      wm8994_writereg(priv, 0x02a, 0x0035);
-      wm8994_writereg(priv, 0x004, 0x0303);
-      wm8994_writereg(priv, 0x440, 0x00db);
-      wm8994_writereg(priv, 0x002, 0x6350);
-      wm8994_writereg(priv, 0x606, 0x0002);
-      wm8994_writereg(priv, 0x607, 0x0002);
-      wm8994_writereg(priv, 0x700, 0x000d);
-      break;
-  case WM8994_INPUT_DEVICE_DIGITAL_MICROPHONE_1:
-      wm8994_writereg(priv, 0x004, 0x030c);
-      wm8994_writereg(priv, 0x440, 0x00db);
-      wm8994_writereg(priv, 0x002, 0x6350);
-      wm8994_writereg(priv, 0x606, 0x0002);
-      wm8994_writereg(priv, 0x607, 0x0002);
-      wm8994_writereg(priv, 0x700, 0x000d);
-      break;
-  case WM8994_INPUT_DEVICE_DIGITAL_MIC1_MIC2:
-      wm8994_writereg(priv, 0x004, 0x0f3c);
-      wm8994_writereg(priv, 0x450, 0x00db);
-      wm8994_writereg(priv, 0x440, 0x00db);
-      wm8994_writereg(priv, 0x002, 0x63a0);
-      wm8994_writereg(priv, 0x606, 0x0002);
-      wm8994_writereg(priv, 0x607, 0x0002);
-      wm8994_writereg(priv, 0x608, 0x0002);
-      wm8994_writereg(priv, 0x609, 0x0002);
-      wm8994_writereg(priv, 0x700, 0x000d);
-      break;
-  case WM8994_INPUT_DEVICE_INPUT_LINE_2:
-  default:
-      break;
-  }
-
-  {
-    switch (WM8994_DEFAULT_SAMPRATE)
     {
-      case WM8994_AUDIO_FREQUENCY_8K:
-        regval = WM8994_AIF1CLK_RATE_2 | WM8994_AIF1_SR_8K;
-
-        /* 0x210 = 0x0003 */
-
-        wm8994_writereg(priv, WM8994_AIF1_RATE, regval);
+      case WM8994_INPUT_DEVICE_DIGITAL_MICROPHONE_2:
+        wm8994_writereg(priv, 0x004, 0x0c30);
+        wm8994_writereg(priv, 0x450, 0x00db);
+        wm8994_writereg(priv, 0x002, 0x6000);
+        wm8994_writereg(priv, 0x608, 0x0002);
+        wm8994_writereg(priv, 0x700, 0x000b);
         break;
-      case WM8994_AUDIO_FREQUENCY_16K:
-        regval = WM8994_AIF1CLK_RATE_2 | WM8994_AIF1_SR_16K;
-
-        /* 0x210 = 0x0033 */
-
-        wm8994_writereg(priv, WM8994_AIF1_RATE, regval);
+      case WM8994_INPUT_DEVICE_INPUT_LINE_1:
+        wm8994_writereg(priv, 0x028, 0x0011);
+        wm8994_writereg(priv, 0x029, 0x0035);
+        wm8994_writereg(priv, 0x02a, 0x0035);
+        wm8994_writereg(priv, 0x004, 0x0303);
+        wm8994_writereg(priv, 0x440, 0x00db);
+        wm8994_writereg(priv, 0x002, 0x6350);
+        wm8994_writereg(priv, 0x606, 0x0002);
+        wm8994_writereg(priv, 0x607, 0x0002);
+        wm8994_writereg(priv, 0x700, 0x000d);
         break;
-      case WM8994_AUDIO_FREQUENCY_22_050K:
-        regval = WM8994_AIF1CLK_RATE_2 | WM8994_AIF1_SR_22K;
-
-        /* 0x210 = 0x0063 */
-
-        wm8994_writereg(priv, WM8994_AIF1_RATE, regval);
+      case WM8994_INPUT_DEVICE_DIGITAL_MICROPHONE_1:
+        wm8994_writereg(priv, 0x004, 0x030c);
+        wm8994_writereg(priv, 0x440, 0x00db);
+        wm8994_writereg(priv, 0x002, 0x6350);
+        wm8994_writereg(priv, 0x606, 0x0002);
+        wm8994_writereg(priv, 0x607, 0x0002);
+        wm8994_writereg(priv, 0x700, 0x000d);
         break;
-        #if 0
-      case WM8994_AUDIO_FREQUENCY_48K:
-        regval = WM8994_AIF1CLK_RATE_2 | WM8994_AIF1_SR_24K;
-        wm8994_writereg(priv, WM8994_AIF1_RATE, regval); /* 0x210 = 0x0083 */
+      case WM8994_INPUT_DEVICE_DIGITAL_MIC1_MIC2:
+        wm8994_writereg(priv, 0x004, 0x0f3c);
+        wm8994_writereg(priv, 0x450, 0x00db);
+        wm8994_writereg(priv, 0x440, 0x00db);
+        wm8994_writereg(priv, 0x002, 0x63a0);
+        wm8994_writereg(priv, 0x606, 0x0002);
+        wm8994_writereg(priv, 0x607, 0x0002);
+        wm8994_writereg(priv, 0x608, 0x0002);
+        wm8994_writereg(priv, 0x609, 0x0002);
+        wm8994_writereg(priv, 0x700, 0x000d);
         break;
-        #endif
-      case WM8994_AUDIO_FREQUENCY_32K:
-        regval = WM8994_AIF1CLK_RATE_2 | WM8994_AIF1_SR_32K;
-        wm8994_writereg(priv, WM8994_AIF1_RATE, regval); /* 0x210 = 0x00a3 */
-        break;
-      case WM8994_AUDIO_FREQUENCY_44_100K:
-        regval = WM8994_AIF1CLK_RATE_2 | WM8994_AIF1_SR_44K;
-        wm8994_writereg(priv, WM8994_AIF1_RATE, regval); /* 0x210 = 0x0013 */
-        break;
-      case WM8994_AUDIO_FREQUENCY_48K:
-        regval = WM8994_AIF1CLK_RATE_2 | WM8994_AIF1_SR_48K;
-        wm8994_writereg(priv, WM8994_AIF1_RATE, regval); /* 0x210 = 0x0043 */
-        break;
-    #if 0
-      case WM8994_AUDIO_FREQUENCY_44_100K:
-        regval = WM8994_AIF1CLK_RATE_2 | WM8994_AIF1_SR_88K;
-        wm8994_writereg(priv, WM8994_AIF1_RATE, regval); /* 0x210 = 0x0073 */
-        break;
-    #endif
-      case WM8994_AUDIO_FREQUENCY_96K:
-        regval = WM8994_AIF1CLK_RATE_2 | WM8994_AIF1_SR_96K;
-
-        /* 0x210 = 0x00a3 */
-
-        wm8994_writereg(priv, WM8994_AIF1_RATE, regval);
-        break;
+      case WM8994_INPUT_DEVICE_INPUT_LINE_2:
       default:
-        regval = WM8994_AIF1CLK_RATE_2 | WM8994_AIF1_SR_48K;
-
-        /* 0x210 = 0x0083 */
-
-        wm8994_writereg(priv, WM8994_AIF1_RATE, regval);
         break;
     }
 
+  {
+    switch (WM8994_DEFAULT_SAMPRATE)
+      {
+        case WM8994_AUDIO_FREQUENCY_8K:
+          regval = WM8994_AIF1CLK_RATE_2 | WM8994_AIF1_SR_8K;
+
+          /* 0x210 = 0x0003 */
+
+          wm8994_writereg(priv, WM8994_AIF1_RATE, regval);
+          break;
+        case WM8994_AUDIO_FREQUENCY_16K:
+          regval = WM8994_AIF1CLK_RATE_2 | WM8994_AIF1_SR_16K;
+
+          /* 0x210 = 0x0033 */
+
+          wm8994_writereg(priv, WM8994_AIF1_RATE, regval);
+          break;
+        case WM8994_AUDIO_FREQUENCY_22_050K:
+          regval = WM8994_AIF1CLK_RATE_2 | WM8994_AIF1_SR_22K;
+
+          /* 0x210 = 0x0063 */
+
+          wm8994_writereg(priv, WM8994_AIF1_RATE, regval);
+          break;
+        #if 0
+        case WM8994_AUDIO_FREQUENCY_48K:
+          regval = WM8994_AIF1CLK_RATE_2 | WM8994_AIF1_SR_24K;
+          wm8994_writereg(priv, WM8994_AIF1_RATE, regval); /* 0x210 = 0x0083 */
+          break;
+        #endif
+        case WM8994_AUDIO_FREQUENCY_32K:
+          regval = WM8994_AIF1CLK_RATE_2 | WM8994_AIF1_SR_32K;
+          wm8994_writereg(priv, WM8994_AIF1_RATE, regval); /* 0x210 = 0x00a3 */
+          break;
+        case WM8994_AUDIO_FREQUENCY_44_100K:
+          regval = WM8994_AIF1CLK_RATE_2 | WM8994_AIF1_SR_44K;
+          wm8994_writereg(priv, WM8994_AIF1_RATE, regval); /* 0x210 = 0x0013 */
+          break;
+        case WM8994_AUDIO_FREQUENCY_48K:
+          regval = WM8994_AIF1CLK_RATE_2 | WM8994_AIF1_SR_48K;
+          wm8994_writereg(priv, WM8994_AIF1_RATE, regval); /* 0x210 = 0x0043 */
+          break;
+    #if 0
+        case WM8994_AUDIO_FREQUENCY_44_100K:
+          regval = WM8994_AIF1CLK_RATE_2 | WM8994_AIF1_SR_88K;
+          wm8994_writereg(priv, WM8994_AIF1_RATE, regval); /* 0x210 = 0x0073 */
+          break;
+    #endif
+        case WM8994_AUDIO_FREQUENCY_96K:
+          regval = WM8994_AIF1CLK_RATE_2 | WM8994_AIF1_SR_96K;
+
+          /* 0x210 = 0x00a3 */
+
+          wm8994_writereg(priv, WM8994_AIF1_RATE, regval);
+          break;
+        default:
+          regval = WM8994_AIF1CLK_RATE_2 | WM8994_AIF1_SR_48K;
+
+          /* 0x210 = 0x0083 */
+
+          wm8994_writereg(priv, WM8994_AIF1_RATE, regval);
+          break;
+      }
+
     if (WM8994_DEFAULT_INPUT_DEVICE == WM8994_INPUT_DEVICE_DIGITAL_MIC1_MIC2)
 
-        /* regval = 0x4018 */
+    /* regval = 0x4018 */
 
+      {
         regval = WM8994_AIF1ADCR_RIGHT_ADC | WM8994_AIF1_WL_16BITS
                                            | WM8994_AIF1_FMT_I2S;
+      }
     else
 
-        /* regval = 0x4010 */
+    /* regval = 0x4010 */
 
+      {
         regval = WM8994_AIF1ADCR_RIGHT_ADC | WM8994_AIF1_WL_16BITS
                                            | WM8994_AIF1_FMT_DSP;
+      }
 
     /* 0x300 = */
 
@@ -2590,35 +2608,35 @@ static void wm8994_hw_reset(FAR struct wm8994_dev_s *priv)
     wm8994_writereg(priv, WM8994_AIF1_CLK1, regval);
 
     if (WM8994_DEFAULT_OUTPUT_DEVICE == WM8994_OUTPUT_DEVICE_HEADPHONE)
-    {
-      regval = WM8994_DAC1L_TO_HPOUT1L_DAC1L;
-
-      /* 0x2d = 0x0100 */
-
-      wm8994_writereg(priv, WM8994_OUTPUT_MIXER1, regval);
-
-      regval = 0;
-      wm8994_writereg(priv, WM8994_OUTPUT_MIXER2, regval); /* 0x2e = 0x0100 */
-
-      if (WM8994_STARTUP_MODE_COLD)
       {
-        regval = 0x8100;
-        wm8994_writereg(priv, WM8994_WR_CTL_SEQ1, regval);
+        regval = WM8994_DAC1L_TO_HPOUT1L_DAC1L;
 
-        /* 0x110 = regval */
+        /* 0x2d = 0x0100 */
 
-        up_mdelay(300);
+        wm8994_writereg(priv, WM8994_OUTPUT_MIXER1, regval);
+
+        regval = 0;
+        wm8994_writereg(priv, WM8994_OUTPUT_MIXER2, regval); /* 0x2e = 0x0100 */
+
+        if (WM8994_STARTUP_MODE_COLD)
+          {
+            regval = 0x8100;
+            wm8994_writereg(priv, WM8994_WR_CTL_SEQ1, regval);
+
+            /* 0x110 = regval */
+
+            up_mdelay(300);
+          }
+        else
+          {
+            regval = 0x8108;
+            wm8994_writereg(priv, WM8994_WR_CTL_SEQ1, regval); /* 0x110 = regval */
+            up_mdelay(50);
+          }
+
+        regval = 0;
+        wm8994_writereg(priv, WM8994_AIF1_DAC1_FILTERS1, regval); /* 0x420 = 0x0000 */
       }
-      else
-      {
-        regval = 0x8108;
-        wm8994_writereg(priv, WM8994_WR_CTL_SEQ1, regval); /* 0x110 = regval */
-        up_mdelay(50);
-      }
-
-      regval = 0;
-      wm8994_writereg(priv, WM8994_AIF1_DAC1_FILTERS1, regval); /* 0x420 = 0x0000 */
-    }
 
     regval = 0;
     wm8994_writereg(priv, WM8994_PM3, regval); /* 0x03 = 0x0300 */
@@ -2636,9 +2654,14 @@ static void wm8994_hw_reset(FAR struct wm8994_dev_s *priv)
     wm8994_writereg(priv, WM8994_PM1, regval);  /* 0x01 = 0x3003 */
 
     if (WM8994_DEFAULT_INPUT_DEVICE == WM8994_INPUT_DEVICE_DIGITAL_MIC1_MIC2)
-      regval = 0x0205;
+      {
+        regval = 0x0205;
+      }
     else
-      regval = 0x0005;
+      {
+        regval = 0x0005;
+      }
+
     wm8994_writereg(priv, WM8994_CLASS_W_1, regval); /* 0x51 = regval */
 
     priv->power_mgnt_reg_1 |= 0x0303 | 0x3003;
@@ -2692,7 +2715,7 @@ static void wm8994_hw_reset(FAR struct wm8994_dev_s *priv)
                 WM8994_INPUT_DEVICE_DIGITAL_MICROPHONE_1)
         || (WM8994_DEFAULT_INPUT_DEVICE ==
             WM8994_INPUT_DEVICE_DIGITAL_MICROPHONE_2))
-    {
+      {
         priv->power_mgnt_reg_1 |= 0x0013;
         wm8994_writereg(priv, 0x01, priv->power_mgnt_reg_1); /* 0x01 = power_mgnt_reg_1 */
 
@@ -2701,10 +2724,10 @@ static void wm8994_hw_reset(FAR struct wm8994_dev_s *priv)
 
         regval = 0x3800;
         wm8994_writereg(priv, 0x411, 0x3800); /* 0x411 = 0x3800 */
-    }
+      }
     else if (WM8994_DEFAULT_INPUT_DEVICE ==
             WM8994_INPUT_DEVICE_DIGITAL_MIC1_MIC2)
-    {
+      {
         priv->power_mgnt_reg_1 |= 0x0013;
         wm8994_writereg(priv, 0x01, priv->power_mgnt_reg_1); /* 0x01 = power_mgnt_reg_1 */
 
@@ -2716,13 +2739,13 @@ static void wm8994_hw_reset(FAR struct wm8994_dev_s *priv)
 
         regval = 0x1800;
         wm8994_writereg(priv, 0x411, regval); /* 0x411 = 0x1800 */
-    }
+      }
     else if ((WM8994_DEFAULT_INPUT_DEVICE ==
                 WM8994_INPUT_DEVICE_INPUT_LINE_1)
         || (WM8994_DEFAULT_INPUT_DEVICE ==
             WM8994_INPUT_DEVICE_INPUT_LINE_2))
 
-    {
+      {
         regval = 0x000b;
         wm8994_writereg(priv, 0x18, regval); /* 0x18 = 0x000b */
 
@@ -2731,8 +2754,9 @@ static void wm8994_hw_reset(FAR struct wm8994_dev_s *priv)
 
         regval = 0x1800;
         wm8994_writereg(priv, 0x410, regval); /* 0x410 = 0x1800 */
-    }
+      }
   }
+
 #endif
   /* Configure the WM8994 hardware as an audio output device */
 

--- a/net/arp/arp_acd.c
+++ b/net/arp/arp_acd.c
@@ -82,6 +82,7 @@ static void arp_acd_arrange_announce(FAR struct net_driver_s *dev)
 
   int ret = work_queue(LPWORK, &dev->d_acd.work, arp_acd_try_announce,
                        (FAR void *)dev, DSEC2TICK(dev->d_acd.ttw));
+
   if (ret != OK)
     {
       nerr("ERROR ret %d \n", ret);

--- a/net/arp/arp_table.c
+++ b/net/arp/arp_table.c
@@ -273,6 +273,7 @@ static void arp_get_arpreq(FAR struct arpreq *output,
 static void arp_unreach_work(FAR void *param)
 {
   FAR struct arp_entry_s *tabptr = (FAR struct arp_entry_s *)param;
+
   iob_free_queue(&tabptr->at_queue);
 }
 #endif
@@ -502,6 +503,7 @@ int arp_find(in_addr_t ipaddr, FAR uint8_t *ethaddr,
                  sizeof(tabptr->at_ethaddr)) == 0)
         {
           clock_t elapsed;
+
           elapsed = clock_systime_ticks() - tabptr->at_time;
           if (elapsed <= ARP_INPROGRESS_TICK)
             {

--- a/net/arp/arp_table.c
+++ b/net/arp/arp_table.c
@@ -262,6 +262,7 @@ static void arp_get_arpreq(FAR struct arpreq *output,
 static void arp_unreach_work(FAR void *param)
 {
   FAR struct arp_entry_s *tabptr = (FAR struct arp_entry_s *)param;
+
   iob_free_queue(&tabptr->at_queue);
 }
 #endif
@@ -491,6 +492,7 @@ int arp_find(in_addr_t ipaddr, FAR uint8_t *ethaddr,
                  sizeof(tabptr->at_ethaddr)) == 0)
         {
           clock_t elapsed;
+
           elapsed = clock_systime_ticks() - tabptr->at_time;
           if (elapsed <= ARP_INPROGRESS_TICK)
             {

--- a/net/bluetooth/bluetooth_sendmsg.c
+++ b/net/bluetooth/bluetooth_sendmsg.c
@@ -324,6 +324,7 @@ static ssize_t bluetooth_sendto(FAR struct socket *psock,
   else if (psock->s_proto == BTPROTO_HCI)
     {
       struct bluetooth_findbyidx_s match;
+
       match.bf_tgt   = conn->bc_ldev;
       match.bf_cur   = 0;
       match.bf_radio = NULL;
@@ -362,12 +363,14 @@ static ssize_t bluetooth_sendto(FAR struct socket *psock,
   if (psock->s_proto == BTPROTO_L2CAP)
     {
       FAR struct sockaddr_l2 *destaddr = (FAR struct sockaddr_l2 *)to;
+
       memcpy(&state.is_destaddr, &destaddr->l2_bdaddr,
              sizeof(bt_addr_t));
     }
   else if (psock->s_proto == BTPROTO_HCI)
     {
       FAR struct sockaddr_hci *destaddr = (FAR struct sockaddr_hci *)to;
+
       state.is_channel = destaddr->hci_channel;
     }
   else

--- a/net/bluetooth/bluetooth_sockif.c
+++ b/net/bluetooth/bluetooth_sockif.c
@@ -114,6 +114,7 @@ static int bluetooth_sockif_alloc(FAR struct socket *psock)
    */
 
   FAR struct bluetooth_conn_s *conn = bluetooth_conn_alloc();
+
   if (conn == NULL)
     {
       /* Failed to reserve a connection structure */
@@ -321,6 +322,7 @@ static int bluetooth_bind(FAR struct socket *psock,
       case BTPROTO_L2CAP:
         {
           FAR const struct sockaddr_l2 *iaddr;
+
           if (addrlen < sizeof(struct sockaddr_l2))
             {
               nerr("ERROR: Invalid address length: %zu < %zu\n",
@@ -335,6 +337,7 @@ static int bluetooth_bind(FAR struct socket *psock,
       case BTPROTO_HCI:
         {
           FAR const struct sockaddr_hci *hciaddr;
+
           if (addrlen < sizeof(struct sockaddr_hci))
             {
               nerr("ERROR: Invalid address length: %zu < %zu\n",

--- a/net/can/can_callback.c
+++ b/net/can/can_callback.c
@@ -126,28 +126,28 @@ uint32_t can_callback(FAR struct net_driver_s *dev,
   if (conn)
     {
 #ifdef CONFIG_NET_TIMESTAMP
-          /* TIMESTAMP sockopt is activated,
-           * create timestamp and copy to iob
-           */
+      /* TIMESTAMP sockopt is activated,
+       * create timestamp and copy to iob
+       */
 
-          if (_SO_GETOPT(conn->sconn.s_options, SO_TIMESTAMP) &&
-            (dev->d_iob != NULL))
+      if (_SO_GETOPT(conn->sconn.s_options, SO_TIMESTAMP) &&
+        (dev->d_iob != NULL))
+        {
+          struct timeval tv;
+          FAR struct timespec *ts = (FAR struct timespec *)&tv;
+          int len;
+
+          clock_systime_timespec(ts);
+          tv.tv_usec = ts->tv_nsec / 1000;
+
+          len = iob_trycopyin(dev->d_iob, (FAR uint8_t *)&tv,
+                              sizeof(struct timeval),
+                              -CONFIG_NET_LL_GUARDSIZE, false);
+          if (len == sizeof(struct timeval))
             {
-              struct timeval tv;
-              FAR struct timespec *ts = (FAR struct timespec *)&tv;
-              int len;
-
-              clock_systime_timespec(ts);
-              tv.tv_usec = ts->tv_nsec / 1000;
-
-              len = iob_trycopyin(dev->d_iob, (FAR uint8_t *)&tv,
-                                  sizeof(struct timeval),
-                                  -CONFIG_NET_LL_GUARDSIZE, false);
-              if (len == sizeof(struct timeval))
-                {
-                  dev->d_len += len;
-                }
+              dev->d_len += len;
             }
+        }
 #endif
 
       conn_lock(&conn->sconn);

--- a/net/can/can_conn.c
+++ b/net/can/can_conn.c
@@ -288,6 +288,7 @@ FAR struct can_conn_s *can_active(FAR struct net_driver_s *dev,
 {
 #ifdef CONFIG_NET_CANPROTO_OPTIONS
   canid_t can_id;
+
   memcpy(&can_id, NETLLBUF, sizeof(canid_t));
 #endif
 

--- a/net/can/can_getsockopt.c
+++ b/net/can/can_getsockopt.c
@@ -136,6 +136,7 @@ int can_getsockopt(FAR struct socket *psock, int level, int option,
         else
           {
             FAR can_err_mask_t *mask = (FAR can_err_mask_t *)value;
+
             *mask = conn->err_mask;
             *value_len = sizeof(can_err_mask_t);
           }
@@ -157,7 +158,7 @@ int can_getsockopt(FAR struct socket *psock, int level, int option,
         if (*value_len < sizeof(int))
           {
             return -EINVAL;
-         }
+          }
 
         /* Sample the current options.  This is atomic operation and so
          * should not require any special steps for thread safety. We
@@ -165,9 +166,9 @@ int can_getsockopt(FAR struct socket *psock, int level, int option,
          * a macro will do.
          */
 
-          *(FAR int *)value = _SO_GETOPT(conn->sconn.s_options, option);
-          *value_len        = sizeof(int);
-          break;
+        *(FAR int *)value = _SO_GETOPT(conn->sconn.s_options, option);
+        *value_len        = sizeof(int);
+        break;
 
 #if CONFIG_NET_RECV_BUFSIZE > 0
       case SO_RCVBUF:
@@ -188,13 +189,13 @@ int can_getsockopt(FAR struct socket *psock, int level, int option,
 #if CONFIG_NET_SEND_BUFSIZE > 0
       case SO_SNDBUF:
         /* Verify that option is the size of an 'int'.  Should also check
-          * that 'value' is properly aligned for an 'int'
-          */
+         * that 'value' is properly aligned for an 'int'
+         */
 
         if (*value_len < sizeof(int))
           {
             return -EINVAL;
-        }
+          }
 
         *(FAR int *)value = conn->sndbufs;
         break;

--- a/net/can/can_input.c
+++ b/net/can/can_input.c
@@ -311,7 +311,7 @@ int can_input(FAR struct net_driver_s *dev)
   if (ret < 0)
     {
 #ifdef CONFIG_NET_STATISTICS
-    g_netstats.can.drop++;
+      g_netstats.can.drop++;
 #endif
     }
 

--- a/net/can/can_sendmsg.c
+++ b/net/can/can_sendmsg.c
@@ -112,6 +112,7 @@ static uint32_t psock_send_eventhandler(FAR struct net_driver_s *dev,
 
           int ret = devif_send(dev, pstate->snd_buffer,
                                pstate->snd_buflen + pstate->pr_msglen, 0);
+
           dev->d_len = dev->d_sndlen - pstate->pr_msglen;
           if (ret <= 0)
             {
@@ -237,6 +238,7 @@ ssize_t can_sendmsg(FAR struct socket *psock, FAR const struct msghdr *msg,
   if (msg->msg_controllen > sizeof(struct cmsghdr))
     {
       FAR struct cmsghdr *cmsg = CMSG_FIRSTHDR(msg);
+
       if (_SO_GETOPT(conn->sconn.s_options, CAN_RAW_TX_DEADLINE) &&
           cmsg->cmsg_level == SOL_CAN_RAW &&
           cmsg->cmsg_type == CAN_RAW_TX_DEADLINE &&

--- a/net/can/can_sockif.c
+++ b/net/can/can_sockif.c
@@ -208,6 +208,7 @@ static int can_setup(FAR struct socket *psock)
        */
 
       FAR struct can_conn_s *conn = can_alloc();
+
       if (conn == NULL)
         {
           /* Failed to reserve a connection structure */
@@ -327,6 +328,7 @@ static int can_bind(FAR struct socket *psock,
 {
   FAR struct sockaddr_can *canaddr;
   FAR struct can_conn_s *conn;
+
   DEBUGASSERT(addr != NULL &&
               addrlen >= sizeof(struct sockaddr_can));
 
@@ -341,6 +343,7 @@ static int can_bind(FAR struct socket *psock,
   conn->dev = netdev_findbyindex(canaddr->can_ifindex);
 #else
   char netdev_name[5] = "can0";
+
   netdev_name[3] += canaddr->can_ifindex;
   conn->dev = netdev_findbyname((const char *)&netdev_name);
 #endif

--- a/net/devif/devif_loopback.c
+++ b/net/devif/devif_loopback.c
@@ -102,13 +102,13 @@ int devif_loopback(FAR struct net_driver_s *dev)
 
   do
     {
-       NETDEV_TXPACKETS(dev);
-       NETDEV_RXPACKETS(dev);
+      NETDEV_TXPACKETS(dev);
+      NETDEV_RXPACKETS(dev);
 
 #ifdef CONFIG_NET_PKT
       /* When packet sockets are enabled, feed the frame into the tap */
 
-       pkt_input(dev);
+      pkt_input(dev);
 #endif
 
       /* We only accept IP packets of the configured type */

--- a/net/devif/devif_poll.c
+++ b/net/devif/devif_poll.c
@@ -120,8 +120,8 @@ static void devif_packet_conversion(FAR struct net_driver_s *dev,
 #ifdef CONFIG_NET_IPv4
           if ((ipv6->vtc & IP_VERSION_MASK) != IPv6_VERSION)
             {
-               nerr("ERROR: IPv6 version error: %02x...  Packet dropped\n",
-                    ipv6->vtc);
+              nerr("ERROR: IPv6 version error: %02x...  Packet dropped\n",
+                   ipv6->vtc);
             }
           else
 #endif

--- a/net/devif/ipv4_input.c
+++ b/net/devif/ipv4_input.c
@@ -149,6 +149,7 @@ static int ipv4_check_opt(FAR struct ipv4_hdr_s *ipv4)
       else if (optlen > 1)
         {
           int len = opt[1];
+
           if (len > optlen)
             {
               return -EINVAL;
@@ -483,7 +484,7 @@ static int ipv4_in(FAR struct net_driver_s *dev)
 #endif
 
 #ifdef NET_ICMP_HAVE_STACK
-  /* Check for ICMP input */
+        /* Check for ICMP input */
 
       case IP_PROTO_ICMP:  /* ICMP input */
         icmp_input(dev);
@@ -491,7 +492,7 @@ static int ipv4_in(FAR struct net_driver_s *dev)
 #endif
 
 #ifdef CONFIG_NET_IGMP
-  /* Check for IGMP input */
+        /* Check for IGMP input */
 
       case IP_PROTO_IGMP:  /* IGMP input */
         igmp_input(dev);

--- a/net/icmp/icmp_sendmsg.c
+++ b/net/icmp/icmp_sendmsg.c
@@ -399,7 +399,7 @@ ssize_t icmp_sendmsg(FAR struct socket *psock, FAR const struct msghdr *msg,
           conn->id = icmp->id;
         }
 
-        conn->dev = dev;
+      conn->dev = dev;
 
       /* Notify the device driver of the availability of TX data */
 

--- a/net/icmp/icmp_sockif.c
+++ b/net/icmp/icmp_sockif.c
@@ -126,6 +126,7 @@ static int icmp_setup(FAR struct socket *psock)
        */
 
       FAR struct icmp_conn_s *conn = icmp_alloc();
+
       if (conn == NULL)
         {
           /* Failed to reserve a connection structure */
@@ -379,26 +380,26 @@ static int icmp_getsockopt(FAR struct socket *psock, int level, int option,
                            FAR void *value, FAR socklen_t *value_len)
 {
   switch (level)
-  {
-    case SOL_SOCKET:
+    {
+      case SOL_SOCKET:
 
-      /* Socket-level options are handled by psock_getsockopt()/inet layer.
-       * Return -ENOPROTOOPT so upper layer will fallback to socket-level
-       * handler without emitting misleading ICMP error logs.
-       */
+        /* Socket-level options are handled by psock_getsockopt()/inet layer.
+         * Return -ENOPROTOOPT so upper layer will fallback to socket-level
+         * handler without emitting misleading ICMP error logs.
+         */
 
-      return -ENOPROTOOPT;
+        return -ENOPROTOOPT;
 
-    case SOL_IP:
-      return ipv4_getsockopt(psock, option, value, value_len);
+      case SOL_IP:
+        return ipv4_getsockopt(psock, option, value, value_len);
 
-    case SOL_RAW:
-      return icmp_getsockopt_internal(psock, option, value, value_len);
+      case SOL_RAW:
+        return icmp_getsockopt_internal(psock, option, value, value_len);
 
-    default:
-      nerr("ERROR: Unrecognized ICMP option: %d\n", option);
-      return -ENOPROTOOPT;
-  }
+      default:
+        nerr("ERROR: Unrecognized ICMP option: %d\n", option);
+        return -ENOPROTOOPT;
+    }
 }
 
 /****************************************************************************
@@ -491,26 +492,26 @@ static int icmp_setsockopt(FAR struct socket *psock, int level, int option,
                            FAR const void *value, socklen_t value_len)
 {
   switch (level)
-  {
-    case SOL_SOCKET:
+    {
+      case SOL_SOCKET:
 
-      /* Socket-level options are handled by psock_setsockopt()/inet layer.
-       * Return -ENOPROTOOPT so upper layer will fallback to socket-level
-       * handler without emitting misleading ICMP error logs.
-       */
+        /* Socket-level options are handled by psock_setsockopt()/inet layer.
+         * Return -ENOPROTOOPT so upper layer will fallback to socket-level
+         * handler without emitting misleading ICMP error logs.
+         */
 
-      return -ENOPROTOOPT;
+        return -ENOPROTOOPT;
 
-    case SOL_IP:
-      return ipv4_setsockopt(psock, option, value, value_len);
+      case SOL_IP:
+        return ipv4_setsockopt(psock, option, value, value_len);
 
-    case SOL_RAW:
-      return icmp_setsockopt_internal(psock, option, value, value_len);
+      case SOL_RAW:
+        return icmp_setsockopt_internal(psock, option, value, value_len);
 
-    default:
-      nerr("ERROR: Unrecognized ICMP option: %d\n", option);
-      return -ENOPROTOOPT;
-  }
+      default:
+        nerr("ERROR: Unrecognized ICMP option: %d\n", option);
+        return -ENOPROTOOPT;
+    }
 }
 #endif
 

--- a/net/icmpv6/icmpv6_input.c
+++ b/net/icmpv6/icmpv6_input.c
@@ -290,386 +290,394 @@ void icmpv6_input(FAR struct net_driver_s *dev, unsigned int iplen)
 
   switch (icmpv6->type)
     {
-    /* If we get a neighbor solicitation for our address we should send
-     * a neighbor advertisement message back.
-     */
+      /* If we get a neighbor solicitation for our address we should send
+       * a neighbor advertisement message back.
+       */
 
-    case ICMPv6_NEIGHBOR_SOLICIT:
-      {
-        FAR struct icmpv6_neighbor_solicit_s *sol;
+      case ICMPv6_NEIGHBOR_SOLICIT:
+        {
+          FAR struct icmpv6_neighbor_solicit_s *sol;
 
-        /* Check if we are the target of the solicitation */
+          /* Check if we are the target of the solicitation */
 
-        sol = ICMPv6SOLICIT;
-        if (NETDEV_IS_MY_V6ADDR(dev, sol->tgtaddr))
-          {
-            if (sol->opttype == ICMPv6_OPT_SRCLLADDR)
-              {
-                /* Save the sender's address mapping in our Neighbor Table. */
+          sol = ICMPv6SOLICIT;
+          if (NETDEV_IS_MY_V6ADDR(dev, sol->tgtaddr))
+            {
+              if (sol->opttype == ICMPv6_OPT_SRCLLADDR)
+                {
+                  /* Save the sender's address mapping in our Neighbor
+                   * Table.
+                   */
 
-                neighbor_add(dev, ipv6->srcipaddr, sol->srclladdr);
-              }
+                  neighbor_add(dev, ipv6->srcipaddr, sol->srclladdr);
+                }
 
-            /* Yes.. Send a neighbor advertisement back to where the neighbor
-             * solicitation came from.
-             */
+              /* Yes.. Send a neighbor advertisement back to where the
+               * neighbor solicitation came from.
+               */
 
-            icmpv6_advertise(dev, sol->tgtaddr, ipv6->srcipaddr);
+              icmpv6_advertise(dev, sol->tgtaddr, ipv6->srcipaddr);
 
-            /* All statistics have been updated.  Nothing to do but exit. */
+              /* All statistics have been updated.  Nothing to do but exit. */
 
-            return;
-          }
-        else
-          {
-            goto icmpv6_drop_packet;
-          }
-      }
-      break;
+              return;
+            }
+          else
+            {
+              goto icmpv6_drop_packet;
+            }
+        }
+        break;
 
-    /* Check if we received a Neighbor Advertisement */
+      /* Check if we received a Neighbor Advertisement */
 
-    case ICMPv6_NEIGHBOR_ADVERTISE:
-      {
-        FAR struct icmpv6_neighbor_advertise_s *adv;
+      case ICMPv6_NEIGHBOR_ADVERTISE:
+        {
+          FAR struct icmpv6_neighbor_advertise_s *adv;
 
-        /* If the IPv6 destination address matches our address, and if so,
-         * add the neighbor address mapping to the list of neighbors.
-         *
-         * Missing checks:
-         *   optlen = 1 (8 octets)
-         *   Should only update Neighbor Table if
-         *     [O]verride bit is set in flags
-         */
+          /* If the IPv6 destination address matches our address, and if so,
+           * add the neighbor address mapping to the list of neighbors.
+           *
+           * Missing checks:
+           *   optlen = 1 (8 octets)
+           *   Should only update Neighbor Table if
+           *     [O]verride bit is set in flags
+           */
 
-        adv = ICMPv6ADVERTISE;
-        if (NETDEV_IS_MY_V6ADDR(dev, ipv6->destipaddr))
-          {
-            /* This message is required to support the Target link-layer
-             * address option.
-             */
+          adv = ICMPv6ADVERTISE;
+          if (NETDEV_IS_MY_V6ADDR(dev, ipv6->destipaddr))
+            {
+              /* This message is required to support the Target link-layer
+               * address option.
+               */
 
-            if (adv->opttype == ICMPv6_OPT_TGTLLADDR)
-              {
-                /* Save the sender's address mapping in our Neighbor Table. */
+              if (adv->opttype == ICMPv6_OPT_TGTLLADDR)
+                {
+                  /* Save the sender's address mapping in our Neighbor
+                   * Table.
+                   */
 
-                neighbor_add(dev, ipv6->srcipaddr, adv->tgtlladdr);
-              }
+                  neighbor_add(dev, ipv6->srcipaddr, adv->tgtlladdr);
+                }
 
 #ifdef CONFIG_NET_ICMPv6_NEIGHBOR
-            /* Then notify any logic waiting for the Neighbor Advertisement */
+              /* Then notify any logic waiting for the Neighbor
+               * Advertisement
+               */
 
-            icmpv6_notify(ipv6->srcipaddr);
+              icmpv6_notify(ipv6->srcipaddr);
 #endif
 
-            /* We consumed the packet but we don't send anything in
-             * response.
-             */
+              /* We consumed the packet but we don't send anything in
+               * response.
+               */
 
-            goto icmpv6_send_nothing;
-          }
+              goto icmpv6_send_nothing;
+            }
 
-        goto icmpv6_drop_packet;
-      }
-      break;
+          goto icmpv6_drop_packet;
+        }
+        break;
 
 #ifdef CONFIG_NET_ICMPv6_ROUTER
-    /* Check if we received a Router Solicitation */
+      /* Check if we received a Router Solicitation */
 
-    case ICMPV6_ROUTER_SOLICIT:
-      {
-        /* Just give a knee-jerk Router Advertisement in respond with no
-         * further examination of the Router Solicitation.
-         */
+      case ICMPV6_ROUTER_SOLICIT:
+        {
+          /* Just give a knee-jerk Router Advertisement in respond with no
+           * further examination of the Router Solicitation.
+           */
 
-        icmpv6_radvertise(dev);
+          icmpv6_radvertise(dev);
 
-        /* All statistics have been updated.  Nothing to do but exit. */
+          /* All statistics have been updated.  Nothing to do but exit. */
 
-        return;
-      }
+          return;
+        }
 #endif
 
 #ifdef CONFIG_NET_ICMPv6_AUTOCONF
-    /* Check if we received a Router Advertisement */
+      /* Check if we received a Router Advertisement */
 
-    case ICMPV6_ROUTER_ADVERTISE:
-      {
-        FAR struct icmpv6_router_advertise_s *adv;
-        FAR uint8_t *options;
-        bool prefix = false;
-        uint16_t pktlen;
-        uint16_t optlen;
-        int ndx;
+      case ICMPV6_ROUTER_ADVERTISE:
+        {
+          FAR struct icmpv6_router_advertise_s *adv;
+          FAR uint8_t *options;
+          bool prefix = false;
+          uint16_t pktlen;
+          uint16_t optlen;
+          int ndx;
 
-        /* Get the length of the option data */
+          /* Get the length of the option data */
 
-        pktlen = (uint16_t)ipv6->len[0] << 8 | ipv6->len[1];
-        if (pktlen <= ICMPv6_RADV_MINLEN)
-          {
-            /* Too small to contain any options */
+          pktlen = (uint16_t)ipv6->len[0] << 8 | ipv6->len[1];
+          if (pktlen <= ICMPv6_RADV_MINLEN)
+            {
+              /* Too small to contain any options */
 
-            goto icmpv6_drop_packet;
-          }
+              goto icmpv6_drop_packet;
+            }
 
-        optlen = ICMPv6_RADV_OPTLEN(pktlen);
+          optlen = ICMPv6_RADV_OPTLEN(pktlen);
 
-        /* We need to have a valid router advertisement with a Prefix and
-         * with the "A" bit set in the flags.  Options immediately follow
-         * the ICMPv6 router advertisement.
-         */
+          /* We need to have a valid router advertisement with a Prefix and
+           * with the "A" bit set in the flags.  Options immediately follow
+           * the ICMPv6 router advertisement.
+           */
 
-        adv     = ICMPv6RADVERTISE;
-        options = (FAR uint8_t *)adv +
-                   sizeof(struct icmpv6_router_advertise_s);
+          adv     = ICMPv6RADVERTISE;
+          options = (FAR uint8_t *)adv +
+                     sizeof(struct icmpv6_router_advertise_s);
 
-        for (ndx = 0; ndx < optlen; )
-          {
-           FAR struct icmpv6_generic_s *opt =
-                                (FAR struct icmpv6_generic_s *)&options[ndx];
+          for (ndx = 0; ndx < optlen; )
+            {
+             FAR struct icmpv6_generic_s *opt =
+               (FAR struct icmpv6_generic_s *)&options[ndx];
 
-            /* RFC 4861 4.6: "The value 0 is invalid. Nodes MUST silently
-             * discard a packet that contains an option with length zero."
-             */
+              /* RFC 4861 4.6: "The value 0 is invalid. Nodes MUST silently
+               * discard a packet that contains an option with length zero."
+               */
 
-            if (opt->optlen == 0)
-              {
-                goto icmpv6_drop_packet;
-              }
+              if (opt->optlen == 0)
+                {
+                  goto icmpv6_drop_packet;
+                }
 
-            switch (opt->opttype)
-              {
-                case ICMPv6_OPT_SRCLLADDR:
-                  {
-                    FAR struct icmpv6_srclladdr_s *sllopt =
-                                      (FAR struct icmpv6_srclladdr_s *)opt;
-                    neighbor_add(dev, ipv6->srcipaddr, sllopt->srclladdr);
-                  }
-                  break;
+              switch (opt->opttype)
+                {
+                  case ICMPv6_OPT_SRCLLADDR:
+                    {
+                      FAR struct icmpv6_srclladdr_s *sllopt =
+                                        (FAR struct icmpv6_srclladdr_s *)opt;
 
-                case ICMPv6_OPT_PREFIX:
-                  {
-                    FAR struct icmpv6_prefixinfo_s *prefixopt =
-                                      (FAR struct icmpv6_prefixinfo_s *)opt;
+                      neighbor_add(dev, ipv6->srcipaddr, sllopt->srclladdr);
+                    }
+                    break;
 
-                   /* Is the "A" flag set? */
+                  case ICMPv6_OPT_PREFIX:
+                    {
+                      FAR struct icmpv6_prefixinfo_s *prefixopt =
+                        (FAR struct icmpv6_prefixinfo_s *)opt;
 
-                    if ((prefixopt->flags & ICMPv6_PRFX_FLAG_A) != 0)
-                      {
-                        /* Yes.. Set the new network addresses. */
+                      /* Is the "A" flag set? */
 
-                        icmpv6_setaddresses(dev, ipv6->srcipaddr,
-                                    prefixopt->prefix, prefixopt->preflen);
-                        netlink_ipv6_prefix_notify(dev, RTM_NEWPREFIX,
-                                                   prefixopt);
-                      }
-                    else if ((adv->flags & ICMPv6_RADV_FLAG_M) != 0)
-                      {
-                        net_ipv6addr_copy(dev->d_ipv6draddr,
-                                          ipv6->srcipaddr);
-                      }
+                      if ((prefixopt->flags & ICMPv6_PRFX_FLAG_A) != 0)
+                        {
+                          /* Yes.. Set the new network addresses. */
+
+                          icmpv6_setaddresses(dev, ipv6->srcipaddr,
+                                      prefixopt->prefix, prefixopt->preflen);
+                          netlink_ipv6_prefix_notify(dev, RTM_NEWPREFIX,
+                                                     prefixopt);
+                        }
+                      else if ((adv->flags & ICMPv6_RADV_FLAG_M) != 0)
+                        {
+                          net_ipv6addr_copy(dev->d_ipv6draddr,
+                                            ipv6->srcipaddr);
+                        }
 
                       /* Notify any waiting threads */
 
                       icmpv6_rnotify(dev, (adv->flags & ICMPv6_RADV_FLAG_M) ?
                                           -EADDRNOTAVAIL : OK);
                       prefix = true;
-                  }
-                  break;
+                    }
+                    break;
 
-                case ICMPv6_OPT_MTU:
-                  {
-                    FAR struct icmpv6_mtu_s *mtuopt =
-                                        (FAR struct icmpv6_mtu_s *)opt;
-                    dev->d_pktsize = MIN(dev->d_pktsize,
-                        NTOHS(mtuopt->mtu[1]) + dev->d_llhdrlen);
-                  }
-                  break;
+                  case ICMPv6_OPT_MTU:
+                    {
+                      FAR struct icmpv6_mtu_s *mtuopt =
+                                          (FAR struct icmpv6_mtu_s *)opt;
+
+                      dev->d_pktsize = MIN(dev->d_pktsize,
+                          NTOHS(mtuopt->mtu[1]) + dev->d_llhdrlen);
+                    }
+                    break;
 
 #ifdef CONFIG_ICMPv6_AUTOCONF_RDNSS
-                case ICMPv6_OPT_RDNSS:
-                  {
-                    FAR struct icmpv6_rdnss_s *rdnss =
-                                          (FAR struct icmpv6_rdnss_s *)opt;
-                    FAR struct in6_addr *servers;
-                    struct sockaddr_in6 addr;
-                    int nservers;
-                    int ret;
+                  case ICMPv6_OPT_RDNSS:
+                    {
+                      FAR struct icmpv6_rdnss_s *rdnss =
+                                            (FAR struct icmpv6_rdnss_s *)opt;
+                      FAR struct in6_addr *servers;
+                      struct sockaddr_in6 addr;
+                      int nservers;
+                      int ret;
 
-                    if (rdnss->optlen < 3)
-                      {
-                        nerr("rdnss error length %d\n", rdnss->optlen);
-                        break;
-                      }
+                      if (rdnss->optlen < 3)
+                        {
+                          nerr("rdnss error length %d\n", rdnss->optlen);
+                          break;
+                        }
 
-                    /* optlen is in units of 8 bytes. The header is 1 unit
-                     * (8 bytes) and each address is another 2 units
-                     * (16 bytes). So the number of addresses is equal to
-                     * (optlen - 1) / 2.
-                     */
+                      /* optlen is in units of 8 bytes. The header is 1 unit
+                       * (8 bytes) and each address is another 2 units
+                       * (16 bytes). So the number of addresses is equal to
+                       * (optlen - 1) / 2.
+                       */
 
-                    servers  = (FAR struct in6_addr *)rdnss->servers;
-                    nservers = (rdnss->optlen - 1) / 2;
+                      servers  = (FAR struct in6_addr *)rdnss->servers;
+                      nservers = (rdnss->optlen - 1) / 2;
 
-                    if (nservers > 0)
-                      {
-                        /* Set the IPv6 DNS server address */
+                      if (nservers > 0)
+                        {
+                          /* Set the IPv6 DNS server address */
 
-                        memset(&addr, 0, sizeof(addr));
-                        addr.sin6_family = AF_INET6;
-                        net_ipv6addr_copy(&addr.sin6_addr, servers);
-                        ret = dns_add_nameserver(
-                                          (FAR const struct sockaddr *)&addr,
-                                          sizeof(struct sockaddr_in6));
-                        if (ret < 0 && ret != -EEXIST)
-                          {
-                            nerr("dns add nameserver failed %d", ret);
-                          }
-                      }
-                  }
-                  break;
+                          memset(&addr, 0, sizeof(addr));
+                          addr.sin6_family = AF_INET6;
+                          net_ipv6addr_copy(&addr.sin6_addr, servers);
+                          ret = dns_add_nameserver(
+                            (FAR const struct sockaddr *)&addr,
+                            sizeof(struct sockaddr_in6));
+                          if (ret < 0 && ret != -EEXIST)
+                            {
+                              nerr("dns add nameserver failed %d", ret);
+                            }
+                        }
+                    }
+                    break;
 #endif
 
-                default:
-                  break;
-              }
+                  default:
+                    break;
+                }
 
-            /* Skip to the next option (units of octets) */
+              /* Skip to the next option (units of octets) */
 
-            ndx += (opt->optlen << 3);
-          }
+              ndx += (opt->optlen << 3);
+            }
 
-        if (prefix)
-          {
-            goto icmpv6_send_nothing;
-          }
+          if (prefix)
+            {
+              goto icmpv6_send_nothing;
+            }
 
-        goto icmpv6_drop_packet;
-      }
-      break;
+          goto icmpv6_drop_packet;
+        }
+        break;
 #endif
 
-    /* Handle the ICMPv6 Echo Request */
+      /* Handle the ICMPv6 Echo Request */
 
-    case ICMPv6_ECHO_REQUEST:
-      {
-        /* ICMPv6 echo (i.e., ping) processing. This is simple, we only
-         * change the ICMPv6 type from ECHO to ECHO_REPLY and update the
-         * ICMPv6 checksum before we return the packet.
-         */
+      case ICMPv6_ECHO_REQUEST:
+        {
+          /* ICMPv6 echo (i.e., ping) processing. This is simple, we only
+           * change the ICMPv6 type from ECHO to ECHO_REPLY and update the
+           * ICMPv6 checksum before we return the packet.
+           */
 
-        FAR const uint16_t *srcaddr;
+          FAR const uint16_t *srcaddr;
 
-        icmpv6->type = ICMPv6_ECHO_REPLY;
+          icmpv6->type = ICMPv6_ECHO_REPLY;
 
-        srcaddr = netdev_ipv6_srcaddr(dev, ipv6->destipaddr);
-        net_ipv6addr_copy(ipv6->destipaddr, ipv6->srcipaddr);
-        net_ipv6addr_copy(ipv6->srcipaddr, srcaddr);
+          srcaddr = netdev_ipv6_srcaddr(dev, ipv6->destipaddr);
+          net_ipv6addr_copy(ipv6->destipaddr, ipv6->srcipaddr);
+          net_ipv6addr_copy(ipv6->srcipaddr, srcaddr);
 
-        icmpv6->chksum = 0;
+          icmpv6->chksum = 0;
 
 #ifdef CONFIG_NET_ICMPv6_CHECKSUMS
-        icmpv6->chksum = ~icmpv6_chksum(dev, iplen);
+          icmpv6->chksum = ~icmpv6_chksum(dev, iplen);
 #endif
-      }
-      break;
+        }
+        break;
 
 #if (CONFIG_NET_ICMPv6_PMTU_ENTRIES > 0)
-    case ICMPv6_PACKET_TOO_BIG:
-      {
-        FAR struct icmpv6_pmtu_entry *entry;
-        FAR struct ipv6_hdr_s *inner;
-        int mtu;
+      case ICMPv6_PACKET_TOO_BIG:
+        {
+          FAR struct icmpv6_pmtu_entry *entry;
+          FAR struct ipv6_hdr_s *inner;
+          int mtu;
 
-        mtu = (ntohs(icmpv6->data[0]) << 16) | (ntohs(icmpv6->data[1]));
-        if (mtu <= 0)
-          {
-            goto icmpv6_type_error;
-          }
+          mtu = (ntohs(icmpv6->data[0]) << 16) | (ntohs(icmpv6->data[1]));
+          if (mtu <= 0)
+            {
+              goto icmpv6_type_error;
+            }
 
-        inner = (FAR struct ipv6_hdr_s *)(icmpv6 + 1);
-        entry = icmpv6_find_pmtu_entry(inner->destipaddr);
-        if (entry == NULL)
-          {
-            icmpv6_add_pmtu_entry(inner->destipaddr, mtu);
-          }
-        else
-          {
-            entry->pmtu = mtu;
-          }
+          inner = (FAR struct ipv6_hdr_s *)(icmpv6 + 1);
+          entry = icmpv6_find_pmtu_entry(inner->destipaddr);
+          if (entry == NULL)
+            {
+              icmpv6_add_pmtu_entry(inner->destipaddr, mtu);
+            }
+          else
+            {
+              entry->pmtu = mtu;
+            }
 
-        goto icmpv6_send_nothing;
-      }
+          goto icmpv6_send_nothing;
+        }
 #endif
 
 #ifdef CONFIG_NET_MLD
-    /* Dispatch received Multicast Listener Discovery (MLD) packets. */
+      /* Dispatch received Multicast Listener Discovery (MLD) packets. */
 
-    case ICMPV6_MCAST_LISTEN_QUERY:      /* Multicast Listener Query, RFC 2710 and RFC 3810 */
-      {
-        FAR struct mld_mcast_listen_query_s *query = MLDQUERY;
-        int ret;
+      case ICMPV6_MCAST_LISTEN_QUERY:      /* Multicast Listener Query, RFC 2710 and RFC 3810 */
+        {
+          FAR struct mld_mcast_listen_query_s *query = MLDQUERY;
+          int ret;
 
-        ret = mld_query(dev, query);
-        if (ret < 0)
-          {
-            goto icmpv6_drop_packet;
-          }
-      }
-      break;
+          ret = mld_query(dev, query);
+          if (ret < 0)
+            {
+              goto icmpv6_drop_packet;
+            }
+        }
+        break;
 
-    case ICMPV6_MCAST_LISTEN_REPORT_V1:  /* Version 1 Multicast Listener Report, RFC 2710 */
-      {
-        FAR struct mld_mcast_listen_report_v1_s *report = MLDREPORT_V1;
-        int ret;
+      case ICMPV6_MCAST_LISTEN_REPORT_V1:  /* Version 1 Multicast Listener Report, RFC 2710 */
+        {
+          FAR struct mld_mcast_listen_report_v1_s *report = MLDREPORT_V1;
+          int ret;
 
-        ret = mld_report_v1(dev, report);
-        if (ret < 0)
-          {
-            goto icmpv6_drop_packet;
-          }
-      }
-      break;
+          ret = mld_report_v1(dev, report);
+          if (ret < 0)
+            {
+              goto icmpv6_drop_packet;
+            }
+        }
+        break;
 
-    case ICMPV6_MCAST_LISTEN_REPORT_V2:  /* Version 2 Multicast Listener Report, RFC 3810 */
-      {
-        FAR struct mld_mcast_listen_report_v2_s *report = MLDREPORT_V2;
-        int ret;
+      case ICMPV6_MCAST_LISTEN_REPORT_V2:  /* Version 2 Multicast Listener Report, RFC 3810 */
+        {
+          FAR struct mld_mcast_listen_report_v2_s *report = MLDREPORT_V2;
+          int ret;
 
-        ret = mld_report_v2(dev, report);
-        if (ret < 0)
-          {
-            goto icmpv6_drop_packet;
-          }
-      }
-      break;
+          ret = mld_report_v2(dev, report);
+          if (ret < 0)
+            {
+              goto icmpv6_drop_packet;
+            }
+        }
+        break;
 
-    case ICMPV6_MCAST_LISTEN_DONE:       /* Multicast Listener Done, RFC 2710 */
-      {
-        FAR struct mld_mcast_listen_done_s *done = MLDDONE;
-        int ret;
+      case ICMPV6_MCAST_LISTEN_DONE:       /* Multicast Listener Done, RFC 2710 */
+        {
+          FAR struct mld_mcast_listen_done_s *done = MLDDONE;
+          int ret;
 
-        ret = mld_done(dev, done);
-        if (ret < 0)
-          {
-            goto icmpv6_drop_packet;
-          }
-      }
-      break;
+          ret = mld_done(dev, done);
+          if (ret < 0)
+            {
+              goto icmpv6_drop_packet;
+            }
+        }
+        break;
 #endif
 
-    default:
-      {
+      default:
+        {
 #ifdef CONFIG_NET_ICMPv6_SOCKET
-        if (delivered)
-          {
-            goto icmpv6_send_nothing;
-          }
+          if (delivered)
+            {
+              goto icmpv6_send_nothing;
+            }
 #endif
 
-        nwarn("WARNING: Unknown ICMPv6 type: %d\n", icmpv6->type);
-        goto icmpv6_type_error;
-      }
+          nwarn("WARNING: Unknown ICMPv6 type: %d\n", icmpv6->type);
+          goto icmpv6_type_error;
+        }
     }
 
 #ifdef CONFIG_NET_STATISTICS

--- a/net/icmpv6/icmpv6_sockif.c
+++ b/net/icmpv6/icmpv6_sockif.c
@@ -125,6 +125,7 @@ static int icmpv6_setup(FAR struct socket *psock)
        */
 
       FAR struct icmpv6_conn_s *conn = icmpv6_alloc();
+
       if (conn == NULL)
         {
           /* Failed to reserve a connection structure */

--- a/net/ieee802154/ieee802154_conn.c
+++ b/net/ieee802154/ieee802154_conn.c
@@ -232,9 +232,9 @@ FAR struct ieee802154_conn_s *
               }
             break;
 
-           default:
-             nerr("ERROR: Invalid address mode: %u\n", conn->raddr.s_mode);
-             return NULL;
+          default:
+            nerr("ERROR: Invalid address mode: %u\n", conn->raddr.s_mode);
+            return NULL;
         }
     }
 

--- a/net/ieee802154/ieee802154_sockif.c
+++ b/net/ieee802154/ieee802154_sockif.c
@@ -104,6 +104,7 @@ static int ieee802154_sockif_alloc(FAR struct socket *psock)
    */
 
   FAR struct ieee802154_conn_s *conn = ieee802154_conn_alloc();
+
   if (conn == NULL)
     {
       /* Failed to reserve a connection structure */

--- a/net/igmp/igmp_send.c
+++ b/net/igmp/igmp_send.c
@@ -73,6 +73,7 @@
 static uint16_t igmp_chksum(FAR uint8_t *buffer, int buflen)
 {
   uint16_t sum = net_chksum((FAR uint16_t *)buffer, buflen);
+
   return sum ? sum : 0xffff;
 }
 #endif

--- a/net/inet/inet_sockif.c
+++ b/net/inet/inet_sockif.c
@@ -165,6 +165,7 @@ static int inet_tcp_alloc(FAR struct socket *psock)
   /* Allocate the TCP connection structure */
 
   FAR struct tcp_conn_s *conn = tcp_alloc(psock->s_domain);
+
   if (conn == NULL)
     {
       /* Failed to reserve a connection structure */
@@ -207,6 +208,7 @@ static int inet_udp_alloc(FAR struct socket *psock)
   /* Allocate the UDP connection structure */
 
   FAR struct udp_conn_s *conn = udp_alloc(psock->s_domain);
+
   if (conn == NULL)
     {
       /* Failed to reserve a connection structure */
@@ -362,6 +364,7 @@ static void inet_addref(FAR struct socket *psock)
   if (psock->s_type == SOCK_STREAM)
     {
       FAR struct tcp_conn_s *conn = psock->s_conn;
+
       DEBUGASSERT(conn->crefs > 0 && conn->crefs < 255);
       conn->crefs++;
     }
@@ -371,6 +374,7 @@ static void inet_addref(FAR struct socket *psock)
   if (psock->s_type == SOCK_DGRAM)
     {
       FAR struct udp_conn_s *conn = psock->s_conn;
+
       DEBUGASSERT(conn->crefs > 0 && conn->crefs < 255);
       conn->crefs++;
     }
@@ -412,20 +416,20 @@ static int inet_bind(FAR struct socket *psock,
   switch (addr->sa_family)
     {
 #ifdef CONFIG_NET_IPv4
-    case AF_INET:
-      minlen = sizeof(struct sockaddr_in);
-      break;
+      case AF_INET:
+        minlen = sizeof(struct sockaddr_in);
+        break;
 #endif
 
 #ifdef CONFIG_NET_IPv6
-    case AF_INET6:
-      minlen = sizeof(struct sockaddr_in6);
-      break;
+      case AF_INET6:
+        minlen = sizeof(struct sockaddr_in6);
+        break;
 #endif
 
-    default:
-      nerr("ERROR: Unrecognized address family: %d\n", addr->sa_family);
-      return -EAFNOSUPPORT;
+      default:
+        nerr("ERROR: Unrecognized address family: %d\n", addr->sa_family);
+        return -EAFNOSUPPORT;
     }
 
   if (addrlen < minlen)
@@ -517,17 +521,17 @@ static int inet_getsockname(FAR struct socket *psock,
   switch (psock->s_domain)
     {
 #ifdef CONFIG_NET_IPv4
-    case PF_INET:
-      return ipv4_getsockname(psock, addr, addrlen);
+      case PF_INET:
+        return ipv4_getsockname(psock, addr, addrlen);
 #endif
 
 #ifdef CONFIG_NET_IPv6
-    case PF_INET6:
-      return ipv6_getsockname(psock, addr, addrlen);
+      case PF_INET6:
+        return ipv6_getsockname(psock, addr, addrlen);
 #endif
 
-    default:
-      return -EAFNOSUPPORT;
+      default:
+        return -EAFNOSUPPORT;
     }
 }
 
@@ -568,17 +572,17 @@ static int inet_getpeername(FAR struct socket *psock,
   switch (psock->s_domain)
     {
 #ifdef CONFIG_NET_IPv4
-    case PF_INET:
-      return ipv4_getpeername(psock, addr, addrlen);
+      case PF_INET:
+        return ipv4_getpeername(psock, addr, addrlen);
 #endif
 
 #ifdef CONFIG_NET_IPv6
-    case PF_INET6:
-      return ipv6_getpeername(psock, addr, addrlen);
+      case PF_INET6:
+        return ipv6_getpeername(psock, addr, addrlen);
 #endif
 
-    default:
-      return -EAFNOSUPPORT;
+      default:
+        return -EAFNOSUPPORT;
     }
 }
 
@@ -637,6 +641,7 @@ static int inet_get_socketlevel_option(FAR struct socket *psock, int option,
           if (psock->s_type == SOCK_STREAM)
             {
               FAR struct tcp_conn_s *tcp = psock->s_conn;
+
               *(FAR int *)value = tcp->rcv_bufs;
             }
           else
@@ -645,6 +650,7 @@ static int inet_get_socketlevel_option(FAR struct socket *psock, int option,
           if (psock->s_type == SOCK_DGRAM)
             {
               FAR struct udp_conn_s *udp = psock->s_conn;
+
               *(FAR int *)value = udp->rcvbufs;
             }
           else
@@ -668,6 +674,7 @@ static int inet_get_socketlevel_option(FAR struct socket *psock, int option,
           if (psock->s_type == SOCK_STREAM)
             {
               FAR struct tcp_conn_s *tcp = psock->s_conn;
+
               *(FAR int *)value = tcp->snd_bufs;
             }
           else
@@ -725,6 +732,7 @@ static int inet_get_socketlevel_option(FAR struct socket *psock, int option,
           if (psock->s_type == SOCK_DGRAM)
             {
               FAR struct udp_conn_s *conn = psock->s_conn;
+
               *(FAR int *)value = (conn->timestamp != 0);
             }
           else
@@ -790,7 +798,7 @@ static int inet_getsockopt(FAR struct socket *psock, int level, int option,
 
 #ifdef CONFIG_NET_IPv6
       case IPPROTO_IPV6:/* IPv6 protocol socket options (see include/netinet/in.h) */
-          return ipv6_getsockopt(psock, option, value, value_len);
+        return ipv6_getsockopt(psock, option, value, value_len);
 #endif
 
       default:
@@ -1036,6 +1044,7 @@ static int inet_set_socketlevel_option(FAR struct socket *psock, int option,
                */
 
               FAR struct udp_conn_s *conn = psock->s_conn;
+
               conn->timestamp = (*((FAR int *)value) != 0);
 
               conn_unlock(psock->s_conn);
@@ -1267,33 +1276,33 @@ static int inet_connect(FAR struct socket *psock,
   switch (inaddr->sin_family)
     {
 #ifdef CONFIG_NET_IPv4
-    case AF_INET:
-      {
-        if (addrlen < sizeof(struct sockaddr_in))
-          {
-            return -EINVAL;
-          }
-      }
-      break;
+      case AF_INET:
+        {
+          if (addrlen < sizeof(struct sockaddr_in))
+            {
+              return -EINVAL;
+            }
+        }
+        break;
 #endif
 
 #ifdef CONFIG_NET_IPv6
-    case AF_INET6:
-      {
-        if (addrlen < sizeof(struct sockaddr_in6))
-          {
-            return -EINVAL;
-          }
-      }
-      break;
+      case AF_INET6:
+        {
+          if (addrlen < sizeof(struct sockaddr_in6))
+            {
+              return -EINVAL;
+            }
+        }
+        break;
 #endif
 
-    case AF_UNSPEC:
-      break;
+      case AF_UNSPEC:
+        break;
 
-    default:
-      DEBUGPANIC();
-      return -EAFNOSUPPORT;
+      default:
+        DEBUGPANIC();
+        return -EAFNOSUPPORT;
     }
 
   /* Perform the connection depending on the protocol type */
@@ -1453,30 +1462,30 @@ static int inet_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
       switch (psock->s_domain)
         {
 #ifdef CONFIG_NET_IPv4
-        case PF_INET:
-          {
-            if (*addrlen < sizeof(struct sockaddr_in))
-              {
-                return -EINVAL;
-              }
-          }
-          break;
+          case PF_INET:
+            {
+              if (*addrlen < sizeof(struct sockaddr_in))
+                {
+                  return -EINVAL;
+                }
+            }
+            break;
 #endif /* CONFIG_NET_IPv4 */
 
 #ifdef CONFIG_NET_IPv6
-        case PF_INET6:
-          {
-            if (*addrlen < sizeof(struct sockaddr_in6))
-              {
-                return -EINVAL;
-              }
-          }
-          break;
+          case PF_INET6:
+            {
+              if (*addrlen < sizeof(struct sockaddr_in6))
+                {
+                  return -EINVAL;
+                }
+            }
+            break;
 #endif /* CONFIG_NET_IPv6 */
 
-        default:
-          DEBUGPANIC();
-          return -EINVAL;
+          default:
+            DEBUGPANIC();
+            return -EINVAL;
         }
     }
 
@@ -1501,9 +1510,9 @@ static int inet_accept(FAR struct socket *psock, FAR struct sockaddr *addr,
       return ret;
     }
 
-   /* Begin monitoring for TCP connection events on the newly connected
-    * socket
-    */
+  /* Begin monitoring for TCP connection events on the newly connected
+   * socket
+   */
 
   ret = tcp_start_monitor(newsock);
   if (ret < 0)
@@ -1647,9 +1656,9 @@ static int inet_poll(FAR struct socket *psock, FAR struct pollfd *fds,
       return inet_pollteardown(psock, fds);
     }
 #else
-    {
-      return -ENOSYS;
-    }
+  {
+    return -ENOSYS;
+  }
 #endif /* NET_TCP_HAVE_STACK || !NET_UDP_HAVE_STACK */
 }
 
@@ -1713,9 +1722,9 @@ static ssize_t inet_send(FAR struct socket *psock, FAR const void *buf,
       case SOCK_DGRAM:
         {
 #if defined(CONFIG_NET_6LOWPAN)
-           /* Try 6LoWPAN UDP packet send */
+          /* Try 6LoWPAN UDP packet send */
 
-           ret = psock_6lowpan_udp_send(psock, buf, len);
+          ret = psock_6lowpan_udp_send(psock, buf, len);
 
 #ifdef NET_UDP_HAVE_STACK
           if (ret < 0)
@@ -1788,20 +1797,20 @@ static ssize_t inet_sendto(FAR struct socket *psock, FAR const void *buf,
   switch (to->sa_family)
     {
 #ifdef CONFIG_NET_IPv4
-    case AF_INET:
-      minlen = sizeof(struct sockaddr_in);
-      break;
+      case AF_INET:
+        minlen = sizeof(struct sockaddr_in);
+        break;
 #endif
 
 #ifdef CONFIG_NET_IPv6
-    case AF_INET6:
-      minlen = sizeof(struct sockaddr_in6);
-      break;
+      case AF_INET6:
+        minlen = sizeof(struct sockaddr_in6);
+        break;
 #endif
 
-    default:
-      nerr("ERROR: Unrecognized address family: %d\n", to->sa_family);
-      return -EAFNOSUPPORT;
+      default:
+        nerr("ERROR: Unrecognized address family: %d\n", to->sa_family);
+        return -EAFNOSUPPORT;
     }
 
   if (tolen < minlen)
@@ -2208,24 +2217,24 @@ static ssize_t inet_recvmsg(FAR struct socket *psock,
       switch (psock->s_domain)
         {
 #ifdef CONFIG_NET_IPv4
-        case PF_INET:
-          {
-            minlen = sizeof(struct sockaddr_in);
-          }
-          break;
+          case PF_INET:
+            {
+              minlen = sizeof(struct sockaddr_in);
+            }
+            break;
 #endif
 
 #ifdef CONFIG_NET_IPv6
-        case PF_INET6:
-          {
-            minlen = sizeof(struct sockaddr_in6);
-          }
-          break;
+          case PF_INET6:
+            {
+              minlen = sizeof(struct sockaddr_in6);
+            }
+            break;
 #endif
 
-        default:
-          DEBUGPANIC();
-          return -EINVAL;
+          default:
+            DEBUGPANIC();
+            return -EINVAL;
         }
 
       if (msg->msg_namelen < minlen)
@@ -2241,35 +2250,35 @@ static ssize_t inet_recvmsg(FAR struct socket *psock,
   switch (psock->s_type)
     {
 #ifdef CONFIG_NET_TCP
-    case SOCK_STREAM:
-      {
+      case SOCK_STREAM:
+        {
 #ifdef NET_TCP_HAVE_STACK
-        ret = psock_tcp_recvfrom(psock, msg, flags);
+          ret = psock_tcp_recvfrom(psock, msg, flags);
 #else
-        ret = -ENOSYS;
+          ret = -ENOSYS;
 #endif
-      }
-      break;
+        }
+        break;
 #endif /* CONFIG_NET_TCP */
 
 #ifdef CONFIG_NET_UDP
-    case SOCK_DGRAM:
-      {
+      case SOCK_DGRAM:
+        {
 #ifdef NET_UDP_HAVE_STACK
-        ret = psock_udp_recvfrom(psock, msg, flags);
+          ret = psock_udp_recvfrom(psock, msg, flags);
 #else
-        ret = -ENOSYS;
+          ret = -ENOSYS;
 #endif
-      }
-      break;
+        }
+        break;
 #endif /* CONFIG_NET_UDP */
 
-    default:
-      {
-        nerr("ERROR: Unsupported socket type: %d\n", psock->s_type);
-        ret = -ENOSYS;
-      }
-      break;
+      default:
+        {
+          nerr("ERROR: Unsupported socket type: %d\n", psock->s_type);
+          ret = -ENOSYS;
+        }
+        break;
     }
 
   return ret;
@@ -2437,9 +2446,9 @@ inet_sockif(sa_family_t family, int type, int protocol)
       return &g_inet_sockif;
     }
 #else
-    {
-      return NULL;
-    }
+  {
+    return NULL;
+  }
 #endif
 }
 

--- a/net/inet/inet_txdrain.c
+++ b/net/inet/inet_txdrain.c
@@ -85,7 +85,7 @@ int inet_txdrain(FAR struct socket *psock, unsigned int timeout)
         break;
 #endif
 
-     /* Other protocols do no support write buffering */
+        /* Other protocols do no support write buffering */
 
       default:
         break;

--- a/net/inet/ipv4_getsockname.c
+++ b/net/inet/ipv4_getsockname.c
@@ -123,12 +123,12 @@ int ipv4_getsockname(FAR struct socket *psock, FAR struct sockaddr *addr,
 
   if (lipaddr == 0)
     {
-       outaddr->sin_family      = psock->s_domain;
-       outaddr->sin_addr.s_addr = 0;
-       memset(outaddr->sin_zero, 0, sizeof(outaddr->sin_zero));
-       *addrlen = sizeof(struct sockaddr_in);
+      outaddr->sin_family      = psock->s_domain;
+      outaddr->sin_addr.s_addr = 0;
+      memset(outaddr->sin_zero, 0, sizeof(outaddr->sin_zero));
+      *addrlen = sizeof(struct sockaddr_in);
 
-       return OK;
+      return OK;
     }
 
   conn_lock(psock->s_conn);

--- a/net/inet/ipv6_setsockopt.c
+++ b/net/inet/ipv6_setsockopt.c
@@ -112,35 +112,35 @@ int ipv6_setsockopt(FAR struct socket *psock, int option,
       case IPV6_MULTICAST_IF:     /* Interface to use for outgoing multicast
                                    * packets */
 #ifdef NET_UDP_HAVE_STACK
-      {
-        FAR struct net_driver_s *dev;
-        FAR struct udp_conn_s *conn = psock->s_conn;
-        int ifindex = *(FAR int *)value;
+        {
+          FAR struct net_driver_s *dev;
+          FAR struct udp_conn_s *conn = psock->s_conn;
+          int ifindex = *(FAR int *)value;
 
-        if (ifindex > 0)
-          {
-            dev = netdev_findbyindex(ifindex);
-            if (dev == NULL)
-              {
-                ret = -ENODEV;
-                break;
-              }
+          if (ifindex > 0)
+            {
+              dev = netdev_findbyindex(ifindex);
+              if (dev == NULL)
+                {
+                  ret = -ENODEV;
+                  break;
+                }
 
 #ifdef CONFIG_NET_BINDTODEVICE
-            if (conn->sconn.s_boundto &&
-                ifindex != conn->sconn.s_boundto)
-              {
-                ret = -EINVAL;
-                break;
-              }
+              if (conn->sconn.s_boundto &&
+                  ifindex != conn->sconn.s_boundto)
+                {
+                  ret = -EINVAL;
+                  break;
+                }
 #endif
-          }
+            }
 
-        conn->mreq.imr_ifindex = ifindex;
+          conn->mreq.imr_ifindex = ifindex;
 
-        ret = OK;
-        break;
-      }
+          ret = OK;
+          break;
+        }
 #endif /* NET_UDP_HAVE_STACK */
 #endif /* CONFIG_NET_MLD */
 

--- a/net/ipfilter/ipfilter.c
+++ b/net/ipfilter/ipfilter.c
@@ -165,6 +165,7 @@ static bool ipfilter_match_proto(FAR const struct ipfilter_entry_s *entry,
             /* Ports in TCP & UDP headers have same offset. */
 
             FAR const struct udp_hdr_s *udp = l4hdr;
+
             return SPORT_MATCH(entry, NTOHS(udp->srcport)) &&
                    DPORT_MATCH(entry, NTOHS(udp->destport));
           }
@@ -173,6 +174,7 @@ static bool ipfilter_match_proto(FAR const struct ipfilter_entry_s *entry,
         if (entry->match_icmp)
           {
             FAR const struct icmp_hdr_s *icmp = l4hdr;
+
             return ICMP_MATCH(entry, icmp);
           }
 
@@ -180,6 +182,7 @@ static bool ipfilter_match_proto(FAR const struct ipfilter_entry_s *entry,
         if (entry->match_icmp)
           {
             FAR const struct icmpv6_hdr_s *icmpv6 = l4hdr;
+
             return ICMP_MATCH(entry, icmpv6);
           }
 
@@ -444,6 +447,7 @@ void ipfilter_cfg_clear(sa_family_t family, enum ipfilter_chain_e chain)
   if (family == PF_INET)
     {
       FAR sq_queue_t *queue = &g_ipv4_filters[chain];
+
       while (!sq_empty(queue))
         {
           kmm_free(sq_remfirst(queue));
@@ -455,6 +459,7 @@ void ipfilter_cfg_clear(sa_family_t family, enum ipfilter_chain_e chain)
   if (family == PF_INET6)
     {
       FAR sq_queue_t *queue = &g_ipv6_filters[chain];
+
       while (!sq_empty(queue))
         {
           kmm_free(sq_remfirst(queue));

--- a/net/ipforward/ipfwd_dropstats.c
+++ b/net/ipforward/ipfwd_dropstats.c
@@ -60,25 +60,25 @@ static int proto_dropstats(int proto)
   switch (proto)
     {
 #ifdef CONFIG_NET_TCP
-    case IP_PROTO_TCP:
-      g_netstats.tcp.drop++;
-      break;
+      case IP_PROTO_TCP:
+        g_netstats.tcp.drop++;
+        break;
 #endif
 
 #ifdef CONFIG_NET_UDP
-    case IP_PROTO_UDP:
-      g_netstats.udp.drop++;
-      break;
+      case IP_PROTO_UDP:
+        g_netstats.udp.drop++;
+        break;
 #endif
 
 #ifdef CONFIG_NET_ICMPv6
-    case IP_PROTO_ICMP6:
-      g_netstats.icmpv6.drop++;
-      break;
+      case IP_PROTO_ICMP6:
+        g_netstats.icmpv6.drop++;
+        break;
 #endif
 
-    default:
-      return -EPROTONOSUPPORT;
+      default:
+        return -EPROTONOSUPPORT;
     }
 
   return OK;

--- a/net/ipforward/ipfwd_poll.c
+++ b/net/ipforward/ipfwd_poll.c
@@ -180,6 +180,7 @@ void ipfwd_poll(FAR struct net_driver_s *dev)
       /* Get the L2 protocol of packet in the device's d_buf */
 
       int proto = ipfwd_packet_proto(dev);
+
       if (proto >= 0)
         {
           /* Perform any necessary conversions on the forwarded packet */

--- a/net/ipforward/ipv4_forward.c
+++ b/net/ipforward/ipv4_forward.c
@@ -87,37 +87,37 @@ static int ipv4_hdrsize(FAR struct ipv4_hdr_s *ipv4)
   switch (ipv4->proto)
     {
 #ifdef CONFIG_NET_TCP
-    case IP_PROTO_TCP:
-      {
-        FAR struct tcp_hdr_s *tcp =
-          (FAR struct tcp_hdr_s *)((FAR uint8_t *)ipv4 + iphdrlen);
-        unsigned int tcpsize;
+      case IP_PROTO_TCP:
+        {
+          FAR struct tcp_hdr_s *tcp =
+            (FAR struct tcp_hdr_s *)((FAR uint8_t *)ipv4 + iphdrlen);
+          unsigned int tcpsize;
 
-        /* The TCP header length is encoded in the top 4 bits of the
-         * tcpoffset field (in units of 32-bit words).
-         */
+          /* The TCP header length is encoded in the top 4 bits of the
+           * tcpoffset field (in units of 32-bit words).
+           */
 
-        tcpsize = ((uint16_t)tcp->tcpoffset >> 4) << 2;
-        return iphdrlen + tcpsize;
-      }
-      break;
+          tcpsize = ((uint16_t)tcp->tcpoffset >> 4) << 2;
+          return iphdrlen + tcpsize;
+        }
+        break;
 #endif
 
 #ifdef CONFIG_NET_UDP
-    case IP_PROTO_UDP:
-      return iphdrlen + UDP_HDRLEN;
-      break;
+      case IP_PROTO_UDP:
+        return iphdrlen + UDP_HDRLEN;
+        break;
 #endif
 
 #ifdef CONFIG_NET_ICMP
-    case IP_PROTO_ICMP:
-      return iphdrlen + ICMP_HDRLEN;
-      break;
+      case IP_PROTO_ICMP:
+        return iphdrlen + ICMP_HDRLEN;
+        break;
 #endif
 
-    default:
-      nwarn("WARNING: Unrecognized proto: %u\n", ipv4->proto);
-      return -EPROTONOSUPPORT;
+      default:
+        nwarn("WARNING: Unrecognized proto: %u\n", ipv4->proto);
+        return -EPROTONOSUPPORT;
     }
 }
 #endif

--- a/net/ipforward/ipv6_forward.c
+++ b/net/ipforward/ipv6_forward.c
@@ -83,43 +83,43 @@ static int ipv6_hdrsize(FAR struct ipv6_hdr_s *ipv6)
   switch (ipv6->proto)
     {
 #ifdef CONFIG_NET_TCP
-    case IP_PROTO_TCP:
-      {
-        FAR struct tcp_hdr_s *tcp =
-          (FAR struct tcp_hdr_s *)((FAR uint8_t *)ipv6 + IPv6_HDRLEN);
-        unsigned int tcpsize;
+      case IP_PROTO_TCP:
+        {
+          FAR struct tcp_hdr_s *tcp =
+            (FAR struct tcp_hdr_s *)((FAR uint8_t *)ipv6 + IPv6_HDRLEN);
+          unsigned int tcpsize;
 
-        /* The TCP header length is encoded in the top 4 bits of the
-         * tcpoffset field (in units of 32-bit words).
-         */
+          /* The TCP header length is encoded in the top 4 bits of the
+           * tcpoffset field (in units of 32-bit words).
+           */
 
-        tcpsize = ((uint16_t)tcp->tcpoffset >> 4) << 2;
-        return IPv6_HDRLEN + tcpsize;
-      }
-      break;
+          tcpsize = ((uint16_t)tcp->tcpoffset >> 4) << 2;
+          return IPv6_HDRLEN + tcpsize;
+        }
+        break;
 #endif
 
 #ifdef CONFIG_NET_UDP
-    case IP_PROTO_UDP:
-      return IPv6_HDRLEN + UDP_HDRLEN;
-      break;
+      case IP_PROTO_UDP:
+        return IPv6_HDRLEN + UDP_HDRLEN;
+        break;
 #endif
 
 #ifdef CONFIG_NET_ICMPv6
-    case IP_PROTO_ICMP6:
-      return IPv6_HDRLEN + ICMPv6_HDRLEN;
-      break;
+      case IP_PROTO_ICMP6:
+        return IPv6_HDRLEN + ICMPv6_HDRLEN;
+        break;
 #endif
 
 #ifdef CONFIG_NET_IPFRAG
-    case NEXT_FRAGMENT_EH:
-      return IPv6_HDRLEN + EXTHDR_FRAG_LEN;
-      break;
+      case NEXT_FRAGMENT_EH:
+        return IPv6_HDRLEN + EXTHDR_FRAG_LEN;
+        break;
 #endif
 
-    default:
-      nwarn("WARNING: Unrecognized proto: %u\n", ipv6->proto);
-      return -EPROTONOSUPPORT;
+      default:
+        nwarn("WARNING: Unrecognized proto: %u\n", ipv6->proto);
+        return -EPROTONOSUPPORT;
     }
 }
 #endif
@@ -697,12 +697,12 @@ int ipv6_forward(FAR struct net_driver_s *dev, FAR struct ipv6_hdr_s *ipv6)
     }
 
 #else /* CONFIG_NET_6LOWPAN */
-    {
-      nwarn(
-         "WARNING: Packet forwarding not supported in this configuration\n");
-      ret = -ENOSYS;
-      goto drop;
-    }
+  {
+    nwarn(
+       "WARNING: Packet forwarding not supported in this configuration\n");
+    ret = -ENOSYS;
+    goto drop;
+  }
 #endif /* CONFIG_NET_6LOWPAN */
 
   /* Return success.  ipv6_input will return to the network driver with

--- a/net/ipfrag/ipfrag.c
+++ b/net/ipfrag/ipfrag.c
@@ -1124,6 +1124,7 @@ void ip_frag_stop(FAR struct net_driver_s *dev)
   while (entry != NULL)
     {
       FAR struct ip_fragsnode_s *node = (FAR struct ip_fragsnode_s *)entry;
+
       entrynext = sq_next(entry);
 
       if (dev == node->dev)
@@ -1179,6 +1180,7 @@ void ip_frag_remallfrags(void)
   while (entry != NULL)
     {
       FAR struct ip_fragsnode_s *node = (FAR struct ip_fragsnode_s *)entry;
+
       entrynext = sq_next(entry);
 
       if (node->frags != NULL)

--- a/net/ipfrag/ipv4_frag.c
+++ b/net/ipfrag/ipv4_frag.c
@@ -222,6 +222,7 @@ ipv4_fragout_buildipv4header(FAR struct ipv4_hdr_s *ref,
   if (ref != ipv4)
     {
       uint32_t iphdrlen = (ref->vhl & IPv4_HLMASK) << 2;
+
       memcpy(ipv4, ref, iphdrlen);
     }
 

--- a/net/ipfrag/ipv6_frag.c
+++ b/net/ipfrag/ipv6_frag.c
@@ -430,9 +430,9 @@ static uint16_t ipv6_fragout_getunfraginfo(FAR struct iob_s *iob,
 
           case NEXT_ROUTING_EH:
           case NEXT_HOPBYBOT_EH:
-              unfraglen = delta + extlen;
-              *hdroff = delta;
-              *hdrtype = exthdr->nxthdr;
+            unfraglen = delta + extlen;
+            *hdroff = delta;
+            *hdrtype = exthdr->nxthdr;
         }
 
       payload += extlen;

--- a/net/local/local_connect.c
+++ b/net/local/local_connect.c
@@ -244,45 +244,45 @@ int psock_local_connect(FAR struct socket *psock,
 
       switch (conn->lc_type)
         {
-        case LOCAL_TYPE_UNNAMED:   /* A Unix socket that is not bound to any name */
-          break;
+          case LOCAL_TYPE_UNNAMED:   /* A Unix socket that is not bound to any name */
+            break;
 
-        case LOCAL_TYPE_ABSTRACT:  /* lc_path is length zero */
-        case LOCAL_TYPE_PATHNAME:  /* lc_path holds a null terminated string */
+          case LOCAL_TYPE_ABSTRACT:  /* lc_path is length zero */
+          case LOCAL_TYPE_PATHNAME:  /* lc_path holds a null terminated string */
 
-          /* Anything in the listener list should be a stream socket in the
-           * listening state
-           */
+            /* Anything in the listener list should be a stream socket in the
+             * listening state
+             */
 
-          if (conn->lc_state == LOCAL_STATE_LISTENING &&
-              conn->lc_type == type && conn->lc_proto == SOCK_STREAM &&
-              strncmp(conn->lc_path, unpath, UNIX_PATH_MAX - 1) == 0)
-            {
-              /* Bind the address and protocol */
+            if (conn->lc_state == LOCAL_STATE_LISTENING &&
+                conn->lc_type == type && conn->lc_proto == SOCK_STREAM &&
+                strncmp(conn->lc_path, unpath, UNIX_PATH_MAX - 1) == 0)
+              {
+                /* Bind the address and protocol */
 
-              client->lc_type  = conn->lc_type;
-              client->lc_proto = conn->lc_proto;
-              client->lc_instance_id = local_generate_instance_id();
+                client->lc_type  = conn->lc_type;
+                client->lc_proto = conn->lc_proto;
+                client->lc_instance_id = local_generate_instance_id();
 
-              /* The client is now bound to an address */
+                /* The client is now bound to an address */
 
-              client->lc_state = LOCAL_STATE_BOUND;
+                client->lc_state = LOCAL_STATE_BOUND;
 
-              /* We have to do more for the SOCK_STREAM family */
+                /* We have to do more for the SOCK_STREAM family */
 
-              ret = local_stream_connect(client, conn,
-                          _SS_ISNONBLOCK(client->lc_conn.s_flags));
+                ret = local_stream_connect(client, conn,
+                            _SS_ISNONBLOCK(client->lc_conn.s_flags));
 
-              local_unlock();
-              return ret;
-            }
+                local_unlock();
+                return ret;
+              }
 
-          break;
+            break;
 
-        default:        /* Bad, memory must be corrupted */
-          DEBUGPANIC(); /* PANIC if debug on */
-          local_unlock();
-          return -EINVAL;
+          default:        /* Bad, memory must be corrupted */
+            DEBUGPANIC(); /* PANIC if debug on */
+            local_unlock();
+            return -EINVAL;
         }
     }
 

--- a/net/local/local_fifo.c
+++ b/net/local/local_fifo.c
@@ -425,7 +425,7 @@ int local_set_pollthreshold(FAR struct local_conn_s *conn,
   ret = local_set_pollinthreshold(&conn->lc_infile, threshold);
   if (ret > 0)
     {
-       ret = local_set_polloutthreshold(&conn->lc_outfile, threshold);
+      ret = local_set_polloutthreshold(&conn->lc_outfile, threshold);
     }
 
   return ret;

--- a/net/local/local_recvmsg.c
+++ b/net/local/local_recvmsg.c
@@ -255,6 +255,7 @@ psock_stream_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
   if (flags & MSG_DONTWAIT)
     {
       int data_len = 0;
+
       ret = file_ioctl(&conn->lc_infile, FIONREAD, &data_len);
       if (ret < 0)
         {

--- a/net/local/local_recvutils.c
+++ b/net/local/local_recvutils.c
@@ -101,7 +101,7 @@ int local_fifo_read(FAR struct file *filep, FAR uint8_t *buf,
            * has closed the FIFO.
            */
 
-            break;
+          break;
         }
       else
         {

--- a/net/local/local_sockif.c
+++ b/net/local/local_sockif.c
@@ -132,6 +132,7 @@ static int local_sockif_alloc(FAR struct socket *psock)
   /* Allocate the local connection structure */
 
   FAR struct local_conn_s *conn;
+
   local_lock();
   conn = local_alloc();
   local_unlock();
@@ -494,7 +495,7 @@ static int local_getpeername(FAR struct socket *psock,
             }
           else
             {
-               strlcpy(unaddr->sun_path, peer->lc_path, namelen);
+              strlcpy(unaddr->sun_path, peer->lc_path, namelen);
             }
 
           *addrlen = sizeof(sa_family_t) + namelen;
@@ -1031,7 +1032,7 @@ static int local_socketpair(FAR struct socket *psocks[2])
 #ifdef CONFIG_NET_LOCAL_STREAM
                            = local_generate_instance_id();
 #else
-                           = -1;
+  = -1;
 #endif
 
   /* Create the FIFOs needed for the connection */
@@ -1132,6 +1133,7 @@ static int local_shutdown(FAR struct socket *psock, int how)
       case SOCK_STREAM:
         {
           FAR struct local_conn_s *conn = psock->s_conn;
+
           if (how & SHUT_RD)
             {
               if (conn->lc_infile.f_inode != NULL)

--- a/net/mld/mld_report.c
+++ b/net/mld/mld_report.c
@@ -192,6 +192,7 @@ int mld_report_v2(FAR struct net_driver_s *dev,
       /* Handle this mcast address in the list */
 
       int status = mld_report(dev, report->addrec[i].mcast);
+
       if (status == OK)
         {
           /* Return success if any address in the listed was processed */

--- a/net/nat/ipv4_nat.c
+++ b/net/nat/ipv4_nat.c
@@ -197,6 +197,7 @@ ipv4_nat_inbound_tcp(FAR struct ipv4_hdr_s *ipv4,
                                              *external_port,
                                              net_ip4addr_conv32(peer_ip),
                                              *peer_port, true);
+
   if (!entry)
     {
       return NULL;
@@ -791,6 +792,7 @@ int ipv4_nat_outbound(FAR struct net_driver_s *dev,
 
       FAR ipv4_nat_entry_t *entry =
           ipv4_nat_outbound_internal(dev, ipv4, manip_type);
+
       if (manip_type == NAT_MANIP_SRC && !entry)
         {
           /* Outbound entry creation failed, should have entry. */

--- a/net/nat/ipv4_nat_entry.c
+++ b/net/nat/ipv4_nat_entry.c
@@ -125,6 +125,7 @@ ipv4_nat_entry_create(uint8_t protocol,
                       in_addr_t peer_ip, uint16_t peer_port)
 {
   FAR ipv4_nat_entry_t *entry = kmm_malloc(sizeof(ipv4_nat_entry_t));
+
   if (entry == NULL)
     {
       nwarn("WARNING: Failed to allocate IPv4 NAT entry\n");

--- a/net/nat/ipv6_nat.c
+++ b/net/nat/ipv6_nat.c
@@ -144,6 +144,7 @@ ipv6_nat_inbound_tcp(FAR struct ipv6_hdr_s *ipv6, FAR struct tcp_hdr_s *tcp,
                  ipv6_nat_inbound_entry_find(IP_PROTO_TCP,
                                              external_ip, *external_port,
                                              peer_ip, *peer_port, true);
+
   if (!entry)
     {
       return NULL;
@@ -679,6 +680,7 @@ int ipv6_nat_outbound(FAR struct net_driver_s *dev,
     {
       FAR ipv6_nat_entry_t *entry =
           ipv6_nat_outbound_internal(dev, ipv6, manip_type);
+
       if (manip_type == NAT_MANIP_SRC && !entry)
         {
           /* Outbound entry creation failed, should have entry. */

--- a/net/nat/ipv6_nat_entry.c
+++ b/net/nat/ipv6_nat_entry.c
@@ -113,6 +113,7 @@ ipv6_nat_entry_create(uint8_t protocol, const net_ipv6addr_t external_ip,
                       uint16_t peer_port)
 {
   FAR ipv6_nat_entry_t *entry = kmm_malloc(sizeof(ipv6_nat_entry_t));
+
   if (entry == NULL)
     {
       nwarn("WARNING: Failed to allocate IPv6 NAT entry\n");

--- a/net/nat/nat.c
+++ b/net/nat/nat.c
@@ -316,6 +316,7 @@ int nat_port_select(FAR struct net_driver_s *dev,
 #ifdef CONFIG_NET_ICMP_SOCKET
           uint16_t id = local_port;
           uint16_t hid = NTOHS(id);
+
           while (icmp_findconn(dev, id) ||
                  nat_port_inuse(domain, IP_PROTO_ICMP, external_ip, id))
             {
@@ -344,6 +345,7 @@ int nat_port_select(FAR struct net_driver_s *dev,
 #ifdef CONFIG_NET_ICMPv6_SOCKET
           uint16_t id = local_port;
           uint16_t hid = NTOHS(id);
+
           while (icmpv6_active(id) ||
                  nat_port_inuse(domain, IP_PROTO_ICMP6, external_ip, id))
             {
@@ -429,7 +431,7 @@ uint32_t nat_expire_time(uint8_t protocol)
       default:
         nwarn("WARNING: Unsupported protocol %" PRIu8 "\n", protocol);
         return 0;
-  }
+    }
 }
 
 /****************************************************************************

--- a/net/netdev/netdev_checksum.c
+++ b/net/netdev/netdev_checksum.c
@@ -96,6 +96,7 @@ static uint8_t hardware_chksum_get_proto(FAR struct net_driver_s *dev)
 #  endif
     {
       FAR struct ipv6_hdr_s *ipv6 = IPv6BUF;
+
       proto = ipv6->proto;
     }
 #endif
@@ -105,6 +106,7 @@ static uint8_t hardware_chksum_get_proto(FAR struct net_driver_s *dev)
 #  endif
     {
       FAR struct ipv4_hdr_s *ipv4 = IPv4BUF;
+
       proto = ipv4->proto;
     }
 #endif

--- a/net/netdev/netdev_findbyaddr.c
+++ b/net/netdev/netdev_findbyaddr.c
@@ -275,6 +275,7 @@ netdev_prefixlen_findby_lipv6addr(const net_ipv6addr_t lipaddr,
 FAR struct net_driver_s *netdev_findby_lipv4addr(in_addr_t lipaddr)
 {
   int8_t prefixlen;
+
   return netdev_prefixlen_findby_lipv4addr(lipaddr, &prefixlen);
 }
 #endif /* CONFIG_NET_IPv4 */
@@ -301,6 +302,7 @@ FAR struct net_driver_s *netdev_findby_lipv6addr(
                                       const net_ipv6addr_t lipaddr)
 {
   int16_t prefixlen;
+
   return netdev_prefixlen_findby_lipv6addr(lipaddr, &prefixlen);
 }
 #endif /* CONFIG_NET_IPv6 */

--- a/net/netdev/netdev_iob.c
+++ b/net/netdev/netdev_iob.c
@@ -101,6 +101,7 @@ int netdev_iob_prepare(FAR struct net_driver_s *dev, bool throttled,
 void netdev_iob_prepare_dynamic(FAR struct net_driver_s *dev, uint16_t size)
 {
   FAR struct iob_s *iob;
+
   size += CONFIG_NET_LL_GUARDSIZE;
 
   if (dev->d_iob && size <= IOB_BUFSIZE(dev->d_iob))

--- a/net/netdev/netdev_ioctl.c
+++ b/net/netdev/netdev_ioctl.c
@@ -270,6 +270,7 @@ static void ioctl_get_ipv4addr(FAR struct sockaddr *outaddr,
                                in_addr_t inaddr)
 {
   FAR struct sockaddr_in *dest  = (FAR struct sockaddr_in *)outaddr;
+
   dest->sin_family              = AF_INET;
   dest->sin_port                = 0;
   dest->sin_addr.s_addr         = inaddr;
@@ -295,6 +296,7 @@ static void ioctl_get_ipv4broadcast(FAR struct sockaddr *outaddr,
                                     in_addr_t inaddr, in_addr_t netmask)
 {
   FAR struct sockaddr_in *dest  = (FAR struct sockaddr_in *)outaddr;
+
   dest->sin_family              = AF_INET;
   dest->sin_port                = 0;
   dest->sin_addr.s_addr         = net_ipv4addr_broadcast(inaddr, netmask);
@@ -319,6 +321,7 @@ static void ioctl_get_ipv6addr(FAR struct sockaddr_storage *outaddr,
                                FAR const net_ipv6addr_t inaddr)
 {
   FAR struct sockaddr_in6 *dest = (FAR struct sockaddr_in6 *)outaddr;
+
   dest->sin6_family             = AF_INET6;
   dest->sin6_port               = 0;
   memcpy(dest->sin6_addr.in6_u.u6_addr8, inaddr, 16);
@@ -343,6 +346,7 @@ static void ioctl_set_ipv4addr(FAR in_addr_t *outaddr,
                                FAR const struct sockaddr *inaddr)
 {
   FAR const struct sockaddr_in *src = (FAR const struct sockaddr_in *)inaddr;
+
   *outaddr = src->sin_addr.s_addr;
 }
 #endif
@@ -366,6 +370,7 @@ static void ioctl_set_ipv6addr(FAR net_ipv6addr_t outaddr,
 {
   FAR const struct sockaddr_in6 *src =
     (FAR const struct sockaddr_in6 *)inaddr;
+
   memcpy(outaddr, src->sin6_addr.in6_u.u6_addr8, 16);
 }
 #endif
@@ -853,6 +858,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
       case SIOCSIFNAME:   /* Set interface name */
         {
           FAR struct net_driver_s *tmpdev;
+
           tmpdev = netdev_findbyindex(req->ifr_ifindex);
           if (tmpdev != NULL)
             {
@@ -868,6 +874,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
       case SIOCGIFNAME:  /* Get interface name */
         {
           FAR struct net_driver_s *tmpdev;
+
           tmpdev = netdev_findbyindex(req->ifr_ifindex);
           if (tmpdev != NULL)
             {
@@ -897,6 +904,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
                  == (ssize_t)sizeof(struct in6_ifreq))
           {
             FAR struct in6_ifreq *ifr6 = (FAR struct in6_ifreq *)req;
+
             dev = netdev_findbyindex(ifr6->ifr6_ifindex);
           }
 
@@ -953,6 +961,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
       case SIOCGLIFADDR:  /* Get IP address */
         {
           FAR struct lifreq *lreq = (FAR struct lifreq *)req;
+
           idx = MIN(idx, CONFIG_NETDEV_MAX_IPv6_ADDR - 1);
           ioctl_get_ipv6addr(&lreq->lifr_addr, dev->d_ipv6[idx].addr);
         }
@@ -961,6 +970,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
       case SIOCSLIFADDR:  /* Set IP address */
         {
           FAR struct lifreq *lreq = (FAR struct lifreq *)req;
+
           idx = MIN(idx, CONFIG_NETDEV_MAX_IPv6_ADDR - 1);
 
           netdev_ipv6_removemcastmac(dev, dev->d_ipv6[idx].addr);
@@ -975,6 +985,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
       case SIOCGLIFDSTADDR:  /* Get P-to-P address */
         {
           FAR struct lifreq *lreq = (FAR struct lifreq *)req;
+
           ioctl_get_ipv6addr(&lreq->lifr_dstaddr, dev->d_ipv6draddr);
         }
         break;
@@ -982,6 +993,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
       case SIOCSLIFDSTADDR:  /* Set P-to-P address */
         {
           FAR struct lifreq *lreq = (FAR struct lifreq *)req;
+
           ioctl_set_ipv6addr(dev->d_ipv6draddr, &lreq->lifr_dstaddr);
         }
         break;
@@ -994,6 +1006,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
       case SIOCGLIFNETMASK:  /* Get network mask */
         {
           FAR struct lifreq *lreq = (FAR struct lifreq *)req;
+
           idx = MIN(idx, CONFIG_NETDEV_MAX_IPv6_ADDR - 1);
           ioctl_get_ipv6addr(&lreq->lifr_addr, dev->d_ipv6[idx].mask);
         }
@@ -1002,6 +1015,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
       case SIOCSLIFNETMASK:  /* Set network mask */
         {
           FAR struct lifreq *lreq = (FAR struct lifreq *)req;
+
           idx = MIN(idx, CONFIG_NETDEV_MAX_IPv6_ADDR - 1);
           ioctl_set_ipv6addr(dev->d_ipv6[idx].mask, &lreq->lifr_addr);
         }
@@ -1175,6 +1189,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
         if (psock->s_domain == PF_INET6)
           {
             FAR struct in6_ifreq *ifr6 = (FAR struct in6_ifreq *)req;
+
             ret = netdev_ipv6_add(dev, ifr6->ifr6_addr.in6_u.u6_addr16,
                                   ifr6->ifr6_prefixlen);
             if (ret == OK)
@@ -1200,6 +1215,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
         if (psock->s_domain == PF_INET6)
           {
             FAR struct in6_ifreq *ifr6 = (FAR struct in6_ifreq *)req;
+
             ret = netdev_ipv6_del(dev, ifr6->ifr6_addr.in6_u.u6_addr16,
                                   ifr6->ifr6_prefixlen);
             if (ret == OK)
@@ -1218,6 +1234,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
           {
             FAR struct mii_ioctl_notify_s *notify =
               &req->ifr_ifru.ifru_mii_notify;
+
             ret = dev->d_ioctl(dev, cmd, (unsigned long)(uintptr_t)notify);
           }
         else
@@ -1234,6 +1251,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
           {
             FAR struct mii_ioctl_data_s *mii_data =
               &req->ifr_ifru.ifru_mii_data;
+
             ret = dev->d_ioctl(dev, cmd,
                                (unsigned long)(uintptr_t)mii_data);
           }
@@ -1261,6 +1279,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
           {
             FAR struct can_ioctl_data_s *can_bitrate_data =
               &req->ifr_ifru.ifru_can_data;
+
             ret = dev->d_ioctl(dev, cmd,
                           (unsigned long)(uintptr_t)can_bitrate_data);
           }
@@ -1281,6 +1300,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
           {
             FAR struct can_ioctl_filter_s *can_filter =
               &req->ifr_ifru.ifru_can_filter;
+
             ret = dev->d_ioctl(dev, cmd,
                           (unsigned long)(uintptr_t)can_filter);
           }
@@ -1298,6 +1318,7 @@ static int netdev_ifr_ioctl(FAR struct socket *psock, int cmd,
           {
             FAR struct can_ioctl_state_s *can_state =
               &req->ifr_ifru.ifru_can_state;
+
             ret = dev->d_ioctl(dev, cmd,
                           (unsigned long)(uintptr_t)can_state);
           }
@@ -1740,7 +1761,7 @@ static int netdev_ioctl(FAR struct socket *psock, int cmd,
 
         break;
 
-    default:
+      default:
         break;
     }
 

--- a/net/netdev/netdev_ipv6.c
+++ b/net/netdev/netdev_ipv6.c
@@ -599,6 +599,7 @@ int netdev_ipv6_foreach(FAR struct net_driver_s *dev,
       if (!net_ipv6addr_cmp(ifaddr->addr, g_ipv6_unspecaddr))
         {
           int ret = callback(dev, ifaddr, arg);
+
           if (ret != 0) /* Stop on any error and return it */
             {
               return ret;

--- a/net/netdev/netdev_lladdrsize.c
+++ b/net/netdev/netdev_lladdrsize.c
@@ -141,14 +141,14 @@ int netdev_lladdrsize(FAR struct net_driver_s *dev)
       case NET_LL_BLUETOOTH:
 #endif
         {
-           /* Return the size of the packet radio address */
+          /* Return the size of the packet radio address */
 
-           return netdev_pktradio_addrlen(dev);
+          return netdev_pktradio_addrlen(dev);
         }
 #endif /* CONFIG_WIRELESS_PKTRADIO || CONFIG_WIRELESS_BLUETOOTH */
 #endif /* CONFIG_NET_6LOWPAN */
 
-       default:
+      default:
         {
           /* The link layer type associated has no address */
 

--- a/net/netdev/netdev_notify_recvcpu.c
+++ b/net/netdev/netdev_notify_recvcpu.c
@@ -233,6 +233,7 @@ static uint32_t compute_crc32c_hash(FAR uint8_t *packet, uint32_t len)
     {
       uint8_t b = packet[i];
       uint8_t index = (crc32 ^ b) & 0xff;
+
       crc32 = ((crc32 >> 8) & 0xffffff) ^ g_crc32c_table[index];
     }
 

--- a/net/netdev/netdev_register.c
+++ b/net/netdev/netdev_register.c
@@ -200,6 +200,7 @@ static int get_ifindex(void)
   for (ndx = 0; ndx < MAX_IFINDEX; ndx++)
     {
       uint32_t bit = 1UL << ndx;
+
       if ((devset & bit) == 0)
         {
           /* Indicate that this index is in use */

--- a/net/netfilter/ip6t_sockopt.c
+++ b/net/netfilter/ip6t_sockopt.c
@@ -119,6 +119,7 @@ static void ip6t_table_init(FAR struct ip6t_table_s *table)
 static FAR struct ip6t_table_s *ip6t_table(FAR const char *name)
 {
   int i;
+
   for (i = 0; i < nitems(g_tables); i++)
     {
       ip6t_table_init(&g_tables[i]);
@@ -143,6 +144,7 @@ static FAR struct ip6t_table_s *ip6t_table(FAR const char *name)
 static FAR struct ip6t_replace *ip6t_table_repl(FAR const char *name)
 {
   FAR struct ip6t_table_s *table = ip6t_table(name);
+
   if (table)
     {
       return table->repl;

--- a/net/netfilter/ipt_filter.c
+++ b/net/netfilter/ipt_filter.c
@@ -171,6 +171,7 @@ static uint8_t convert_target(FAR const struct xt_entry_target *target)
   if (strcmp(target->u.user.name, XT_STANDARD_TARGET) == 0)
     {
       int verdict = ((FAR const struct xt_standard_target *)target)->verdict;
+
       verdict = -verdict - 1;
 
       if (verdict == NF_ACCEPT)
@@ -209,6 +210,7 @@ convert_ipv4entry(FAR const struct ipt_entry *entry)
   FAR const struct xt_entry_target *target;
   FAR struct ipv4_filter_entry_s *filter =
               (FAR struct ipv4_filter_entry_s *)ipfilter_cfg_alloc(PF_INET);
+
   if (filter == NULL)
     {
       return NULL;
@@ -245,6 +247,7 @@ convert_ipv4entry(FAR const struct ipt_entry *entry)
         if (strcmp(match->u.user.name, XT_MATCH_NAME_TCP) == 0)
           {
             FAR struct xt_tcp *tcp = (FAR struct xt_tcp *)(match + 1);
+
             convert_tcpudp(&filter->common, tcp->spts, tcp->dpts,
                            tcp->invflags);
           }
@@ -254,6 +257,7 @@ convert_ipv4entry(FAR const struct ipt_entry *entry)
         if (strcmp(match->u.user.name, XT_MATCH_NAME_UDP) == 0)
           {
             FAR struct xt_udp *udp = (FAR struct xt_udp *)(match + 1);
+
             convert_tcpudp(&filter->common, udp->spts, udp->dpts,
                            udp->invflags);
           }
@@ -263,6 +267,7 @@ convert_ipv4entry(FAR const struct ipt_entry *entry)
         if (strcmp(match->u.user.name, XT_MATCH_NAME_ICMP) == 0)
           {
             FAR struct ipt_icmp *icmp = (FAR struct ipt_icmp *)(match + 1);
+
             convert_icmp(&filter->common, icmp->type, icmp->invflags);
           }
         break;
@@ -284,6 +289,7 @@ convert_ipv6entry(FAR const struct ip6t_entry *entry)
   FAR const struct xt_entry_target *target;
   FAR struct ipv6_filter_entry_s *filter =
               (FAR struct ipv6_filter_entry_s *)ipfilter_cfg_alloc(PF_INET6);
+
   if (filter == NULL)
     {
       return NULL;
@@ -320,6 +326,7 @@ convert_ipv6entry(FAR const struct ip6t_entry *entry)
         if (strcmp(match->u.user.name, XT_MATCH_NAME_TCP) == 0)
           {
             FAR struct xt_tcp *tcp = (FAR struct xt_tcp *)(match + 1);
+
             convert_tcpudp(&filter->common, tcp->spts, tcp->dpts,
                            tcp->invflags);
           }
@@ -329,6 +336,7 @@ convert_ipv6entry(FAR const struct ip6t_entry *entry)
         if (strcmp(match->u.user.name, XT_MATCH_NAME_UDP) == 0)
           {
             FAR struct xt_udp *udp = (FAR struct xt_udp *)(match + 1);
+
             convert_tcpudp(&filter->common, udp->spts, udp->dpts,
                            udp->invflags);
           }
@@ -339,6 +347,7 @@ convert_ipv6entry(FAR const struct ip6t_entry *entry)
           {
             FAR struct ip6t_icmp *icmp6 =
                                         (FAR struct ip6t_icmp *)(match + 1);
+
             convert_icmp(&filter->common, icmp6->type, icmp6->invflags);
           }
         break;
@@ -391,6 +400,7 @@ static void adjust_ipv4filter(FAR const struct ipt_replace *repl)
       ipt_entry_for_every(entry, head, size)
         {
           FAR struct ipv4_filter_entry_s *filter = convert_ipv4entry(entry);
+
           if (filter != NULL)
             {
               ipfilter_cfg_add(&filter->common, PF_INET, chain);
@@ -432,6 +442,7 @@ static void adjust_ipv6filter(FAR const struct ip6t_replace *repl)
       ip6t_entry_for_every(entry, head, size)
         {
           FAR struct ipv6_filter_entry_s *filter = convert_ipv6entry(entry);
+
           if (filter != NULL)
             {
               ipfilter_cfg_add(&filter->common, PF_INET6, chain);

--- a/net/netfilter/ipt_sockopt.c
+++ b/net/netfilter/ipt_sockopt.c
@@ -120,6 +120,7 @@ static void ipt_table_init(FAR struct ipt_table_s *table)
 static FAR struct ipt_table_s *ipt_table(FAR const char *name)
 {
   int i;
+
   for (i = 0; i < nitems(g_tables); i++)
     {
       ipt_table_init(&g_tables[i]);
@@ -144,6 +145,7 @@ static FAR struct ipt_table_s *ipt_table(FAR const char *name)
 static FAR struct ipt_replace *ipt_table_repl(FAR const char *name)
 {
   FAR struct ipt_table_s *table = ipt_table(name);
+
   if (table)
     {
       return table->repl;

--- a/net/netlink/netlink_netfilter.c
+++ b/net/netlink/netlink_netfilter.c
@@ -561,6 +561,7 @@ static int netlink_list_conntrack(NETLINK_HANDLE handle,
 {
   struct nfnl_info_s info;
   uint8_t type = NFNL_MSG_TYPE(req->hdr.nlmsg_type);
+
   if (type != IPCTNL_MSG_CT_GET)
     {
       return -ENOSYS;

--- a/net/netlink/netlink_notifier.c
+++ b/net/netlink/netlink_notifier.c
@@ -100,6 +100,7 @@ int netlink_notifier_setup(worker_t worker, FAR struct netlink_conn_s *conn,
 void netlink_notifier_teardown(FAR void *arg)
 {
   FAR struct netlink_conn_s *conn = arg;
+
   DEBUGASSERT(conn != NULL);
 
   /* This is just a simple wrapper around work_notifier_teardown(). */

--- a/net/netlink/netlink_route.c
+++ b/net/netlink/netlink_route.c
@@ -1381,7 +1381,7 @@ ssize_t netlink_route_sendto(NETLINK_HANDLE handle,
 
         if (req->gen.rtgen_family == AF_INET6)
           {
-             ret = netlink_get_neighborlist(handle, AF_INET6, req);
+            ret = netlink_get_neighborlist(handle, AF_INET6, req);
           }
         else
 #endif
@@ -1612,7 +1612,7 @@ void netlink_route_notify(FAR const void *route, int type, int domain)
                                     type, NULL);
       group = RTNLGRP_IPV6_ROUTE;
     }
-    else
+  else
 #endif
     {
       nwarn("netlink_route_notify unknown type %d domain %d\n",

--- a/net/netlink/netlink_sockif.c
+++ b/net/netlink/netlink_sockif.c
@@ -150,6 +150,7 @@ static int netlink_setup(FAR struct socket *psock)
        */
 
       FAR struct netlink_conn_s *conn = netlink_alloc();
+
       if (conn == NULL)
         {
           /* Failed to reserve a connection structure */
@@ -638,8 +639,8 @@ static ssize_t netlink_sendmsg(FAR struct socket *psock,
 #endif
 
       default:
-       ret = -EOPNOTSUPP;
-       break;
+        ret = -EOPNOTSUPP;
+        break;
     }
 
   return ret;

--- a/net/pkt/pkt_conn.c
+++ b/net/pkt/pkt_conn.c
@@ -163,6 +163,7 @@ FAR struct pkt_conn_s *pkt_active(FAR struct net_driver_s *dev)
   if (dev->d_lltype == NET_LL_ETHERNET || dev->d_lltype == NET_LL_IEEE80211)
     {
       FAR struct eth_hdr_s *ethhdr = NETLLBUF;
+
       ethertype = ethhdr->type;
     }
 

--- a/net/pkt/pkt_getsockopt.c
+++ b/net/pkt/pkt_getsockopt.c
@@ -98,6 +98,7 @@ int pkt_getsockopt(FAR struct socket *psock, int level, int option,
       case SO_SNDBUF:
         {
           FAR struct pkt_conn_s *conn;
+
           conn = psock->s_conn;
           /* Verify that option is the size of an 'int'.  Should also check
            * that 'value' is properly aligned for an 'int'
@@ -108,9 +109,9 @@ int pkt_getsockopt(FAR struct socket *psock, int level, int option,
               return -EINVAL;
             }
 
-            *(FAR int *)value = conn->sndbufs;
-            break;
-          }
+          *(FAR int *)value = conn->sndbufs;
+          break;
+        }
 #endif
 
       default:

--- a/net/pkt/pkt_recvmsg.c
+++ b/net/pkt/pkt_recvmsg.c
@@ -393,6 +393,7 @@ static inline void pkt_readahead(FAR struct pkt_recvfrom_s *pstate)
           _SO_GETOPT(conn->sconn.s_options, SO_TIMESTAMPNS))
         {
           struct timespec ts;
+
           recvlen = iob_copyout((FAR uint8_t *)&ts, iob,
                                 sizeof(struct timespec),
                                 -sizeof(struct timespec));
@@ -407,6 +408,7 @@ static inline void pkt_readahead(FAR struct pkt_recvfrom_s *pstate)
       if (pstate->pr_type == SOCK_DGRAM)
         {
           FAR struct net_driver_s *dev = pkt_find_device(conn);
+
           if (dev != NULL)
             {
               /* For SOCK_DGRAM, we need skip the l2 header */

--- a/net/pkt/pkt_sendmsg_buffered.c
+++ b/net/pkt/pkt_sendmsg_buffered.c
@@ -329,6 +329,7 @@ ssize_t pkt_sendmsg(FAR struct socket *psock, FAR const struct msghdr *msg,
     {
       FAR struct eth_hdr_s *ethhdr =
           (FAR struct eth_hdr_s *)(IOB_DATA(iob) - NET_LL_HDRLEN(dev));
+
       memcpy(ethhdr->dest, addr->sll_addr, ETHER_ADDR_LEN);
       memcpy(ethhdr->src, &dev->d_mac.ether, ETHER_ADDR_LEN);
       ethhdr->type = addr->sll_protocol;

--- a/net/pkt/pkt_sendmsg_unbuffered.c
+++ b/net/pkt/pkt_sendmsg_unbuffered.c
@@ -134,6 +134,7 @@ static uint32_t psock_send_eventhandler(FAR struct net_driver_s *dev,
           if (pstate->snd_sock->s_type == SOCK_DGRAM)
             {
               FAR struct eth_hdr_s *ethhdr = NETLLBUF;
+
               memcpy(ethhdr->dest, pstate->addr->sll_addr, ETHER_ADDR_LEN);
               memcpy(ethhdr->src, &dev->d_mac.ether, ETHER_ADDR_LEN);
               ethhdr->type = pstate->addr->sll_protocol;

--- a/net/pkt/pkt_setsockopt.c
+++ b/net/pkt/pkt_setsockopt.c
@@ -96,6 +96,7 @@ int pkt_setsockopt(FAR struct socket *psock, int level, int option,
       case SO_SNDBUF:
         {
           FAR struct pkt_conn_s *conn;
+
           conn = psock->s_conn;
           int buffersize;
 

--- a/net/pkt/pkt_sockif.c
+++ b/net/pkt/pkt_sockif.c
@@ -108,6 +108,7 @@ static int pkt_sockif_alloc(FAR struct socket *psock)
    */
 
   FAR struct pkt_conn_s *conn = pkt_alloc();
+
   if (conn == NULL)
     {
       /* Failed to reserve a connection structure */

--- a/net/procfs/net_procfs_route.c
+++ b/net/procfs/net_procfs_route.c
@@ -537,20 +537,20 @@ static ssize_t route_read(FAR struct file *filep, FAR char *buffer,
   switch (procfile->node)
     {
 #ifdef CONFIG_NET_IPv4
-    case PROC_ROUTE_IPv4: /* IPv4 routing table */
-      ret = route_ipv4_table(procfile, buffer, buflen, filep->f_pos);
-      break;
+      case PROC_ROUTE_IPv4: /* IPv4 routing table */
+        ret = route_ipv4_table(procfile, buffer, buflen, filep->f_pos);
+        break;
 #endif
 
 #ifdef CONFIG_NET_IPv6
-    case PROC_ROUTE_IPv6: /* IPv6 routing table */
-      ret = route_ipv6_table(procfile, buffer, buflen, filep->f_pos);
-      break;
+      case PROC_ROUTE_IPv6: /* IPv6 routing table */
+        ret = route_ipv6_table(procfile, buffer, buflen, filep->f_pos);
+        break;
 #endif
 
-     default:
-      ret = -EINVAL;
-      break;
+      default:
+        ret = -EINVAL;
+        break;
     }
 
   /* Update the file offset */

--- a/net/procfs/netdev_statistics.c
+++ b/net/procfs/netdev_statistics.c
@@ -215,6 +215,7 @@ static int netprocfs_linklayer(FAR struct netprocfs_file_s *netfile)
       case NET_LL_IEEE80211:
         {
           char hwaddr[20];
+
           len += snprintf(&netfile->line[len], NET_LINELEN - len,
                           "%s\tLink encap:Ethernet HWaddr %s",
                           dev->d_ifname,

--- a/net/route/net_fileroute.c
+++ b/net/route/net_fileroute.c
@@ -596,6 +596,7 @@ int net_routesize_ipv6(void)
 int net_lockroute_ipv4(void)
 {
   int ret = nxrmutex_lock(&g_ipv4_lock);
+
   if (ret < 0)
     {
       nerr("ERROR: nxrmutex_lock() failed: %d\n", ret);
@@ -609,6 +610,7 @@ int net_lockroute_ipv4(void)
 int net_lockroute_ipv6(void)
 {
   int ret = nxrmutex_lock(&g_ipv6_lock);
+
   if (ret < 0)
     {
       nerr("ERROR: nxrmutex_lock() failed: %d\n", ret);
@@ -637,6 +639,7 @@ int net_lockroute_ipv6(void)
 int net_unlockroute_ipv4(void)
 {
   int ret = nxrmutex_unlock(&g_ipv4_lock);
+
   if (ret < 0)
     {
       nerr("ERROR: nxrmutex_unlock() failed: %d\n", ret);
@@ -650,6 +653,7 @@ int net_unlockroute_ipv4(void)
 int net_unlockroute_ipv6(void)
 {
   int ret = nxrmutex_unlock(&g_ipv6_lock);
+
   if (ret < 0)
     {
       nerr("ERROR: nxrmutex_unlock() failed: %d\n", ret);

--- a/net/rpmsg/rpmsg_sockif.c
+++ b/net/rpmsg/rpmsg_sockif.c
@@ -503,6 +503,7 @@ static void rpmsg_socket_format_name(FAR struct rpmsg_socket_conn_s *conn,
     {
       uint32_t crc = crc32((const uint8_t *)conn->rpaddr.rp_name,
                            strlen(conn->rpaddr.rp_name));
+
       snprintf(namebuf, RPMSG_NAME_SIZE, "%s%.2s%08" PRIx32 "%s",
                RPMSG_SOCKET_NAME_PREFIX, conn->rpaddr.rp_name,
                crc, conn->nameid);
@@ -991,6 +992,7 @@ static uint32_t rpmsg_socket_get_iovlen(FAR const struct iovec *buf,
                                         size_t iovcnt)
 {
   uint32_t len = 0;
+
   while (iovcnt--)
     {
       len += (buf++)->iov_len;
@@ -1060,6 +1062,7 @@ static ssize_t rpmsg_socket_send_continuous(FAR struct socket *psock,
       while (block_written < block)
         {
           uint32_t chunk = MIN(block - block_written, buf->iov_len - offset);
+
           memcpy(msg->data + block_written,
                  (FAR const uint8_t *)buf->iov_base + offset, chunk);
           offset += chunk;
@@ -1451,7 +1454,9 @@ static int rpmsg_socket_shutdown(FAR struct socket *psock, int how)
 
   ret = rpmsg_send(&conn->ept, &msg, sizeof(msg));
   if (ret < 0)
+    {
       return ret;
+    }
 
   return OK;
 }

--- a/net/sixlowpan/sixlowpan_framelist.c
+++ b/net/sixlowpan/sixlowpan_framelist.c
@@ -585,6 +585,7 @@ int sixlowpan_queue_frames(FAR struct radio_driver_s *radio,
       if (protosize > 0)
         {
           FAR uint8_t *src = (FAR uint8_t *)ipv6 + IPv6_HDRLEN;
+
           memcpy(fptr + g_frame_hdrlen, src, protosize);
         }
 
@@ -737,6 +738,7 @@ int sixlowpan_queue_frames(FAR struct radio_driver_s *radio,
       if (protosize > 0)
         {
           FAR uint8_t *src = (FAR uint8_t *)ipv6 + IPv6_HDRLEN;
+
           memcpy(fptr + g_frame_hdrlen, src, protosize);
         }
 

--- a/net/sixlowpan/sixlowpan_hc06.c
+++ b/net/sixlowpan/sixlowpan_hc06.c
@@ -408,8 +408,8 @@ static uint8_t compress_laddr(FAR const net_ipv6addr_t srcipaddr,
               macaddr->nv_addr[6], macaddr->nv_addr[7]);
         break;
 
-       default:
-         ninfo("           Unsupported addrlen %u\n", macaddr->nv_addrlen);
+      default:
+        ninfo("           Unsupported addrlen %u\n", macaddr->nv_addrlen);
     }
 #endif
 
@@ -880,22 +880,22 @@ int sixlowpan_compresshdr_hc06(FAR struct radio_driver_s *radio,
 
   switch (ipv6->ttl)
     {
-    case 1:
-      iphc0 |= SIXLOWPAN_IPHC_HLIM_1;
-      break;
+      case 1:
+        iphc0 |= SIXLOWPAN_IPHC_HLIM_1;
+        break;
 
-    case 64:
-      iphc0 |= SIXLOWPAN_IPHC_HLIM_64;
-      break;
+      case 64:
+        iphc0 |= SIXLOWPAN_IPHC_HLIM_64;
+        break;
 
-    case 255:
-      iphc0 |= SIXLOWPAN_IPHC_HLIM_255;
-      break;
+      case 255:
+        iphc0 |= SIXLOWPAN_IPHC_HLIM_255;
+        break;
 
-    default:
-      *g_hc06ptr = ipv6->ttl;
-      g_hc06ptr += 1;
-      break;
+      default:
+        *g_hc06ptr = ipv6->ttl;
+        g_hc06ptr += 1;
+        break;
     }
 
   /* Source address - cannot be multicast */
@@ -1487,83 +1487,83 @@ int sixlowpan_uncompresshdr_hc06(FAR struct radio_driver_s *radio,
 
           switch (*g_hc06ptr & SIXLOWPAN_NHC_UDP_CS_P_11)
             {
-            case SIXLOWPAN_NHC_UDP_CS_P_00:
+              case SIXLOWPAN_NHC_UDP_CS_P_00:
 
-              HC06_CHECK(g_hc06ptr, 5, endofframe);
+                HC06_CHECK(g_hc06ptr, 5, endofframe);
 
-              /* 1 byte for NHC, 4 byte for ports, 2 bytes chksum */
+                /* 1 byte for NHC, 4 byte for ports, 2 bytes chksum */
 
-              memcpy(&udp->srcport, g_hc06ptr + 1, 2);
-              memcpy(&udp->destport, g_hc06ptr + 3, 2);
+                memcpy(&udp->srcport, g_hc06ptr + 1, 2);
+                memcpy(&udp->destport, g_hc06ptr + 3, 2);
 
-              ninfo("Uncompressed UDP ports (ptr+5): %x, %x\n",
-                    HTONS(udp->srcport), HTONS(udp->destport));
+                ninfo("Uncompressed UDP ports (ptr+5): %x, %x\n",
+                      HTONS(udp->srcport), HTONS(udp->destport));
 
-              g_hc06ptr += 5;
-              break;
+                g_hc06ptr += 5;
+                break;
 
-            case SIXLOWPAN_NHC_UDP_CS_P_01:
+              case SIXLOWPAN_NHC_UDP_CS_P_01:
 
-              HC06_CHECK(g_hc06ptr, 4, endofframe);
+                HC06_CHECK(g_hc06ptr, 4, endofframe);
 
-              /* 1 byte for NHC + source 16bit inline, dest = 0xF0 + 8 bit
-               * inline
-               */
+                /* 1 byte for NHC + source 16bit inline, dest = 0xF0 + 8 bit
+                 * inline
+                 */
 
-              ninfo("Decompressing destination\n");
+                ninfo("Decompressing destination\n");
 
-              memcpy(&udp->srcport, g_hc06ptr + 1, 2);
-              udp->destport =
-                HTONS(SIXLOWPAN_UDP_8_BIT_PORT_MIN + (*(g_hc06ptr + 3)));
+                memcpy(&udp->srcport, g_hc06ptr + 1, 2);
+                udp->destport =
+                  HTONS(SIXLOWPAN_UDP_8_BIT_PORT_MIN + (*(g_hc06ptr + 3)));
 
-              ninfo("Uncompressed UDP ports (ptr+4): %x, %x\n",
-                    HTONS(udp->srcport), HTONS(udp->destport));
+                ninfo("Uncompressed UDP ports (ptr+4): %x, %x\n",
+                      HTONS(udp->srcport), HTONS(udp->destport));
 
-              g_hc06ptr += 4;
-              break;
+                g_hc06ptr += 4;
+                break;
 
-            case SIXLOWPAN_NHC_UDP_CS_P_10:
+              case SIXLOWPAN_NHC_UDP_CS_P_10:
 
-              HC06_CHECK(g_hc06ptr, 4, endofframe);
+                HC06_CHECK(g_hc06ptr, 4, endofframe);
 
-              /* 1 byte for NHC + source = 0xF0 + 8bit inline, dest = 16 bit
-               * inline
-               */
+                /* 1 byte for NHC + source = 0xF0 + 8bit inline,
+                 * dest = 16 bit inline
+                 */
 
-              ninfo("Decompressing source\n");
+                ninfo("Decompressing source\n");
 
-              udp->srcport =
-                HTONS(SIXLOWPAN_UDP_8_BIT_PORT_MIN + (*(g_hc06ptr + 1)));
-              memcpy(&udp->destport, g_hc06ptr + 2, 2);
+                udp->srcport =
+                  HTONS(SIXLOWPAN_UDP_8_BIT_PORT_MIN + (*(g_hc06ptr + 1)));
+                memcpy(&udp->destport, g_hc06ptr + 2, 2);
 
-              ninfo("Uncompressed UDP ports (ptr+4): %x, %x\n",
-                    HTONS(udp->srcport), HTONS(udp->destport));
+                ninfo("Uncompressed UDP ports (ptr+4): %x, %x\n",
+                      HTONS(udp->srcport), HTONS(udp->destport));
 
-              g_hc06ptr += 4;
-              break;
+                g_hc06ptr += 4;
+                break;
 
-            case SIXLOWPAN_NHC_UDP_CS_P_11:
+              case SIXLOWPAN_NHC_UDP_CS_P_11:
 
-              HC06_CHECK(g_hc06ptr, 2, endofframe);
+                HC06_CHECK(g_hc06ptr, 2, endofframe);
 
-              /* 1 byte for NHC, 1 byte for ports */
+                /* 1 byte for NHC, 1 byte for ports */
 
-              udp->srcport =
-                HTONS(SIXLOWPAN_UDP_4_BIT_PORT_MIN +
-                          (*(g_hc06ptr + 1) >> 4));
-              udp->destport =
-                HTONS(SIXLOWPAN_UDP_4_BIT_PORT_MIN +
-                          ((*(g_hc06ptr + 1)) & 0x0f));
+                udp->srcport =
+                  HTONS(SIXLOWPAN_UDP_4_BIT_PORT_MIN +
+                            (*(g_hc06ptr + 1) >> 4));
+                udp->destport =
+                  HTONS(SIXLOWPAN_UDP_4_BIT_PORT_MIN +
+                            ((*(g_hc06ptr + 1)) & 0x0f));
 
-              ninfo("Uncompressed UDP ports (ptr+2): %x, %x\n",
-                    HTONS(udp->srcport), HTONS(udp->destport));
+                ninfo("Uncompressed UDP ports (ptr+2): %x, %x\n",
+                      HTONS(udp->srcport), HTONS(udp->destport));
 
-              g_hc06ptr += 2;
-              break;
+                g_hc06ptr += 2;
+                break;
 
-            default:
-              nerr("ERROR: Error unsupported UDP compression\n");
-              return -EINVAL;
+              default:
+                nerr("ERROR: Error unsupported UDP compression\n");
+                return -EINVAL;
             }
 
           if (!checksum_compressed)
@@ -1610,6 +1610,7 @@ int sixlowpan_uncompresshdr_hc06(FAR struct radio_driver_s *radio,
     {
       FAR struct udp_hdr_s *udp =
                           (FAR struct udp_hdr_s *)(bptr + IPv6_HDRLEN);
+
       memcpy(&udp->udplen, &ipv6->len[0], 2);
     }
 

--- a/net/sixlowpan/sixlowpan_hc1.c
+++ b/net/sixlowpan/sixlowpan_hc1.c
@@ -179,91 +179,91 @@ int sixlowpan_compresshdr_hc1(FAR struct radio_driver_s *radio,
       switch (ipv6->proto)
         {
 #ifdef CONFIG_NET_ICMPv6
-        case IP_PROTO_ICMP6:
-          {
-            /* HC1 encoding and ttl */
+          case IP_PROTO_ICMP6:
+            {
+              /* HC1 encoding and ttl */
 
-            hc1[SIXLOWPAN_HC1_ENCODING] = 0xfc;
-            hc1[SIXLOWPAN_HC1_TTL]      = ipv6->ttl;
-            g_frame_hdrlen             += SIXLOWPAN_HC1_HDR_LEN;
-          }
-          break;
+              hc1[SIXLOWPAN_HC1_ENCODING] = 0xfc;
+              hc1[SIXLOWPAN_HC1_TTL]      = ipv6->ttl;
+              g_frame_hdrlen             += SIXLOWPAN_HC1_HDR_LEN;
+            }
+            break;
 #endif
 #ifdef CONFIG_NET_TCP
-        case IP_PROTO_TCP:
-          {
-            /* HC1 encoding and ttl */
+          case IP_PROTO_TCP:
+            {
+              /* HC1 encoding and ttl */
 
-            hc1[SIXLOWPAN_HC1_ENCODING] = 0xfe;
-            hc1[SIXLOWPAN_HC1_TTL]      = ipv6->ttl;
-            g_frame_hdrlen             += SIXLOWPAN_HC1_HDR_LEN;
-          }
-          break;
+              hc1[SIXLOWPAN_HC1_ENCODING] = 0xfe;
+              hc1[SIXLOWPAN_HC1_TTL]      = ipv6->ttl;
+              g_frame_hdrlen             += SIXLOWPAN_HC1_HDR_LEN;
+            }
+            break;
 #endif
 #ifdef CONFIG_NET_UDP
-        case IP_PROTO_UDP:
-          {
-            FAR struct udp_hdr_s *udp =
-              &(((FAR struct ipv6udp_hdr_s *)ipv6)->udp);
+          case IP_PROTO_UDP:
+            {
+              FAR struct udp_hdr_s *udp =
+                &(((FAR struct ipv6udp_hdr_s *)ipv6)->udp);
 
-            /* Try to compress UDP header (we do only full compression).
-             * This is feasible if both src and dest ports are between
-             * CONFIG_NET_6LOWPAN_MINPORT and CONFIG_NET_6LOWPAN_MINPORT +
-             * 15
-             */
+              /* Try to compress UDP header (we do only full compression).
+               * This is feasible if both src and dest ports are between
+               * CONFIG_NET_6LOWPAN_MINPORT and CONFIG_NET_6LOWPAN_MINPORT +
+               * 15
+               */
 
-            ninfo("local/remote port %04x/%04x\n",
-                   udp->srcport, udp->destport);
+              ninfo("local/remote port %04x/%04x\n",
+                     udp->srcport, udp->destport);
 
-            if (NTOHS(udp->srcport)  >=  CONFIG_NET_6LOWPAN_MINPORT &&
-                NTOHS(udp->srcport)  <  (CONFIG_NET_6LOWPAN_MINPORT + 16) &&
-                NTOHS(udp->destport) >=  CONFIG_NET_6LOWPAN_MINPORT &&
-                NTOHS(udp->destport) <  (CONFIG_NET_6LOWPAN_MINPORT + 16))
-              {
-                FAR uint8_t *hcudp = fptr + g_frame_hdrlen;
+              if (NTOHS(udp->srcport) >= CONFIG_NET_6LOWPAN_MINPORT &&
+                  NTOHS(udp->srcport) < (CONFIG_NET_6LOWPAN_MINPORT + 16) &&
+                  NTOHS(udp->destport) >= CONFIG_NET_6LOWPAN_MINPORT &&
+                  NTOHS(udp->destport) < (CONFIG_NET_6LOWPAN_MINPORT + 16))
+                {
+                  FAR uint8_t *hcudp = fptr + g_frame_hdrlen;
 
-                /* HC1 encoding */
+                  /* HC1 encoding */
 
-                hcudp[SIXLOWPAN_HC1_HC_UDP_HC1_ENCODING] = 0xfb;
+                  hcudp[SIXLOWPAN_HC1_HC_UDP_HC1_ENCODING] = 0xfb;
 
-                /* HC_UDP encoding, ttl, src and dest ports, checksum */
+                  /* HC_UDP encoding, ttl, src and dest ports, checksum */
 
-                hcudp[SIXLOWPAN_HC1_HC_UDP_UDP_ENCODING] = 0xe0;
-                hcudp[SIXLOWPAN_HC1_HC_UDP_TTL]          = ipv6->ttl;
-                hcudp[SIXLOWPAN_HC1_HC_UDP_PORTS]        =
-                  (uint8_t)((NTOHS(udp->srcport) -
-                            CONFIG_NET_6LOWPAN_MINPORT) << 4) +
-                  (uint8_t)((NTOHS(udp->destport) -
-                            CONFIG_NET_6LOWPAN_MINPORT));
+                  hcudp[SIXLOWPAN_HC1_HC_UDP_UDP_ENCODING] = 0xe0;
+                  hcudp[SIXLOWPAN_HC1_HC_UDP_TTL]          = ipv6->ttl;
+                  hcudp[SIXLOWPAN_HC1_HC_UDP_PORTS]        =
+                    (uint8_t)((NTOHS(udp->srcport) -
+                              CONFIG_NET_6LOWPAN_MINPORT) << 4) +
+                    (uint8_t)((NTOHS(udp->destport) -
+                              CONFIG_NET_6LOWPAN_MINPORT));
 
-                memcpy(&hcudp[SIXLOWPAN_HC1_HC_UDP_CHKSUM],
-                       &udp->udpchksum, 2);
+                  memcpy(&hcudp[SIXLOWPAN_HC1_HC_UDP_CHKSUM],
+                         &udp->udpchksum, 2);
 
-                g_frame_hdrlen  += SIXLOWPAN_HC1_HC_UDP_HDR_LEN;
-                g_uncomp_hdrlen += UDP_HDRLEN;
-              }
-            else
-              {
-                /* HC1 encoding and ttl */
+                  g_frame_hdrlen  += SIXLOWPAN_HC1_HC_UDP_HDR_LEN;
+                  g_uncomp_hdrlen += UDP_HDRLEN;
+                }
+              else
+                {
+                  /* HC1 encoding and ttl */
 
-                hc1[SIXLOWPAN_HC1_ENCODING] = 0xfa;
-                hc1[SIXLOWPAN_HC1_TTL]      = ipv6->ttl;
-                g_frame_hdrlen             += SIXLOWPAN_HC1_HDR_LEN;
-              }
+                  hc1[SIXLOWPAN_HC1_ENCODING] = 0xfa;
+                  hc1[SIXLOWPAN_HC1_TTL]      = ipv6->ttl;
+                  g_frame_hdrlen             += SIXLOWPAN_HC1_HDR_LEN;
+                }
 
-            ret = COMPRESS_HDR_ELIDED;
-          }
-          break;
+              ret = COMPRESS_HDR_ELIDED;
+            }
+            break;
 #endif /* CONFIG_NET_UDP */
 
-        default:
-          {
-            /* Test above assures that this will never happen */
+          default:
+            {
+              /* Test above assures that this will never happen */
 
-            nerr("ERROR: Unhandled protocol\n");
-            DEBUGPANIC();
-          }
-          break;
+              nerr("ERROR: Unhandled protocol\n");
+              DEBUGPANIC();
+            }
+            break;
         }
     }
 
@@ -329,74 +329,74 @@ int sixlowpan_uncompresshdr_hc1(FAR struct radio_driver_s *radio,
   switch (hc1[SIXLOWPAN_HC1_ENCODING] & 0x06)
     {
 #ifdef CONFIG_NET_ICMPv6
-    case SIXLOWPAN_HC1_NH_ICMPv6:
-      ipv6->proto     = IP_PROTO_ICMP6;
-      ipv6->ttl       = hc1[SIXLOWPAN_HC1_TTL];
-      g_frame_hdrlen += SIXLOWPAN_HC1_HDR_LEN;
-      break;
+      case SIXLOWPAN_HC1_NH_ICMPv6:
+        ipv6->proto     = IP_PROTO_ICMP6;
+        ipv6->ttl       = hc1[SIXLOWPAN_HC1_TTL];
+        g_frame_hdrlen += SIXLOWPAN_HC1_HDR_LEN;
+        break;
 #endif
 #ifdef CONFIG_NET_TCP
-    case SIXLOWPAN_HC1_NH_TCP:
-      ipv6->proto     = IP_PROTO_TCP;
-      ipv6->ttl       = hc1[SIXLOWPAN_HC1_TTL];
-      g_frame_hdrlen += SIXLOWPAN_HC1_HDR_LEN;
-      break;
+      case SIXLOWPAN_HC1_NH_TCP:
+        ipv6->proto     = IP_PROTO_TCP;
+        ipv6->ttl       = hc1[SIXLOWPAN_HC1_TTL];
+        g_frame_hdrlen += SIXLOWPAN_HC1_HDR_LEN;
+        break;
 #endif
 #ifdef CONFIG_NET_UDP
-    case SIXLOWPAN_HC1_NH_UDP:
-      {
-        FAR struct udp_hdr_s *udp =
-                         (FAR struct udp_hdr_s *)(bptr + IPv6_HDRLEN);
-        FAR uint8_t *hcudp = fptr + g_frame_hdrlen;
+      case SIXLOWPAN_HC1_NH_UDP:
+        {
+          FAR struct udp_hdr_s *udp =
+                           (FAR struct udp_hdr_s *)(bptr + IPv6_HDRLEN);
+          FAR uint8_t *hcudp = fptr + g_frame_hdrlen;
 
-        ipv6->proto = IP_PROTO_UDP;
+          ipv6->proto = IP_PROTO_UDP;
 
-        /* Check for HC_UDP encoding */
+          /* Check for HC_UDP encoding */
 
-        if ((hcudp[SIXLOWPAN_HC1_HC_UDP_HC1_ENCODING] & 0x01) != 0)
-          {
-            /* UDP header is compressed with HC_UDP */
+          if ((hcudp[SIXLOWPAN_HC1_HC_UDP_HC1_ENCODING] & 0x01) != 0)
+            {
+              /* UDP header is compressed with HC_UDP */
 
-            if (hcudp[SIXLOWPAN_HC1_HC_UDP_UDP_ENCODING] !=
-                SIXLOWPAN_HC_UDP_ALL_C)
-              {
-                nwarn("WARNING: "
-                      "sixlowpan (uncompress_hdr), packet not supported");
-                return -EOPNOTSUPP;
-              }
+              if (hcudp[SIXLOWPAN_HC1_HC_UDP_UDP_ENCODING] !=
+                  SIXLOWPAN_HC_UDP_ALL_C)
+                {
+                  nwarn("WARNING: "
+                        "sixlowpan (uncompress_hdr), packet not supported");
+                  return -EOPNOTSUPP;
+                }
 
-            /* IP TTL */
+              /* IP TTL */
 
-            ipv6->ttl = hcudp[SIXLOWPAN_HC1_HC_UDP_TTL];
+              ipv6->ttl = hcudp[SIXLOWPAN_HC1_HC_UDP_TTL];
 
-            /* UDP ports, len, checksum */
+              /* UDP ports, len, checksum */
 
-            udp->srcport =
-              HTONS(CONFIG_NET_6LOWPAN_MINPORT +
-                    (hcudp[SIXLOWPAN_HC1_HC_UDP_PORTS] >> 4));
-            udp->destport =
-              HTONS(CONFIG_NET_6LOWPAN_MINPORT +
-                    (hcudp[SIXLOWPAN_HC1_HC_UDP_PORTS] & 0x0f));
+              udp->srcport =
+                HTONS(CONFIG_NET_6LOWPAN_MINPORT +
+                      (hcudp[SIXLOWPAN_HC1_HC_UDP_PORTS] >> 4));
+              udp->destport =
+                HTONS(CONFIG_NET_6LOWPAN_MINPORT +
+                      (hcudp[SIXLOWPAN_HC1_HC_UDP_PORTS] & 0x0f));
 
-            ninfo("UDP srcport=%04x destport=%04x\n",
-                   udp->srcport, udp->destport);
+              ninfo("UDP srcport=%04x destport=%04x\n",
+                     udp->srcport, udp->destport);
 
-            memcpy(&udp->udpchksum,
-                   &hcudp[SIXLOWPAN_HC1_HC_UDP_CHKSUM], 2);
+              memcpy(&udp->udpchksum,
+                     &hcudp[SIXLOWPAN_HC1_HC_UDP_CHKSUM], 2);
 
-            g_uncomp_hdrlen += UDP_HDRLEN;
-            g_frame_hdrlen  += SIXLOWPAN_HC1_HC_UDP_HDR_LEN;
-          }
-        else
-          {
-            g_frame_hdrlen  += SIXLOWPAN_HC1_HDR_LEN;
-          }
-      }
-      break;
+              g_uncomp_hdrlen += UDP_HDRLEN;
+              g_frame_hdrlen  += SIXLOWPAN_HC1_HC_UDP_HDR_LEN;
+            }
+          else
+            {
+              g_frame_hdrlen  += SIXLOWPAN_HC1_HDR_LEN;
+            }
+        }
+        break;
 #endif /* CONFIG_NET_UDP */
 
-    default:
-      return -EPROTONOSUPPORT;
+      default:
+        return -EPROTONOSUPPORT;
     }
 
   /* Re-create the link-local, mac-based IP address from src/dest node
@@ -484,6 +484,7 @@ int sixlowpan_uncompresshdr_hc1(FAR struct radio_driver_s *radio,
     {
       FAR struct udp_hdr_s *udp =
                            (FAR struct udp_hdr_s *)(bptr + IPv6_HDRLEN);
+
       memcpy(&udp->udplen, &ipv6->len[0], 2);
 
       ninfo("IPv6 len=%04x\n", udp->udplen);

--- a/net/sixlowpan/sixlowpan_input.c
+++ b/net/sixlowpan/sixlowpan_input.c
@@ -208,43 +208,43 @@ static int sixlowpan_uncompress_ipv6proto(FAR struct iob_s *iob,
   switch (ipv6->proto)
     {
 #ifdef CONFIG_NET_TCP
-    case IP_PROTO_TCP:
-      {
-        FAR struct tcp_hdr_s *tcp =
-          (FAR struct tcp_hdr_s *)(fptr + g_frame_hdrlen);
+      case IP_PROTO_TCP:
+        {
+          FAR struct tcp_hdr_s *tcp =
+            (FAR struct tcp_hdr_s *)(fptr + g_frame_hdrlen);
 
-        /* Check if the frame is too short */
+          /* Check if the frame is too short */
 
-        if (fptr + g_frame_hdrlen + sizeof(struct tcp_hdr_s) > endofframe)
-          {
-            nerr("ERROR: Frame too short for TCP header\n");
-            return -EINVAL;
-          }
+          if (fptr + g_frame_hdrlen + sizeof(struct tcp_hdr_s) > endofframe)
+            {
+              nerr("ERROR: Frame too short for TCP header\n");
+              return -EINVAL;
+            }
 
-        /* The TCP header length is encoded in the top 4 bits of the
-         * tcpoffset field (in units of 32-bit words).
-         */
+          /* The TCP header length is encoded in the top 4 bits of the
+           * tcpoffset field (in units of 32-bit words).
+           */
 
-        protosize = ((uint16_t)tcp->tcpoffset >> 4) << 2;
-      }
-      break;
+          protosize = ((uint16_t)tcp->tcpoffset >> 4) << 2;
+        }
+        break;
 #endif
 
 #ifdef CONFIG_NET_UDP
-    case IP_PROTO_UDP:
-      protosize = sizeof(struct udp_hdr_s);
-      break;
+      case IP_PROTO_UDP:
+        protosize = sizeof(struct udp_hdr_s);
+        break;
 #endif
 
 #ifdef CONFIG_NET_ICMPv6
-    case IP_PROTO_ICMP6:
-      protosize = sizeof(struct icmpv6_hdr_s);
-      break;
+      case IP_PROTO_ICMP6:
+        protosize = sizeof(struct icmpv6_hdr_s);
+        break;
 #endif
 
-    default:
-      nwarn("WARNING: Unrecognized proto: %u\n", ipv6->proto);
-      return 0;
+      default:
+        nwarn("WARNING: Unrecognized proto: %u\n", ipv6->proto);
+        return 0;
     }
 
   /* Check if the TCP header exceeds the frame size */
@@ -349,133 +349,136 @@ static int sixlowpan_frame_process(FAR struct radio_driver_s *radio,
   fragptr = fptr + hdrsize;
   switch ((GETUINT16(fragptr, SIXLOWPAN_FRAG_DISPATCH_SIZE) & 0xf800) >> 8)
     {
-    /* First fragment of new reassembly */
+      /* First fragment of new reassembly */
 
-    case SIXLOWPAN_DISPATCH_FRAG1:
-      {
-        /* Set up for the reassembly */
+      case SIXLOWPAN_DISPATCH_FRAG1:
+        {
+          /* Set up for the reassembly */
 
-        fragsize = GETUINT16(fragptr, SIXLOWPAN_FRAG_DISPATCH_SIZE) & 0x07ff;
-        fragtag  = GETUINT16(fragptr, SIXLOWPAN_FRAG_TAG);
-        g_frame_hdrlen += SIXLOWPAN_FRAG1_HDR_LEN;
+          fragsize = GETUINT16(fragptr, SIXLOWPAN_FRAG_DISPATCH_SIZE) &
+                     0x07ff;
+          fragtag  = GETUINT16(fragptr, SIXLOWPAN_FRAG_TAG);
+          g_frame_hdrlen += SIXLOWPAN_FRAG1_HDR_LEN;
 
-        ninfo("FRAG1: fragsize=%d fragtag=%d fragoffset=%d\n",
-              fragsize, fragtag, fragoffset);
+          ninfo("FRAG1: fragsize=%d fragtag=%d fragoffset=%d\n",
+                fragsize, fragtag, fragoffset);
 
-        /* Drop any zero length fragments */
+          /* Drop any zero length fragments */
 
-        if (fragsize == 0)
-          {
-            nwarn("WARNING: Dropping zero-length 6LoWPAN fragment\n");
-            return INPUT_PARTIAL;
-          }
+          if (fragsize == 0)
+            {
+              nwarn("WARNING: Dropping zero-length 6LoWPAN fragment\n");
+              return INPUT_PARTIAL;
+            }
 
-        /* Drop the packet if it cannot fit into the d_buf */
+          /* Drop the packet if it cannot fit into the d_buf */
 
-        if (fragsize > CONFIG_NET_6LOWPAN_PKTSIZE)
-          {
-            nwarn("WARNING:  Reassembled packet size exceeds "
-                  "CONFIG_NET_6LOWPAN_PKTSIZE\n");
-            return -ENOSPC;
-          }
+          if (fragsize > CONFIG_NET_6LOWPAN_PKTSIZE)
+            {
+              nwarn("WARNING:  Reassembled packet size exceeds "
+                    "CONFIG_NET_6LOWPAN_PKTSIZE\n");
+              return -ENOSPC;
+            }
 
-        /* Extract the source address from the 'metadata'. */
+          /* Extract the source address from the 'metadata'. */
 
-        ret = sixlowpan_extract_srcaddr(radio, metadata, &fragsrc);
-        if (ret < 0)
-          {
-            nerr("ERROR: sixlowpan_extract_srcaddr failed: %d\n", ret);
-            return ret;
-          }
+          ret = sixlowpan_extract_srcaddr(radio, metadata, &fragsrc);
+          if (ret < 0)
+            {
+              nerr("ERROR: sixlowpan_extract_srcaddr failed: %d\n", ret);
+              return ret;
+            }
 
-        /* Allocate a new reassembly buffer */
+          /* Allocate a new reassembly buffer */
 
-        reass = sixlowpan_reass_allocate(fragtag, &fragsrc);
-        if (reass == NULL)
-          {
-            nerr("ERROR: Failed to allocate a reassembly buffer\n");
-            return -ENOMEM;
-          }
+          reass = sixlowpan_reass_allocate(fragtag, &fragsrc);
+          if (reass == NULL)
+            {
+              nerr("ERROR: Failed to allocate a reassembly buffer\n");
+              return -ENOMEM;
+            }
 
-        radio->r_dev.d_buf = reass->rb_buf;
-        radio->r_dev.d_len = 0;
-        reass->rb_pktlen   = fragsize;
+          radio->r_dev.d_buf = reass->rb_buf;
+          radio->r_dev.d_len = 0;
+          reass->rb_pktlen   = fragsize;
 
-        /* Indicate the first fragment of the reassembly */
+          /* Indicate the first fragment of the reassembly */
 
-        bptr               = reass->rb_buf;
-        isfrag1            = true;
-        isfrag             = true;
-      }
-      break;
+          bptr               = reass->rb_buf;
+          isfrag1            = true;
+          isfrag             = true;
+        }
+        break;
 
-    case SIXLOWPAN_DISPATCH_FRAGN:
-      {
-        /* Get offset, tag, size.  Offset is in units of 8 bytes. */
+      case SIXLOWPAN_DISPATCH_FRAGN:
+        {
+          /* Get offset, tag, size.  Offset is in units of 8 bytes. */
 
-        fragoffset = fragptr[SIXLOWPAN_FRAG_OFFSET];
-        fragtag  = GETUINT16(fragptr, SIXLOWPAN_FRAG_TAG);
-        fragsize = GETUINT16(fragptr, SIXLOWPAN_FRAG_DISPATCH_SIZE) & 0x07ff;
-        g_frame_hdrlen += SIXLOWPAN_FRAGN_HDR_LEN;
+          fragoffset = fragptr[SIXLOWPAN_FRAG_OFFSET];
+          fragtag  = GETUINT16(fragptr, SIXLOWPAN_FRAG_TAG);
+          fragsize = GETUINT16(fragptr, SIXLOWPAN_FRAG_DISPATCH_SIZE) &
+                     0x07ff;
+          g_frame_hdrlen += SIXLOWPAN_FRAGN_HDR_LEN;
 
-        /* Extract the source address from the 'metadata'. */
+          /* Extract the source address from the 'metadata'. */
 
-        ret = sixlowpan_extract_srcaddr(radio, metadata, &fragsrc);
-        if (ret < 0)
-          {
-            nerr("ERROR: sixlowpan_extract_srcaddr failed: %d\n", ret);
-            return ret;
-          }
+          ret = sixlowpan_extract_srcaddr(radio, metadata, &fragsrc);
+          if (ret < 0)
+            {
+              nerr("ERROR: sixlowpan_extract_srcaddr failed: %d\n", ret);
+              return ret;
+            }
 
-        /* Find the existing reassembly buffer
-         * with the same tag and source address
+          /* Find the existing reassembly buffer
+           * with the same tag and source address
+           */
+
+          reass = sixlowpan_reass_find(fragtag, &fragsrc);
+          if (reass == NULL)
+            {
+              nerr("ERROR: Failed to find a reassembly buffer for "
+                   "tag=%04x\n", fragtag);
+              return -ENOENT;
+            }
+
+          if (fragsize != reass->rb_pktlen)
+            {
+              /* The packet is a fragment but its size does not match. */
+
+              nwarn("WARNING: Dropping 6LoWPAN packet. "
+                    "Bad fragsize: %u vs %u\n",
+                    fragsize, reass->rb_pktlen);
+              ret = -EPERM;
+              goto errout_with_reass;
+            }
+
+          radio->r_dev.d_buf  = reass->rb_buf;
+          radio->r_dev.d_len  = 0;
+
+          ninfo("FRAGN: fragsize=%d fragtag=%d fragoffset=%d\n",
+                fragsize, fragtag, fragoffset);
+          ninfo("FRAGN: rb_accumlen=%d paysize=%u fragsize=%u\n",
+                reass->rb_accumlen, iob->io_len - g_frame_hdrlen, fragsize);
+
+          /* Indicate that this frame is a another fragment for reassembly */
+
+          bptr   = g_bitbucket;
+          isfrag = true;
+        }
+        break;
+
+      /* Not a fragment */
+
+      default:
+        /* We still need a packet buffer.  But in this case, the driver
+         * should have provided one.
          */
 
-        reass = sixlowpan_reass_find(fragtag, &fragsrc);
-        if (reass == NULL)
-          {
-            nerr("ERROR: Failed to find a reassembly buffer for tag=%04x\n",
-                 fragtag);
-            return -ENOENT;
-          }
-
-       if (fragsize != reass->rb_pktlen)
-        {
-          /* The packet is a fragment but its size does not match. */
-
-          nwarn("WARNING: Dropping 6LoWPAN packet. Bad fragsize: %u vs %u\n",
-                fragsize, reass->rb_pktlen);
-          ret = -EPERM;
-          goto errout_with_reass;
-        }
-
-        radio->r_dev.d_buf  = reass->rb_buf;
-        radio->r_dev.d_len  = 0;
-
-        ninfo("FRAGN: fragsize=%d fragtag=%d fragoffset=%d\n",
-              fragsize, fragtag, fragoffset);
-        ninfo("FRAGN: rb_accumlen=%d paysize=%u fragsize=%u\n",
-              reass->rb_accumlen, iob->io_len - g_frame_hdrlen, fragsize);
-
-        /* Indicate that this frame is a another fragment for reassembly */
-
-        bptr   = g_bitbucket;
-        isfrag = true;
-      }
-      break;
-
-    /* Not a fragment */
-
-    default:
-      /* We still need a packet buffer.  But in this case, the driver should
-       * have provided one.
-       */
-
-      DEBUGASSERT(radio->r_dev.d_buf != NULL);
-      reass = (FAR struct sixlowpan_reassbuf_s *)radio->r_dev.d_buf;
-      reass->rb_pool = REASS_POOL_RADIO;
-      bptr  = reass->rb_buf;
-      break;
+        DEBUGASSERT(radio->r_dev.d_buf != NULL);
+        reass = (FAR struct sixlowpan_reassbuf_s *)radio->r_dev.d_buf;
+        reass->rb_pool = REASS_POOL_RADIO;
+        bptr  = reass->rb_buf;
+        break;
     }
 
   /* Process next dispatch and headers */

--- a/net/socket/connect.c
+++ b/net/socket/connect.c
@@ -147,6 +147,7 @@ int psock_connect(FAR struct socket *psock, FAR const struct sockaddr *addr,
   if (ret >= 0 && addr->sa_family != AF_UNSPEC)
     {
       FAR struct socket_conn_s *conn = psock->s_conn;
+
       conn->s_flags |= _SF_CONNECTED;
     }
 

--- a/net/socket/getsockopt.c
+++ b/net/socket/getsockopt.c
@@ -104,8 +104,8 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
             }
 
           /* Get the timeout value.  This is a atomic operation and should
-         * require no special operation.
-         */
+           * require no special operation.
+           */
 
           if (option == SO_RCVTIMEO)
             {
@@ -161,7 +161,7 @@ static int psock_socketlevel_option(FAR struct socket *psock, int option,
           if (*value_len < sizeof(int))
             {
               return -EINVAL;
-           }
+            }
 
           /* Sample the current options.  This is atomic operation and so
            * should not require any special steps for thread safety. We

--- a/net/socket/listen.c
+++ b/net/socket/listen.c
@@ -94,6 +94,7 @@ int psock_listen(FAR struct socket *psock, int backlog)
   if (ret >= 0)
     {
       FAR struct socket_conn_s *conn = psock->s_conn;
+
       conn->s_flags |= _SF_LISTENING;
     }
   else

--- a/net/socket/net_fstat.c
+++ b/net/socket/net_fstat.c
@@ -108,64 +108,64 @@ int psock_fstat(FAR struct socket *psock, FAR struct stat *buf)
   switch (psock->s_type)
     {
 #if defined(NET_TCP_HAVE_STACK)
-       case SOCK_STREAM:
-         {
-           FAR struct tcp_conn_s *tcp_conn = psock->s_conn;
+      case SOCK_STREAM:
+        {
+          FAR struct tcp_conn_s *tcp_conn = psock->s_conn;
 
-           /* For TCP, the MSS is a dynamic value that maintained in the
-            * connection structure.
-            */
+          /* For TCP, the MSS is a dynamic value that maintained in the
+           * connection structure.
+           */
 
-           buf->st_blksize = tcp_conn->mss;
-         }
-         break;
+          buf->st_blksize = tcp_conn->mss;
+        }
+        break;
 #endif
 
 #if defined(NET_UDP_HAVE_STACK)
-       case SOCK_DGRAM:
-         {
-           FAR struct udp_conn_s *udp_conn = psock->s_conn;
-           FAR struct net_driver_s *dev;
-           uint16_t iplen;
+      case SOCK_DGRAM:
+        {
+          FAR struct udp_conn_s *udp_conn = psock->s_conn;
+          FAR struct net_driver_s *dev;
+          uint16_t iplen;
 
-           /* For a connected UDP socket, we have do do a little more work:
-            *
-            *   MSS = MTU - LL_HDRLEN - UDP_HDRLEN - IP_HDRLEN
-            *
-            * We need to have the device that services the connection in
-            * order to get the MTU and LL_HDRLEN:
-            */
+          /* For a connected UDP socket, we have do do a little more work:
+           *
+           *   MSS = MTU - LL_HDRLEN - UDP_HDRLEN - IP_HDRLEN
+           *
+           * We need to have the device that services the connection in
+           * order to get the MTU and LL_HDRLEN:
+           */
 
-           dev = udp_find_raddr_device(udp_conn, NULL);
-           if (dev == NULL)
-             {
-               /* This should never happen except perhaps in some rare race
-                * condition.  If the UDP socket is connected, then the device
-                * service the network that it is connected to should always
-                * exist.
-                */
+          dev = udp_find_raddr_device(udp_conn, NULL);
+          if (dev == NULL)
+            {
+              /* This should never happen except perhaps in some rare race
+               * condition.  If the UDP socket is connected, then the device
+               * service the network that it is connected to should always
+               * exist.
+               */
 
-               nerr("ERROR:  Could not find network device\n");
-               ret = -ENODEV;
-             }
-           else
-             {
-               /* We need the length of the IP header */
+              nerr("ERROR:  Could not find network device\n");
+              ret = -ENODEV;
+            }
+          else
+            {
+              /* We need the length of the IP header */
 
-               iplen = net_ip_domain_select(udp_conn->domain,
-                                            IPv4_HDRLEN, IPv6_HDRLEN);
+              iplen = net_ip_domain_select(udp_conn->domain,
+                                           IPv4_HDRLEN, IPv6_HDRLEN);
 
-               /* Now we can calculate the MSS */
+              /* Now we can calculate the MSS */
 
-               buf->st_blksize = UDP_MSS(dev, iplen);
-             }
-         }
-         break;
+              buf->st_blksize = UDP_MSS(dev, iplen);
+            }
+        }
+        break;
 #endif
-       default:
-         nwarn("WARNING:  Unhandled socket type: %u\n", psock->s_type);
-         break;
-     }
+      default:
+        nwarn("WARNING:  Unhandled socket type: %u\n", psock->s_type);
+        break;
+    }
 
   return ret;
 }

--- a/net/socket/net_sockif.c
+++ b/net/socket/net_sockif.c
@@ -215,59 +215,59 @@ net_sockif(sa_family_t family, int type, int protocol)
     {
 #if defined(HAVE_PFINET_SOCKETS) || defined(HAVE_PFINET6_SOCKETS)
 #  ifdef HAVE_PFINET_SOCKETS
-    case PF_INET:
+      case PF_INET:
 #  endif
 #  ifdef HAVE_PFINET6_SOCKETS
-    case PF_INET6:
+      case PF_INET6:
 #  endif
-      sockif = inet_sockif(family, type, protocol);
-      break;
+        sockif = inet_sockif(family, type, protocol);
+        break;
 #endif
 
 #ifdef CONFIG_NET_LOCAL
-    case PF_LOCAL:
-      sockif = &g_local_sockif;
-      break;
+      case PF_LOCAL:
+        sockif = &g_local_sockif;
+        break;
 #endif
 
 #ifdef CONFIG_NET_CAN
-    case PF_CAN:
-      sockif = &g_can_sockif;
-      break;
+      case PF_CAN:
+        sockif = &g_can_sockif;
+        break;
 #endif
 
 #ifdef CONFIG_NET_NETLINK
-    case PF_NETLINK:
-      sockif = &g_netlink_sockif;
-      break;
+      case PF_NETLINK:
+        sockif = &g_netlink_sockif;
+        break;
 #endif
 
 #ifdef CONFIG_NET_PKT
-    case PF_PACKET:
-      sockif = &g_pkt_sockif;
-      break;
+      case PF_PACKET:
+        sockif = &g_pkt_sockif;
+        break;
 #endif
 
 #ifdef CONFIG_NET_BLUETOOTH
-    case PF_BLUETOOTH:
-      sockif = &g_bluetooth_sockif;
-      break;
+      case PF_BLUETOOTH:
+        sockif = &g_bluetooth_sockif;
+        break;
 #endif
 
 #ifdef CONFIG_NET_IEEE802154
-    case PF_IEEE802154:
-      sockif = &g_ieee802154_sockif;
-      break;
+      case PF_IEEE802154:
+        sockif = &g_ieee802154_sockif;
+        break;
 #endif
 
 #ifdef CONFIG_NET_RPMSG
-    case PF_RPMSG:
-      sockif = &g_rpmsg_sockif;
-      break;
+      case PF_RPMSG:
+        sockif = &g_rpmsg_sockif;
+        break;
 #endif
 
-    default:
-      nerr("ERROR: Address family unsupported: %d\n", family);
+      default:
+        nerr("ERROR: Address family unsupported: %d\n", family);
     }
 
   return sockif;

--- a/net/socket/recvfrom.c
+++ b/net/socket/recvfrom.c
@@ -95,7 +95,9 @@ ssize_t psock_recvfrom(FAR struct socket *psock, FAR void *buf, size_t len,
 
   ret = psock_recvmsg(psock, &msg, flags);
   if (ret >= 0 && fromlen != NULL)
-    *fromlen = msg.msg_namelen;
+    {
+      *fromlen = msg.msg_namelen;
+    }
 
   return ret;
 }

--- a/net/tcp/tcp_appsend.c
+++ b/net/tcp/tcp_appsend.c
@@ -224,21 +224,21 @@ void tcp_appsend(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn,
         {
 #endif
 
-      /* If d_sndlen > 0, the application has data to be sent. */
+          /* If d_sndlen > 0, the application has data to be sent. */
 
-      if (dev->d_sndlen > 0)
-        {
-          /* Remember how much data we send out now so that we know
-           * when everything has been acknowledged.  Just increment the
-           * amount of data sent.  This will be needed in sequence number
-           * calculations and we know that this is not a re-transmission.
-           * Retransmissions do not go through this path.
-           */
+          if (dev->d_sndlen > 0)
+            {
+              /* Remember how much data we send out now so that we know
+               * when everything has been acknowledged.  Just increment the
+               * amount of data sent.  This will be needed in sequence number
+               * calculations and we know that this is not a re-transmission.
+               * Retransmissions do not go through this path.
+               */
 
-          conn->tx_unacked += dev->d_sndlen;
-        }
+              conn->tx_unacked += dev->d_sndlen;
+            }
 
-      conn->nrtx = 0;
+          conn->nrtx = 0;
 
 #ifdef CONFIG_NET_TCP_WRITE_BUFFERS
         }

--- a/net/tcp/tcp_conn.c
+++ b/net/tcp/tcp_conn.c
@@ -1024,6 +1024,7 @@ FAR struct tcp_conn_s *tcp_alloc_accept(FAR struct net_driver_s *dev,
 
 #if defined(CONFIG_NET_IPv4) && defined(CONFIG_NET_IPv6)
   bool ipv6 = IFF_IS_IPv6(dev->d_flags);
+
   domain = ipv6 ? PF_INET6 : PF_INET;
 #elif defined(CONFIG_NET_IPv4)
   domain = PF_INET;
@@ -1377,6 +1378,7 @@ int tcp_connect(FAR struct tcp_conn_s *conn, FAR const struct sockaddr *addr)
       if (net_ipv6addr_cmp(addr, g_ipv6_unspecaddr))
         {
           struct in6_addr loopback_sin6_addr = IN6ADDR_LOOPBACK_INIT;
+
           net_ipv6addr_copy(conn->u.ipv6.raddr,
                             loopback_sin6_addr.s6_addr16);
         }

--- a/net/tcp/tcp_getsockopt.c
+++ b/net/tcp/tcp_getsockopt.c
@@ -129,6 +129,7 @@ int tcp_getsockopt(FAR struct socket *psock, int option,
         else
           {
             FAR int *keepalive = (FAR int *)value;
+
             *keepalive         = conn->keepalive;
             *value_len         = sizeof(int);
             ret                = OK;
@@ -168,6 +169,7 @@ int tcp_getsockopt(FAR struct socket *psock, int option,
           else if (*value_len == sizeof(int))
             {
               FAR int *pdsecs = (FAR int *)value;
+
               *pdsecs         = dsecs;
               ret             = OK;
             }
@@ -196,6 +198,7 @@ int tcp_getsockopt(FAR struct socket *psock, int option,
         else
           {
             FAR int *keepcnt = (FAR int *)value;
+
             *keepcnt         = conn->keepcnt;
             *value_len       = sizeof(int);
             ret              = OK;
@@ -234,6 +237,7 @@ int tcp_getsockopt(FAR struct socket *psock, int option,
         else
           {
             FAR int *mss = (FAR int *)value;
+
             *mss         = conn->mss;
             *value_len   = sizeof(int);
             ret          = OK;

--- a/net/tcp/tcp_input.c
+++ b/net/tcp/tcp_input.c
@@ -763,6 +763,7 @@ static void tcp_input(FAR struct net_driver_s *dev, uint8_t domain,
       if ((conn->tcpstateflags & TCP_STATE_MASK) == TCP_SYN_SENT)
         {
           uint32_t ackseq;
+
           if ((tcp->flags & TCP_ACK) != 0)
             {
               ackseq = tcp_getsequence(tcp->ackno);
@@ -1221,6 +1222,7 @@ found:
            */
 
           uint32_t sndseq = tcp_getsequence(conn->sndseq);
+
           if (TCP_SEQ_LTE(sndseq, ackseq))
             {
               ninfo("sndseq: %08" PRIx32 "->%08" PRIx32
@@ -1239,6 +1241,7 @@ found:
       if (conn->nrtx == 0)
         {
           signed char m;
+
           m = conn->rto - conn->timer;
 
           /* This is taken directly from VJs original code in his paper */
@@ -1578,15 +1581,15 @@ skip_rtt:
                 dev->d_urglen = dev->d_len;
               }
 
-             /* The d_len field contains the length of the incoming data.
-              * d_urgdata points to the "urgent" data at the beginning of
-              * the payload; d_appdata field points to the any "normal" data
-              * that may follow the urgent data.
-              *
-              * NOTE: If the urgent data continues in the next packet, then
-              * d_len will be zero and d_appdata will point past the end of
-              * the payload (which is OK).
-              */
+            /* The d_len field contains the length of the incoming data.
+             * d_urgdata points to the "urgent" data at the beginning of
+             * the payload; d_appdata field points to the any "normal" data
+             * that may follow the urgent data.
+             *
+             * NOTE: If the urgent data continues in the next packet, then
+             * d_len will be zero and d_appdata will point past the end of
+             * the payload (which is OK).
+             */
 
             net_incr32(conn->rcvseq, dev->d_urglen);
             dev->d_len     -= dev->d_urglen;
@@ -1762,9 +1765,9 @@ skip_rtt:
       case TCP_CLOSE_WAIT:
 #ifdef CONFIG_NET_TCP_KEEPALIVE
         /* If the established socket receives an ACK or any kind of data
-        * from the remote peer (whether we accept it or not), then reset
-        * the keep alive timer.
-        */
+         * from the remote peer (whether we accept it or not), then reset
+         * the keep alive timer.
+         */
 
         if (conn->keepalive && (tcp->flags & TCP_ACK) != 0)
           {

--- a/net/tcp/tcp_recvfrom.c
+++ b/net/tcp/tcp_recvfrom.c
@@ -423,6 +423,7 @@ static uint32_t tcp_recvhandler(FAR struct net_driver_s *dev,
               iob_reserve(iob, CONFIG_NET_LL_GUARDSIZE);
               int ret = iob_clone_partial(dev->d_iob, dev->d_iob->io_pktlen,
                                           0, iob, 0, false, false);
+
               if (ret < 0)
                 {
                   iob_free_chain(iob);

--- a/net/tcp/tcp_send.c
+++ b/net/tcp/tcp_send.c
@@ -471,6 +471,7 @@ void tcp_reset(FAR struct net_driver_s *dev, FAR struct tcp_conn_s *conn)
   else
     {
       uint32_t ackno;
+
       tcp->flags = TCP_RST | TCP_ACK;
       tcp_setsequence(tcp->seqno, 0);
       ackno = tcp_addsequence(tcp->ackno, acklen);

--- a/net/tcp/tcp_send_buffered.c
+++ b/net/tcp/tcp_send_buffered.c
@@ -118,9 +118,11 @@ static void psock_insert_segment(FAR struct tcp_wrbuffer_s *wrb,
   FAR sq_entry_t *insert = NULL;
 
   FAR sq_entry_t *itr;
+
   for (itr = sq_peek(q); itr; itr = sq_next(itr))
     {
       FAR struct tcp_wrbuffer_s *wrb0 = (FAR struct tcp_wrbuffer_s *)itr;
+
       if (TCP_WBSEQNO(wrb0) < TCP_WBSEQNO(wrb))
         {
           insert = itr;
@@ -870,16 +872,16 @@ static uint32_t psock_send_eventhandler(FAR struct net_driver_s *dev,
         }
 
 #ifdef CONFIG_NET_TCP_CC_NEWRENO
-          /* After Fast retransmitted, set ssthresh to the maximum of
-           * the unacked and the 2*SMSS, and enter to Fast Recovery.
-           * ssthresh = max (FlightSize / 2, 2*SMSS) referring to rfc5681
-           * cwnd=ssthresh + 3*SMSS  referring to rfc5681
-           */
+      /* After Fast retransmitted, set ssthresh to the maximum of
+       * the unacked and the 2*SMSS, and enter to Fast Recovery.
+       * ssthresh = max (FlightSize / 2, 2*SMSS) referring to rfc5681
+       * cwnd=ssthresh + 3*SMSS  referring to rfc5681
+       */
 
-          if (conn->flags & TCP_INFT)
-            {
-              tcp_cc_update(conn, NULL);
-            }
+      if (conn->flags & TCP_INFT)
+        {
+          tcp_cc_update(conn, NULL);
+        }
 #endif
     }
   else
@@ -1152,7 +1154,7 @@ static uint32_t psock_send_eventhandler(FAR struct net_driver_s *dev,
 
           if (TCP_SEQ_GT(predicted_seqno, conn->sndseq_max))
             {
-               conn->sndseq_max = predicted_seqno;
+              conn->sndseq_max = predicted_seqno;
             }
 
           ninfo("SEND: wrb=%p nrtx=%u tx_unacked=%" PRIu32
@@ -1235,6 +1237,7 @@ static uint32_t tcp_max_wrb_size(FAR struct tcp_conn_s *conn)
   if (size > mss)
     {
       const uint32_t odd = size % mss;
+
       size -= odd;
     }
 

--- a/net/tcp/tcp_sendfile.c
+++ b/net/tcp/tcp_sendfile.c
@@ -556,6 +556,7 @@ errout_locked:
       /* Use lseek to get the current file position */
 
       off_t curpos = file_seek(infile, 0, SEEK_CUR);
+
       if (curpos < 0)
         {
           return curpos;

--- a/net/tcp/tcp_seqno.c
+++ b/net/tcp/tcp_seqno.c
@@ -89,6 +89,7 @@ static uint32_t tcp_isn_rfc6528(FAR struct tcp_conn_s *conn)
 {
   const size_t addrlen = net_ip_domain_select(conn->domain,
                                   sizeof(in_addr_t), sizeof(net_ipv6addr_t));
+
   MD5_CTX ctx;
   uint32_t digest[MD5_DIGEST_LENGTH / 4];
   uint32_t m;

--- a/net/tcp/tcp_setsockopt.c
+++ b/net/tcp/tcp_setsockopt.c
@@ -161,10 +161,10 @@ int tcp_setsockopt(FAR struct socket *psock, int option,
             }
 
           if (dsecs > UINT16_MAX)
-             {
-               nwarn("WARNING: value out of range: %u\n", dsecs);
-               return -EDOM;
-             }
+            {
+              nwarn("WARNING: value out of range: %u\n", dsecs);
+              return -EDOM;
+            }
 
           if (option == TCP_KEEPIDLE)
             {
@@ -175,7 +175,7 @@ int tcp_setsockopt(FAR struct socket *psock, int option,
               conn->keepintvl = dsecs;
             }
 
-           /* Reset timer */
+          /* Reset timer */
 
           if (conn->keepalive)
             {

--- a/net/tcp/tcp_timer.c
+++ b/net/tcp/tcp_timer.c
@@ -201,6 +201,7 @@ static void tcp_xmit_probe(FAR struct net_driver_s *dev,
 
   uint16_t hdrlen = tcpip_hdrsize(conn);
   uint32_t saveseq = tcp_getsequence(conn->sndseq);
+
   tcp_setsequence(conn->sndseq, saveseq - 1);
 
   tcp_send(dev, conn, TCP_ACK, hdrlen);

--- a/net/udp/udp_callback.c
+++ b/net/udp/udp_callback.c
@@ -275,7 +275,7 @@ net_dataevent(FAR struct net_driver_s *dev, FAR struct udp_conn_s *conn,
        * read-ahead buffers to retain the data -- drop the packet.
        */
 
-     ninfo("Dropped %d bytes\n", dev->d_len);
+      ninfo("Dropped %d bytes\n", dev->d_len);
 
 #ifdef CONFIG_NET_STATISTICS
       g_netstats.udp.drop++;

--- a/net/udp/udp_conn.c
+++ b/net/udp/udp_conn.c
@@ -1003,6 +1003,7 @@ int udp_connect(FAR struct udp_conn_s *conn, FAR const struct sockaddr *addr)
           if (net_ipv6addr_cmp(addr, g_ipv6_unspecaddr))
             {
               struct in6_addr loopback_sin6_addr = IN6ADDR_LOOPBACK_INIT;
+
               net_ipv6addr_copy(conn->u.ipv6.raddr,
                                 loopback_sin6_addr.s6_addr16);
             }

--- a/net/udp/udp_finddev.c
+++ b/net/udp/udp_finddev.c
@@ -68,47 +68,47 @@ FAR struct net_driver_s *udp_find_laddr_device(FAR struct udp_conn_s *conn)
 
 #ifdef CONFIG_NET_IPv4
 #ifdef CONFIG_NET_IPv6
-      if (conn->domain == PF_INET)
+  if (conn->domain == PF_INET)
 #endif
-        {
-          /* Make sure that the socket is bound to some non-zero, local
-           * address.  Zero is used as an indication that the laddr is
-           * uninitialized and that the socket is, hence, not bound.
-           */
+    {
+      /* Make sure that the socket is bound to some non-zero, local
+       * address.  Zero is used as an indication that the laddr is
+       * uninitialized and that the socket is, hence, not bound.
+       */
 
-          if (conn->u.ipv4.laddr == 0)
-            {
-              return NULL;
-            }
-          else
-            {
-              return netdev_findby_ripv4addr(conn->u.ipv4.laddr,
-                                             conn->u.ipv4.laddr);
-            }
+      if (conn->u.ipv4.laddr == 0)
+        {
+          return NULL;
         }
+      else
+        {
+          return netdev_findby_ripv4addr(conn->u.ipv4.laddr,
+                                         conn->u.ipv4.laddr);
+        }
+    }
 #endif
 
 #ifdef CONFIG_NET_IPv6
 #ifdef CONFIG_NET_IPv4
-      else
+  else
 #endif
-        {
-          /* Make sure that the socket is bound to some non-zero, local
-           * address.  The IPv6 unspecified address is used as an indication
-           * that the laddr is uninitialized and that the socket is, hence,
-           * not bound.
-           */
+    {
+      /* Make sure that the socket is bound to some non-zero, local
+       * address.  The IPv6 unspecified address is used as an indication
+       * that the laddr is uninitialized and that the socket is, hence,
+       * not bound.
+       */
 
-          if (net_ipv6addr_cmp(conn->u.ipv6.laddr, g_ipv6_unspecaddr))
-            {
-              return NULL;
-            }
-          else
-            {
-              return netdev_findby_ripv6addr(conn->u.ipv6.laddr,
-                                             conn->u.ipv6.laddr);
-            }
+      if (net_ipv6addr_cmp(conn->u.ipv6.laddr, g_ipv6_unspecaddr))
+        {
+          return NULL;
         }
+      else
+        {
+          return netdev_findby_ripv6addr(conn->u.ipv6.laddr,
+                                         conn->u.ipv6.laddr);
+        }
+    }
 #endif
 }
 
@@ -140,122 +140,125 @@ udp_find_raddr_device(FAR struct udp_conn_s *conn,
 
 #ifdef CONFIG_NET_IPv4
 #ifdef CONFIG_NET_IPv6
-      if (conn->domain == PF_INET)
+  if (conn->domain == PF_INET)
 #endif
-        {
-          in_addr_t raddr;
+    {
+      in_addr_t raddr;
 
-          if (remote)
-            {
-              FAR const struct sockaddr_in *inaddr =
-                (FAR const struct sockaddr_in *)remote;
-              net_ipv4addr_copy(raddr, inaddr->sin_addr.s_addr);
-            }
-          else
-            {
-              net_ipv4addr_copy(raddr, conn->u.ipv4.raddr);
-            }
+      if (remote)
+        {
+          FAR const struct sockaddr_in *inaddr =
+            (FAR const struct sockaddr_in *)remote;
+
+          net_ipv4addr_copy(raddr, inaddr->sin_addr.s_addr);
+        }
+      else
+        {
+          net_ipv4addr_copy(raddr, conn->u.ipv4.raddr);
+        }
 
 #if defined(CONFIG_NET_IGMP) && defined(CONFIG_NET_BINDTODEVICE)
-          if (IN_MULTICAST(NTOHL(raddr)))
+      if (IN_MULTICAST(NTOHL(raddr)))
+        {
+          if ((conn->sconn.s_boundto == 0) &&
+              (conn->mreq.imr_ifindex != 0))
             {
-              if ((conn->sconn.s_boundto == 0) &&
-                  (conn->mreq.imr_ifindex != 0))
-                {
-                  return netdev_findbyindex(conn->mreq.imr_ifindex);
-                }
+              return netdev_findbyindex(conn->mreq.imr_ifindex);
             }
-          else
+        }
+      else
 #endif
+        {
+          if (conn->u.ipv4.laddr != INADDR_ANY)
             {
-              if (conn->u.ipv4.laddr != INADDR_ANY)
-                {
-                  /* If the socket is bound to some non-zero, local address.
-                   * Normal lookup using the verified local address.
-                   */
+              /* If the socket is bound to some non-zero, local address.
+               * Normal lookup using the verified local address.
+               */
 
-                  return netdev_findby_lipv4addr(conn->u.ipv4.laddr);
-                }
+              return netdev_findby_lipv4addr(conn->u.ipv4.laddr);
+            }
 
 #ifdef CONFIG_NET_BINDTODEVICE
-              if (conn->sconn.s_boundto != 0)
-                {
-                  /* If the socket is bound to a local network device.
-                   * Select the network device that has been bound.
-                   * If the index is invalid, return NULL.
-                   */
+          if (conn->sconn.s_boundto != 0)
+            {
+              /* If the socket is bound to a local network device.
+               * Select the network device that has been bound.
+               * If the index is invalid, return NULL.
+               */
 
-                  return netdev_findbyindex(conn->sconn.s_boundto);
-                }
-#endif
+              return netdev_findbyindex(conn->sconn.s_boundto);
             }
-
-          /* Normal lookup using the verified remote address */
-
-          return netdev_findby_ripv4addr(conn->u.ipv4.laddr, raddr);
+#endif
         }
+
+      /* Normal lookup using the verified remote address */
+
+      return netdev_findby_ripv4addr(conn->u.ipv4.laddr, raddr);
+    }
 #endif
 
 #ifdef CONFIG_NET_IPv6
 #ifdef CONFIG_NET_IPv4
+  else
+#endif
+    {
+      struct in6_addr raddr;
+
+      if (remote)
+        {
+          FAR const struct sockaddr_in6 *inaddr =
+            (FAR const struct sockaddr_in6 *)remote;
+
+          net_ipv6addr_copy(raddr.in6_u.u6_addr16,
+                            inaddr->sin6_addr.s6_addr16);
+        }
+      else
+        {
+          net_ipv6addr_copy(raddr.in6_u.u6_addr16, conn->u.ipv6.raddr);
+        }
+
+#if defined(CONFIG_NET_MLD) && defined(CONFIG_NET_BINDTODEVICE)
+      if (IN6_IS_ADDR_MULTICAST(&raddr))
+        {
+          if (conn->mreq.imr_ifindex != 0)
+            {
+              return netdev_findbyindex(conn->mreq.imr_ifindex);
+            }
+          else if (conn->sconn.s_boundto != 0)
+            {
+              return netdev_findbyindex(conn->sconn.s_boundto);
+            }
+        }
       else
 #endif
         {
-          struct in6_addr raddr;
-          if (remote)
+          if (!net_ipv6addr_cmp(conn->u.ipv6.laddr, g_ipv6_unspecaddr))
             {
-              FAR const struct sockaddr_in6 *inaddr =
-                (FAR const struct sockaddr_in6 *)remote;
-              net_ipv6addr_copy(raddr.in6_u.u6_addr16,
-                                inaddr->sin6_addr.s6_addr16);
-            }
-          else
-            {
-              net_ipv6addr_copy(raddr.in6_u.u6_addr16, conn->u.ipv6.raddr);
-            }
+              /* If the socket is bound to some non-zero, local address.
+               * Normal lookup using the verified local address.
+               */
 
-#if defined(CONFIG_NET_MLD) && defined(CONFIG_NET_BINDTODEVICE)
-          if (IN6_IS_ADDR_MULTICAST(&raddr))
-            {
-              if (conn->mreq.imr_ifindex != 0)
-                {
-                  return netdev_findbyindex(conn->mreq.imr_ifindex);
-                }
-              else if (conn->sconn.s_boundto != 0)
-                {
-                  return netdev_findbyindex(conn->sconn.s_boundto);
-                }
+              return netdev_findby_lipv6addr(conn->u.ipv6.laddr);
             }
-          else
-#endif
-            {
-              if (!net_ipv6addr_cmp(conn->u.ipv6.laddr, g_ipv6_unspecaddr))
-                {
-                  /* If the socket is bound to some non-zero, local address.
-                   * Normal lookup using the verified local address.
-                   */
-
-                  return netdev_findby_lipv6addr(conn->u.ipv6.laddr);
-                }
 
 #ifdef CONFIG_NET_BINDTODEVICE
-              if (conn->sconn.s_boundto != 0)
-                {
-                  /* If the socket is bound to a local network device.
-                   * Select the network device that has been bound.
-                   * If the index is invalid, return NULL.
-                   */
+          if (conn->sconn.s_boundto != 0)
+            {
+              /* If the socket is bound to a local network device.
+               * Select the network device that has been bound.
+               * If the index is invalid, return NULL.
+               */
 
-                  return netdev_findbyindex(conn->sconn.s_boundto);
-                }
-#endif
+              return netdev_findbyindex(conn->sconn.s_boundto);
             }
-
-          /* Normal lookup using the verified remote address */
-
-          return netdev_findby_ripv6addr(conn->u.ipv6.laddr,
-                                         raddr.in6_u.u6_addr16);
+#endif
         }
+
+      /* Normal lookup using the verified remote address */
+
+      return netdev_findby_ripv6addr(conn->u.ipv6.laddr,
+                                     raddr.in6_u.u6_addr16);
+    }
 #endif
 }
 

--- a/net/udp/udp_input.c
+++ b/net/udp/udp_input.c
@@ -103,6 +103,7 @@ static bool udp_is_broadcast(FAR struct net_driver_s *dev)
 #  endif
     {
       FAR struct ipv6_hdr_s *ipv6 = IPv6BUF;
+
       return net_is_addr_mcast(ipv6->destipaddr);
     }
 #endif
@@ -381,7 +382,7 @@ static int udp_input(FAR struct net_driver_s *dev, unsigned int iplen)
 #  endif /* CONFIG_NET_IPv4 */
 #  ifdef CONFIG_NET_IPv6
 #    ifdef CONFIG_NET_IPv4
-           else
+          else
 #    endif
             {
 #    ifdef CONFIG_NET_ICMPv6

--- a/net/udp/udp_ioctl.c
+++ b/net/udp/udp_ioctl.c
@@ -127,6 +127,7 @@ int udp_ioctl(FAR struct udp_conn_s *conn, int cmd, unsigned long arg)
         if (iob)
           {
             uint16_t datalen;
+
             iob_copyout((FAR uint8_t *)&datalen, iob, sizeof(datalen), 0);
             *(FAR int *)((uintptr_t)arg) = datalen;
           }

--- a/net/udp/udp_recvfrom.c
+++ b/net/udp/udp_recvfrom.c
@@ -225,6 +225,7 @@ static inline void udp_readahead(struct udp_recvfrom_s *pstate)
       if (conn->timestamp)
         {
           struct timespec timestamp;
+
           recvlen = iob_copyout((FAR uint8_t *)&timestamp, iob,
                                 sizeof(struct timespec), offset);
           DEBUGASSERT(recvlen == sizeof(struct timespec));

--- a/net/udp/udp_send.c
+++ b/net/udp/udp_send.c
@@ -87,6 +87,7 @@
 static void udp_send_loopback(FAR struct net_driver_s *dev)
 {
   FAR struct iob_s *iob = netdev_iob_clone(dev, true);
+
   if (iob == NULL)
     {
       nerr("ERROR: IOB clone failed when looping UDP.\n");

--- a/net/udp/udp_sendto_unbuffered.c
+++ b/net/udp/udp_sendto_unbuffered.c
@@ -202,6 +202,7 @@ static uint32_t sendto_eventhandler(FAR struct net_driver_s *dev,
             {
               int ret = devif_send(dev, pstate->st_buffer, pstate->st_buflen,
                                    udpip_hdrsize(pstate->st_conn));
+
               if (ret <= 0)
                 {
                   pstate->st_sndlen = ret;
@@ -216,9 +217,9 @@ static uint32_t sendto_eventhandler(FAR struct net_driver_s *dev,
                   goto end_wait;
                 }
 
-                iob_update_pktlen(dev->d_iob, udpip_hdrsize(pstate->st_conn),
-                                  false);
-                dev->d_sndlen = 0;
+              iob_update_pktlen(dev->d_iob, udpip_hdrsize(pstate->st_conn),
+                                false);
+              dev->d_sndlen = 0;
             }
 
           dev->d_len = dev->d_iob->io_pktlen;

--- a/net/udp/udp_wrbuffer.c
+++ b/net/udp/udp_wrbuffer.c
@@ -205,7 +205,7 @@ FAR struct udp_wrbuffer_s *udp_wrbuffer_tryalloc(void)
 #ifdef CONFIG_NET_JUMBO_FRAME
     iob_alloc_dynamic(len);
 #else
-    iob_tryalloc(false);
+  iob_tryalloc(false);
 #endif
   if (!wrb->wb_iob)
     {

--- a/net/usrsock/usrsock_devif.c
+++ b/net/usrsock/usrsock_devif.c
@@ -200,55 +200,57 @@ static ssize_t usrsock_handle_event(FAR const void *buffer, size_t len)
 
   switch (common->msgid)
     {
-    case USRSOCK_MESSAGE_SOCKET_EVENT:
-      {
-        FAR const struct usrsock_message_socket_event_s *hdr = buffer;
-        FAR struct usrsock_conn_s *conn;
-        int ret;
+      case USRSOCK_MESSAGE_SOCKET_EVENT:
+        {
+          FAR const struct usrsock_message_socket_event_s *hdr = buffer;
+          FAR struct usrsock_conn_s *conn;
+          int ret;
 
-        if (len < sizeof(*hdr))
-          {
-            nerr("message too short, %zu < %zu.\n", len, sizeof(*hdr));
-            return -EINVAL;
-          }
+          if (len < sizeof(*hdr))
+            {
+              nerr("message too short, %zu < %zu.\n", len, sizeof(*hdr));
+              return -EINVAL;
+            }
 
-        len = sizeof(*hdr);
+          len = sizeof(*hdr);
 
-        /* Get corresponding usrsock connection. */
+          /* Get corresponding usrsock connection. */
 
-        conn = usrsock_active(hdr->usockid);
-        if (!conn)
-          {
-            nerr("no active connection for usockid=%d, events=%x.\n",
-                 hdr->usockid, hdr->head.events);
+          conn = usrsock_active(hdr->usockid);
+          if (!conn)
+            {
+              nerr("no active connection for usockid=%d, events=%x.\n",
+                   hdr->usockid, hdr->head.events);
 
-            /* We may receive event after socket close if message from lower
-             * layer is out of order, but it's OK to ignore such error.
-             */
+              /* We may receive event after socket close if message from
+               * lower layer is out of order, but it's OK to ignore such
+               * error.
+               */
 
-            return len;
-          }
+              return len;
+            }
 
 #ifdef CONFIG_DEV_RANDOM
-        /* Add randomness. */
+          /* Add randomness. */
 
-        add_sw_randomness((hdr->head.events << 16) - hdr->usockid);
+          add_sw_randomness((hdr->head.events << 16) - hdr->usockid);
 #endif
 
-        /* Handle event. */
+          /* Handle event. */
 
-        conn->resp.events = hdr->head.events & ~USRSOCK_EVENT_INTERNAL_MASK;
-        ret = usrsock_event(conn);
-        if (ret < 0)
-          {
-            return ret;
-          }
-      }
-      break;
+          conn->resp.events = hdr->head.events &
+                              ~USRSOCK_EVENT_INTERNAL_MASK;
+          ret = usrsock_event(conn);
+          if (ret < 0)
+            {
+              return ret;
+            }
+        }
+        break;
 
-    default:
-      nerr("Unknown event type: %d\n", common->msgid);
-      return -EINVAL;
+      default:
+        nerr("Unknown event type: %d\n", common->msgid);
+        return -EINVAL;
     }
 
   return len;
@@ -444,21 +446,21 @@ static ssize_t usrsock_handle_req_response(FAR const void *buffer,
 
   switch (hdr->head.msgid)
     {
-    case USRSOCK_MESSAGE_RESPONSE_ACK:
-      hdrlen = sizeof(struct usrsock_message_req_ack_s);
-      handle_response = &usrsock_handle_response;
-      break;
+      case USRSOCK_MESSAGE_RESPONSE_ACK:
+        hdrlen = sizeof(struct usrsock_message_req_ack_s);
+        handle_response = &usrsock_handle_response;
+        break;
 
-    case USRSOCK_MESSAGE_RESPONSE_DATA_ACK:
-      hdrlen = sizeof(struct usrsock_message_datareq_ack_s);
-      handle_response = &usrsock_handle_datareq_response;
-      break;
+      case USRSOCK_MESSAGE_RESPONSE_DATA_ACK:
+        hdrlen = sizeof(struct usrsock_message_datareq_ack_s);
+        handle_response = &usrsock_handle_datareq_response;
+        break;
 
-    default:
-      nerr("unknown message type: %d, flags: %d, xid: %" PRIu32 ", "
-           "result: %" PRId32 "\n",
-           hdr->head.msgid, hdr->head.flags, hdr->xid, hdr->result);
-      return -EINVAL;
+      default:
+        nerr("unknown message type: %d, flags: %d, xid: %" PRIu32 ", "
+             "result: %" PRId32 "\n",
+             hdr->head.msgid, hdr->head.flags, hdr->xid, hdr->result);
+        return -EINVAL;
     }
 
   if (len < hdrlen)

--- a/net/usrsock/usrsock_ioctl.c
+++ b/net/usrsock/usrsock_ioctl.c
@@ -136,6 +136,7 @@ static int do_ioctl_request(FAR struct usrsock_conn_s *conn, int cmd,
   if (WL_IS80211POINTERCMD(cmd))
     {
       FAR struct iwreq *wlreq = arg;
+
       bufs[2].iov_base = wlreq->u.data.pointer;
       bufs[2].iov_len = wlreq->u.data.length;
     }
@@ -224,6 +225,7 @@ int usrsock_ioctl(FAR struct socket *psock, int cmd, unsigned long arg_)
   if (WL_IS80211POINTERCMD(cmd))
     {
       FAR struct iwreq *wlreq = arg;
+
       inbufs[1].iov_base = wlreq->u.data.pointer;
       inbufs[1].iov_len = wlreq->u.data.length;
     }

--- a/net/usrsock/usrsock_sendmsg.c
+++ b/net/usrsock/usrsock_sendmsg.c
@@ -364,7 +364,7 @@ ssize_t usrsock_sendmsg(FAR struct socket *psock,
 
       /* MSG_DONTWAIT is only use in usrsock. */
 
-       flags &= ~MSG_DONTWAIT;
+      flags &= ~MSG_DONTWAIT;
 
       /* Request user-space daemon to close socket. */
 

--- a/net/utils/net_bufpool.c
+++ b/net/utils/net_bufpool.c
@@ -69,6 +69,7 @@ static void net_bufpool_init(FAR struct net_bufpool_s *pool)
     {
       FAR struct net_bufnode_s *node = (FAR struct net_bufnode_s *)
                                       (pool->pool + i * pool->nodesize);
+
       sq_addlast(&node->node, &pool->freebuffers);
     }
 }

--- a/net/utils/net_dsec2timeval.c
+++ b/net/utils/net_dsec2timeval.c
@@ -57,6 +57,7 @@
 void net_dsec2timeval(uint16_t dsec, FAR struct timeval *tv)
 {
   uint16_t remainder;
+
   tv->tv_sec  = dsec / DSEC_PER_SEC;
   remainder   = dsec - tv->tv_sec * DSEC_PER_SEC;
   tv->tv_usec = remainder * USEC_PER_DSEC;

--- a/net/utils/net_mask2pref.c
+++ b/net/utils/net_mask2pref.c
@@ -150,6 +150,7 @@ uint8_t net_ipv4_mask2pref(in_addr_t mask)
 {
   uint32_t hmask = NTOHL(mask);
   uint8_t ones = net_msbits16((uint16_t)(hmask >> 16));
+
   if (ones == 16)
     {
       ones += net_msbits16((uint16_t)(hmask & 0xffff));

--- a/net/utils/net_timeval2dsec.c
+++ b/net/utils/net_timeval2dsec.c
@@ -61,17 +61,17 @@ unsigned int net_timeval2dsec(FAR struct timeval *tv,
 
   switch (remainder)
     {
-    default:
-    case TV2DS_TRUNC: /* Truncate microsecond remainder */
-      break;
+      default:
+      case TV2DS_TRUNC: /* Truncate microsecond remainder */
+        break;
 
-    case TV2DS_ROUND: /* Round to the nearest full decisecond */
-      adjust = (USEC_PER_DSEC / 2);
-      break;
+      case TV2DS_ROUND: /* Round to the nearest full decisecond */
+        adjust = (USEC_PER_DSEC / 2);
+        break;
 
-    case TV2DS_CEIL:  /* Force to next larger full decisecond */
-      adjust = (USEC_PER_DSEC - 1);
-      break;
+      case TV2DS_CEIL:  /* Force to next larger full decisecond */
+        adjust = (USEC_PER_DSEC - 1);
+        break;
     }
 
   return (unsigned int)(tv->tv_sec * DSEC_PER_SEC +

--- a/sched/addrenv/addrenv.c
+++ b/sched/addrenv/addrenv.c
@@ -349,6 +349,7 @@ int addrenv_select(FAR struct addrenv_s *addrenv,
                    FAR struct addrenv_s **oldenv)
 {
   FAR struct tcb_s *tcb = this_task();
+
   addrenv_take(addrenv);
   *oldenv = tcb->addrenv_curr;
   tcb->addrenv_curr = addrenv;
@@ -374,6 +375,7 @@ int addrenv_select(FAR struct addrenv_s *addrenv,
 int addrenv_restore(FAR struct addrenv_s *addrenv)
 {
   FAR struct tcb_s *tcb = this_task();
+
   addrenv_give(tcb->addrenv_curr);
   tcb->addrenv_curr = addrenv;
   return addrenv_switch(tcb);

--- a/sched/addrenv/addrenv.c
+++ b/sched/addrenv/addrenv.c
@@ -414,6 +414,7 @@ int addrenv_select(FAR struct addrenv_s *addrenv,
                    FAR struct addrenv_s **oldenv)
 {
   FAR struct tcb_s *tcb = this_task();
+
   addrenv_take(addrenv);
   *oldenv = tcb->addrenv_curr;
   tcb->addrenv_curr = addrenv;
@@ -439,6 +440,7 @@ int addrenv_select(FAR struct addrenv_s *addrenv,
 int addrenv_restore(FAR struct addrenv_s *addrenv)
 {
   FAR struct tcb_s *tcb = this_task();
+
   addrenv_give(tcb->addrenv_curr);
   tcb->addrenv_curr = addrenv;
   return addrenv_switch(tcb);

--- a/sched/clock/clock_timekeeping.c
+++ b/sched/clock/clock_timekeeping.c
@@ -248,6 +248,7 @@ void clock_update_wall_time(void)
   if (g_clock_adjust != 0 && sec > 0)
     {
       long adjust = NTP_MAX_ADJUST * (long)sec;
+
       if (g_clock_adjust < adjust && g_clock_adjust > -adjust)
         {
           adjust = g_clock_adjust;

--- a/sched/environ/env_clearenv.c
+++ b/sched/environ/env_clearenv.c
@@ -60,6 +60,7 @@
 int clearenv(void)
 {
   FAR struct tcb_s *tcb = this_task();
+
   DEBUGASSERT(tcb->group);
 
   env_release(tcb->group);

--- a/sched/group/group_free.c
+++ b/sched/group/group_free.c
@@ -56,6 +56,7 @@ void group_free(FAR struct task_group_s *group, FAR void *mem)
   if (!group)
     {
       FAR struct tcb_s *tcb = this_task();
+
       DEBUGASSERT(tcb && tcb->group);
       group = tcb->group;
     }

--- a/sched/group/group_malloc.c
+++ b/sched/group/group_malloc.c
@@ -59,6 +59,7 @@ FAR void *group_malloc(FAR struct task_group_s *group, size_t nbytes)
   if (!group)
     {
       FAR struct tcb_s *tcb = this_task();
+
       DEBUGASSERT(tcb && tcb->group);
       group = tcb->group;
     }

--- a/sched/group/group_realloc.c
+++ b/sched/group/group_realloc.c
@@ -60,6 +60,7 @@ FAR void *group_realloc(FAR struct task_group_s *group, FAR void *oldmem,
   if (group == NULL)
     {
       FAR struct tcb_s *tcb = this_task();
+
       DEBUGASSERT(tcb && tcb->group);
       group = tcb->group;
     }

--- a/sched/group/group_zalloc.c
+++ b/sched/group/group_zalloc.c
@@ -50,6 +50,7 @@
 FAR void *group_zalloc(FAR struct task_group_s *group, size_t nbytes)
 {
   FAR void *mem = group_malloc(group, nbytes);
+
   if (mem)
     {
       memset(mem, 0, nbytes);

--- a/sched/hrtimer/hrtimer_cancel.c
+++ b/sched/hrtimer/hrtimer_cancel.c
@@ -141,7 +141,7 @@ int hrtimer_cancel_sync(FAR hrtimer_t *hrtimer)
     {
       /* Wait until all the timer callbacks finish. */
 
-       hrtimer_wait(hrtimer);
+      hrtimer_wait(hrtimer);
     }
 
   return ret;

--- a/sched/init/nx_start.c
+++ b/sched/init/nx_start.c
@@ -541,38 +541,38 @@ void nx_start(void)
     defined(CONFIG_MM_PGALLOC)
   /* Initialize the memory manager */
 
-    {
-      FAR void *heap_start;
-      size_t heap_size;
+  {
+    FAR void *heap_start;
+    size_t heap_size;
 
 #ifdef MM_KERNEL_USRHEAP_INIT
-      /* Get the user-mode heap from the platform specific code and configure
-       * the user-mode memory allocator.
-       */
+    /* Get the user-mode heap from the platform specific code and configure
+     * the user-mode memory allocator.
+     */
 
-      up_allocate_heap(&heap_start, &heap_size);
-      kumm_initialize(heap_start, heap_size);
+    up_allocate_heap(&heap_start, &heap_size);
+    kumm_initialize(heap_start, heap_size);
 #endif
 
 #ifdef CONFIG_MM_KERNEL_HEAP
-      /* Get the kernel-mode heap from the platform specific code and
-       * configure the kernel-mode memory allocator.
-       */
+    /* Get the kernel-mode heap from the platform specific code and
+     * configure the kernel-mode memory allocator.
+     */
 
-      up_allocate_kheap(&heap_start, &heap_size);
-      kmm_initialize(heap_start, heap_size);
+    up_allocate_kheap(&heap_start, &heap_size);
+    kmm_initialize(heap_start, heap_size);
 #endif
 
 #ifdef CONFIG_MM_PGALLOC
-      /* If there is a page allocator in the configuration, then get the page
-       * heap information from the platform-specific code and configure the
-       * page allocator.
-       */
+    /* If there is a page allocator in the configuration, then get the page
+     * heap information from the platform-specific code and configure the
+     * page allocator.
+     */
 
-      up_allocate_pgheap(&heap_start, &heap_size);
-      mm_pginitialize(heap_start, heap_size);
+    up_allocate_pgheap(&heap_start, &heap_size);
+    mm_pginitialize(heap_start, heap_size);
 #endif
-    }
+  }
 #endif
 
 #ifdef CONFIG_MM_KMAP

--- a/sched/irq/irq_attach.c
+++ b/sched/irq/irq_attach.c
@@ -74,9 +74,11 @@ int irq_to_ndx(int irq)
   DEBUGASSERT(g_irqmap_count < CONFIG_ARCH_NUSER_INTERRUPTS);
 
   irqstate_t flags = spin_lock_irqsave(&g_irqlock);
+
   if (g_irqmap[irq] == 0)
     {
       int ndx = g_irqmap_count++;
+
       g_irqmap[irq] = ndx;
       g_irqrevmap[ndx] = irq;
     }
@@ -116,6 +118,7 @@ int irq_attach(int irq, xcpt_t isr, FAR void *arg)
   int ret = OK;
 #if NR_IRQS > 0
   int ndx = IRQ_TO_NDX(irq);
+
   if (ndx < 0)
     {
       ret = ndx;
@@ -128,6 +131,7 @@ int irq_attach(int irq, xcpt_t isr, FAR void *arg)
        */
 
       irqstate_t flags = spin_lock_irqsave(&g_irqlock);
+
       if (isr == NULL)
         {
           /* Disable the interrupt if we can before detaching it.  We might

--- a/sched/irq/irq_attach_thread.c
+++ b/sched/irq/irq_attach_thread.c
@@ -156,6 +156,7 @@ int irq_attach_thread(int irq, xcpt_t isr, xcpt_t isrthread, FAR void *arg,
   char arg4[32];  /* arg */
   pid_t pid;
   int ndx = IRQ_TO_NDX(irq);
+
   if (ndx < 0)
     {
       ret = ndx;

--- a/sched/irq/irq_attach_wqueue.c
+++ b/sched/irq/irq_attach_wqueue.c
@@ -176,6 +176,7 @@ int irq_attach_wqueue(int irq, xcpt_t isr, xcpt_t isrwork,
   int ret = OK;
 #if NR_IRQS > 0
   int ndx = IRQ_TO_NDX(irq);
+
   if (ndx < 0)
     {
       ret = ndx;

--- a/sched/irq/irq_chain.c
+++ b/sched/irq/irq_chain.c
@@ -217,6 +217,7 @@ int irqchain_detach(int irq, xcpt_t isr, FAR void *arg)
   FAR struct irqchain_s *curr;
   FAR struct irqchain_s *first;
   int ndx = IRQ_TO_NDX(irq);
+
   if (ndx < 0)
     {
       ret = ndx;

--- a/sched/irq/irq_csection.c
+++ b/sched/irq/irq_csection.c
@@ -268,6 +268,7 @@ irqstate_t enter_critical_section_notrace(void)
   if (!up_interrupt_context())
     {
       FAR struct tcb_s *rtcb = this_task();
+
       DEBUGASSERT(rtcb != NULL);
 
       /* Have we just entered the critical section?  Or is this a nested
@@ -367,6 +368,7 @@ void leave_critical_section_notrace(irqstate_t flags)
                       g_cpu_nestcount[cpu] == 1);
 
           FAR struct tcb_s *rtcb = current_task(cpu);
+
           DEBUGASSERT(rtcb != NULL);
           DEBUGASSERT((g_cpu_irqset & (1 << cpu)) != 0);
 
@@ -441,6 +443,7 @@ void leave_critical_section_notrace(irqstate_t flags)
   if (!up_interrupt_context())
     {
       FAR struct tcb_s *rtcb = this_task();
+
       DEBUGASSERT(rtcb != NULL);
 
       /* Have we left entered the critical section?  Or are we still

--- a/sched/irq/irq_dispatch.c
+++ b/sched/irq/irq_dispatch.c
@@ -159,7 +159,7 @@ void irq_dispatch(int irq, FAR void *context)
 
 #if defined(CONFIG_STACKCHECK_MARGIN) && (CONFIG_STACKCHECK_MARGIN > 0) && \
     defined(CONFIG_ARCH_INTERRUPTSTACK) && (CONFIG_ARCH_INTERRUPTSTACK > 0)
-    DEBUGASSERT(up_check_intstack(this_cpu(),
-                                  CONFIG_STACKCHECK_MARGIN) == 0);
+  DEBUGASSERT(up_check_intstack(this_cpu(),
+                                CONFIG_STACKCHECK_MARGIN) == 0);
 #endif
 }

--- a/sched/irq/irq_procfs.c
+++ b/sched/irq/irq_procfs.c
@@ -214,6 +214,7 @@ static int irq_callback(int irq, FAR struct irq_info_s *info,
   else
     {
       uint64_t intcount = ((uint64_t)intpart * elapsed);
+
       fracpart = (unsigned int)
         (((copy.count * TICK_PER_SEC - intcount) * 1000) / elapsed);
     }

--- a/sched/irq/irq_spinlock.c
+++ b/sched/irq/irq_spinlock.c
@@ -73,6 +73,7 @@
 irqstate_t read_lock_irqsave(FAR rwlock_t *lock)
 {
   irqstate_t ret;
+
   ret = up_irq_save();
 
   read_lock(lock);
@@ -137,6 +138,7 @@ void read_unlock_irqrestore(rwlock_t *lock, irqstate_t flags)
 irqstate_t write_lock_irqsave(rwlock_t *lock)
 {
   irqstate_t ret;
+
   ret = up_irq_save();
 
   write_lock(lock);

--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -210,6 +210,7 @@ static void dump_stackinfo(FAR const char *tag, uintptr_t sp,
   if (sp != 0)
     {
       uintptr_t top = base + size;
+
       _alert("    sp: %p\n", (FAR void *)sp);
 
       /* Get more information */
@@ -252,6 +253,7 @@ static void dump_stacks(FAR struct tcb_s *rtcb, uintptr_t sp)
   int cpu = rtcb->cpu;
 #else
   int cpu = this_cpu();
+
   UNUSED(cpu);
 #endif
 #if CONFIG_ARCH_INTERRUPTSTACK > 0
@@ -477,6 +479,7 @@ static void dump_backtrace(FAR struct tcb_s *tcb, FAR void *arg)
 static void dump_fdlist(FAR struct tcb_s *tcb, FAR void *arg)
 {
   FAR struct fdlist *list = &tcb->group->tg_fdlist;
+
   fdlist_dump(list);
 }
 #endif

--- a/sched/misc/coredump.c
+++ b/sched/misc/coredump.c
@@ -374,7 +374,7 @@ static void elf_emit_note(FAR struct elf_dumpinfo_s *cinfo)
 
   if (cinfo->pid == INVALID_PROCESS_ID)
     {
-     FAR struct tcb_s *rtcb = running_task();
+      FAR struct tcb_s *rtcb = running_task();
 
       /* Emit the current (typically crashing) task first so that GDB's
        * default thread selection shows the crashing backtrace on the initial
@@ -650,6 +650,7 @@ static void elf_emit_phdr(FAR struct elf_dumpinfo_s *cinfo,
 {
   off_t offset = cinfo->stream->nput +
                  (stksegs + memsegs + 1 + 1) * sizeof(Elf_Phdr);
+
   Elf_Phdr phdr;
   int i;
 

--- a/sched/mqueue/mq_initialize.c
+++ b/sched/mqueue/mq_initialize.c
@@ -135,6 +135,7 @@ static FAR void *sysv_msgblockinit(FAR struct list_node *list,
                                    FAR struct msgbuf_s *msg, uint16_t nmsgs)
 {
   int i;
+
   for (i = 0; i < nmsgs; i++)
     {
       list_add_tail(list, &msg->node);

--- a/sched/paging/pg_worker.c
+++ b/sched/paging/pg_worker.c
@@ -148,6 +148,7 @@ static void pg_callback(FAR struct tcb_s *tcb, int result)
        */
 
       int priority = g_pftcb->sched_priority;
+
       if (htcb && priority < htcb->sched_priority)
         {
           priority = htcb->sched_priority;
@@ -266,6 +267,7 @@ static inline bool pg_dequeue(void)
                    */
 
                   int priority = g_pftcb->sched_priority;
+
                   if (priority < CONFIG_PAGING_DEFPRIO)
                     {
                       priority = CONFIG_PAGING_DEFPRIO;
@@ -447,6 +449,7 @@ static inline bool pg_startfill(void)
 static inline void pg_alldone(void)
 {
   FAR struct tcb_s *wtcb = this_task();
+
   g_pftcb = NULL;
   pginfo("New worker priority. %d->%d\n",
          wtcb->sched_priority, CONFIG_PAGING_DEFPRIO);

--- a/sched/sched/sched_cpuload.c
+++ b/sched/sched/sched_cpuload.c
@@ -113,6 +113,7 @@ volatile clock_t g_cpuload_total;
 static void cpuload_callback(wdparm_t arg)
 {
   FAR struct wdog_s *wdog = (FAR struct wdog_s *)arg;
+
   nxsched_process_cpuload_ticks(CPULOAD_SAMPLING_PERIOD);
   wd_start_next(wdog, CPULOAD_SAMPLING_PERIOD, cpuload_callback, arg);
 }
@@ -196,6 +197,7 @@ void nxsched_process_cpuload_ticks(clock_t ticks)
   for (i = 0; i < CONFIG_SMP_NCPUS; i++)
     {
       FAR struct tcb_s *rtcb = current_task(i);
+
       nxsched_process_taskload_ticks(rtcb, ticks);
     }
 }

--- a/sched/sched/sched_critmonitor.c
+++ b/sched/sched/sched_critmonitor.c
@@ -154,6 +154,7 @@ static void nxsched_critmon_cpuload(FAR struct tcb_s *tcb, clock_t current,
                                     clock_t tick)
 {
   int i;
+
   UNUSED(i);
 
   /* Update the cpuload of the thread ready to be suspended */
@@ -374,6 +375,7 @@ void nxsched_switch_critmon(FAR struct tcb_s *from, FAR struct tcb_s *to)
 
 #ifdef CONFIG_SCHED_CPULOAD_CRITMONITOR
   clock_t tick = elapsed * CLOCKS_PER_SEC / perf_getfreq();
+
   nxsched_critmon_cpuload(from, current, tick);
   to->run_start = current;
 #endif
@@ -465,6 +467,7 @@ void nxsched_update_critmon(FAR struct tcb_s *tcb)
     {
 #ifdef CONFIG_SCHED_CPULOAD_CRITMONITOR
       clock_t tick = elapsed * CLOCKS_PER_SEC / perf_getfreq();
+
       nxsched_process_taskload_ticks(tcb, tick);
 #endif
 

--- a/sched/sched/sched_get_stateinfo.c
+++ b/sched/sched/sched_get_stateinfo.c
@@ -102,6 +102,7 @@ void nxsched_get_stateinfo(FAR struct tcb_s *tcb, FAR char *state,
       ((FAR sem_t *)(tcb->waitobj))->flags & SEM_TYPE_MUTEX)
     {
       pid_t holder = nxmutex_get_holder((FAR mutex_t *)tcb->waitobj);
+
       leave_critical_section(flags);
 
       snprintf(state, length, "Waiting,Mutex:%d", holder);

--- a/sched/sched/sched_getaffinity.c
+++ b/sched/sched/sched_getaffinity.c
@@ -133,6 +133,7 @@ int nxsched_get_affinity(pid_t pid, size_t cpusetsize, FAR cpu_set_t *mask)
 int sched_getaffinity(pid_t pid, size_t cpusetsize, FAR cpu_set_t *mask)
 {
   int ret = nxsched_get_affinity(pid, cpusetsize, mask);
+
   if (ret < 0)
     {
       set_errno(-ret);

--- a/sched/sched/sched_getparam.c
+++ b/sched/sched/sched_getparam.c
@@ -57,6 +57,7 @@ static void nxsched_get_sporadic_param(FAR struct tcb_s *tcb,
   if ((tcb->flags & TCB_FLAG_POLICY_MASK) == TCB_FLAG_SCHED_SPORADIC)
     {
       FAR struct sporadic_s *sporadic = tcb->sporadic;
+
       DEBUGASSERT(sporadic != NULL);
 
       /* Return parameters associated with SCHED_SPORADIC */
@@ -205,6 +206,7 @@ int nxsched_get_param(pid_t pid, FAR struct sched_param *param)
 int sched_getparam(pid_t pid, FAR struct sched_param *param)
 {
   int ret = nxsched_get_param(pid, param);
+
   if (ret < 0)
     {
       set_errno(-ret);

--- a/sched/sched/sched_getscheduler.c
+++ b/sched/sched/sched_getscheduler.c
@@ -126,6 +126,7 @@ int nxsched_get_scheduler(pid_t pid)
 int sched_getscheduler(pid_t pid)
 {
   int ret = nxsched_get_scheduler(pid);
+
   if (ret < 0)
     {
       set_errno(-ret);

--- a/sched/sched/sched_lockcount.c
+++ b/sched/sched/sched_lockcount.c
@@ -55,5 +55,6 @@
 int sched_lockcount(void)
 {
   FAR struct tcb_s *rtcb = this_task();
+
   return (int)rtcb->lockcount;
 }

--- a/sched/sched/sched_process_delivered.c
+++ b/sched/sched/sched_process_delivered.c
@@ -101,10 +101,12 @@ void nxsched_process_delivered(int cpu)
        */
 
       FAR struct tcb_s *tcb = (FAR struct tcb_s *)dq_peek(list_readytorun());
+
       if (tcb)
         {
           int target_cpu = tcb->flags & TCB_FLAG_CPU_LOCKED ?
             tcb->cpu : nxsched_select_cpu(tcb->affinity);
+
           if (target_cpu != cpu &&
               current_task(target_cpu)->sched_priority < tcb->sched_priority)
             {

--- a/sched/sched/sched_processtickless.c
+++ b/sched/sched/sched_processtickless.c
@@ -106,6 +106,7 @@ int up_timer_gettick(FAR clock_t *ticks)
 {
   struct timespec ts;
   int ret;
+
   ret = up_timer_gettime(&ts);
   *ticks = clock_time2ticks_floor(&ts);
   return ret;
@@ -116,6 +117,7 @@ int up_timer_gettick(FAR clock_t *ticks)
 int up_alarm_tick_start(clock_t ticks)
 {
   struct timespec ts;
+
   clock_ticks2time(&ts, ticks);
   return up_alarm_start(&ts);
 }
@@ -125,6 +127,7 @@ int up_alarm_tick_start(clock_t ticks)
 int up_timer_tick_start(clock_t ticks)
 {
   struct timespec ts;
+
   clock_ticks2time(&ts, ticks);
   return up_timer_start(&ts);
 }
@@ -213,6 +216,7 @@ static clock_t nxsched_cpu_scheduler(int cpu, clock_t ticks,
   if ((rtcb->flags & TCB_FLAG_POLICY_MASK) == TCB_FLAG_SCHED_SPORADIC)
     {
       FAR struct sporadic_s *sporadic = rtcb->sporadic;
+
       DEBUGASSERT(sporadic);
 
       /* Save the last time that the scheduler ran.  This time was saved
@@ -385,6 +389,7 @@ void nxsched_process_timer(void)
   /* Workaround for SCHED_RR, see the note. */
 
   irqstate_t flags = enter_critical_section();
+
   nxsched_process_event(ticks, true);
   leave_critical_section(flags);
 #  endif

--- a/sched/sched/sched_profil.c
+++ b/sched/sched/sched_profil.c
@@ -96,6 +96,7 @@ static void profil_timer_handler(wdparm_t arg)
 
 #ifdef CONFIG_SMP
   cpu_set_t cpus = (1 << CONFIG_SMP_NCPUS) - 1;
+
   CPU_CLR(this_cpu(), &cpus);
   nxsched_smp_call_async(cpus, &g_call_data);
 #endif

--- a/sched/sched/sched_removereadytorun.c
+++ b/sched/sched/sched_removereadytorun.c
@@ -82,6 +82,7 @@ bool nxsched_remove_readytorun(FAR struct tcb_s *rtcb)
        */
 
       FAR struct tcb_s *nxttcb = (FAR struct tcb_s *)rtcb->flink;
+
       DEBUGASSERT(nxttcb != NULL);
 
       nxttcb->task_state = TSTATE_TASK_RUNNING;

--- a/sched/sched/sched_reprioritize.c
+++ b/sched/sched/sched_reprioritize.c
@@ -73,6 +73,7 @@ int nxsched_reprioritize(FAR struct tcb_s *tcb, int sched_priority)
    */
 
   int ret = nxsched_set_priority(tcb, sched_priority);
+
   if (ret == 0)
     {
       /* Reset the base_priority -- the priority that the thread would return

--- a/sched/sched/sched_setaffinity.c
+++ b/sched/sched/sched_setaffinity.c
@@ -189,6 +189,7 @@ int sched_setaffinity(pid_t pid, size_t cpusetsize,
                       FAR const cpu_set_t *mask)
 {
   int ret = nxsched_set_affinity(pid, cpusetsize, mask);
+
   if (ret < 0)
     {
       set_errno(-ret);

--- a/sched/sched/sched_setparam.c
+++ b/sched/sched/sched_setparam.c
@@ -271,6 +271,7 @@ int nxsched_set_param(pid_t pid, FAR const struct sched_param *param)
 int sched_setparam(pid_t pid, FAR const struct sched_param *param)
 {
   int ret = nxsched_set_param(pid, param);
+
   if (ret < 0)
     {
       set_errno(-ret);

--- a/sched/sched/sched_setpriority.c
+++ b/sched/sched/sched_setpriority.c
@@ -127,6 +127,7 @@ static inline void nxsched_running_setpriority(FAR struct tcb_s *tcb,
           do
             {
               bool check = nxsched_remove_readytorun(nxttcb);
+
               DEBUGASSERT(check == false);
               UNUSED(check);
 
@@ -330,7 +331,7 @@ int nxsched_set_priority(FAR struct tcb_s *tcb, int sched_priority)
         }
 
       leave_critical_section(flags);
-   }
+    }
 
   return ret;
 }

--- a/sched/sched/sched_setpriority.c
+++ b/sched/sched/sched_setpriority.c
@@ -108,6 +108,7 @@ static inline void nxsched_running_setpriority(FAR struct tcb_s *tcb,
           do
             {
               bool check = nxsched_remove_readytorun(nxttcb);
+
               DEBUGASSERT(check == false);
               UNUSED(check);
 
@@ -311,7 +312,7 @@ int nxsched_set_priority(FAR struct tcb_s *tcb, int sched_priority)
         }
 
       leave_critical_section(flags);
-   }
+    }
 
   return ret;
 }

--- a/sched/sched/sched_setscheduler.c
+++ b/sched/sched/sched_setscheduler.c
@@ -314,6 +314,7 @@ int sched_setscheduler(pid_t pid, int policy,
                        FAR const struct sched_param *param)
 {
   int ret = nxsched_set_scheduler(pid, policy, param);
+
   if (ret < 0)
     {
       set_errno(-ret);

--- a/sched/sched/sched_smp.c
+++ b/sched/sched/sched_smp.c
@@ -244,6 +244,7 @@ int nxsched_smp_call(cpu_set_t cpuset, nxsched_smp_call_t func,
   for (i = 0; i < cpucnt; i++)
     {
       int rc = nxsem_wait_uninterruptible(&cookie.sem);
+
       if (rc < 0)
         {
           ret = rc;

--- a/sched/sched/sched_sporadic.c
+++ b/sched/sched/sched_sporadic.c
@@ -731,6 +731,7 @@ FAR struct replenishment_s *
       for (i = 0; i < sporadic->max_repl; i++)
         {
           FAR struct replenishment_s *tmp = &sporadic->replenishments[i];
+
           if ((tmp->flags & SPORADIC_FLAG_ALLOCED) == 0)
             {
               repl        = tmp;

--- a/sched/sched/sched_suspend.c
+++ b/sched/sched/sched_suspend.c
@@ -117,6 +117,7 @@ void nxsched_suspend(FAR struct tcb_s *tcb)
   sq_for_every(&tcb->sigpendactionq, entry)
     {
       FAR sigq_t *sigq = (FAR sigq_t *)entry;
+
       if (sigq->info.si_signo == SIGCONT)
         {
           leave_critical_section(flags);

--- a/sched/semaphore/sem_post.c
+++ b/sched/semaphore/sem_post.c
@@ -206,6 +206,7 @@ int nxsem_post_slow(FAR sem_t *sem)
                 {
                   uint32_t blocking_bit = dq_empty(SEM_WAITLIST(sem)) ?
                     0 : NXSEM_MBLOCKING_BIT;
+
                   atomic_set(NXSEM_MHOLDER(sem),
                             ((uint32_t)stcb->pid) | blocking_bit);
                 }

--- a/sched/semaphore/sem_post.c
+++ b/sched/semaphore/sem_post.c
@@ -209,6 +209,7 @@ int nxsem_post_slow(FAR sem_t *sem)
                 {
                   uint32_t blocking_bit = dq_empty(SEM_WAITLIST(sem)) ?
                     0 : NXSEM_MBLOCKING_BIT;
+
                   atomic_set(NXSEM_MHOLDER(sem),
                             ((uint32_t)stcb->pid) | blocking_bit);
                 }

--- a/sched/semaphore/sem_recover.c
+++ b/sched/semaphore/sem_recover.c
@@ -113,6 +113,7 @@ void nxsem_recover(FAR struct tcb_s *tcb)
             {
               uint32_t mholder =
                 atomic_fetch_and(NXSEM_MHOLDER(sem), ~NXSEM_MBLOCKING_BIT);
+
               DEBUGASSERT(NXSEM_MBLOCKING(mholder));
             }
         }

--- a/sched/semaphore/sem_recover.c
+++ b/sched/semaphore/sem_recover.c
@@ -113,6 +113,7 @@ void nxsem_recover(FAR struct tcb_s *tcb)
             {
               uint32_t mholder =
                 atomic_and(NXSEM_MHOLDER(sem), ~NXSEM_MBLOCKING_BIT);
+
               DEBUGASSERT(NXSEM_MBLOCKING(mholder));
             }
         }

--- a/sched/signal/sig_clockwait.c
+++ b/sched/signal/sig_clockwait.c
@@ -261,8 +261,8 @@ int nxsig_clockwait(int clockid, int flags,
           expect = clock_time2ticks(rqtp);
         }
 
-        wd_start_abstick(&rtcb->waitdog, expect,
-                         nxsig_timeout, (uintptr_t)rtcb);
+      wd_start_abstick(&rtcb->waitdog, expect,
+                       nxsig_timeout, (uintptr_t)rtcb);
     }
 
   /* Remove the tcb task from the ready-to-run list. */

--- a/sched/signal/sig_default.c
+++ b/sched/signal/sig_default.c
@@ -313,7 +313,7 @@ static void nxsig_stop_task(int signo)
       if (group->tg_statloc != NULL)
         {
           *group->tg_statloc = 0;
-           group->tg_statloc = NULL;
+          group->tg_statloc = NULL;
         }
 
       /* tg_waitflags == 0 means that the flags are available to another

--- a/sched/signal/sig_dispatch.c
+++ b/sched/signal/sig_dispatch.c
@@ -788,6 +788,7 @@ int nxsig_dispatch(pid_t pid, FAR siginfo_t *info, bool thread)
        */
 
       FAR struct task_group_s *group = task_getgroup(pid);
+
       if (group != NULL)
         {
           return group_signal(group, info);
@@ -799,6 +800,7 @@ int nxsig_dispatch(pid_t pid, FAR siginfo_t *info, bool thread)
       /* Get the TCB associated with the thread TID */
 
       FAR struct tcb_s *stcb = nxsched_get_tcb(pid);
+
       if (stcb != NULL)
         {
           return nxsig_tcbdispatch(stcb, info, false);

--- a/sched/task/task_create.c
+++ b/sched/task/task_create.c
@@ -204,6 +204,7 @@ int task_create_with_stack(FAR const char *name, int priority,
 {
   int ret = nxtask_create(name, priority, stack_addr,
                           stack_size, entry, argv, NULL);
+
   if (ret < 0)
     {
       set_errno(-ret);

--- a/sched/task/task_delete.c
+++ b/sched/task/task_delete.c
@@ -169,6 +169,7 @@ int nxtask_delete(pid_t pid)
 int task_delete(pid_t pid)
 {
   int ret = nxtask_delete(pid);
+
   if (ret < 0)
     {
       set_errno(-ret);

--- a/sched/task/task_getgroup.c
+++ b/sched/task/task_getgroup.c
@@ -59,6 +59,7 @@
 FAR struct task_group_s *task_getgroup(pid_t pid)
 {
   FAR struct tcb_s *tcb = nxsched_get_tcb(pid);
+
   if (tcb)
     {
       return tcb->group;

--- a/sched/task/task_restart.c
+++ b/sched/task/task_restart.c
@@ -306,6 +306,7 @@ errout_with_lock:
 int task_restart(pid_t pid)
 {
   int ret = nxtask_restart(pid);
+
   if (ret < 0)
     {
       set_errno(-ret);

--- a/sched/task/task_setup.c
+++ b/sched/task/task_setup.c
@@ -227,6 +227,7 @@ retry:
 static inline void nxtask_inherit_affinity(FAR struct tcb_s *tcb)
 {
   FAR struct tcb_s *rtcb = this_task();
+
   tcb->affinity = rtcb->affinity;
 }
 #else
@@ -359,6 +360,7 @@ static inline void nxtask_save_parent(FAR struct tcb_s *tcb, uint8_t ttype)
 static inline void nxtask_dup_dspace(FAR struct tcb_s *tcb)
 {
   FAR struct tcb_s *rtcb = this_task();
+
   if (rtcb->dspace != NULL)
     {
       /* Copy the D-Space structure reference and increment the reference

--- a/sched/task/task_spawnparms.c
+++ b/sched/task/task_spawnparms.c
@@ -161,6 +161,7 @@ int spawn_execattrs(pid_t pid, FAR const posix_spawnattr_t *attr)
   if ((attr->flags & POSIX_SPAWN_SETSIGMASK) != 0u)
     {
       FAR struct tcb_s *tcb = nxsched_get_tcb(pid);
+
       if (tcb)
         {
           tcb->sigprocmask = attr->sigmask;

--- a/sched/timer/timer_delete.c
+++ b/sched/timer/timer_delete.c
@@ -65,6 +65,7 @@
 int timer_delete(timer_t timerid)
 {
   int ret = timer_release(timer_gethandle(timerid));
+
   if (ret < 0)
     {
       set_errno(-ret);

--- a/sched/wdog/wd_start.c
+++ b/sched/wdog/wd_start.c
@@ -369,6 +369,7 @@ uint64_t wd_timer(const hrtimer_t *timer, uint64_t expired)
   clock_t  tick = div_const(expired, NSEC_PER_TICK);
   clock_t delay = wd_expiration(tick) - tick;
   uint64_t nsec = TICK2NSEC(delay);
+
   return nsec <= HRTIMER_MAX_DELAY ? nsec : HRTIMER_MAX_DELAY;
 }
 #endif

--- a/sched/wqueue/kwork_thread.c
+++ b/sched/wqueue/kwork_thread.c
@@ -211,7 +211,7 @@ static int work_thread(int argc, FAR char *argv[])
        * so ourselves, and (2) there will be no changes to the work queue
        */
 
-       flags = spin_lock_irqsave_nopreempt(&wqueue->lock);
+      flags = spin_lock_irqsave_nopreempt(&wqueue->lock);
 
       /* If the wqueue timer is expired and non-active, it indicates that
        * there might be expired work in the pending queue.
@@ -373,6 +373,7 @@ void work_timer_expired(wdparm_t arg)
    */
 
   FAR struct kwork_wqueue_s *wq = (FAR struct kwork_wqueue_s *)arg;
+
   nxsem_post(&wq->sem);
 }
 

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -1349,6 +1349,27 @@ static bool white_content_list(const char *ident, int lineno)
 }
 
 /********************************************************************************
+ * Name: check_keyword
+ *
+ * Description:
+ *   Return true if line[ndx] holds the keyword 'kw', delimited by a character
+ *   that cannot be part of an identifier.
+ *
+ ********************************************************************************/
+
+static bool check_keyword(const char *line, int ndx, const char *kw)
+{
+  size_t len = strlen(kw);
+
+  if (strncmp(&line[ndx], kw, len) != 0)
+    {
+      return false;
+    }
+
+  return isalnum((int)line[ndx + len]) == 0 && line[ndx + len] != '_';
+}
+
+/********************************************************************************
  * Public Functions
  ********************************************************************************/
 
@@ -1371,6 +1392,11 @@ int main(int argc, char **argv, char **envp)
   bool bquote;          /* True: Backslash quoted character next */
   bool bblank;          /* Used to verify block comment terminator */
   bool bexternc;        /* True: Within 'extern "C"' */
+  bool bppline;         /* True: This line is a pre-processor line */
+  bool bctrlline;       /* True: A control statement starts on this line */
+  const char *ctrl_kw;  /* Control keyword whose header is being parsed */
+  const char *brace_kw; /* Control keyword still waiting for its left brace */
+  int ctrl_hdrend;      /* Index of the last character of that header */
   enum pptype_e ppline; /* > 0: The next line the continuation of a
                          * pre-processor command */
   int rhcomment;        /* Indentation of Comment to the right of code
@@ -1509,6 +1535,11 @@ int main(int argc, char **argv, char **envp)
   bcase          = false;       /* True: Within a case statement of a switch */
   bstring        = false;       /* True: Within a string */
   bexternc       = false;       /* True: Within 'extern "C"' */
+  bppline        = false;       /* True: This line is a pre-processor line */
+  bctrlline      = false;       /* True: A control statement starts here */
+  ctrl_kw        = NULL;        /* Control keyword being parsed */
+  brace_kw       = NULL;        /* Control keyword waiting for a brace */
+  ctrl_hdrend    = -1;          /* Index of the end of that header */
   bif            = false;       /* True: This line is beginning of a 'if' statement */
   ppline         = PPLINE_NONE; /* > 0: The next line the continuation of a
                                  * pre-processor command */
@@ -1543,6 +1574,9 @@ int main(int argc, char **argv, char **envp)
       bstatm       = false;    /* True: This line is beginning of a
                                 * statement */
       bfor         = false;    /* REVISIT: Implies for() is all on one line */
+      bppline      = false;    /* True: This line is a pre-processor line */
+      bctrlline    = false;    /* No control statement starts on this line */
+      ctrl_hdrend  = -1;       /* The header has not ended on this line yet */
 
       /* If we are not in a comment, then this certainly is not a right-hand
        * comment.
@@ -1824,6 +1858,8 @@ int main(int argc, char **argv, char **envp)
         {
           int len;
           int ii;
+
+          bppline = true;
 
           /* Suppress error for comment following conditional compilation */
 
@@ -2312,6 +2348,60 @@ int main(int argc, char **argv, char **envp)
               ERROR("Missing whitespace after keyword", lineno, n);
               bfor   = true;
               bstatm = true;
+            }
+
+          /* A control statement whose body must be braced.  ctrl_kw stays
+           * set while the condition continues over several lines.
+           */
+
+          if (bnest > 0 && dnest == 0 && ctrl_kw == NULL)
+            {
+              bctrlline = true;
+
+              if (check_keyword(line, indent, "else"))
+                {
+                  int ndx = indent + 4;
+
+                  while (line[ndx] == ' ')
+                    {
+                      ndx++;
+                    }
+
+                  if (check_keyword(line, ndx, "if"))
+                    {
+                      ctrl_kw = "else if";
+                    }
+                  else
+                    {
+                      ctrl_kw     = "else";
+                      ctrl_hdrend = indent + 3;
+                    }
+                }
+              else if (check_keyword(line, indent, "do"))
+                {
+                  ctrl_kw     = "do";
+                  ctrl_hdrend = indent + 1;
+                }
+              else if (check_keyword(line, indent, "if"))
+                {
+                  ctrl_kw = "if";
+                }
+              else if (check_keyword(line, indent, "while"))
+                {
+                  ctrl_kw = "while";
+                }
+              else if (check_keyword(line, indent, "for"))
+                {
+                  ctrl_kw = "for";
+                }
+              else if (check_keyword(line, indent, "switch"))
+                {
+                  ctrl_kw = "switch";
+                }
+              else
+                {
+                  bctrlline = false;
+                }
             }
         }
 
@@ -2934,6 +3024,13 @@ int main(int argc, char **argv, char **envp)
                       {
                         bif = false;
                       }
+
+                    /* Remember where the header ends, to see what follows */
+
+                    if (ctrl_kw != NULL && pnest == 0 && ctrl_hdrend < 0)
+                      {
+                        ctrl_hdrend = n;
+                      }
                   }
                   break;
 
@@ -3479,6 +3576,75 @@ int main(int argc, char **argv, char **envp)
                 {
                   ERROR("Long line found", lineno, m);
                 }
+            }
+        }
+
+      /* STEP 3b: The body of a control statement must be braced, even when
+       * it is a single statement or is empty.
+       */
+
+      if (ncomment == 0 && prevncomment == 0 && !bstring && inasm == 0 &&
+          !bppline)
+        {
+          bool bcommentline = line[indent] == '/' &&
+                              (line[indent + 1] == '*' ||
+                               line[indent + 1] == '/');
+
+          /* Does this line supply a brace an earlier statement promised?
+           * A comment between the two is tolerated.
+           */
+
+          if (brace_kw != NULL && !bcommentline)
+            {
+              /* A control statement may stand where the brace was expected:
+               * an 'else if', or alternatives sharing the braces that follow.
+               */
+
+              if (line[indent] != '{' && !bctrlline)
+                {
+                  snprintf(buffer, sizeof(buffer),
+                           "Missing braces after '%s'", brace_kw);
+                  ERROR(buffer, lineno, indent);
+                }
+
+              brace_kw = NULL;
+            }
+
+          /* Has the header ended on this line?  If so, see what follows */
+
+          if (ctrl_kw != NULL && pnest == 0 && ctrl_hdrend >= 0)
+            {
+              int ndx = ctrl_hdrend + 1;
+
+              while (line[ndx] == ' ' || line[ndx] == '\t')
+                {
+                  ndx++;
+                }
+
+              if (line[ndx] == '\n' || line[ndx] == '\0' ||
+                  (line[ndx] == '/' &&
+                   (line[ndx + 1] == '*' || line[ndx + 1] == '/')))
+                {
+                  /* The brace must appear on a following line */
+
+                  brace_kw = ctrl_kw;
+                }
+              else if (line[ndx] == ';' &&
+                       (strcmp(ctrl_kw, "while") == 0 ||
+                        strcmp(ctrl_kw, "for") == 0))
+                {
+                  /* A null statement needs no braces; also the 'while' of
+                   * a 'do .. while'.
+                   */
+                }
+              else
+                {
+                  snprintf(buffer, sizeof(buffer),
+                           "Statement on same line as '%s'", ctrl_kw);
+                  ERROR(buffer, lineno, ndx);
+                }
+
+              ctrl_kw = NULL;
             }
         }
 

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -1402,6 +1402,107 @@ static bool check_keyword(const char *line, int ndx, const char *kw)
 }
 
 /********************************************************************************
+ * Name: check_declaration
+ *
+ * Description:
+ *   Return true if the line has the shape of a declaration: two or more names
+ *   in a row, ending in '=', ';', '[', ',' or a parameter list.  No list of
+ *   type names can be complete, so the shape is used instead.
+ *
+ ********************************************************************************/
+
+static bool check_declaration(const char *line, int ndx)
+{
+  static const char *const nondecl[] =
+  {
+    "return", "if", "else", "while", "for", "do", "switch", "case",
+    "default", "break", "continue", "goto", "sizeof", "asm", "__asm",
+    "__asm__", NULL
+  };
+
+  const char *const *kw;
+  int nident = 0;
+  int i = ndx;
+
+  /* Must open with a type name; keeps out '*ptr = x;' and comment lines */
+
+  if (isalpha((int)line[ndx]) == 0 && line[ndx] != '_')
+    {
+      return false;
+    }
+
+  for (kw = nondecl; *kw != NULL; kw++)
+    {
+      if (check_keyword(line, ndx, *kw))
+        {
+          return false;
+        }
+    }
+
+  while (line[i] != '\0' && line[i] != '\n')
+    {
+      if (isalpha((int)line[i]) != 0 || line[i] == '_')
+        {
+          nident++;
+          while (isalnum((int)line[i]) != 0 || line[i] == '_')
+            {
+              i++;
+            }
+        }
+      else if (line[i] == ' ' || line[i] == '*')
+        {
+          i++;
+        }
+      else
+        {
+          /* Only a terminator that can follow the declared name counts */
+
+          /* '<type> (*<name>)(...)' declares a pointer to a function.  The
+           * second parameter list tells it from a call like 'foo(*ptr)'.
+           */
+
+          if (line[i] == '(' && nident == 1)
+            {
+              int j = i + 1;
+
+              while (line[j] == ' ')
+                {
+                  j++;
+                }
+
+              if (line[j] == '*')
+                {
+                  j++;
+                  while (line[j] == ' ')
+                    {
+                      j++;
+                    }
+
+                  while (isalnum((int)line[j]) != 0 || line[j] == '_')
+                    {
+                      j++;
+                    }
+
+                  while (line[j] == ' ')
+                    {
+                      j++;
+                    }
+
+                  if (line[j] == ')' && line[j + 1] == '(')
+                    {
+                      return true;
+                    }
+                }
+            }
+
+          return nident >= 2 && strchr("=;[(,", line[i]) != NULL;
+        }
+    }
+
+  return false;
+}
+
+/********************************************************************************
  * Public Functions
  ********************************************************************************/
 
@@ -1464,7 +1565,10 @@ int main(int argc, char **argv, char **envp)
   int externc_lineno;   /* Last line where 'extern "C"' declared */
   bool bexact;          /* True: The expected indentation below is exact */
   bool bppline;         /* True: This line is a pre-processor line */
+  bool bdeclline;       /* True: This line begins a local declaration */
   bool blabelline;      /* True: This line holds nothing but a label */
+  bool bindecl;         /* True: A local declaration is being continued */
+  int decl_lineno;      /* Line on which the last declaration ended */
   bool bstmtstart;      /* True: A new statement begins on this line */
   bool bprevstmtend;    /* True: The preceding line of code ended a statement */
   bool bctrlline;       /* True: A control statement starts on this line */
@@ -1595,7 +1699,10 @@ int main(int argc, char **argv, char **envp)
   brace_indent   = 0;           /* Indentation of the awaiting keyword */
   bexact         = false;       /* True: Expected indentation is exact */
   bppline        = false;       /* True: This line is a pre-processor line */
+  bdeclline      = false;       /* True: This line begins a declaration */
   blabelline     = false;       /* True: This line holds nothing but a label */
+  bindecl        = false;       /* True: A declaration is being continued */
+  decl_lineno    = -1;          /* Line on which a declaration last ended */
   bstmtstart     = true;        /* True: A statement begins on this line */
   bprevstmtend   = true;        /* True: The preceding code ended a statement */
   bctrlline      = false;       /* True: A control statement starts here */
@@ -1650,6 +1757,7 @@ int main(int argc, char **argv, char **envp)
       bctrlline    = false;    /* No control statement starts on this line */
       ctrl_bswitch = false;    /* That brace does not open a switch body */
       bppline      = false;    /* True: This line is a pre-processor line */
+      bdeclline    = false;    /* True: This line begins a declaration */
 
       /* A label ends the preceding statement, like a 'case' does */
 
@@ -2270,7 +2378,6 @@ int main(int argc, char **argv, char **envp)
         }
 
       /* Check for some kind of declaration.
-       * REVISIT: The following logic fails for any non-standard types.
        * REVISIT: Terminator after keyword might not be a space.  Might be
        * a newline, for example.  struct and unions are often unnamed, for
        * example.
@@ -2278,6 +2385,16 @@ int main(int argc, char **argv, char **envp)
 
       else if (inasm == 0)
         {
+          /* Note a local declaration, for the blank line that must follow */
+
+          if (bfunctions && bnest > 0 && pnest == 0 && dnest == 0 &&
+              ncomment == 0 && prevncomment == 0 && !bstring && bstmtstart &&
+              check_declaration(line, indent))
+            {
+              bdeclline = true;
+              bindecl   = true;
+            }
+
           if (check_type_name(line, indent) ||
                    strncmp(&line[indent], "auto ", 5) == 0 ||
                    strncmp(&line[indent], "bool ", 5) == 0 ||
@@ -3860,12 +3977,21 @@ int main(int argc, char **argv, char **envp)
                           (lastcode == ':' && (bcaseline || blabelline)));
         }
 
-      /* A line that follows one ending in ';', '{', '}' or ':' begins a new
-       * statement.  Anything else is the continuation of the statement on the
-       * preceding line and may be aligned freely.  Pre-processor lines are
-       * ignored so that a macro definition does not hide the statement that
-       * precedes it.
-       */
+      /* Remember the line on which the last declaration ended */
+
+      if (bindecl && lastcode == ';' && pnest == 0)
+        {
+          decl_lineno = lineno;
+          bindecl     = false;
+        }
+
+      /* A blank line must separate the declarations from the code */
+
+      if (bexact && prevdnest == 0 && !bppline && !bdeclline && !bindecl &&
+          bstmtstart && lineno == decl_lineno + 1 && lastcode != '\0')
+        {
+          ERROR("Missing blank line after declarations", lineno, indent);
+        }
 
       /* STEP 4: Check alignment */
 

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -1572,6 +1572,7 @@ int main(int argc, char **argv, char **envp)
   bool bstmtstart;      /* True: A new statement begins on this line */
   bool bprevstmtend;    /* True: The preceding line of code ended a statement */
   bool bctrlline;       /* True: A control statement starts on this line */
+  bool bppalt;          /* True: In an alternative branch awaiting braces */
   char lastcode;        /* Last code character seen on this line */
   char prevlastcode;    /* Last code character on the preceding line */
   int prevcodeindent;   /* Indentation of the preceding line of code */
@@ -1706,6 +1707,7 @@ int main(int argc, char **argv, char **envp)
   bstmtstart     = true;        /* True: A statement begins on this line */
   bprevstmtend   = true;        /* True: The preceding code ended a statement */
   bctrlline      = false;       /* True: A control statement starts here */
+  bppalt         = false;       /* True: Alternative branch awaiting braces */
   lastcode       = '\0';        /* Last code character seen on this line */
   prevlastcode   = '\0';        /* Last code character on the preceding line */
   prevcodeindent = 0;           /* Indentation of the preceding line of code */
@@ -2089,6 +2091,17 @@ int main(int argc, char **argv, char **envp)
           int ii;
 
           bppline = true;
+
+          /* Alternative branches share the braces that close the construct,
+           * and may hold statements of their own before reaching them.
+           */
+
+          if (brace_kw != NULL &&
+              (strncmp(&line[indent], "#else", 5) == 0 ||
+               strncmp(&line[indent], "#elif", 5) == 0))
+            {
+              bppalt = true;
+            }
 
           /* Suppress error for comment following conditional compilation */
 
@@ -3882,14 +3895,20 @@ int main(int argc, char **argv, char **envp)
                * an 'else if', or alternatives sharing the braces that follow.
                */
 
-              else if (!bctrlline)
+              else if (!bctrlline && !bppalt)
                 {
                   snprintf(buffer, sizeof(buffer),
                            "Missing braces after '%s'", brace_kw);
                   ERROR(buffer, lineno, indent);
                 }
 
-              brace_kw = NULL;
+              /* An alternative branch may hold statements first */
+
+              if (line[indent] == '{' || bctrlline || !bppalt)
+                {
+                  brace_kw = NULL;
+                  bppalt   = false;
+                }
             }
 
           /* Has the header ended on this line?  If so, see what follows */

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -48,6 +48,7 @@
 #define LINE_SIZE      512
 #define RANGE_NUMBER   4096
 #define DEFAULT_WIDTH  78
+#define MAX_BRACE      64
 
 #define FIRST_SECTION  INCLUDED_FILES
 #define LAST_SECTION   PUBLIC_FUNCTION_PROTOTYPES
@@ -1397,6 +1398,11 @@ int main(int argc, char **argv, char **envp)
   const char *ctrl_kw;  /* Control keyword whose header is being parsed */
   const char *brace_kw; /* Control keyword still waiting for its left brace */
   int ctrl_hdrend;      /* Index of the last character of that header */
+  int ctrl_indent;      /* Indentation of that control keyword */
+  int brace_indent;     /* Indentation of the keyword awaiting a brace */
+  int ctrl_brace;       /* Alignment required of a brace on this line, or -1 */
+  int rbrace_match;     /* Alignment of the left brace closed on this line */
+  int lbrace_indent[MAX_BRACE]; /* Indentation of each open left brace */
   enum pptype_e ppline; /* > 0: The next line the continuation of a
                          * pre-processor command */
   int rhcomment;        /* Indentation of Comment to the right of code
@@ -1540,6 +1546,8 @@ int main(int argc, char **argv, char **envp)
   ctrl_kw        = NULL;        /* Control keyword being parsed */
   brace_kw       = NULL;        /* Control keyword waiting for a brace */
   ctrl_hdrend    = -1;          /* Index of the end of that header */
+  ctrl_indent    = 0;           /* Indentation of that control keyword */
+  brace_indent   = 0;           /* Indentation of the awaiting keyword */
   bif            = false;       /* True: This line is beginning of a 'if' statement */
   ppline         = PPLINE_NONE; /* > 0: The next line the continuation of a
                                  * pre-processor command */
@@ -1577,6 +1585,8 @@ int main(int argc, char **argv, char **envp)
       bppline      = false;    /* True: This line is a pre-processor line */
       bctrlline    = false;    /* No control statement starts on this line */
       ctrl_hdrend  = -1;       /* The header has not ended on this line yet */
+      ctrl_brace   = -1;       /* No brace is required on this line */
+      rbrace_match = -1;       /* No left brace is closed on this line */
 
       /* If we are not in a comment, then this certainly is not a right-hand
        * comment.
@@ -2356,7 +2366,8 @@ int main(int argc, char **argv, char **envp)
 
           if (bnest > 0 && dnest == 0 && ctrl_kw == NULL)
             {
-              bctrlline = true;
+              bctrlline   = true;
+              ctrl_indent = indent;
 
               if (check_keyword(line, indent, "else"))
                 {
@@ -2814,6 +2825,16 @@ int main(int argc, char **argv, char **envp)
                       }
 
                     bnest++;
+
+                    /* Remember where a brace beginning a line sits, so the
+                     * brace closing it can be checked.  -1 for any other.
+                     */
+
+                    if (bnest >= 1 && bnest <= MAX_BRACE)
+                      {
+                        lbrace_indent[bnest - 1] = n == indent ? indent : -1;
+                      }
+
                     if (dnest > 0)
                       {
                         dnest++;
@@ -2852,6 +2873,13 @@ int main(int argc, char **argv, char **envp)
                          {
                            bnest = 0;
                            bswitch = false;
+                         }
+
+                       /* Recover the alignment of the matching left brace */
+
+                       if (n == indent && bnest < MAX_BRACE)
+                         {
+                           rbrace_match = lbrace_indent[bnest];
                          }
                      }
 
@@ -3600,7 +3628,13 @@ int main(int argc, char **argv, char **envp)
                * an 'else if', or alternatives sharing the braces that follow.
                */
 
-              if (line[indent] != '{' && !bctrlline)
+              if (line[indent] == '{')
+                {
+                  /* The brace sits one level in from the keyword */
+
+                  ctrl_brace = brace_indent + 2;
+                }
+              else if (!bctrlline)
                 {
                   snprintf(buffer, sizeof(buffer),
                            "Missing braces after '%s'", brace_kw);
@@ -3627,7 +3661,8 @@ int main(int argc, char **argv, char **envp)
                 {
                   /* The brace must appear on a following line */
 
-                  brace_kw = ctrl_kw;
+                  brace_kw     = ctrl_kw;
+                  brace_indent = ctrl_indent;
                 }
               else if (line[ndx] == ';' &&
                        (strcmp(ctrl_kw, "while") == 0 ||
@@ -3805,6 +3840,26 @@ int main(int argc, char **argv, char **envp)
                * the coding standard.
                */
 
+              /* A brace opening the body of a control statement must be
+               * indented exactly one level from its keyword.
+               */
+
+              else if (ctrl_brace >= 0)
+                {
+                  if (indent != ctrl_brace)
+                    {
+                      ERROR("Bad left brace alignment", lineno, indent);
+                    }
+
+                  /* Record what the brace should have been so that the brace
+                   * closing it is held to the same alignment.
+                   */
+
+                  if (bnest >= 1 && bnest <= MAX_BRACE)
+                    {
+                      lbrace_indent[bnest - 1] = ctrl_brace;
+                    }
+                }
               else if (!bfunctions && (indent & 1) != 0)
                 {
                   ERROR("Bad left brace alignment", lineno, indent);
@@ -3821,7 +3876,16 @@ int main(int argc, char **argv, char **envp)
                * the coding standard.
                */
 
-              if (!bfunctions && (indent & 1) != 0)
+              /* A right brace must line up with the left brace it closes */
+
+              if (rbrace_match >= 0)
+                {
+                  if (indent != rbrace_match)
+                    {
+                      ERROR("Bad right brace alignment", lineno, indent);
+                    }
+                }
+              else if (!bfunctions && (indent & 1) != 0)
                 {
                   ERROR("Bad left brace alignment", lineno, indent);
                 }

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -1450,6 +1450,7 @@ int main(int argc, char **argv, char **envp)
   char lastcode;        /* Last code character seen on this line */
   char prevlastcode;    /* Last code character on the preceding line */
   int prevcodeindent;   /* Indentation of the preceding line of code */
+  int stmt_lineindent;  /* Indentation of the line starting that statement */
   bool bfuncbody;       /* True: The outermost brace opened a function body */
   int stmt_indent;      /* Expected indentation of a statement, or -1 */
   int case_indent;      /* Expected indentation of a 'case' label, or -1 */
@@ -1580,6 +1581,7 @@ int main(int argc, char **argv, char **envp)
   lastcode       = '\0';        /* Last code character seen on this line */
   prevlastcode   = '\0';        /* Last code character on the preceding line */
   prevcodeindent = 0;           /* Indentation of the preceding line of code */
+  stmt_lineindent = 0;          /* Indentation where that statement began */
   bfuncbody      = false;       /* True: Inside the body of a function */
   stmt_indent    = 0;           /* Expected indentation of a statement */
   case_indent    = -1;          /* Expected indentation of a 'case' label */
@@ -4039,7 +4041,9 @@ int main(int argc, char **argv, char **envp)
                * that way.
                */
 
-              else if (prevlastcode == ')' && indent == prevcodeindent + 2)
+              else if (prevlastcode == ')' &&
+                       (indent == prevcodeindent + 2 ||
+                        indent == stmt_lineindent + 2))
                 {
                 }
               else if (indent > 0 && dnest == 0 &&
@@ -4132,6 +4136,11 @@ int main(int argc, char **argv, char **envp)
         {
           prevlastcode   = lastcode;
           prevcodeindent = indent;
+
+          if (bstmtstart)
+            {
+              stmt_lineindent = indent;
+            }
         }
     }
 

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -1558,6 +1558,7 @@ int main(int argc, char **argv, char **envp)
   bool bstmtstart;      /* True: A new statement begins on this line */
   bool bprevstmtend;    /* True: The preceding line of code ended a statement */
   bool bctrlline;       /* True: A control statement starts on this line */
+  bool bppalt;          /* True: In an alternative branch awaiting braces */
   char lastcode;        /* Last code character seen on this line */
   char prevlastcode;    /* Last code character on the preceding line */
   int prevcodeindent;   /* Indentation of the preceding line of code */
@@ -1692,6 +1693,7 @@ int main(int argc, char **argv, char **envp)
   bstmtstart     = true;        /* True: A statement begins on this line */
   bprevstmtend   = true;        /* True: The preceding code ended a statement */
   bctrlline      = false;       /* True: A control statement starts here */
+  bppalt         = false;       /* True: Alternative branch awaiting braces */
   lastcode       = '\0';        /* Last code character seen on this line */
   prevlastcode   = '\0';        /* Last code character on the preceding line */
   prevcodeindent = 0;           /* Indentation of the preceding line of code */
@@ -2074,6 +2076,17 @@ int main(int argc, char **argv, char **envp)
           int ii;
 
           bppline = true;
+
+          /* Alternative branches share the braces that close the construct,
+           * and may hold statements of their own before reaching them.
+           */
+
+          if (brace_kw != NULL &&
+              (strncmp(&line[indent], "#else", 5) == 0 ||
+               strncmp(&line[indent], "#elif", 5) == 0))
+            {
+              bppalt = true;
+            }
 
           /* Suppress error for comment following conditional compilation */
 
@@ -3859,13 +3872,20 @@ int main(int argc, char **argv, char **envp)
                * an 'else if', or alternatives sharing the braces that follow.
                */
 
-              else if (!bctrlline)
+              else if (!bctrlline && !bppalt)
                 {
                   snprintf(buffer, sizeof(buffer),
                            "Missing braces after '%s'", brace_kw);
                   ERROR(buffer, lineno, indent);
                 }
-              brace_kw = NULL;
+
+              /* An alternative branch may hold statements first */
+
+              if (line[indent] == '{' || bctrlline || !bppalt)
+                {
+                  brace_kw = NULL;
+                  bppalt   = false;
+                }
             }
 
           /* Has the header ended on this line?  If so, see what follows */

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -1540,6 +1540,7 @@ int main(int argc, char **argv, char **envp)
   int dnest;            /* Data declaration nesting level on this line */
   int prevdnest;        /* Data declaration nesting level on the previous line */
   int pnest;            /* Parenthesis nesting level on this line */
+  int prevpnest;        /* Parenthesis nesting level on the previous line */
   int ppifnest;         /* #if nesting level on this line */
   int inasm;            /* > 0: Within #ifdef __ASSEMBLY__ */
   int comment_lineno;   /* Line on which the last comment was closed */
@@ -1710,6 +1711,7 @@ int main(int argc, char **argv, char **envp)
   bnest          = 0;           /* Brace nesting level on this line */
   dnest          = 0;           /* Data declaration nesting level on this line */
   pnest          = 0;           /* Parenthesis nesting level on this line */
+  prevpnest      = 0;           /* Parenthesis nesting on the previous line */
   ppifnest       = 0;           /* #if nesting level on this line */
   inasm          = 0;           /* > 0: Within #ifdef __ASSEMBLY__ */
   comment_lineno = -1;          /* Line on which the last comment was closed */
@@ -1726,6 +1728,7 @@ int main(int argc, char **argv, char **envp)
       lineno++;
       indent       = 0;
       prevbnest    = bnest;    /* Brace nesting level on the previous line */
+      prevpnest    = pnest;    /* Parenthesis nesting on the previous line */
       prevdnest    = dnest;    /* Data declaration nesting level on the
                                 * previous line */
       prevncomment = ncomment; /* Comment nesting level on the previous line */
@@ -3929,7 +3932,7 @@ int main(int argc, char **argv, char **envp)
             }
         }
 
-      bexact = bnest > 0 && dnest == 0 && pnest == 0 && stmt_indent > 0 &&
+      bexact = bnest > 0 && dnest == 0 && prevpnest == 0 && stmt_indent > 0 &&
                bfunctions && bfuncbody;
 
       /* A line after one ending in ';', '{', '}' or a label begins a new

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -922,7 +922,7 @@ static void backslash_to_slash(char *str)
     {
       if (*p == '\\')
         {
-           *p = '/';
+          *p = '/';
         }
     }
 }
@@ -1005,8 +1005,8 @@ static void check_spaces_left(char *line, int lineno, int ndx)
 
   if (ndx-- > 0 && line[ndx] != ' ' && line[ndx] != '(' && line[ndx] != ')')
     {
-       ERROR("Operator/assignment must be preceded with whitespace",
-             lineno, ndx);
+      ERROR("Operator/assignment must be preceded with whitespace",
+            lineno, ndx);
     }
 }
 
@@ -1021,14 +1021,14 @@ static void check_spaces_leftright(char *line, int lineno, int ndx1, int ndx2)
 {
   if (ndx1 > 0 && line[ndx1 - 1] != ' ')
     {
-       ERROR("Operator/assignment must be preceded with whitespace",
-             lineno, ndx1);
+      ERROR("Operator/assignment must be preceded with whitespace",
+            lineno, ndx1);
     }
 
   if (line[ndx2 + 1] != '\0' && line[ndx2 + 1] != '\n' && line[ndx2 + 1] != ' ')
     {
-       ERROR("Operator/assignment must be followed with whitespace",
-             lineno, ndx2);
+      ERROR("Operator/assignment must be followed with whitespace",
+            lineno, ndx2);
     }
 }
 
@@ -1519,8 +1519,12 @@ int main(int argc, char **argv, char **envp)
   int ctrl_brace;       /* Alignment required of a brace on this line, or -1 */
   bool ctrl_bswitch;    /* True: That brace opens the body of a switch */
   int rbrace_match;     /* Alignment of the left brace closed on this line */
-  int lbrace_indent[MAX_BRACE]; /* Indentation of each open left brace */
-  bool lbrace_switch[MAX_BRACE]; /* True: That brace opens a switch body */
+
+  /* Indentation of each open left brace, and whether it opens a switch */
+
+  int lbrace_indent[MAX_BRACE];
+  bool lbrace_switch[MAX_BRACE];
+
   bool bstring;         /* True: Within a string */
   bool bquote;          /* True: Backslash quoted character next */
   bool bblank;          /* Used to verify block comment terminator */
@@ -1576,48 +1580,48 @@ int main(int argc, char **argv, char **envp)
   while ((c = getopt(argc, argv, ":hv:gm:r:")) != -1)
     {
       switch (c)
-      {
-      case 'm':
-        excess = atoi(optarg);
-        if (excess < 1)
-          {
-            show_usage(argv[0], 1, "Bad value for <excess>.");
-            excess = 0;
-          }
+        {
+          case 'm':
+            excess = atoi(optarg);
+            if (excess < 1)
+              {
+                show_usage(argv[0], 1, "Bad value for <excess>.");
+                excess = 0;
+              }
 
-        break;
+            break;
 
-      case 'v':
-        g_verbose = atoi(optarg);
-        if (g_verbose < 0 || g_verbose > 2)
-          {
-            show_usage(argv[0], 1, "Bad value for <level>.");
-          }
+          case 'v':
+            g_verbose = atoi(optarg);
+            if (g_verbose < 0 || g_verbose > 2)
+              {
+                show_usage(argv[0], 1, "Bad value for <level>.");
+              }
 
-        break;
+            break;
 
-      case 'r':
-        g_rangestart[g_rangenumber] = atoi(strtok(optarg, ","));
-        g_rangecount[g_rangenumber++] = atoi(strtok(NULL, ","));
-        break;
+          case 'r':
+            g_rangestart[g_rangenumber] = atoi(strtok(optarg, ","));
+            g_rangecount[g_rangenumber++] = atoi(strtok(NULL, ","));
+            break;
 
-      case 'h':
-        show_usage(argv[0], 0, NULL);
-        break;
+          case 'h':
+            show_usage(argv[0], 0, NULL);
+            break;
 
-      case ':':
-        show_usage(argv[0], 1, "Missing argument.");
-        break;
+          case ':':
+            show_usage(argv[0], 1, "Missing argument.");
+            break;
 
-      case '?':
-        show_usage(argv[0], 1, "Unrecognized option.");
-        break;
+          case '?':
+            show_usage(argv[0], 1, "Unrecognized option.");
+            break;
 
-      default:
-        show_usage(argv[0], 0, NULL);
-        break;
-      }
-  }
+          default:
+            show_usage(argv[0], 0, NULL);
+            break;
+        }
+    }
 
   if (optind < argc - 1 || argv[optind] == NULL)
     {
@@ -1857,8 +1861,8 @@ int main(int argc, char **argv, char **envp)
 
               if (line[n] != '}' && line[n] != '#' && prevrhcmt == 0)
                 {
-                   ERROR("Missing blank line after comment", comment_lineno,
-                         1);
+                  ERROR("Missing blank line after comment", comment_lineno,
+                        1);
                 }
             }
 
@@ -1869,7 +1873,7 @@ int main(int argc, char **argv, char **envp)
 
           if (lineno == 1 && (line[n] != '/' || line[n + 1] != '*'))
             {
-               ERROR("Missing file header comment block", lineno, 1);
+              ERROR("Missing file header comment block", lineno, 1);
             }
 
           if (lineno == 2)
@@ -1899,6 +1903,7 @@ int main(int argc, char **argv, char **envp)
                    */
 
                   char *basedir = strstr(g_file_name, TOPDIR);
+
                   if (basedir != NULL)
                     {
                       /* Add 1 to the offset for the slash character */
@@ -1989,8 +1994,8 @@ int main(int argc, char **argv, char **envp)
                   strncmp(&line[n], "while", 5) != 0 &&
                   strncmp(&line[n], "break", 5) != 0)
                 {
-                   ERROR("Right brace must be followed by a blank line",
-                         rbrace_lineno, n + 1);
+                  ERROR("Right brace must be followed by a blank line",
+                        rbrace_lineno, n + 1);
                 }
 
               /* If the right brace is followed by a pre-processor command
@@ -2024,43 +2029,43 @@ int main(int argc, char **argv, char **envp)
         {
           switch (line[n])
             {
-            case ' ':
-              {
-                indent++;
-              }
-              break;
+              case ' ':
+                {
+                  indent++;
+                }
+                break;
 
-            case '\t':
-              {
-                if (!btabs)
-                  {
-                    ERROR("TABs found.  First detected", lineno, n);
-                    btabs = true;
-                  }
+              case '\t':
+                {
+                  if (!btabs)
+                    {
+                      ERROR("TABs found.  First detected", lineno, n);
+                      btabs = true;
+                    }
 
-                indent = (indent + 4) & ~3;
-              }
-              break;
+                  indent = (indent + 4) & ~3;
+                }
+                break;
 
-            case '\r':
-              {
-                if (!bcrs)
-                  {
-                    ERROR("Carriage returns found.  "
-                            "First detected", lineno, n);
-                    bcrs = true;
-                  }
-              }
-              break;
+              case '\r':
+                {
+                  if (!bcrs)
+                    {
+                      ERROR("Carriage returns found.  "
+                              "First detected", lineno, n);
+                      bcrs = true;
+                    }
+                }
+                break;
 
-            default:
-              {
-                 snprintf(buffer, sizeof(buffer),
-                          "Unexpected white space character %02x found",
-                          line[n]);
-                 ERROR(buffer, lineno, n);
-              }
-              break;
+              default:
+                {
+                  snprintf(buffer, sizeof(buffer),
+                           "Unexpected white space character %02x found",
+                           line[n]);
+                  ERROR(buffer, lineno, n);
+                }
+                break;
             }
         }
 
@@ -2110,8 +2115,8 @@ int main(int argc, char **argv, char **envp)
               if (line[ii] != '\0')
                 {
                   /* Make sure that pre-processor definitions are all in
-                  * the pre-processor definitions section.
-                  */
+                   * the pre-processor definitions section.
+                   */
 
                   ppline = PPLINE_OTHER;
 
@@ -2202,7 +2207,7 @@ int main(int argc, char **argv, char **envp)
 
                       ppline = PPLINE_ENDIF;
                     }
-               }
+                }
             }
 
           if (ppline == PPLINE_IF || ppline == PPLINE_ELIF)
@@ -2272,7 +2277,7 @@ int main(int argc, char **argv, char **envp)
                 }
               else if (!isspace((int)line[n + 2]) && line[n + 2] != '*')
                 {
-                   ERROR("Missing space after opening C comment", lineno, n);
+                  ERROR("Missing space after opening C comment", lineno, n);
                 }
 
               if (strstr(lptr, "*/") == NULL)
@@ -2351,7 +2356,7 @@ int main(int argc, char **argv, char **envp)
                    * by a label.
                    */
 
-                   ERROR("Missing blank line before comment found", lineno, 1);
+                  ERROR("Missing blank line before comment found", lineno, 1);
                 }
 
               /* 'comment_lineno 'holds the line number of the last closing
@@ -2474,7 +2479,7 @@ int main(int argc, char **argv, char **envp)
                     {
                       if (tmppnest == 0 && !tmpbstring && line[i] == ',')
                         {
-                           ERROR("Multiple data definitions", lineno, i + 1);
+                          ERROR("Multiple data definitions", lineno, i + 1);
                           break;
                         }
                       else if (line[i] == '(')
@@ -2706,78 +2711,78 @@ int main(int argc, char **argv, char **envp)
                    *   Hz          for frequencies (including KHz, MHz, etc.)
                    */
 
-                   if (!have_lower && islower(line[n]))
-                     {
-                       switch (line[n])
-                       {
-                         /* A sequence containing 'v' may occur at the
-                          * beginning of the identifier.
-                          */
+                  if (!have_lower && islower(line[n]))
+                    {
+                      switch (line[n])
+                        {
+                          /* A sequence containing 'v' may occur at the
+                           * beginning of the identifier.
+                           */
 
-                         case 'v':
-                           if (n > 1 &&
-                               line[n - 2] == 'I' &&
-                               line[n - 1] == 'P' &&
-                               (line[n + 1] == '4' ||
-                                line[n + 1] == '6'))
-                             {
-                             }
-                           else if (n > 3 &&
-                                    line[n - 4] == 'I' &&
-                                    line[n - 3] == 'C' &&
-                                    line[n - 2] == 'M' &&
-                                    line[n - 1] == 'P' &&
-                                    line[n + 1] == '6')
-                             {
-                             }
-                           else if (n > 3 &&
-                                    line[n - 4] == 'I' &&
-                                    line[n - 3] == 'G' &&
-                                    line[n - 2] == 'M' &&
-                                    line[n - 1] == 'P' &&
-                                    line[n + 1] == '2')
-                             {
-                             }
-                           else
-                             {
-                               have_lower = true;
-                             }
-                           break;
+                          case 'v':
+                            if (n > 1 &&
+                                line[n - 2] == 'I' &&
+                                line[n - 1] == 'P' &&
+                                (line[n + 1] == '4' ||
+                                 line[n + 1] == '6'))
+                              {
+                              }
+                            else if (n > 3 &&
+                                     line[n - 4] == 'I' &&
+                                     line[n - 3] == 'C' &&
+                                     line[n - 2] == 'M' &&
+                                     line[n - 1] == 'P' &&
+                                     line[n + 1] == '6')
+                              {
+                              }
+                            else if (n > 3 &&
+                                     line[n - 4] == 'I' &&
+                                     line[n - 3] == 'G' &&
+                                     line[n - 2] == 'M' &&
+                                     line[n - 1] == 'P' &&
+                                     line[n + 1] == '2')
+                              {
+                              }
+                            else
+                              {
+                                have_lower = true;
+                              }
+                            break;
 
-                         /* Sequences containing 'p', 'd', or 'z' must have
-                          * been preceded by upper case characters.
-                          */
+                          /* Sequences containing 'p', 'd', or 'z' must have
+                           * been preceded by upper case characters.
+                           */
 
-                         case 'p':
-                           if (!have_upper || n < 1 ||
-                               !isdigit(line[n - 1]) ||
-                               !isdigit(line[n + 1]))
-                             {
-                               have_lower = true;
-                             }
-                             break;
+                          case 'p':
+                            if (!have_upper || n < 1 ||
+                                !isdigit(line[n - 1]) ||
+                                !isdigit(line[n + 1]))
+                              {
+                                have_lower = true;
+                              }
+                            break;
 
-                         case 'd':
-                           if (!have_upper || !isdigit(line[n + 1]))
-                             {
-                               have_lower = true;
-                             }
-                             break;
+                          case 'd':
+                            if (!have_upper || !isdigit(line[n + 1]))
+                              {
+                                have_lower = true;
+                              }
+                            break;
 
-                         case 'z':
-                           if (!have_upper || n < 1 ||
-                               line[n - 1] != 'H')
-                             {
-                               have_lower = true;
-                             }
-                             break;
-                           break;
+                          case 'z':
+                            if (!have_upper || n < 1 ||
+                                line[n - 1] != 'H')
+                              {
+                                have_lower = true;
+                              }
+                            break;
+                            break;
 
-                         default:
-                           have_lower = true;
-                           break;
-                       }
-                     }
+                          default:
+                            have_lower = true;
+                            break;
+                        }
+                    }
 
                   n++;
                 }
@@ -2805,13 +2810,13 @@ int main(int argc, char **argv, char **envp)
                             line[ident_index] != 'X') ||
                            line[ident_index - 1] != '0')
                     {
-                       ERROR("Mixed case identifier found",
-                             lineno, ident_index);
+                      ERROR("Mixed case identifier found",
+                            lineno, ident_index);
                     }
                   else if (have_upper)
                     {
-                       ERROR("Upper case hex constant found",
-                             lineno, ident_index);
+                      ERROR("Upper case hex constant found",
+                            lineno, ident_index);
                     }
                 }
 
@@ -2837,7 +2842,7 @@ int main(int argc, char **argv, char **envp)
                     }
                   else if (!isspace((int)line[n + 2]) && line[n + 2] != '*')
                     {
-                       ERROR("Missing space after opening C comment", lineno, n);
+                      ERROR("Missing space after opening C comment", lineno, n);
                     }
 
                   /* Increment the count of nested comments */
@@ -2899,8 +2904,8 @@ int main(int argc, char **argv, char **envp)
                     }
                   else if (!isspace((int)line[n - 2]) && line[n - 2] != '*')
                     {
-                       ERROR("Missing space before closing C comment", lineno,
-                             n);
+                      ERROR("Missing space before closing C comment", lineno,
+                            n);
                     }
 
                   /* Check for block comments that are not on a separate line.
@@ -2911,8 +2916,8 @@ int main(int argc, char **argv, char **envp)
 
                   if (prevncomment > 0 && !bblank && rhcomment == 0)
                     {
-                       ERROR("Block comment terminator must be on a "
-                              "separate line", lineno, n);
+                      ERROR("Block comment terminator must be on a "
+                             "separate line", lineno, n);
                     }
 
 #if 0
@@ -2922,7 +2927,7 @@ int main(int argc, char **argv, char **envp)
 
                   if (line[n + 1] != '\n')
                     {
-                       ERROR("Garbage on line after C comment", lineno, n);
+                      ERROR("Garbage on line after C comment", lineno, n);
                     }
 #endif
 
@@ -3026,737 +3031,744 @@ int main(int argc, char **argv, char **envp)
             {
               switch (line[n])
                 {
-                /* Handle logic nested with curly braces */
+                  /* Handle logic nested with curly braces */
 
-                case '{':
-                  {
-                    if (n > indent)
+                  case '{':
+                    {
+                      if (n > indent)
+                        {
+                          /* REVISIT: dnest is always > 0 here if bfunctions ==
+                           * false.
+                           */
+
+                          if (dnest == 0 || !bfunctions ||
+                              lineno == rbrace_lineno)
+                            {
+                              ERROR("Left bracket not on separate line", lineno,
+                                    n);
+                            }
+                        }
+                      else if (line[n + 1] != '\n')
+                        {
+                          if (dnest == 0)
+                            {
+                              ERROR("Garbage follows left bracket", lineno, n);
+                            }
+                        }
+
+                      bnest++;
+
+                      /* Remember where a brace beginning a line sits, so the
+                       * brace closing it can be checked.  -1 for any other.
+                       */
+
+                      if (bnest >= 1 && bnest <= MAX_BRACE)
+                        {
+                          lbrace_indent[bnest - 1] = n == indent ? indent : -1;
+                          lbrace_switch[bnest - 1] = false;
+                        }
+
+                      /* An outermost brace follows a parameter list for a
+                       * function, or '=' for data, which indents differently.
+                       */
+
+                      if (bnest == 1)
+                        {
+                          bfuncbody = prevlastcode == ')';
+                        }
+
+                      if (dnest > 0)
+                        {
+                          dnest++;
+                        }
+
+                      /* Check if we are within 'extern "C"', we don't
+                       * normally indent in that case because the 'extern "C"'
+                       * is conditioned on __cplusplus.
+                       */
+
+                      if (lineno == externc_lineno ||
+                          lineno - 1 == externc_lineno)
+                        {
+                          bexternc = true;
+                        }
+
+                      /* Suppress error for comment following a left brace */
+
+                      noblank_lineno = lineno;
+                      lbrace_lineno  = lineno;
+                    }
+                    break;
+
+                  case '}':
+                    {
+                      /* Decrement the brace nesting level */
+
+                      if (bnest < 1)
+                        {
+                          ERROR("Unmatched right brace", lineno, n);
+                        }
+                      else
+                        {
+                          bnest--;
+                          if (bnest < 1)
+                            {
+                              bnest     = 0;
+                              bfuncbody = false;
+                            }
+
+                          /* Recover the alignment of the matching left brace */
+
+                          if (n == indent && bnest < MAX_BRACE)
+                            {
+                              rbrace_match = lbrace_indent[bnest];
+                            }
+                        }
+
+                      /* Decrement the declaration nesting level */
+
+                      if (dnest < 3)
+                        {
+                          dnest = 0;
+                          bexternc = false;
+                        }
+                      else
+                        {
+                          dnest--;
+                        }
+
+                      /* The right brace should be on a separate line */
+
+                      if (n > indent)
+                        {
+                          if (dnest == 0)
+                            {
+                              ERROR("Right bracket not on separate line",
+                                    lineno, n);
+                            }
+                        }
+
+                      /* Check for garbage following the left brace */
+
+                      if (line[n + 1] != '\n' &&
+                          line[n + 1] != ',' &&
+                          line[n + 1] != ';')
+                        {
+                          int sndx = n + 1;
+                          bool whitespace = false;
+
+                          /* Skip over spaces */
+
+                          while (line[sndx] == ' ')
+                            {
+                              sndx++;
+                            }
+
+                          /* One possibility is that the right bracket is
+                           * followed by an identifier then a semi-colon.
+                           * Comma is possible to but would be a case of
+                           * multiple declaration of multiple instances.
+                           */
+
+                          if (line[sndx] == '_' || isalpha(line[sndx]))
+                            {
+                              int endx = sndx;
+
+                              /* Skip to the end of the identifier.  Checking
+                               * for mixed case identifiers will be done
+                               * elsewhere.
+                               */
+
+                              while (line[endx] == '_' ||
+                                     isalnum(line[endx]))
+                                {
+                                  endx++;
+                                }
+
+                              /* Skip over spaces */
+
+                              while (line[endx] == ' ')
+                                {
+                                  whitespace = true;
+                                  endx++;
+                                }
+
+                              /* Handle according to what comes after the
+                               * identifier.
+                               */
+
+                              if (strncmp(&line[sndx], "while", 5) == 0)
+                                {
+                                  ERROR("'while' must be on a separate line",
+                                         lineno, sndx);
+                                }
+                              else if (line[endx] == ',')
+                                {
+                                  ERROR("Multiple data definitions on line",
+                                         lineno, endx);
+                                }
+                              else if (line[endx] == ';')
+                                {
+                                  if (whitespace)
+                                    {
+                                      ERROR("Space precedes semi-colon",
+                                            lineno, endx);
+                                    }
+                                }
+                              else if (line[endx] == '=')
+                                {
+                                  /* There's a struct initialization following */
+
+                                  check_spaces_leftright(line, lineno,
+                                                         endx, endx);
+                                  dnest = 1;
+                                }
+                              else
+                                {
+                                  ERROR("Garbage follows right bracket",
+                                        lineno, n);
+                                }
+                            }
+                          else
+                            {
+                              ERROR("Garbage follows right bracket", lineno, n);
+                            }
+                        }
+
+                      /* The right brace should not be preceded with a a blank
+                       * line.
+                       */
+
+                      if (lineno == blank_lineno + 1)
+                        {
+                          ERROR("Blank line precedes right brace at line",
+                                 lineno, 1);
+                        }
+
+                      rbrace_lineno  = lineno;
+                    }
+                    break;
+
+                  /* Handle logic with parentheses */
+
+                  case '(':
+                    {
+                      /* Increase the parenthetical nesting level */
+
+                      pnest++;
+
+                      /* Check for inappropriate space around parentheses */
+
+                      if (line[n + 1] == ' ')
+                        {
+                          ERROR("Space follows left parenthesis", lineno, n);
+                        }
+                    }
+                    break;
+
+                  case ')':
+                    {
+                      /* Decrease the parenthetical nesting level */
+
+                      if (pnest < 1)
+                        {
+                          ERROR("Unmatched right parentheses", lineno, n);
+                          pnest = 0;
+                        }
+                      else
+                        {
+                          pnest--;
+                        }
+
+                      /* Allow ')' as first thing on the line (n == indent)
+                       * Allow "for (xx; xx; )" (bfor == true)
+                       */
+
+                      if (n > 0 && n != indent && line[n - 1] == ' ' && !bfor)
+                        {
+                          ERROR("Space precedes right parenthesis", lineno, n);
+                        }
+
+                      /* Unset bif if last parenthesis is closed */
+
+                      if (bif == true && pnest == 0)
+                        {
+                          bif = false;
+                        }
+
+                      /* Remember where the header ends, to see what follows */
+
+                      if (ctrl_kw != NULL && pnest == 0 && ctrl_hdrend < 0)
+                        {
+                          ctrl_hdrend = n;
+                        }
+                    }
+                    break;
+
+                  /* Check for inappropriate space around square brackets */
+
+                  case '[':
+                    {
+                      if (line[n + 1] == ' ')
+                        {
+                          ERROR("Space follows left bracket", lineno, n);
+                        }
+                    }
+                    break;
+
+                  case ']':
+                    {
+                      if (n > 0 && line[n - 1] == ' ')
+                        {
+                          ERROR("Space precedes right bracket", lineno, n);
+                        }
+                    }
+                    break;
+
+                  /* Semi-colon may terminate a declaration */
+
+                  case ';':
+                    {
+                      if (!isspace((int)line[n + 1]))
+                        {
+                          ERROR("Missing whitespace after semicolon", lineno, n);
+                        }
+
+                      /* Semicolon terminates a declaration/definition if there
+                       * was no left curly brace (i.e., dnest is only 1).
+                       */
+
+                      if (dnest == 1)
+                        {
+                          dnest = 0;
+                        }
+                    }
+                    break;
+                  case ':':
+                    {
+                      if (bcase == true)
+                        {
+                          char *ndx = &line[n + 1];
+
+                          while ((int)isspace(*ndx))
+                            {
+                              ndx++;
+                            }
+
+                          if (*ndx != '\0' && *ndx != '/')
+                            {
+                              ERROR("Case statement should be on a new line",
+                                    lineno, n);
+                            }
+
+                          bcase = false;
+                        }
+                    }
+                    break;
+                  case ',':
+                    {
+                      if (!isspace((int)line[n + 1]))
+                        {
+                          ERROR("Missing whitespace after comma", lineno, n);
+                        }
+                    }
+                    break;
+
+                  /* Skip over character constants */
+
+                  case '\'':
+                    {
+                      int endndx = n + 2;
+
+                      if (line[n + 1] != '\n' && line[n + 1] != '\0')
+                        {
+                          if (line[n + 1] == '\\')
+                            {
+                              for (;
+                                   line[endndx] != '\n' &&
+                                   line[endndx] != '\0' &&
+                                   line[endndx] != '\'';
+                                   endndx++);
+                            }
+
+                          n = endndx;
+                        }
+                    }
+                    break;
+
+                  /* Check for space around various operators */
+
+                  case '-':
+
+                    /* -> */
+
+                    if (line[n + 1] == '>')
                       {
-                        /* REVISIT: dnest is always > 0 here if bfunctions ==
-                         * false.
+                        /* -> must have no whitespaces on its left or right */
+
+                        check_nospaces_leftright(line, lineno, n, n + 1);
+                        n++;
+                      }
+
+                    /* -- */
+
+                    else if (line[n + 1] == '-')
+                      {
+                        /* "--" should be next to its operand. If there are
+                         * whitespaces or non-operand characters on both left
+                         * and right (e.g. "a -- ", "a[i --]", "(-- i)"),
+                         * there's an error.
                          */
 
-                        if (dnest == 0 || !bfunctions || lineno == rbrace_lineno)
-                          {
-                             ERROR("Left bracket not on separate line", lineno,
-                                   n);
-                          }
+                        check_operand_leftright(line, lineno, n, n + 1);
+                        n++;
                       }
-                    else if (line[n + 1] != '\n')
+
+                    /* -= */
+
+                    else if (line[n + 1] == '=')
                       {
-                        if (dnest == 0)
-                          {
-                             ERROR("Garbage follows left bracket", lineno, n);
-                          }
+                        check_spaces_leftright(line, lineno, n, n + 1);
+                        n++;
                       }
 
-                    bnest++;
-
-                    /* Remember where a brace beginning a line sits, so the
-                     * brace closing it can be checked.  -1 for any other.
+                    /* Scientific notation with a negative exponent (eg. 10e-10)
+                     * REVISIT: This fails for cases where the variable name
+                     *          ends with 'e' preceded by a digit:
+                     *          a = abc1e-10;
+                     *          a = ABC1E-10;
                      */
 
-                    if (bnest >= 1 && bnest <= MAX_BRACE)
+                    else if ((line[n - 1] == 'e' || line[n - 1] == 'E') &&
+                             isdigit(line[n + 1]) && isdigit(line[n - 2]))
                       {
-                        lbrace_indent[bnest - 1] = n == indent ? indent : -1;
-                        lbrace_switch[bnest - 1] = false;
-                      }
-
-                    /* An outermost brace follows a parameter list for a
-                     * function, or '=' for data, which indents differently.
-                     */
-
-                    if (bnest == 1)
-                      {
-                        bfuncbody = prevlastcode == ')';
-                      }
-
-                    if (dnest > 0)
-                      {
-                        dnest++;
-                      }
-
-                    /* Check if we are within 'extern "C"', we don't
-                     * normally indent in that case because the 'extern "C"'
-                     * is conditioned on __cplusplus.
-                     */
-
-                    if (lineno == externc_lineno ||
-                        lineno - 1 == externc_lineno)
-                      {
-                        bexternc = true;
-                      }
-
-                    /* Suppress error for comment following a left brace */
-
-                    noblank_lineno = lineno;
-                    lbrace_lineno  = lineno;
-                  }
-                  break;
-
-                case '}':
-                  {
-                   /* Decrement the brace nesting level */
-
-                   if (bnest < 1)
-                     {
-                       ERROR("Unmatched right brace", lineno, n);
-                     }
-                   else
-                     {
-                       bnest--;
-                       if (bnest < 1)
-                         {
-                           bnest     = 0;
-                           bfuncbody = false;
-                         }
-
-                       /* Recover the alignment of the matching left brace */
-
-                       if (n == indent && bnest < MAX_BRACE)
-                         {
-                           rbrace_match = lbrace_indent[bnest];
-                         }
-                     }
-
-                    /* Decrement the declaration nesting level */
-
-                    if (dnest < 3)
-                      {
-                        dnest = 0;
-                        bexternc = false;
+                        n++;
                       }
                     else
                       {
-                        dnest--;
-                      }
-
-                    /* The right brace should be on a separate line */
-
-                    if (n > indent)
-                      {
-                        if (dnest == 0)
-                          {
-                             ERROR("Right bracket not on separate line",
-                                   lineno, n);
-                          }
-                      }
-
-                    /* Check for garbage following the left brace */
-
-                    if (line[n + 1] != '\n' &&
-                        line[n + 1] != ',' &&
-                        line[n + 1] != ';')
-                      {
-                        int sndx = n + 1;
-                        bool whitespace = false;
-
-                        /* Skip over spaces */
-
-                        while (line[sndx] == ' ')
-                          {
-                            sndx++;
-                          }
-
-                        /* One possibility is that the right bracket is
-                         * followed by an identifier then a semi-colon.
-                         * Comma is possible to but would be a case of
-                         * multiple declaration of multiple instances.
+                        /* '-' may function as a unary operator and snuggle
+                         * on the left.
                          */
 
-                        if (line[sndx] == '_' || isalpha(line[sndx]))
-                          {
-                            int endx = sndx;
-
-                            /* Skip to the end of the identifier.  Checking
-                             * for mixed case identifiers will be done
-                             * elsewhere.
-                             */
-
-                            while (line[endx] == '_' ||
-                                   isalnum(line[endx]))
-                              {
-                                endx++;
-                              }
-
-                            /* Skip over spaces */
-
-                            while (line[endx] == ' ')
-                              {
-                                whitespace = true;
-                                endx++;
-                              }
-
-                            /* Handle according to what comes after the
-                             * identifier.
-                             */
-
-                            if (strncmp(&line[sndx], "while", 5) == 0)
-                              {
-                                 ERROR("'while' must be on a separate line",
-                                        lineno, sndx);
-                              }
-                            else if (line[endx] == ',')
-                              {
-                                 ERROR("Multiple data definitions on line",
-                                        lineno, endx);
-                              }
-                            else if (line[endx] == ';')
-                              {
-                                if (whitespace)
-                                  {
-                                     ERROR("Space precedes semi-colon",
-                                           lineno, endx);
-                                  }
-                              }
-                            else if (line[endx] == '=')
-                              {
-                                /* There's a struct initialization following */
-
-                                check_spaces_leftright(line, lineno, endx, endx);
-                                dnest = 1;
-                              }
-                            else
-                              {
-                                 ERROR("Garbage follows right bracket",
-                                       lineno, n);
-                              }
-                          }
-                        else
-                          {
-                             ERROR("Garbage follows right bracket", lineno, n);
-                          }
+                        check_spaces_left(line, lineno, n);
                       }
 
-                    /* The right brace should not be preceded with a a blank
-                     * line.
-                     */
+                    break;
 
-                    if (lineno == blank_lineno + 1)
+                  case '+':
+
+                    /* ++ */
+
+                    if (line[n + 1] == '+')
                       {
-                         ERROR("Blank line precedes right brace at line",
-                                lineno, 1);
+                        /* "++" should be next to its operand. If there are
+                         * whitespaces or non-operand characters on both left
+                         * and right (e.g. "a ++ ", "a[i ++]", "(++ i)"),
+                         * there's an error.
+                         */
+
+                        check_operand_leftright(line, lineno, n, n + 1);
+                        n++;
                       }
 
-                    rbrace_lineno  = lineno;
-                  }
-                  break;
+                    /* += */
 
-                /* Handle logic with parentheses */
-
-                case '(':
-                  {
-                    /* Increase the parenthetical nesting level */
-
-                    pnest++;
-
-                   /* Check for inappropriate space around parentheses */
-
-                    if (line[n + 1] == ' ')
+                    else if (line[n + 1] == '=')
                       {
-                         ERROR("Space follows left parenthesis", lineno, n);
-                      }
-                  }
-                  break;
-
-                case ')':
-                  {
-                    /* Decrease the parenthetical nesting level */
-
-                    if (pnest < 1)
-                      {
-                        ERROR("Unmatched right parentheses", lineno, n);
-                        pnest = 0;
+                        check_spaces_leftright(line, lineno, n, n + 1);
+                        n++;
                       }
                     else
-                     {
-                       pnest--;
-                     }
-
-                    /* Allow ')' as first thing on the line (n == indent)
-                     * Allow "for (xx; xx; )" (bfor == true)
-                     */
-
-                    if (n > 0 && n != indent && line[n - 1] == ' ' && !bfor)
                       {
-                        ERROR("Space precedes right parenthesis", lineno, n);
+                        /* '+' may function as a unary operator and snuggle
+                         * on the left.
+                         */
+
+                        check_spaces_left(line, lineno, n);
                       }
 
-                    /* Unset bif if last parenthesis is closed */
+                    break;
 
-                    if (bif == true && pnest == 0)
+                  case '&':
+
+                    /* &<variable> OR &(<expression>) */
+
+                    if (isalpha((int)line[n + 1]) || line[n + 1] == '_' ||
+                        line[n + 1] == '(')
                       {
-                        bif = false;
                       }
 
-                    /* Remember where the header ends, to see what follows */
+                    /* &&, &= */
 
-                    if (ctrl_kw != NULL && pnest == 0 && ctrl_hdrend < 0)
+                    else if (line[n + 1] == '=' || line[n + 1] == '&')
                       {
-                        ctrl_hdrend = n;
+                        check_spaces_leftright(line, lineno, n, n + 1);
+                        n++;
                       }
-                  }
-                  break;
-
-                /* Check for inappropriate space around square brackets */
-
-                case '[':
-                  {
-                    if (line[n + 1] == ' ')
+                    else
                       {
-                         ERROR("Space follows left bracket", lineno, n);
-                      }
-                  }
-                  break;
-
-                case ']':
-                  {
-                    if (n > 0 && line[n - 1] == ' ')
-                      {
-                         ERROR("Space precedes right bracket", lineno, n);
-                      }
-                  }
-                  break;
-
-                /* Semi-colon may terminate a declaration */
-
-                case ';':
-                  {
-                    if (!isspace((int)line[n + 1]))
-                      {
-                        ERROR("Missing whitespace after semicolon", lineno, n);
+                        check_spaces_leftright(line, lineno, n, n);
                       }
 
-                    /* Semicolon terminates a declaration/definition if there
-                     * was no left curly brace (i.e., dnest is only 1).
-                     */
+                    break;
 
-                    if (dnest == 1)
+                  case '/':
+
+                    /* C comment terminator */
+
+                    if (line[n - 1] == '*')
                       {
-                        dnest = 0;
+                        n++;
                       }
-                  }
-                  break;
-                case ':':
-                  {
-                    if (bcase == true)
-                      {
-                        char *ndx = &line[n + 1];
-                        while ((int)isspace(*ndx))
-                          {
-                            ndx++;
-                          }
-
-                        if (*ndx != '\0' && *ndx != '/')
-                          {
-                            ERROR("Case statement should be on a new line",
-                                  lineno, n);
-                          }
-
-                        bcase = false;
-                      }
-                  }
-                  break;
-                case ',':
-                  {
-                    if (!isspace((int)line[n + 1]))
-                      {
-                        ERROR("Missing whitespace after comma", lineno, n);
-                      }
-                  }
-                  break;
-
-                /* Skip over character constants */
-
-                case '\'':
-                  {
-                    int endndx = n + 2;
-
-                    if (line[n + 1] != '\n' && line[n + 1] != '\0')
-                      {
-                        if (line[n + 1] == '\\')
-                          {
-                            for (;
-                                 line[endndx] != '\n' &&
-                                 line[endndx] != '\0' &&
-                                 line[endndx] != '\'';
-                                 endndx++);
-                          }
-
-                        n = endndx;
-                      }
-                  }
-                  break;
-
-                /* Check for space around various operators */
-
-                case '-':
-
-                  /* -> */
-
-                  if (line[n + 1] == '>')
-                    {
-                      /* -> must have no whitespaces on its left or right */
-
-                      check_nospaces_leftright(line, lineno, n, n + 1);
-                      n++;
-                    }
-
-                  /* -- */
-
-                  else if (line[n + 1] == '-')
-                    {
-                      /* "--" should be next to its operand. If there are
-                       * whitespaces or non-operand characters on both left
-                       * and right (e.g. "a -- ", "a[i --]", "(-- i)"),
-                       * there's an error.
-                       */
-
-                      check_operand_leftright(line, lineno, n, n + 1);
-                      n++;
-                    }
-
-                  /* -= */
-
-                  else if (line[n + 1] == '=')
-                    {
-                      check_spaces_leftright(line, lineno, n, n + 1);
-                      n++;
-                    }
-
-                  /* Scientific notation with a negative exponent (eg. 10e-10)
-                   * REVISIT: This fails for cases where the variable name
-                   *          ends with 'e' preceded by a digit:
-                   *          a = abc1e-10;
-                   *          a = ABC1E-10;
-                   */
-
-                  else if ((line[n - 1] == 'e' || line[n - 1] == 'E') &&
-                           isdigit(line[n + 1]) && isdigit(line[n - 2]))
-                    {
-                      n++;
-                    }
-                  else
-                    {
-                      /* '-' may function as a unary operator and snuggle
-                       * on the left.
-                       */
-
-                      check_spaces_left(line, lineno, n);
-                    }
-
-                  break;
-
-                case '+':
-
-                  /* ++ */
-
-                  if (line[n + 1] == '+')
-                    {
-                      /* "++" should be next to its operand. If there are
-                       * whitespaces or non-operand characters on both left
-                       * and right (e.g. "a ++ ", "a[i ++]", "(++ i)"),
-                       * there's an error.
-                       */
-
-                      check_operand_leftright(line, lineno, n, n + 1);
-                      n++;
-                    }
-
-                  /* += */
-
-                  else if (line[n + 1] == '=')
-                    {
-                      check_spaces_leftright(line, lineno, n, n + 1);
-                      n++;
-                    }
-                  else
-                    {
-                      /* '+' may function as a unary operator and snuggle
-                       * on the left.
-                       */
-
-                      check_spaces_left(line, lineno, n);
-                    }
-
-                  break;
-
-                case '&':
-
-                  /* &<variable> OR &(<expression>) */
-
-                  if (isalpha((int)line[n + 1]) || line[n + 1] == '_' ||
-                      line[n + 1] == '(')
-                    {
-                    }
-
-                  /* &&, &= */
-
-                  else if (line[n + 1] == '=' || line[n + 1] == '&')
-                    {
-                      check_spaces_leftright(line, lineno, n, n + 1);
-                      n++;
-                    }
-                  else
-                    {
-                      check_spaces_leftright(line, lineno, n, n);
-                    }
-
-                  break;
-
-                case '/':
-
-                  /* C comment terminator */
-
-                  if (line[n - 1] == '*')
-                    {
-                      n++;
-                    }
 
                     /* C++-style comment */
 
-                  else if (line[n + 1] == '/')
-                    {
-                      /* Check for "http://" or "https://" */
+                    else if (line[n + 1] == '/')
+                      {
+                        /* Check for "http://" or "https://" */
 
-                      if ((n < 5 || strncmp(&line[n - 5], "http://", 7) != 0) &&
-                          (n < 6 || strncmp(&line[n - 6], "https://", 8) != 0))
-                        {
-                          ERROR("C++ style comment on at %d:%d\n",
-                                lineno, n);
-                        }
+                        if ((n < 5 ||
+                             strncmp(&line[n - 5], "http://", 7) != 0) &&
+                            (n < 6 ||
+                             strncmp(&line[n - 6], "https://", 8) != 0))
+                          {
+                            ERROR("C++ style comment on at %d:%d\n",
+                                  lineno, n);
+                          }
 
-                      n++;
-                    }
+                        n++;
+                      }
 
-                  /* /= */
+                    /* /= */
 
-                  else if (line[n + 1] == '=')
-                    {
-                      check_spaces_leftright(line, lineno, n, n + 1);
-                      n++;
-                    }
+                    else if (line[n + 1] == '=')
+                      {
+                        check_spaces_leftright(line, lineno, n, n + 1);
+                        n++;
+                      }
 
-                  /* Division operator */
+                    /* Division operator */
 
-                  else
-                    {
-                      check_spaces_leftright(line, lineno, n, n);
-                    }
+                    else
+                      {
+                        check_spaces_leftright(line, lineno, n, n);
+                      }
 
-                  break;
+                    break;
 
-                case '*':
+                  case '*':
 
-                  /* *\/, ** */
+                    /* *\/, ** */
 
-                  if (line[n] == '*' &&
-                      (line[n + 1] == '/' ||
-                       line[n + 1] == '*'))
-                    {
-                     n++;
-                     break;
-                    }
+                    if (line[n] == '*' &&
+                        (line[n + 1] == '/' ||
+                         line[n + 1] == '*'))
+                      {
+                        n++;
+                        break;
+                      }
 
-                  /* *<variable>, *(<expression>) */
+                    /* *<variable>, *(<expression>) */
 
-                  else if (isalpha((int)line[n + 1]) ||
-                           line[n + 1] == '_' ||
-                           line[n + 1] == '(')
-                    {
-                      break;
-                    }
+                    else if (isalpha((int)line[n + 1]) ||
+                             line[n + 1] == '_' ||
+                             line[n + 1] == '(')
+                      {
+                        break;
+                      }
 
-                  /* (<type> *) */
+                    /* (<type> *) */
 
-                  else if (line[n + 1] == ')')
-                    {
-                      /* REVISIT: This gives false alarms on syntax like *--ptr */
+                    else if (line[n + 1] == ')')
+                      {
+                        /* REVISIT: This gives false alarms on syntax
+                         * like *--ptr
+                         */
 
-                      if (line[n - 1] != ' ' && line[n - 1] != '(')
-                        {
-                           ERROR("Operator/assignment must be preceded "
-                                  "with whitespace", lineno, n);
-                        }
+                        if (line[n - 1] != ' ' && line[n - 1] != '(')
+                          {
+                            ERROR("Operator/assignment must be preceded "
+                                   "with whitespace", lineno, n);
+                          }
 
-                      break;
-                    }
+                        break;
+                      }
 
-                  /* *= */
+                    /* *= */
 
-                  else if (line[n + 1] == '=')
-                    {
-                      check_spaces_leftright(line, lineno, n, n + 1);
-                      n++;
-                    }
-                  else
-                    {
-                      /* A single '*' may be an binary operator, but
-                       * it could also be a unary operator when used to deference
-                       * a pointer.
-                       */
+                    else if (line[n + 1] == '=')
+                      {
+                        check_spaces_leftright(line, lineno, n, n + 1);
+                        n++;
+                      }
+                    else
+                      {
+                        /* A single '*' may be an binary operator, but
+                         * it could also be a unary operator when used to
+                         * deference a pointer.
+                         */
 
-                      check_spaces_left(line, lineno, n);
-                    }
+                        check_spaces_left(line, lineno, n);
+                      }
 
-                  break;
+                    break;
 
-                case '%':
+                  case '%':
 
-                  /* %= */
+                    /* %= */
 
-                  if (line[n + 1] == '=')
-                    {
-                      check_spaces_leftright(line, lineno, n, n + 1);
-                      n++;
-                    }
-                  else
-                    {
-                      check_spaces_leftright(line, lineno, n, n);
-                    }
+                    if (line[n + 1] == '=')
+                      {
+                        check_spaces_leftright(line, lineno, n, n + 1);
+                        n++;
+                      }
+                    else
+                      {
+                        check_spaces_leftright(line, lineno, n, n);
+                      }
 
-                  break;
+                    break;
 
-                case '<':
+                  case '<':
 
-                  /* <=, <<, <<= */
+                    /* <=, <<, <<= */
 
-                  if (line[n + 1] == '=')
-                    {
-                      check_spaces_leftright(line, lineno, n, n + 1);
-                      n++;
-                    }
-                  else if (line[n + 1] == '<')
-                    {
-                      if (line[n + 2] == '=')
-                        {
-                          check_spaces_leftright(line, lineno, n, n + 2);
-                          n += 2;
-                        }
-                      else
-                        {
-                          check_spaces_leftright(line, lineno, n, n + 1);
-                          n++;
-                        }
-                    }
-                  else
-                    {
-                      check_spaces_leftright(line, lineno, n, n);
-                    }
+                    if (line[n + 1] == '=')
+                      {
+                        check_spaces_leftright(line, lineno, n, n + 1);
+                        n++;
+                      }
+                    else if (line[n + 1] == '<')
+                      {
+                        if (line[n + 2] == '=')
+                          {
+                            check_spaces_leftright(line, lineno, n, n + 2);
+                            n += 2;
+                          }
+                        else
+                          {
+                            check_spaces_leftright(line, lineno, n, n + 1);
+                            n++;
+                          }
+                      }
+                    else
+                      {
+                        check_spaces_leftright(line, lineno, n, n);
+                      }
 
-                  break;
+                    break;
 
-                case '>':
+                  case '>':
 
-                  /* >=, >>, >>= */
+                    /* >=, >>, >>= */
 
-                  if (line[n + 1] == '=')
-                    {
-                      check_spaces_leftright(line, lineno, n, n + 1);
-                      n++;
-                    }
-                  else if (line[n + 1] == '>')
-                    {
-                      if (line[n + 2] == '=')
-                        {
-                          check_spaces_leftright(line, lineno, n, n + 2);
-                          n += 2;
-                        }
-                      else
-                        {
-                          check_spaces_leftright(line, lineno, n, n + 1);
-                          n++;
-                        }
-                    }
-                  else
-                    {
-                      check_spaces_leftright(line, lineno, n, n);
-                    }
+                    if (line[n + 1] == '=')
+                      {
+                        check_spaces_leftright(line, lineno, n, n + 1);
+                        n++;
+                      }
+                    else if (line[n + 1] == '>')
+                      {
+                        if (line[n + 2] == '=')
+                          {
+                            check_spaces_leftright(line, lineno, n, n + 2);
+                            n += 2;
+                          }
+                        else
+                          {
+                            check_spaces_leftright(line, lineno, n, n + 1);
+                            n++;
+                          }
+                      }
+                    else
+                      {
+                        check_spaces_leftright(line, lineno, n, n);
+                      }
 
-                  break;
+                    break;
 
-                case '|':
+                  case '|':
 
-                  /* |=, || */
+                    /* |=, || */
 
-                  if (line[n + 1] == '=')
-                    {
-                      check_spaces_leftright(line, lineno, n, n + 1);
-                      n++;
-                    }
-                  else if (line[n + 1] == '|')
-                    {
-                      check_spaces_leftright(line, lineno, n, n + 1);
-                      n++;
-                    }
-                  else
-                    {
-                      check_spaces_leftright(line, lineno, n, n);
-                    }
+                    if (line[n + 1] == '=')
+                      {
+                        check_spaces_leftright(line, lineno, n, n + 1);
+                        n++;
+                      }
+                    else if (line[n + 1] == '|')
+                      {
+                        check_spaces_leftright(line, lineno, n, n + 1);
+                        n++;
+                      }
+                    else
+                      {
+                        check_spaces_leftright(line, lineno, n, n);
+                      }
 
-                  break;
-                case '^':
+                    break;
+                  case '^':
 
-                  /* ^= */
+                    /* ^= */
 
-                  if (line[n + 1] == '=')
-                    {
-                      check_spaces_leftright(line, lineno, n, n + 1);
-                      n++;
-                    }
-                  else
-                    {
-                      check_spaces_leftright(line, lineno, n, n);
-                    }
+                    if (line[n + 1] == '=')
+                      {
+                        check_spaces_leftright(line, lineno, n, n + 1);
+                        n++;
+                      }
+                    else
+                      {
+                        check_spaces_leftright(line, lineno, n, n);
+                      }
 
-                  break;
+                    break;
 
-                case '=':
+                  case '=':
 
-                  /* == */
+                    /* == */
 
-                  if (line[n + 1] == '=')
-                    {
-                      check_spaces_leftright(line, lineno, n, n + 1);
-                      n++;
-                    }
-                  else
-                    {
-                      check_spaces_leftright(line, lineno, n, n);
-                    }
+                    if (line[n + 1] == '=')
+                      {
+                        check_spaces_leftright(line, lineno, n, n + 1);
+                        n++;
+                      }
+                    else
+                      {
+                        check_spaces_leftright(line, lineno, n, n);
+                      }
 
-                  break;
+                    break;
 
-                case '~':
-                  check_spaces_left(line, lineno, n);
-                  break;
+                  case '~':
+                    check_spaces_left(line, lineno, n);
+                    break;
 
-                case '!':
+                  case '!':
 
-                  /* != */
+                    /* != */
 
-                  if (line[n + 1] == '=')
-                    {
-                      check_spaces_leftright(line, lineno, n, n + 1);
-                      n++;
-                    }
+                    if (line[n + 1] == '=')
+                      {
+                        check_spaces_leftright(line, lineno, n, n + 1);
+                        n++;
+                      }
 
-                  /* !! */
+                    /* !! */
 
-                  else if (line[n + 1] == '!')
-                    {
-                      check_spaces_left(line, lineno, n);
-                      n++;
-                    }
-                  else
-                    {
-                      check_spaces_left(line, lineno, n);
-                    }
+                    else if (line[n + 1] == '!')
+                      {
+                        check_spaces_left(line, lineno, n);
+                        n++;
+                      }
+                    else
+                      {
+                        check_spaces_left(line, lineno, n);
+                      }
 
-                  break;
+                    break;
 
-                default:
-                  break;
+                  default:
+                    break;
                 }
             }
         }
@@ -3770,6 +3782,7 @@ int main(int argc, char **argv, char **envp)
            */
 
           int m = n;
+
           if (line[m] == '\0' && m > 0)
             {
               m--;
@@ -4045,7 +4058,7 @@ int main(int argc, char **argv, char **envp)
                                  indent != case_indent)
                               : (indent & 3) != 2))
                     {
-                       ERROR("Bad comment alignment", lineno, indent);
+                      ERROR("Bad comment alignment", lineno, indent);
                     }
 
                   /* REVISIT:  This screws up in cases where there is C code,
@@ -4054,7 +4067,7 @@ int main(int argc, char **argv, char **envp)
 
                   else if (line[indent + 1] != '*')
                     {
-                       ERROR("Missing asterisk in comment", lineno, indent);
+                      ERROR("Missing asterisk in comment", lineno, indent);
                     }
                 }
               else if (line[indent] == '*')
@@ -4075,7 +4088,7 @@ int main(int argc, char **argv, char **envp)
                                   indent != case_indent + 1))
                               : (indent & 3) != 3))
                     {
-                       ERROR("Bad comment block alignment", lineno, indent);
+                      ERROR("Bad comment block alignment", lineno, indent);
                     }
 
                   if (line[indent + 1] != ' ' &&
@@ -4083,8 +4096,8 @@ int main(int argc, char **argv, char **envp)
                       line[indent + 1] != '\n' &&
                       line[indent + 1] != '/')
                     {
-                       ERROR("Invalid character after asterisk "
-                             "in comment block", lineno, indent);
+                      ERROR("Invalid character after asterisk "
+                            "in comment block", lineno, indent);
                     }
                 }
 
@@ -4105,9 +4118,9 @@ int main(int argc, char **argv, char **envp)
         {
           if (indent == 0 && strchr("\n#{}", line[0]) == NULL)
             {
-               /* Ignore if we are at global scope */
+              /* Ignore if we are at global scope */
 
-               if (prevbnest > 0)
+              if (prevbnest > 0)
                 {
                   bool blabel = false;
 

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -1443,6 +1443,9 @@ int main(int argc, char **argv, char **envp)
   int externc_lineno;   /* Last line where 'extern "C"' declared */
   bool bexact;          /* True: The expected indentation below is exact */
   bool bppline;         /* True: This line is a pre-processor line */
+  bool blabelline;      /* True: This line holds nothing but a label */
+  bool bstmtstart;      /* True: A new statement begins on this line */
+  bool bprevstmtend;    /* True: The preceding line of code ended a statement */
   bool bctrlline;       /* True: A control statement starts on this line */
   char lastcode;        /* Last code character seen on this line */
   char prevlastcode;    /* Last code character on the preceding line */
@@ -1570,6 +1573,9 @@ int main(int argc, char **argv, char **envp)
   brace_indent   = 0;           /* Indentation of the awaiting keyword */
   bexact         = false;       /* True: Expected indentation is exact */
   bppline        = false;       /* True: This line is a pre-processor line */
+  blabelline     = false;       /* True: This line holds nothing but a label */
+  bstmtstart     = true;        /* True: A statement begins on this line */
+  bprevstmtend   = true;        /* True: The preceding code ended a statement */
   bctrlline      = false;       /* True: A control statement starts here */
   lastcode       = '\0';        /* Last code character seen on this line */
   prevlastcode   = '\0';        /* Last code character on the preceding line */
@@ -1621,7 +1627,25 @@ int main(int argc, char **argv, char **envp)
       bctrlline    = false;    /* No control statement starts on this line */
       ctrl_bswitch = false;    /* That brace does not open a switch body */
       bppline      = false;    /* True: This line is a pre-processor line */
+
+      /* A label ends the preceding statement, like a 'case' does */
+
+      blabelline = false;
+
+      if (isalpha((int)line[indent]) != 0 || line[indent] == '_')
+        {
+          int ii = indent;
+
+          while (isalnum((int)line[ii]) != 0 || line[ii] == '_')
+            {
+              ii++;
+            }
+
+          blabelline = line[ii] == ':' && line[ii + 1] != ':';
+        }
+
       lastcode     = '\0';     /* No code has been seen on this line yet */
+      bstmtstart   = bprevstmtend;
       rbrace_match = -1;       /* No left brace is closed on this line */
 
       /* Where a statement on this line is expected to begin: two columns in
@@ -3796,6 +3820,22 @@ int main(int argc, char **argv, char **envp)
       bexact = bnest > 0 && dnest == 0 && prevpnest == 0 && stmt_indent > 0 &&
                bfunctions && bfuncbody;
 
+      /* A line after one ending in ';', '{', '}' or a label begins a new
+       * statement; anything else continues the previous one.
+       */
+
+      if (lastcode != '\0' && !bppline)
+        {
+          /* A colon ends a statement only in a label, and a line left inside
+           * parentheses is always continued, so a 'for' clause does not.
+           */
+
+          bprevstmtend = pnest == 0 &&
+                         (lastcode == ';' || lastcode == '{' ||
+                          lastcode == '}' ||
+                          (lastcode == ':' && (bcaseline || blabelline)));
+        }
+
       /* A line that follows one ending in ';', '{', '}' or ':' begins a new
        * statement.  Anything else is the continuation of the statement on the
        * preceding line and may be aligned freely.  Pre-processor lines are
@@ -4054,6 +4094,7 @@ int main(int argc, char **argv, char **envp)
                     }
                 }
               else if ((bstatm ||                         /* Begins with C keyword */
+                  (bstmtstart && bexact) ||               /* Begins a statement */
                   (line[indent] == '/' &&
                   bfunctions &&
                   line[indent + 1] == '*')) &&            /* Comment in functions */

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -1360,6 +1360,27 @@ static bool white_content_list(const char *ident, int lineno)
 }
 
 /********************************************************************************
+ * Name: check_type_name
+ *
+ * Description:
+ *   Return true if the identifier at line[ndx] ends in '_t'.
+ *
+ ********************************************************************************/
+
+static bool check_type_name(const char *line, int ndx)
+{
+  int i = ndx;
+
+  while (isalnum((int)line[i]) != 0 || line[i] == '_')
+    {
+      i++;
+    }
+
+  return i >= ndx + 3 && line[i] == ' ' &&
+         line[i - 1] == 't' && line[i - 2] == '_';
+}
+
+/********************************************************************************
  * Name: check_keyword
  *
  * Description:
@@ -2257,7 +2278,8 @@ int main(int argc, char **argv, char **envp)
 
       else if (inasm == 0)
         {
-          if (strncmp(&line[indent], "auto ", 5) == 0 ||
+          if (check_type_name(line, indent) ||
+                   strncmp(&line[indent], "auto ", 5) == 0 ||
                    strncmp(&line[indent], "bool ", 5) == 0 ||
                    strncmp(&line[indent], "char ", 5) == 0 ||
                    strncmp(&line[indent], "CODE ", 5) == 0 ||

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -1561,6 +1561,7 @@ int main(int argc, char **argv, char **envp)
   char lastcode;        /* Last code character seen on this line */
   char prevlastcode;    /* Last code character on the preceding line */
   int prevcodeindent;   /* Indentation of the preceding line of code */
+  int stmt_lineindent;  /* Indentation of the line starting that statement */
   bool bfuncbody;       /* True: The outermost brace opened a function body */
   int stmt_indent;      /* Expected indentation of a statement, or -1 */
   int case_indent;      /* Expected indentation of a 'case' label, or -1 */
@@ -1694,6 +1695,7 @@ int main(int argc, char **argv, char **envp)
   lastcode       = '\0';        /* Last code character seen on this line */
   prevlastcode   = '\0';        /* Last code character on the preceding line */
   prevcodeindent = 0;           /* Indentation of the preceding line of code */
+  stmt_lineindent = 0;          /* Indentation where that statement began */
   bfuncbody      = false;       /* True: Inside the body of a function */
   stmt_indent    = 0;           /* Expected indentation of a statement */
   case_indent    = -1;          /* Expected indentation of a 'case' label */
@@ -4163,7 +4165,9 @@ int main(int argc, char **argv, char **envp)
                * that way.
                */
 
-              else if (prevlastcode == ')' && indent == prevcodeindent + 2)
+              else if (prevlastcode == ')' &&
+                       (indent == prevcodeindent + 2 ||
+                        indent == stmt_lineindent + 2))
                 {
                 }
               else if (indent > 0 && dnest == 0 &&
@@ -4256,6 +4260,11 @@ int main(int argc, char **argv, char **envp)
         {
           prevlastcode   = lastcode;
           prevcodeindent = indent;
+
+          if (bstmtstart)
+            {
+              stmt_lineindent = indent;
+            }
         }
     }
 

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -1392,6 +1392,107 @@ static bool check_keyword(const char *line, int ndx, const char *kw)
 }
 
 /********************************************************************************
+ * Name: check_declaration
+ *
+ * Description:
+ *   Return true if the line has the shape of a declaration: two or more names
+ *   in a row, ending in '=', ';', '[', ',' or a parameter list.  No list of
+ *   type names can be complete, so the shape is used instead.
+ *
+ ********************************************************************************/
+
+static bool check_declaration(const char *line, int ndx)
+{
+  static const char *const nondecl[] =
+  {
+    "return", "if", "else", "while", "for", "do", "switch", "case",
+    "default", "break", "continue", "goto", "sizeof", "asm", "__asm",
+    "__asm__", NULL
+  };
+
+  const char *const *kw;
+  int nident = 0;
+  int i = ndx;
+
+  /* Must open with a type name; keeps out '*ptr = x;' and comment lines */
+
+  if (isalpha((int)line[ndx]) == 0 && line[ndx] != '_')
+    {
+      return false;
+    }
+
+  for (kw = nondecl; *kw != NULL; kw++)
+    {
+      if (check_keyword(line, ndx, *kw))
+        {
+          return false;
+        }
+    }
+
+  while (line[i] != '\0' && line[i] != '\n')
+    {
+      if (isalpha((int)line[i]) != 0 || line[i] == '_')
+        {
+          nident++;
+          while (isalnum((int)line[i]) != 0 || line[i] == '_')
+            {
+              i++;
+            }
+        }
+      else if (line[i] == ' ' || line[i] == '*')
+        {
+          i++;
+        }
+      else
+        {
+          /* Only a terminator that can follow the declared name counts */
+
+          /* '<type> (*<name>)(...)' declares a pointer to a function.  The
+           * second parameter list tells it from a call like 'foo(*ptr)'.
+           */
+
+          if (line[i] == '(' && nident == 1)
+            {
+              int j = i + 1;
+
+              while (line[j] == ' ')
+                {
+                  j++;
+                }
+
+              if (line[j] == '*')
+                {
+                  j++;
+                  while (line[j] == ' ')
+                    {
+                      j++;
+                    }
+
+                  while (isalnum((int)line[j]) != 0 || line[j] == '_')
+                    {
+                      j++;
+                    }
+
+                  while (line[j] == ' ')
+                    {
+                      j++;
+                    }
+
+                  if (line[j] == ')' && line[j + 1] == '(')
+                    {
+                      return true;
+                    }
+                }
+            }
+
+          return nident >= 2 && strchr("=;[(,", line[i]) != NULL;
+        }
+    }
+
+  return false;
+}
+
+/********************************************************************************
  * Public Functions
  ********************************************************************************/
 
@@ -1449,7 +1550,10 @@ int main(int argc, char **argv, char **envp)
   int externc_lineno;   /* Last line where 'extern "C"' declared */
   bool bexact;          /* True: The expected indentation below is exact */
   bool bppline;         /* True: This line is a pre-processor line */
+  bool bdeclline;       /* True: This line begins a local declaration */
   bool blabelline;      /* True: This line holds nothing but a label */
+  bool bindecl;         /* True: A local declaration is being continued */
+  int decl_lineno;      /* Line on which the last declaration ended */
   bool bstmtstart;      /* True: A new statement begins on this line */
   bool bprevstmtend;    /* True: The preceding line of code ended a statement */
   bool bctrlline;       /* True: A control statement starts on this line */
@@ -1579,7 +1683,10 @@ int main(int argc, char **argv, char **envp)
   brace_indent   = 0;           /* Indentation of the awaiting keyword */
   bexact         = false;       /* True: Expected indentation is exact */
   bppline        = false;       /* True: This line is a pre-processor line */
+  bdeclline      = false;       /* True: This line begins a declaration */
   blabelline     = false;       /* True: This line holds nothing but a label */
+  bindecl        = false;       /* True: A declaration is being continued */
+  decl_lineno    = -1;          /* Line on which a declaration last ended */
   bstmtstart     = true;        /* True: A statement begins on this line */
   bprevstmtend   = true;        /* True: The preceding code ended a statement */
   bctrlline      = false;       /* True: A control statement starts here */
@@ -1631,6 +1738,7 @@ int main(int argc, char **argv, char **envp)
       bctrlline    = false;    /* No control statement starts on this line */
       ctrl_bswitch = false;    /* That brace does not open a switch body */
       bppline      = false;    /* True: This line is a pre-processor line */
+      bdeclline    = false;    /* True: This line begins a declaration */
 
       /* A label ends the preceding statement, like a 'case' does */
 
@@ -2250,7 +2358,6 @@ int main(int argc, char **argv, char **envp)
         }
 
       /* Check for some kind of declaration.
-       * REVISIT: The following logic fails for any non-standard types.
        * REVISIT: Terminator after keyword might not be a space.  Might be
        * a newline, for example.  struct and unions are often unnamed, for
        * example.
@@ -2258,6 +2365,16 @@ int main(int argc, char **argv, char **envp)
 
       else if (inasm == 0)
         {
+          /* Note a local declaration, for the blank line that must follow */
+
+          if (bfunctions && bnest > 0 && pnest == 0 && dnest == 0 &&
+              ncomment == 0 && prevncomment == 0 && !bstring && bstmtstart &&
+              check_declaration(line, indent))
+            {
+              bdeclline = true;
+              bindecl   = true;
+            }
+
           if (check_type_name(line, indent) ||
                    strncmp(&line[indent], "auto ", 5) == 0 ||
                    strncmp(&line[indent], "bool ", 5) == 0 ||
@@ -3831,12 +3948,21 @@ int main(int argc, char **argv, char **envp)
                           (lastcode == ':' && (bcaseline || blabelline)));
         }
 
-      /* A line that follows one ending in ';', '{', '}' or ':' begins a new
-       * statement.  Anything else is the continuation of the statement on the
-       * preceding line and may be aligned freely.  Pre-processor lines are
-       * ignored so that a macro definition does not hide the statement that
-       * precedes it.
-       */
+      /* Remember the line on which the last declaration ended */
+
+      if (bindecl && lastcode == ';' && pnest == 0)
+        {
+          decl_lineno = lineno;
+          bindecl     = false;
+        }
+
+      /* A blank line must separate the declarations from the code */
+
+      if (bexact && prevdnest == 0 && !bppline && !bdeclline && !bindecl &&
+          bstmtstart && lineno == decl_lineno + 1 && lastcode != '\0')
+        {
+          ERROR("Missing blank line after declarations", lineno, indent);
+        }
 
       /* STEP 4: Check alignment */
 

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -1350,6 +1350,27 @@ static bool white_content_list(const char *ident, int lineno)
 }
 
 /********************************************************************************
+ * Name: check_type_name
+ *
+ * Description:
+ *   Return true if the identifier at line[ndx] ends in '_t'.
+ *
+ ********************************************************************************/
+
+static bool check_type_name(const char *line, int ndx)
+{
+  int i = ndx;
+
+  while (isalnum((int)line[i]) != 0 || line[i] == '_')
+    {
+      i++;
+    }
+
+  return i >= ndx + 3 && line[i] == ' ' &&
+         line[i - 1] == 't' && line[i - 2] == '_';
+}
+
+/********************************************************************************
  * Name: check_keyword
  *
  * Description:
@@ -2237,7 +2258,8 @@ int main(int argc, char **argv, char **envp)
 
       else if (inasm == 0)
         {
-          if (strncmp(&line[indent], "auto ", 5) == 0 ||
+          if (check_type_name(line, indent) ||
+                   strncmp(&line[indent], "auto ", 5) == 0 ||
                    strncmp(&line[indent], "bool ", 5) == 0 ||
                    strncmp(&line[indent], "char ", 5) == 0 ||
                    strncmp(&line[indent], "CODE ", 5) == 0 ||

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -1387,22 +1387,22 @@ int main(int argc, char **argv, char **envp)
   bool bstatm;          /* True: This line is beginning of a statement */
   bool bfor;            /* True: This line is beginning of a 'for' statement */
   bool bif;             /* True: This line is beginning of a 'if' statement */
-  bool bswitch;         /* True: Within a switch statement */
   bool bcase;           /* True: Within a case statement of a switch */
-  bool bstring;         /* True: Within a string */
-  bool bquote;          /* True: Backslash quoted character next */
-  bool bblank;          /* Used to verify block comment terminator */
-  bool bexternc;        /* True: Within 'extern "C"' */
-  bool bppline;         /* True: This line is a pre-processor line */
-  bool bctrlline;       /* True: A control statement starts on this line */
+  bool bcaseline;       /* True: This line begins with 'case' or 'default' */
   const char *ctrl_kw;  /* Control keyword whose header is being parsed */
   const char *brace_kw; /* Control keyword still waiting for its left brace */
   int ctrl_hdrend;      /* Index of the last character of that header */
   int ctrl_indent;      /* Indentation of that control keyword */
   int brace_indent;     /* Indentation of the keyword awaiting a brace */
   int ctrl_brace;       /* Alignment required of a brace on this line, or -1 */
+  bool ctrl_bswitch;    /* True: That brace opens the body of a switch */
   int rbrace_match;     /* Alignment of the left brace closed on this line */
   int lbrace_indent[MAX_BRACE]; /* Indentation of each open left brace */
+  bool lbrace_switch[MAX_BRACE]; /* True: That brace opens a switch body */
+  bool bstring;         /* True: Within a string */
+  bool bquote;          /* True: Backslash quoted character next */
+  bool bblank;          /* Used to verify block comment terminator */
+  bool bexternc;        /* True: Within 'extern "C"' */
   enum pptype_e ppline; /* > 0: The next line the continuation of a
                          * pre-processor command */
   int rhcomment;        /* Indentation of Comment to the right of code
@@ -1426,6 +1426,15 @@ int main(int argc, char **argv, char **envp)
   int lbrace_lineno;    /* Line number of last left brace */
   int rbrace_lineno;    /* Last line containing a right brace */
   int externc_lineno;   /* Last line where 'extern "C"' declared */
+  bool bexact;          /* True: The expected indentation below is exact */
+  bool bppline;         /* True: This line is a pre-processor line */
+  bool bctrlline;       /* True: A control statement starts on this line */
+  char lastcode;        /* Last code character seen on this line */
+  char prevlastcode;    /* Last code character on the preceding line */
+  int prevcodeindent;   /* Indentation of the preceding line of code */
+  bool bfuncbody;       /* True: The outermost brace opened a function body */
+  int stmt_indent;      /* Expected indentation of a statement, or -1 */
+  int case_indent;      /* Expected indentation of a 'case' label, or -1 */
   int linelen;          /* Length of the line */
   int excess;
   int n;
@@ -1537,17 +1546,24 @@ int main(int argc, char **argv, char **envp)
   btabs          = false;       /* True: TAB characters found on the line */
   bcrs           = false;       /* True: Carriage return found on the line */
   bfunctions     = false;       /* True: In private or public functions */
-  bswitch        = false;       /* True: Within a switch statement */
   bcase          = false;       /* True: Within a case statement of a switch */
-  bstring        = false;       /* True: Within a string */
-  bexternc       = false;       /* True: Within 'extern "C"' */
-  bppline        = false;       /* True: This line is a pre-processor line */
-  bctrlline      = false;       /* True: A control statement starts here */
+  bcaseline      = false;       /* True: This line begins with 'case' */
   ctrl_kw        = NULL;        /* Control keyword being parsed */
   brace_kw       = NULL;        /* Control keyword waiting for a brace */
   ctrl_hdrend    = -1;          /* Index of the end of that header */
   ctrl_indent    = 0;           /* Indentation of that control keyword */
   brace_indent   = 0;           /* Indentation of the awaiting keyword */
+  bexact         = false;       /* True: Expected indentation is exact */
+  bppline        = false;       /* True: This line is a pre-processor line */
+  bctrlline      = false;       /* True: A control statement starts here */
+  lastcode       = '\0';        /* Last code character seen on this line */
+  prevlastcode   = '\0';        /* Last code character on the preceding line */
+  prevcodeindent = 0;           /* Indentation of the preceding line of code */
+  bfuncbody      = false;       /* True: Inside the body of a function */
+  stmt_indent    = 0;           /* Expected indentation of a statement */
+  case_indent    = -1;          /* Expected indentation of a 'case' label */
+  bstring        = false;       /* True: Within a string */
+  bexternc       = false;       /* True: Within 'extern "C"' */
   bif            = false;       /* True: This line is beginning of a 'if' statement */
   ppline         = PPLINE_NONE; /* > 0: The next line the continuation of a
                                  * pre-processor command */
@@ -1582,11 +1598,41 @@ int main(int argc, char **argv, char **envp)
       bstatm       = false;    /* True: This line is beginning of a
                                 * statement */
       bfor         = false;    /* REVISIT: Implies for() is all on one line */
-      bppline      = false;    /* True: This line is a pre-processor line */
-      bctrlline    = false;    /* No control statement starts on this line */
+      bcaseline    = false;    /* True: This line begins a case of a switch */
       ctrl_hdrend  = -1;       /* The header has not ended on this line yet */
       ctrl_brace   = -1;       /* No brace is required on this line */
+      bctrlline    = false;    /* No control statement starts on this line */
+      ctrl_bswitch = false;    /* That brace does not open a switch body */
+      bppline      = false;    /* True: This line is a pre-processor line */
+      lastcode     = '\0';     /* No code has been seen on this line yet */
       rbrace_match = -1;       /* No left brace is closed on this line */
+
+      /* Where a statement on this line is expected to begin: two columns in
+       * from the enclosing brace, or four within a switch, where the 'case'
+       * labels take the first position.  Negative if the enclosing brace did
+       * not begin its line, leaving nothing to align against.
+       */
+
+      case_indent = -1;
+
+      if (bnest == 0)
+        {
+          stmt_indent = 0;
+        }
+      else if (bnest <= MAX_BRACE && lbrace_indent[bnest - 1] >= 0)
+        {
+          stmt_indent = lbrace_indent[bnest - 1] + 2;
+
+          if (lbrace_switch[bnest - 1])
+            {
+              case_indent  = stmt_indent;
+              stmt_indent += 2;
+            }
+        }
+      else
+        {
+          stmt_indent = -1;
+        }
 
       /* If we are not in a comment, then this certainly is not a right-hand
        * comment.
@@ -2311,32 +2357,31 @@ int main(int argc, char **argv, char **envp)
               bfor   = true;
               bstatm = true;
             }
-          else if (strncmp(&line[indent], "switch ", 7) == 0)
-            {
-              bswitch = true;
-            }
           else if (strncmp(&line[indent], "switch(", 7) == 0)
             {
               ERROR("Missing whitespace after keyword", lineno, n);
-              bswitch = true;
             }
           else if (strncmp(&line[indent], "case ", 5) == 0)
             {
               bcase = true;
+              bcaseline = true;
             }
           else if (strncmp(&line[indent], "case(", 5) == 0)
             {
               ERROR("Missing whitespace after keyword", lineno, n);
               bcase = true;
+              bcaseline = true;
             }
           else if (strncmp(&line[indent], "default ", 8) == 0)
             {
               ERROR("Missing whitespace after keyword", lineno, n);
               bcase = true;
+              bcaseline = true;
             }
           else if (strncmp(&line[indent], "default:", 8) == 0)
             {
               bcase = true;
+              bcaseline = true;
             }
 
           /* Also check for C keywords with missing white space */
@@ -2366,8 +2411,8 @@ int main(int argc, char **argv, char **envp)
 
           if (bnest > 0 && dnest == 0 && ctrl_kw == NULL)
             {
-              bctrlline   = true;
               ctrl_indent = indent;
+              bctrlline   = true;
 
               if (check_keyword(line, indent, "else"))
                 {
@@ -2833,6 +2878,16 @@ int main(int argc, char **argv, char **envp)
                     if (bnest >= 1 && bnest <= MAX_BRACE)
                       {
                         lbrace_indent[bnest - 1] = n == indent ? indent : -1;
+                        lbrace_switch[bnest - 1] = false;
+                      }
+
+                    /* An outermost brace follows a parameter list for a
+                     * function, or '=' for data, which indents differently.
+                     */
+
+                    if (bnest == 1)
+                      {
+                        bfuncbody = prevlastcode == ')';
                       }
 
                     if (dnest > 0)
@@ -2871,8 +2926,8 @@ int main(int argc, char **argv, char **envp)
                        bnest--;
                        if (bnest < 1)
                          {
-                           bnest = 0;
-                           bswitch = false;
+                           bnest     = 0;
+                           bfuncbody = false;
                          }
 
                        /* Recover the alignment of the matching left brace */
@@ -3624,23 +3679,24 @@ int main(int argc, char **argv, char **envp)
 
           if (brace_kw != NULL && !bcommentline)
             {
-              /* A control statement may stand where the brace was expected:
-               * an 'else if', or alternatives sharing the braces that follow.
-               */
-
               if (line[indent] == '{')
                 {
                   /* The brace sits one level in from the keyword */
 
-                  ctrl_brace = brace_indent + 2;
+                  ctrl_brace   = brace_indent + 2;
+                  ctrl_bswitch = strcmp(brace_kw, "switch") == 0;
                 }
+
+              /* A control statement may stand where the brace was expected:
+               * an 'else if', or alternatives sharing the braces that follow.
+               */
+
               else if (!bctrlline)
                 {
                   snprintf(buffer, sizeof(buffer),
                            "Missing braces after '%s'", brace_kw);
                   ERROR(buffer, lineno, indent);
                 }
-
               brace_kw = NULL;
             }
 
@@ -3683,6 +3739,43 @@ int main(int argc, char **argv, char **envp)
             }
         }
 
+      /* Alignment is only exact inside a function body, where the enclosing
+       * brace began its line.  Elsewhere fall back to a multiple of the
+       * indentation unit.
+       */
+
+      /* Last character of code on the line, skipping any comment to the
+       * right of it.  A comment-only line leaves this at '\0'.
+       */
+
+      lastcode = '\0';
+
+      if (prevncomment == 0 && !bstring && inasm == 0 &&
+          !(line[indent] == '/' &&
+            (line[indent + 1] == '*' || line[indent + 1] == '/')))
+        {
+          int e = rhcomment > 0 ? rhcomment : n;
+
+          while (--e >= indent && isspace((int)line[e]))
+            {
+            }
+
+          if (e >= indent)
+            {
+              lastcode = line[e];
+            }
+        }
+
+      bexact = bnest > 0 && dnest == 0 && pnest == 0 && stmt_indent > 0 &&
+               bfunctions && bfuncbody;
+
+      /* A line that follows one ending in ';', '{', '}' or ':' begins a new
+       * statement.  Anything else is the continuation of the statement on the
+       * preceding line and may be aligned freely.  Pre-processor lines are
+       * ignored so that a macro definition does not hide the statement that
+       * precedes it.
+       */
+
       /* STEP 4: Check alignment */
 
       /* Within a comment block, we need only check on the alignment of the
@@ -3724,16 +3817,20 @@ int main(int argc, char **argv, char **envp)
                   ERROR("Expected indentation line", lineno, indent);
                 }
             }
-          else if (indent > 0 && !bswitch)
+          else if (indent > 0)
             {
               if (line[indent] == '/')
                 {
-                  /* Comments should like at offsets 2, 6, 10, ...
-                   * This rule is not followed, however, if the comments are
-                   * aligned to the right of the code.
+                  /* Comments align with the code that they describe, or with
+                   * the 'case' label when they introduce one.  This rule is
+                   * not followed, however, if the comments are aligned to the
+                   * right of the code.
                    */
 
-                  if ((indent & 3) != 2 && rhcomment == 0)
+                  if (rhcomment == 0 &&
+                      (bexact ? (indent != stmt_indent &&
+                                 indent != case_indent)
+                              : (indent & 3) != 2))
                     {
                        ERROR("Bad comment alignment", lineno, indent);
                     }
@@ -3759,8 +3856,11 @@ int main(int argc, char **argv, char **envp)
                    * Those may be unaligned.
                    */
 
-                  if ((indent & 3) != 3 && bfunctions && dnest == 0 &&
-                      rhcomment == 0)
+                  if (bfunctions && dnest == 0 && rhcomment == 0 &&
+                      (bexact ? (indent != stmt_indent + 1 &&
+                                 (case_indent < 0 ||
+                                  indent != case_indent + 1))
+                              : (indent & 3) != 3))
                     {
                        ERROR("Bad comment block alignment", lineno, indent);
                     }
@@ -3835,11 +3935,6 @@ int main(int argc, char **argv, char **envp)
                   ERROR("Blank line before opening left brace", lineno, indent);
                 }
 
-              /* REVISIT:  Possible false alarms in compound statements
-               * without a preceding conditional.  That usage often violates
-               * the coding standard.
-               */
-
               /* A brace opening the body of a control statement must be
                * indented exactly one level from its keyword.
                */
@@ -3858,24 +3953,36 @@ int main(int argc, char **argv, char **envp)
                   if (bnest >= 1 && bnest <= MAX_BRACE)
                     {
                       lbrace_indent[bnest - 1] = ctrl_brace;
+                      lbrace_switch[bnest - 1] = ctrl_bswitch;
                     }
                 }
               else if (!bfunctions && (indent & 1) != 0)
                 {
                   ERROR("Bad left brace alignment", lineno, indent);
                 }
-              else if ((indent & 3) != 0 && !bswitch && dnest == 0)
+
+              /* Any other brace opens a compound statement, a function body
+               * or a definition.  Those align with the surrounding code
+               * rather than one level in from it.
+               */
+
+              /* A macro that takes a block of code behaves like a control
+               * statement, so the brace following it is indented one level
+               * from it.  Iterator and critical section macros are written
+               * that way.
+               */
+
+              else if (prevlastcode == ')' && indent == prevcodeindent + 2)
+                {
+                }
+              else if (indent > 0 && dnest == 0 &&
+                       (bexact ? indent != stmt_indent : (indent & 3) != 0))
                 {
                   ERROR("Bad left brace alignment", lineno, indent);
                 }
             }
           else if (line[indent] == '}')
             {
-              /* REVISIT:  Possible false alarms in compound statements
-               * without a preceding conditional.  That usage often violates
-               * the coding standard.
-               */
-
               /* A right brace must line up with the left brace it closes */
 
               if (rbrace_match >= 0)
@@ -3889,7 +3996,8 @@ int main(int argc, char **argv, char **envp)
                 {
                   ERROR("Bad left brace alignment", lineno, indent);
                 }
-              else if ((indent & 3) != 0 && !bswitch && prevdnest == 0)
+              else if (indent > 0 && prevdnest == 0 &&
+                       (bexact ? indent != stmt_indent : (indent & 3) != 0))
                 {
                   ERROR("Bad right brace alignment", lineno, indent);
                 }
@@ -3907,14 +4015,32 @@ int main(int argc, char **argv, char **envp)
                * comments before beginning of function definitions.
                */
 
-              if ((bstatm ||                              /* Begins with C keyword */
+              /* 'case' and 'default' labels sit one level in from the brace
+               * that opens the switch body, not with the case logic.
+               */
+
+              if (bcaseline)
+                {
+                  if (case_indent >= 0 && indent != case_indent)
+                    {
+                      ERROR("Bad alignment", lineno, indent);
+                    }
+                }
+              else if ((bstatm ||                         /* Begins with C keyword */
                   (line[indent] == '/' &&
                   bfunctions &&
                   line[indent + 1] == '*')) &&            /* Comment in functions */
-                  !bswitch &&                             /* Not in a switch */
                   dnest == 0)                             /* Not a data definition */
                 {
-                  if ((indent & 3) != 2)
+                  /* A comment that describes a 'case' label is aligned with
+                   * the label rather than with the case logic.
+                   */
+
+                  bool bcasecmt = line[indent] == '/' && case_indent >= 0 &&
+                                  indent == case_indent;
+
+                  if (bexact ? (indent != stmt_indent && !bcasecmt)
+                             : (indent & 3) != 2)
                     {
                       ERROR("Bad alignment", lineno, indent);
                     }
@@ -3930,6 +4056,14 @@ int main(int argc, char **argv, char **envp)
                   ERROR("Small odd alignment", lineno, indent);
                 }
             }
+        }
+
+      /* Remember this line for the checks made on the line that follows it */
+
+      if (lastcode != '\0')
+        {
+          prevlastcode   = lastcode;
+          prevcodeindent = indent;
         }
     }
 

--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -1428,6 +1428,9 @@ int main(int argc, char **argv, char **envp)
   int externc_lineno;   /* Last line where 'extern "C"' declared */
   bool bexact;          /* True: The expected indentation below is exact */
   bool bppline;         /* True: This line is a pre-processor line */
+  bool blabelline;      /* True: This line holds nothing but a label */
+  bool bstmtstart;      /* True: A new statement begins on this line */
+  bool bprevstmtend;    /* True: The preceding line of code ended a statement */
   bool bctrlline;       /* True: A control statement starts on this line */
   char lastcode;        /* Last code character seen on this line */
   char prevlastcode;    /* Last code character on the preceding line */
@@ -1555,6 +1558,9 @@ int main(int argc, char **argv, char **envp)
   brace_indent   = 0;           /* Indentation of the awaiting keyword */
   bexact         = false;       /* True: Expected indentation is exact */
   bppline        = false;       /* True: This line is a pre-processor line */
+  blabelline     = false;       /* True: This line holds nothing but a label */
+  bstmtstart     = true;        /* True: A statement begins on this line */
+  bprevstmtend   = true;        /* True: The preceding code ended a statement */
   bctrlline      = false;       /* True: A control statement starts here */
   lastcode       = '\0';        /* Last code character seen on this line */
   prevlastcode   = '\0';        /* Last code character on the preceding line */
@@ -1604,7 +1610,25 @@ int main(int argc, char **argv, char **envp)
       bctrlline    = false;    /* No control statement starts on this line */
       ctrl_bswitch = false;    /* That brace does not open a switch body */
       bppline      = false;    /* True: This line is a pre-processor line */
+
+      /* A label ends the preceding statement, like a 'case' does */
+
+      blabelline = false;
+
+      if (isalpha((int)line[indent]) != 0 || line[indent] == '_')
+        {
+          int ii = indent;
+
+          while (isalnum((int)line[ii]) != 0 || line[ii] == '_')
+            {
+              ii++;
+            }
+
+          blabelline = line[ii] == ':' && line[ii + 1] != ':';
+        }
+
       lastcode     = '\0';     /* No code has been seen on this line yet */
+      bstmtstart   = bprevstmtend;
       rbrace_match = -1;       /* No left brace is closed on this line */
 
       /* Where a statement on this line is expected to begin: two columns in
@@ -3769,6 +3793,22 @@ int main(int argc, char **argv, char **envp)
       bexact = bnest > 0 && dnest == 0 && pnest == 0 && stmt_indent > 0 &&
                bfunctions && bfuncbody;
 
+      /* A line after one ending in ';', '{', '}' or a label begins a new
+       * statement; anything else continues the previous one.
+       */
+
+      if (lastcode != '\0' && !bppline)
+        {
+          /* A colon ends a statement only in a label, and a line left inside
+           * parentheses is always continued, so a 'for' clause does not.
+           */
+
+          bprevstmtend = pnest == 0 &&
+                         (lastcode == ';' || lastcode == '{' ||
+                          lastcode == '}' ||
+                          (lastcode == ':' && (bcaseline || blabelline)));
+        }
+
       /* A line that follows one ending in ';', '{', '}' or ':' begins a new
        * statement.  Anything else is the continuation of the statement on the
        * preceding line and may be aligned freely.  Pre-processor lines are
@@ -4027,6 +4067,7 @@ int main(int argc, char **argv, char **envp)
                     }
                 }
               else if ((bstatm ||                         /* Begins with C keyword */
+                  (bstmtstart && bexact) ||               /* Begins a statement */
                   (line[indent] == '/' &&
                   bfunctions &&
                   line[indent + 1] == '*')) &&            /* Comment in functions */


### PR DESCRIPTION
## Summary

This PR fixes a lot of gaps in the nxstyle tool. Unfortunately, the codebase contains many inconsistencies with the coding standard. Fixing everything might mess up git history a bit, so I'm not sure if it's worth it. 

For now I only fixed nxstyle.c, sched, audio and net

## Impact

better compatibility with nuttx coding style.

This solves some of the issues related to nxstyle, but I didn't check which ones: https://github.com/apache/nuttx/issues?q=is%3Aissue%20state%3Aopen%20nxstyle

## Testing

Output from `/tools/nxstyle_sweep.sh` that checks all files:

```
nxstyle-errors.txt:  101060 diagnostics                    
nxstyle-files.txt: 2690 files

Checked 17165 files, 2690 failed
```
