### PR TITLE
arch/x86: default CROSSDEV on a macOS host

### DIFF
--- a/arch/x86/src/common/Toolchain.defs
+++ b/arch/x86/src/common/Toolchain.defs
@@ -44,11 +44,16 @@ ARCHCPUFLAGS += -m32
 LDFLAGS += -m elf_i386
 endif
 
-# We have to use a cross-development toolchain under Cygwin because the native
-# Cygwin toolchains don't generate ELF binaries.
+# A cross-development toolchain is required under Cygwin, whose native
+# toolchains don't generate ELF binaries, and on macOS, which has no i386 host
+# compiler at all -- Apple clang cannot target i386 on Apple Silicon.
+# arch/x86_64 defaults CROSSDEV the same way.  Note that a 64-bit toolchain
+# with -m32 is not a substitute unless it was built with multilib.
 
 ifeq ($(CONFIG_WINDOWS_CYGWIN),y)
-CROSSDEV = i486-nuttx-elf-
+CROSSDEV ?= i486-nuttx-elf-
+else ifeq ($(CONFIG_HOST_MACOS),y)
+CROSSDEV ?= i686-elf-
 endif
 
 CC = $(CROSSDEV)gcc


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

`arch/x86/src/common/Toolchain.defs` sets `CROSSDEV` only under Cygwin:

```make
ifeq ($(CONFIG_WINDOWS_CYGWIN),y)
CROSSDEV = i486-nuttx-elf-
endif

CC = $(CROSSDEV)gcc
```

Everywhere else `CROSSDEV` is empty, so `CC` becomes the bare host `gcc`. That
is fine on an x86 Linux box and useless anywhere else. On macOS the host
compiler is Apple clang, which on Apple Silicon cannot target i386 at all, so
the build fails in a thoroughly misleading way — the *ARM* assembler rejecting
x86 inline asm out of an x86 header:

```
include/arch/i486/irq.h:249:5: error: invalid instruction, did you mean: push?
include/arch/i486/irq.h:283:16: error: invalid instruction, did you mean: stc, stm, stmib, str, tst?
```

This gives `CROSSDEV` a sane default on macOS and makes the Cygwin one
overridable (`=` → `?=`), matching what `arch/x86_64` already does.

Homebrew's `i686-elf-gcc` is the intended target; a 64-bit x86 toolchain with
`-m32` is not a substitute unless built with multilib, since it compiles 32-bit
objects and then has no 32-bit libgcc to link them against — which surfaces
only at the final link as undefined `__udivdi3` and friends.

## Impact

Only `CONFIG_HOST_MACOS=y` builds of `arch/x86` change, and only by picking a
compiler that can actually target the architecture. `?=` keeps any existing
override — including the Cygwin default — working.

## Testing

`qemu-i486:nsh` on macOS 15 / Apple Silicon, Homebrew `i686-elf-gcc` 16.1.0:

* before: host clang is invoked, build dies on ARM instruction errors.
* after: `i686-elf-gcc` is invoked and the build completes — **rc 0**, 3.0 MB
  `nuttx.elf`.

One caveat worth recording for anyone reproducing this: the shipped
`qemu-i486:nsh` defconfig sets `CONFIG_LIBM_TOOLCHAIN=y`, which defers `math.h`
to the toolchain, and Homebrew's `i686-elf-gcc` is bare-metal with no newlib
headers. Selecting NuttX's own `CONFIG_LIBM=y` instead builds cleanly. That is
independent of this change and is not addressed here.

`tools/checkpatch.sh -c -u -m -g` clean.
