### PR TITLE
arch/x86_64: six fixes to make BUILD_KERNEL and the HPET alarm work

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -151,6 +151,7 @@ config ARCH_X86_64
 	select ARCH_HAVE_SETJMP
 	select ARCH_HAVE_PERF_EVENTS
 	select ARCH_HAVE_POWEROFF
+	select ARCH_HAVE_SYSCALL if LIB_SYSCALL
 	---help---
 		x86-64 architectures.
 
@@ -610,6 +611,12 @@ config ARCH_HAVE_FETCHADD
 config ARCH_HAVE_RTC_SUBSECONDS
 	bool
 	default n
+
+config ARCH_HAVE_SYSCALL
+	bool
+	default n
+	---help---
+		Indicates that the architecture provides the system call interface.
 
 config ARCH_HAVE_SYSCALL_HOOKS
 	bool

--- a/arch/x86_64/src/common/x86_64_addrenv.c
+++ b/arch/x86_64/src/common/x86_64_addrenv.c
@@ -70,6 +70,8 @@
 
 #include <nuttx/spinlock.h>
 
+#include <arch/arch.h>
+
 #include "addrenv.h"
 #include "pgalloc.h"
 #include "x86_64_mmu.h"
@@ -192,10 +194,18 @@ static int create_spgtables(arch_addrenv_t *addrenv)
 static void copy_kernel_mappings(arch_addrenv_t *addrenv)
 {
   uintptr_t *pdpt = (uintptr_t *)x86_64_pgvaddr(addrenv->spgtables[1]);
+  int        i;
 
   /* Kernel mapping - lower 1GB maps to 4GB-5GB */
 
   pdpt[4] = X86_PDPT_KERNEL_MAP;
+
+  /* Inherit the boot identity mapping of the low 4GB. */
+
+  for (i = 0; i < X86_MMU_LOWMEM_PDPTS; i++)
+    {
+      pdpt[i] = g_pdpt[i];
+    }
 }
 
 /****************************************************************************

--- a/arch/x86_64/src/common/x86_64_mmu.h
+++ b/arch/x86_64/src/common/x86_64_mmu.h
@@ -57,6 +57,10 @@
 #define X86_MMU_VADDR_INDEX(vaddr, ptlevel) \
   ((vaddr >> X86_MMU_VADDR_SHIFT(ptlevel)) & X86_MMU_VPN_MASK)
 
+/* Number of PDPT entries in the boot low-memory identity mapping. */
+
+#define X86_MMU_LOWMEM_PDPTS    4
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/

--- a/arch/x86_64/src/intel64/Kconfig
+++ b/arch/x86_64/src/intel64/Kconfig
@@ -70,6 +70,10 @@ config ARCH_INTEL64_TSC
 
 config ARCH_INTEL64_HPET_ALARM
 	bool "HPET timer alarm support"
+	select INTEL64_ONESHOT
+	select ONESHOT
+	select ONESHOT_COUNT
+	select ONESHOT_FAST_DIVISION
 	select ALARM_ARCH
 	---help---
 		With this option you can enable ALARM_ARCH features that works on top of

--- a/arch/x86_64/src/intel64/intel64_freq.c
+++ b/arch/x86_64/src/intel64/intel64_freq.c
@@ -150,10 +150,12 @@ void x86_64_timer_calibrate_freq(void)
   g_x86_64_timer_freq = CONFIG_ARCH_INTEL64_APIC_FREQ_KHZ * 1000ul;
 #endif
 
+#ifdef CONFIG_ARCH_INTEL64_HAVE_TSC
   if (g_x86_64_timer_freq == 0)
     {
       /* The TSC frequency is not available */
 
       PANIC();
     }
+#endif
 }

--- a/arch/x86_64/src/intel64/intel64_oneshot_lower.c
+++ b/arch/x86_64/src/intel64/intel64_oneshot_lower.c
@@ -149,9 +149,13 @@ static void intel64_timer_start_absolute(struct oneshot_lowerhalf_s *lower,
     (struct intel64_oneshot_lowerhalf_s *)lower;
   irqstate_t flags    = spin_lock_irqsave(&g_oneshotlow_spin);
   int        ret      = intel64_oneshot_current(&priv->oneshot, &current_us);
-  uint64_t   delta_us = expected - current_us;
+  uint64_t   delta_us;
 
   DEBUGASSERT(ret == OK);
+
+  /* Use the shortest delay when the deadline has passed. */
+
+  delta_us = expected > current_us ? expected - current_us : 0;
 
   ts.tv_sec  = delta_us / USEC_PER_SEC;
   ts.tv_nsec = delta_us % USEC_PER_SEC * 1000ull;

--- a/arch/x86_64/src/intel64/intel64_pgalloc.c
+++ b/arch/x86_64/src/intel64/intel64_pgalloc.c
@@ -61,15 +61,17 @@ void up_allocate_pgheap(void **heap_start, size_t *heap_size)
 {
   DEBUGASSERT(heap_start && heap_size);
 
+  /* The page allocator uses physical addresses. */
+
 #ifndef CONFIG_ARCH_PGPOOL_MAPPING
   /* pgheap at the end of RAM */
 
-  *heap_start = (void *)(X86_64_PGPOOL_BASE + X86_64_LOAD_OFFSET);
+  *heap_start = (void *)X86_64_PGPOOL_BASE;
   *heap_size  = (size_t)X86_64_PGPOOL_SIZE;
 #else
   /* pgheap defined with Kconfig options */
 
-  *heap_start = (void *)CONFIG_ARCH_PGPOOL_VBASE;
+  *heap_start = (void *)CONFIG_ARCH_PGPOOL_PBASE;
   *heap_size  = (size_t)CONFIG_ARCH_PGPOOL_SIZE;
 #endif
 }


### PR DESCRIPTION
## Summary

Six independent x86_64 bugs. Each is a separate commit; together they are what
had to be fixed before an x86_64 target could be built and run at all.

| | Commit | Area | What it breaks |
|---|---|---|---|
| 1 | `make ARCH_INTEL64_HPET_ALARM buildable` | Kconfig | anything selecting the HPET |
| 2 | `do not demand a TSC frequency for a clock that has none` | boot | anything selecting the HPET |
| 3 | `define the missing CONFIG_ARCH_HAVE_SYSCALL` | Kconfig | `knsh_romfs`, `knsh_romfs_pci` |
| 4 | `give the page allocator the physical page pool base` | addrenv | `knsh_romfs`, `knsh_romfs_pci` |
| 5 | `inherit the kernel low memory mapping in an address environment` | addrenv | `knsh_romfs`, `knsh_romfs_pci` |
| 6 | `do not wrap the HPET oneshot on a deadline that has passed` | timer | anything selecting the HPET |

There is a reason there are six of them, and it is bug 3: `CONFIG_BUILD_KERNEL`
on x86_64 has been unbuildable since May 2025, so nothing behind it has been
exercised in a year, and the HPET alarm looks like it has never been exercised
at all.

## Why these are reachable from master alone

**Two in-tree configurations are affected directly.** `qemu-intel64:knsh_romfs`
and `qemu-intel64:knsh_romfs_pci` are the only `CONFIG_BUILD_KERNEL`
configurations in tree. Bugs 3, 4 and 5 each independently stop them from
reaching a shell prompt.

**Bug 3 dates the problem.** 794c325947 ("arch/x64:Syscall support is enabled by
default", 2025-05-27) switched nine guards from `CONFIG_LIB_SYSCALL` to
`CONFIG_ARCH_HAVE_SYSCALL` without adding the Kconfig symbol. `git grep` finds
only `ARCH_HAVE_SYSCALL_HOOKS`; the bare symbol is defined nowhere in tree, so
it is always unset and `x86_64_syscall.c` has not been compiled since — see
`arch/x86_64/src/common/Make.defs:37` and `CMakeLists.txt:41`. Those two
configurations still *link*, because nothing references the missing pieces and
`libstubs.a` is simply never pulled in, and then die the first time user code
executes `SYSCALL`.

**The HPET path looks like it has never been exercised.** No defconfig in tree
selects `ARCH_INTEL64_HPET_ALARM`, yet the board code supports it
(`boards/x86_64/qemu/qemu-intel64/src/qemu_bringup.c:55`). Selecting it does not
compile (bug 1); with that fixed the board panics in `x86_64_lowsetup()` (bug 2);
with that fixed ostest hangs in `wdog_test` (bug 6).

## Impact

No API, ABI or defconfig change. Bugs 1, 2 and 6 affect only
`ARCH_INTEL64_HPET_ALARM`, which nothing in tree selects today. Bugs 4 and 5
affect only `CONFIG_ARCH_ADDRENV` builds. Bug 3 restores the system call
interface for `CONFIG_BUILD_KERNEL` and `CONFIG_BUILD_PROTECTED` and leaves
`CONFIG_BUILD_FLAT` exactly as it is — `qemu-intel64:nsh` still builds with
`ARCH_HAVE_SYSCALL` unset.

## Dependencies

Needs `nuttx-apps` ≥ 57e761f72 ("build: Omit default priority ELF symbol.",
already merged) to run ostest under `CONFIG_BUILD_KERNEL`. Without it the ELF
loader creates programs that declare `PRIORITY = SCHED_PRIORITY_DEFAULT` at
priority 0, and `qemu-intel64:knsh_romfs` trips
`Assertion failed sched_priority >= 1` at `sched/sched/sched.h:466` before
ostest starts. That is a separate, architecture-independent bug and it is
already fixed on the apps side.

## Testing

**Host:** macOS 26.5.1 on Apple Silicon (arm64), `x86_64-elf-gcc` 16.1.0,
`qemu-system-x86_64` 11.0.3 under TCG — there is no hardware x86 virtualisation
on this host.

```
qemu-system-x86_64 -machine pc,hpet=on -cpu max -m 2G \
                   -kernel ./nuttx -nographic -no-reboot -net none
```

Three config tweaks are applied to both configurations. None is related to this
patch set:

* `ARCH_INTEL64_HAVE_PCID=n`, `ARCH_INTEL64_TSC_DEADLINE=n` →
  `ARCH_INTEL64_HPET_ALARM=y`. TCG implements neither PCID nor the TSC-deadline
  timer, and `x86_64_check_and_enable_capability()` halts if a requested feature
  is missing. This is *why* the HPET path got exercised, and hence why bugs 1, 2
  and 6 were found.
* `SCHED_THREAD_LOCAL=n` — broken on x86_64 on unmodified master, see the note
  at the end. It is off by default in both defconfigs.

### Before

**Bug 1**, stock master, `qemu-intel64:nsh` with the choice moved to the HPET.
Three stages, each uncovered by fixing the previous one by hand:

```
# ARCH_INTEL64_HPET_ALARM=y
intel64/intel64_hpet_alarm.c:41:24: error:
    'CONFIG_ARCH_INTEL64_HPET_ALARM_CHAN' undeclared

# + INTEL64_HPET=y
undefined reference to `oneshot_initialize'

# + INTEL64_ONESHOT=y
intel64_oneshot_lower.c: error: 'const struct oneshot_operations_s' has no
    member named 'start_absolute'
intel64_oneshot_lower.c: error: implicit declaration of function
    'oneshot_count_init'
    (plus four incompatible-pointer-type errors on the ops table)
```

One added `select` closes all three stages, because `INTEL64_ONESHOT` selects
`INTEL64_HPET` in turn.

**Bug 6**, all fixes applied except commit 6, `qemu-intel64:nsh`. ostest reaches
the wdog test and never returns; killed at a 300 s timeout:

```
user_main: spinlock test
user_main: wdog test
wdtest_once 0 ns
wdtest_once 1 ns
wdtest_once 0 ns
wdtest_once 0 ns
wdtest_once 0 ns
                        <- nothing further, 300s
```

`apps/testing/ostest/wdog.c:281` asks for a zero delay, `NSEC2TICK()` takes the
next few (1 ns, 10 ns) to zero ticks as well, and `wdog_test` runs on several
threads, which is why the same line repeats.

Bugs 2, 4 and 5 have no "before" log to show: each stops the machine before or
during `x86_64_earlyserialinit()`, or triple-faults out of the panic handler, so
the console stays empty. See the note at the end.

### After

Both configurations, stock `nuttx-apps` master (57e761f72), nothing but these
six commits on top of master.

`qemu-intel64:knsh_romfs` (`CONFIG_BUILD_KERNEL`), ostest loaded from ROMFS:

```
boot -> prompt      0.09s
typed 19 chars      0.03s
command            71.54s
                   Exiting with status 0
```

`qemu-intel64:nsh` (`CONFIG_BUILD_FLAT`) — the configuration that actually runs
`wdog_test`, since `ostest_main.c:569` is inside `#ifdef CONFIG_BUILD_FLAT`:

```
boot -> prompt      0.06s
typed 7 chars       0.01s
command           155.79s
                   Exiting with status 0
```

with the zero-delay watchdog now completing:

```
user_main: wdog test
wdtest_once 0 ns
wdtest_once 1 ns
wdtest_once 10 ns
wdtest_once 100 ns
wdtest_once 1000 ns
wdtest_once 10000 ns
wdtest_once 100000 ns
wdtest_once 1000000 ns
```

`tools/checkpatch.sh -g <commit>` is clean on all six.

## Two problems seen and not fixed here

**Any `PANIC()` before `x86_64_cpu_priv_set(0)` cannot be reported.** `_assert()`
reads `up_interrupt_context()`, which is `movb %gs:6, ...`, and the GS base is
not programmed until the second-to-last step of `__nxstart()`. The page fault at
linear address 6 then double- and triple-faults, so the machine resets with a
completely empty console. Bugs 2, 3 and 4 all presented this way and had to be
found by attaching gdb to QEMU and reading `RIP`.

**`CONFIG_SCHED_THREAD_LOCAL` is broken on x86_64.**
`sched_thread_local_test()` reads a `__thread` variable, the thread pointer at
`%fs:0` reads back as 0, the access faults at linear address -8, and the CPU
triple-faults out of the panic handler as above. Reproduces on unmodified
master.
