### PR TITLE
sched/sched_critmonitor: remove duplicate preemption start block

### DIFF
--- a/sched/sched/sched_critmonitor.c
+++ b/sched/sched/sched_critmonitor.c
@@ -454,18 +454,6 @@ void nxsched_switch_critmon(FAR struct tcb_s *from, FAR struct tcb_s *to)
     }
 
 #endif /* CONFIG_SCHED_CRITMONITOR_MAXTIME_CSECTION */
-
-#if CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION >= 0
-
-  /* Did this task disable pre-emption? */
-
-  if (to->lockcount > 0)
-    {
-      /* Yes.. Save the start time */
-
-      to->premp_start = current;
-    }
-#endif /* CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION */
 }
 
 void nxsched_update_critmon(FAR struct tcb_s *tcb)


### PR DESCRIPTION
## Summary

The `to->preemp_start = current` assignment when `to->lockcount > 0` was executed twice under CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION, once in the main preemption block and again after the csection block. Remove the redundant duplicate.

## Impact

Only affects the scheduler critmon preemption time monitoring path, and is a redundant code cleanup with no behavioral change.

## Testing

ci test 
