### PR TITLE
tools/mkallsyms.py: let the dependency error actually reach the user

### DIFF
--- a/tools/mkallsyms.py
+++ b/tools/mkallsyms.py
@@ -23,7 +23,6 @@
 
 import argparse
 import errno
-import os
 import re
 import sys
 
@@ -36,7 +35,7 @@ try:
 except ModuleNotFoundError:
     print("Please execute the following command to install dependencies:")
     print("pip install pyelftools cxxfilt")
-    os._exit(errno.EINVAL)
+    sys.exit(errno.EINVAL)
 
 
 class SymbolTables(object):
@@ -126,7 +125,7 @@ def usage():
     print(
         "Usage: mkallsyms.py [noconst] <ELFBIN> [output file] [order symbols by name]"
     )
-    os._exit(errno.ENOENT)
+    sys.exit(errno.ENOENT)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

`tools/mkallsyms.py` tells you what to install when its dependencies are
missing, and then throws the message away:

```python
except ModuleNotFoundError:
    print("Please execute the following command to install dependencies:")
    print("pip install pyelftools cxxfilt")
    os._exit(errno.EINVAL)
```

`os._exit()` terminates the process immediately, without flushing stdio. When
stdout is a pipe — which it always is under `make` — `print()` is
block-buffered, so the buffer is discarded and nothing is ever shown. What the
developer sees, building any `CONFIG_ALLSYMS=y` configuration, is:

```
LD: nuttx
make[1]: *** [Makefile:65: nuttx] Error 22
```

and nothing else anywhere in the build output. "Error 22" is just
`errno.EINVAL` leaking out as an exit status. `usage()` discards its message the
same way, exiting `ENOENT`.

`sys.exit()` raises `SystemExit`, which lets the interpreter flush on the way
out. Exit statuses are unchanged. `os` is no longer referenced afterwards, so
the import goes with it.

## Impact

None on a working setup. On a machine without `pyelftools`/`cxxfilt` it turns
an unexplained build failure into the actionable message the author already
wrote.

Worth noting that no `CONFIG_ALLSYMS=y` configuration is built by the `make`
backend in CI — the eight in-tree ones are absent from `tools/ci/testlist/` —
so this path is easy to hit and hard to diagnose locally.

## Testing

```
$ python3 tools/mkallsyms.py            # dependencies present
usage: mkallsyms.py [-h] [--noconst] ...
```

With the modules hidden, the message now survives redirection to a pipe;
before, `python3 tools/mkallsyms.py ... | cat` printed nothing and returned 22.
`tools/checkpatch.sh -c -u -m -g` clean (black, isort, flake8 and codespell all
installed).
