### PR TITLE
rp2040/rp23xx: order the USB BUFF_STATUS clear before the AVAILABLE re-arm

### DIFF
--- a/arch/arm/src/rp2040/rp2040_usbdev.c
+++ b/arch/arm/src/rp2040/rp2040_usbdev.c
@@ -38,6 +38,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
 #include <nuttx/kmalloc.h>
+#include <arch/barriers.h>
 #include <nuttx/usb/usb.h>
 #include <nuttx/usb/usbdev.h>
 #include <nuttx/usb/usbdev_trace.h>
@@ -483,6 +484,18 @@ static void rp2040_update_buffer_control(struct rp2040_ep_s *privep,
 
       if (or_mask & RP2040_USBCTRL_DPSRAM_EP_BUFF_CTRL_AVAIL)
         {
+          /* Order the preceding BUFF_STATUS clear (in the USB controller
+           * register block) ahead of the AVAILABLE re-arm (in DPSRAM):
+           * these are two different peripheral regions whose stores the
+           * bus fabric may reorder.  Without the barrier the controller
+           * can observe the re-arm before the clear, transmit the next IN
+           * packet and latch its completion in BUFF_STATUS, then have that
+           * bit wiped by the late-landing clear -- the lost completion
+           * stops all further buffer interrupts and TX wedges.
+           */
+
+          UP_DMB();
+
           /* RP2040 datasheet 4.1.2.5.1: the AVAILABLE bit must be set
            * after the rest of the buffer control register has been
            * written and had time to settle across the clock domain

--- a/arch/arm/src/rp23xx/rp23xx_usbdev.c
+++ b/arch/arm/src/rp23xx/rp23xx_usbdev.c
@@ -38,6 +38,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
 #include <nuttx/kmalloc.h>
+#include <arch/barriers.h>
 #include <nuttx/usb/usb.h>
 #include <nuttx/usb/usbdev.h>
 #include <nuttx/usb/usbdev_trace.h>
@@ -483,6 +484,18 @@ static void rp23xx_update_buffer_control(struct rp23xx_ep_s *privep,
 
       if (or_mask & RP23XX_USBCTRL_DPSRAM_EP_BUFF_CTRL_AVAIL)
         {
+          /* Order the preceding BUFF_STATUS clear (in the USB controller
+           * register block) ahead of the AVAILABLE re-arm (in DPSRAM):
+           * these are two different peripheral regions whose stores the
+           * Cortex-M33 bus fabric may reorder.  Without the barrier the
+           * controller can observe the re-arm before the clear, transmit
+           * the next IN packet and latch its completion in BUFF_STATUS,
+           * then have that bit wiped by the late-landing clear -- the lost
+           * completion stops all further buffer interrupts and TX wedges.
+           */
+
+          UP_DMB();
+
           /* The AVAILABLE bit must be set after the rest of the buffer
            * control register has been written and had time to settle
            * across the clock domain crossing, or the controller may act


### PR DESCRIPTION
## Summary

`rp2040_update_buffer_control()` / `rp23xx_update_buffer_control()` re-arm an
endpoint buffer by setting the `AVAILABLE` bit in the buffer-control word,
which lives in **DPSRAM**. When a buffer is re-armed from the completion path
(`rp2040_usbintr_buffstat` / `rp23xx_usbintr_buffstat`), that runs right after
the handler clears the endpoint's bit in `BUFF_STATUS`, which lives in the
**USB controller register block** — a different peripheral region.

The bus fabric may reorder those two stores. If the controller observes the
`AVAILABLE` re-arm before the `BUFF_STATUS` clear lands, it can transmit the
next IN packet and latch its completion in `BUFF_STATUS` *before* the clear
arrives; the late clear then wipes that just-set completion bit. The lost
completion edge stops all further buffer interrupts for the endpoint, so the
class driver's write-complete callback never runs and TX wedges permanently.

The fix adds a `UP_DMB()` at the top of the `AVAILABLE` re-arm so the preceding
`BUFF_STATUS` clear is ordered ahead of it. (Non-SMP builds reduce
`spin_lock_irqsave` to a barrier-free `up_irq_save`, so nothing else orders
these two stores.)

This is the hardware-ordering issue tracked in #19472. The recently merged
#19470 fixed the `cdcncm`-layer write-buffer handling; this is the companion
controller-level fix it referenced, needed for full TX stability on RP2350
under maximal IN density.

## Impact

- Most visible on RP2350 (Cortex-M33) under dense/bursty IN traffic — e.g.
  CDC-NCM with `CONFIG_NET_TCP_WRITE_BUFFERS=y` — where TX would wedge after a
  handful of large transfers.
- One `UP_DMB()` per chip on the re-arm path; no API or behavior change
  otherwise. The barrier is a single `dmb` instruction.

## Testing

- **Silicon:** RP2350 (Raspberry Pi Pico 2 W class board) running CDC-NCM over
  USB with TCP write buffers. Before: TX wedges after ~5 large transfers
  (endpoint stops raising buffer interrupts). After: a 144 dense/concurrent
  HTTP download soak completes with 0 wedges (~486 KB/s sustained).
- **Build:** `raspberrypi-pico-2:usbnsh` (compiles `rp23xx_usbdev.c`) and
  `raspberrypi-pico:usbnsh` (compiles `rp2040_usbdev.c`) both build and link
  clean.
- `tools/checkpatch.sh -c -u -m -g` passes.

---
*Disclosure: this change was developed with the help of an AI agent and
reviewed by a human before submission.*
