### PR TITLE
drivers/sensors/sensor: fix poll()/read() for fetch()-only sensors

### DIFF
--- a/drivers/sensors/Kconfig
+++ b/drivers/sensors/Kconfig
@@ -861,17 +861,19 @@ config SENSORS_L3GD20
 	bool "STMicro L3GD20 Gyroscope Sensor support"
 	default n
 	select SPI
-	select SCHED_HPWORK if SENSORS_L3GD20_BUFFER_SIZE > 0
+	select SCHED_HPWORK
 	---help---
 		Enable driver support for the STMicro L3GD20 gyroscope sensor.
 
 config SENSORS_L3GD20_BUFFER_SIZE
 	int "size of buffer"
 	default 1
+	range 1 32
 	depends on SENSORS_L3GD20
 	---help---
-		The size of the circular buffer used. If the value equal to zero,
-		indicates that the circular buffer is disabled.
+		The number of events that the circular buffer can hold. The data
+		ready interrupt pushes each sample into it, so at least one event
+		is required.
 
 config SENSOR_KXTJ9
 	bool "Kionix KXTJ9 Accelerometer support"

--- a/drivers/sensors/l3gd20_uorb.c
+++ b/drivers/sensors/l3gd20_uorb.c
@@ -69,12 +69,10 @@ struct l3gd20_dev_s
                                        * L3GD20 sensor */
   uint64_t timestamp;                 /* Units is microseconds */
   struct sensor_lowerhalf_s lower;    /* The struct of lower half driver */
-#if CONFIG_SENSORS_L3GD20_BUFFER_SIZE > 0
   struct work_s work;                 /* The work queue is responsible for
                                        * retrieving the data from the sensor
                                        * after the arrival of new data was
                                        * signalled in an interrupt */
-#endif
 };
 
 /****************************************************************************
@@ -100,13 +98,7 @@ static int l3gd20_interrupt_handler(int irq, FAR void *context,
                                     FAR void *arg);
 static int l3gd20_activate(FAR struct sensor_lowerhalf_s *lower,
                            FAR struct file *filep, bool enable);
-#if CONFIG_SENSORS_L3GD20_BUFFER_SIZE > 0
 static void l3gd20_worker(FAR void *arg);
-#else
-static int l3gd20_fetch(FAR struct sensor_lowerhalf_s *lower,
-                        FAR struct file *filep,
-                        FAR char *buffer, size_t buflen);
-#endif
 
 /****************************************************************************
  * Private Data
@@ -119,11 +111,7 @@ static const struct sensor_ops_s g_l2gd20_ops =
   .activate = l3gd20_activate,
   .set_interval = NULL,
   .batch = NULL,
-#if CONFIG_SENSORS_L3GD20_BUFFER_SIZE > 0
   .fetch = NULL,
-#else
-  .fetch = l3gd20_fetch,
-#endif
   .control = NULL
 };
 
@@ -359,7 +347,6 @@ static int l3gd20_interrupt_handler(int irq, FAR void *context,
 
   priv->timestamp = sensor_get_timestamp();
 
-#if CONFIG_SENSORS_L3GD20_BUFFER_SIZE > 0
   /* Task the worker with retrieving the latest sensor data. We should not do
    * this in a interrupt since it might take too long. Also we cannot lock
    * the SPI bus from within an interrupt.
@@ -373,17 +360,10 @@ static int l3gd20_interrupt_handler(int irq, FAR void *context,
       snerr("ERROR: Failed to queue work: %d\n", ret);
       return ret;
     }
-#else
 
-  /* notify event to upper half driver */
-
-  priv->lower.notify_event(priv->lower.priv);
-
-#endif
   return OK;
 }
 
-#if CONFIG_SENSORS_L3GD20_BUFFER_SIZE > 0
 /****************************************************************************
  * Name: l3gd20_worker
  ****************************************************************************/
@@ -404,33 +384,6 @@ static void l3gd20_worker(FAR void *arg)
   priv->lower.push_event(priv->lower.priv, &temp,
                          sizeof(struct sensor_gyro_uncal));
 }
-
-#else
-
-/****************************************************************************
- * Name: l3gd20_fetch
- ****************************************************************************/
-
-static int l3gd20_fetch(FAR struct sensor_lowerhalf_s *lower,
-                        FAR struct file *filep,
-                        FAR char *buffer, size_t buflen)
-{
-  FAR struct l3gd20_dev_s *priv = container_of(lower,
-                                               FAR struct l3gd20_dev_s,
-                                               lower);
-
-  if (buflen != sizeof(struct sensor_gyro_uncal))
-      return 0;
-
-  DEBUGASSERT(priv != NULL);
-
-  /* Read out the latest sensor data */
-
-  l3gd20_read_measurement_data(priv, (FAR struct sensor_gyro_uncal *)buffer);
-
-  return sizeof(struct sensor_gyro_uncal);
-}
-#endif
 
 /****************************************************************************
  * Name: l3gd20_activate
@@ -563,9 +516,7 @@ int l3gd20_register(int devno, FAR struct spi_dev_s *spi,
 
   priv->spi              = spi;
   priv->config           = config;
-#if CONFIG_SENSORS_L3GD20_BUFFER_SIZE > 0
   priv->work.worker      = NULL;
-#endif
   priv->timestamp        = 0;
 
   priv->lower.type = SENSOR_TYPE_GYROSCOPE_UNCALIBRATED;

--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -101,7 +101,6 @@ struct sensor_user_s
                                 */
   unsigned int     event;      /* The event of this sensor, eg: SENSOR_EVENT_FLUSH_COMPLETE. */
   bool             flushing;   /* The is used to indicate user is flushing */
-  sem_t            buffersem;  /* Wakeup user waiting for data in circular buffer */
   size_t           bufferpos;  /* The index of user generation in buffer */
 
   /* The subscriber info
@@ -774,7 +773,6 @@ static int sensor_open(FAR struct file *filep)
   user->state.interval = UINT32_MAX;
   user->state.esize = upper->state.esize;
   user->state.nonwakeup = true;
-  nxsem_init(&user->buffersem, 0, 0);
   list_add_tail(&upper->userlist, &user->node);
 
   /* The new user generation, notify to other users */
@@ -835,7 +833,6 @@ static int sensor_close(FAR struct file *filep)
     }
 
   list_delete(&user->node);
-  nxsem_destroy(&user->buffersem);
 
   /* The user is closed, notify to other users */
 
@@ -871,24 +868,18 @@ static ssize_t sensor_read(FAR struct file *filep, FAR char *buffer,
           return -EINVAL;
         }
 
-      if (!(filep->f_oflags & O_NONBLOCK))
-        {
-          nxrmutex_unlock(&upper->lock);
-          ret = nxsem_wait_uninterruptible(&user->buffersem);
-          if (ret < 0)
-            {
-              return ret;
-            }
+      /* Fetch the data from the device directly, there is nothing to wait
+       * for. This matches the POLLIN sensor_poll() always reports for a
+       * fetch only sensor.
+       */
 
-          nxrmutex_lock(&upper->lock);
-        }
-      else if (!upper->state.nsubscribers)
+      if (!upper->state.nsubscribers)
         {
           ret = -EAGAIN;
           goto out;
         }
 
-        ret = lower->ops->fetch(lower, filep, buffer, len);
+      ret = lower->ops->fetch(lower, filep, buffer, len);
     }
   else if (circbuf_is_empty(&upper->buffer))
     {
@@ -1166,7 +1157,6 @@ static int sensor_poll(FAR struct file *filep,
   FAR struct sensor_lowerhalf_s *lower = upper->lower;
   FAR struct sensor_user_s *user = filep->f_priv;
   pollevent_t eventset = 0;
-  int semcount;
   int ret = 0;
 
   nxrmutex_lock(&upper->lock);
@@ -1184,20 +1174,12 @@ static int sensor_poll(FAR struct file *filep,
       fds->priv = filep;
       if (lower->ops->fetch)
         {
-          /* Always return POLLIN for fetch data directly(non-block) */
+          /* Always return POLLIN for fetch only sensor: the data is read
+           * from the device on demand by sensor_read(), so there is never
+           * anything to wait for.
+           */
 
-          if (filep->f_oflags & O_NONBLOCK)
-            {
-              eventset |= POLLIN;
-            }
-          else
-            {
-              nxsem_get_value(&user->buffersem, &semcount);
-              if (semcount > 0)
-                {
-                  eventset |= POLLIN;
-                }
-            }
+          eventset |= POLLIN;
         }
       else if (sensor_is_updated(upper, user))
         {
@@ -1229,7 +1211,6 @@ static ssize_t sensor_push_event(FAR void *priv, FAR const void *data,
   FAR struct sensor_lowerhalf_s *lower = upper->lower;
   FAR struct sensor_user_s *user;
   unsigned long envcount;
-  int semcount;
   int ret;
 
   nxrmutex_lock(&upper->lock);
@@ -1287,12 +1268,6 @@ static ssize_t sensor_push_event(FAR void *priv, FAR const void *data,
     {
       if (sensor_is_updated(upper, user))
         {
-          nxsem_get_value(&user->buffersem, &semcount);
-          if (semcount < 1)
-            {
-              nxsem_post(&user->buffersem);
-            }
-
           sensor_pollnotify_one(user, POLLIN, SENSOR_ROLE_RD);
         }
     }
@@ -1305,17 +1280,10 @@ static void sensor_notify_event(FAR void *priv)
 {
   FAR struct sensor_upperhalf_s *upper = priv;
   FAR struct sensor_user_s *user;
-  int semcount;
 
   nxrmutex_lock(&upper->lock);
   list_for_every_entry(&upper->userlist, user, struct sensor_user_s, node)
     {
-      nxsem_get_value(&user->buffersem, &semcount);
-      if (semcount < 1)
-        {
-          nxsem_post(&user->buffersem);
-        }
-
       sensor_pollnotify_one(user, POLLIN, SENSOR_ROLE_RD);
     }
 

--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -43,6 +43,7 @@
 #include <nuttx/mutex.h>
 #include <nuttx/sensors/sensor.h>
 #include <nuttx/lib/lib.h>
+#include <nuttx/wdog.h>
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -96,6 +97,8 @@ struct sensor_user_s
   struct list_node node;       /* Node of users list */
   struct pollfd   *fds;        /* The poll structure of thread waiting events */
   sensor_role_t    role;       /* The is used to indicate user's role based on open flags */
+  struct wdog_s    wdog;       /* Paces POLLIN at the requested interval */
+  uint64_t         fetched;    /* When POLLIN was last reported, in usec */
   bool             changed;    /* This is used to indicate event happens and need to
                                 * asynchronous notify other users
                                 */
@@ -142,6 +145,7 @@ static int     sensor_poll(FAR struct file *filep, FAR struct pollfd *fds,
                            bool setup);
 static ssize_t sensor_push_event(FAR void *priv, FAR const void *data,
                                  size_t bytes);
+static void    sensor_fetch_expired(wdparm_t arg);
 
 /****************************************************************************
  * Private Data
@@ -687,6 +691,23 @@ static void sensor_pollnotify_one(FAR struct sensor_user_s *user,
   poll_notify(&user->fds, 1, eventset);
 }
 
+static void sensor_fetch_expired(wdparm_t arg)
+{
+  FAR struct sensor_user_s *user = (FAR struct sensor_user_s *)arg;
+
+  /* Timer context, so no lock: a teardown that raced us cleared fds, which
+   * makes both the notify and the re-arm below no-ops.
+   */
+
+  if (user->fds != NULL)
+    {
+      user->fetched = sensor_get_timestamp();
+      sensor_pollnotify_one(user, POLLIN, SENSOR_ROLE_RD);
+      wd_start(&user->wdog, USEC2TICK(user->state.interval),
+               sensor_fetch_expired, arg);
+    }
+}
+
 static void sensor_pollnotify(FAR struct sensor_upperhalf_s *upper,
                               pollevent_t eventset, sensor_role_t role)
 {
@@ -868,10 +889,7 @@ static ssize_t sensor_read(FAR struct file *filep, FAR char *buffer,
           return -EINVAL;
         }
 
-      /* Fetch the data from the device directly, there is nothing to wait
-       * for. This matches the POLLIN sensor_poll() always reports for a
-       * fetch only sensor.
-       */
+      /* Read the device directly, there is nothing to wait for */
 
       if (!upper->state.nsubscribers)
         {
@@ -1174,12 +1192,31 @@ static int sensor_poll(FAR struct file *filep,
       fds->priv = filep;
       if (lower->ops->fetch)
         {
-          /* Always return POLLIN for fetch only sensor: the data is read
-           * from the device on demand by sensor_read(), so there is never
-           * anything to wait for.
+          /* Always ready, unless a rate was requested: then once per
+           * interval, woken by sensor_fetch_expired().
            */
 
-          eventset |= POLLIN;
+          if (user->state.interval == UINT32_MAX)
+            {
+              eventset |= POLLIN;
+            }
+          else
+            {
+              uint64_t now = sensor_get_timestamp();
+              uint64_t elapsed = now - user->fetched;
+
+              if (elapsed >= user->state.interval)
+                {
+                  user->fetched = now;
+                  eventset |= POLLIN;
+                }
+              else
+                {
+                  wd_start(&user->wdog,
+                           USEC2TICK(user->state.interval - elapsed),
+                           sensor_fetch_expired, (wdparm_t)user);
+                }
+            }
         }
       else if (sensor_is_updated(upper, user))
         {
@@ -1197,6 +1234,7 @@ static int sensor_poll(FAR struct file *filep,
     {
       user->fds = NULL;
       fds->priv = NULL;
+      wd_cancel(&user->wdog);
     }
 
 errout:

--- a/include/nuttx/sensors/sensor.h
+++ b/include/nuttx/sensors/sensor.h
@@ -353,10 +353,10 @@ struct sensor_ops_s
    * If fetch isn't NULL, upper half driver will disable intermediate
    * buffer and userspace can't set buffer size by ioctl.
    *
-   * You can call this function to read sensor register data by I2C/SPI bus
-   * when open mode is non-block, and poll are always successful.
-   * When you call this function and open mode is block, you will wait
-   * until sensor data ready, then read sensor data.
+   * You can call this function to read sensor register data by I2C/SPI
+   * bus. The data is read from the device on demand, so it is always
+   * available: poll() always reports POLLIN and read() never blocks,
+   * whether or not the open mode is non-block.
    *
    * Input Parameters:
    *   lower      - The instance of lower half sensor driver.


### PR DESCRIPTION
## Summary

A `fetch()`-only lower half reads the device on demand, so it's always
ready, nothing to wait for. The upper half didn't reflect that:
`sensor_poll()` only reported `POLLIN` when opened `O_NONBLOCK`, and a
blocking `read()` waited on `buffersem`, which only a driver-owned
interrupt (`notify_event`) posts. A `fetch()`-only sensor with no
interrupt therefore never satisfied `poll()`/`read()` at all — e.g.
in-tree `nucleo-h563zi:dts` hangs on a blocking `read()` today.
Applications worked around this with `O_NONBLOCK` (apache/nuttx-apps#3686);
this PR fixes it at the root instead, per reviewer feedback there.

Three commits:

1. **l3gd20 → push-only.** Its `BUFFER_SIZE == 0` mode set `fetch()` while
   still gating readiness on the data-ready interrupt. That mix was buggy,
   not just inconsistent: `poll()` reported `POLLIN` from `O_NONBLOCK`, not
   from the interrupt, so a multi-descriptor loop could read it stale or
   twice. Now always `push_event`, the path it already took by default; no
   in-tree config enables it.
2. **`sensor_poll()`/`sensor_read()` always ready for `fetch()`-only.** The
   actual fix. `buffersem` goes with it: its only two readers were the ones
   removed here, so the semaphore and its posts are now dead. `notify_event`
   is likewise dead for `fetch()`-only lower halves, but I left that API
   alone rather than widen the patch.
3. **Pace `POLLIN` at the requested interval.** A rate request got no help
   from `poll()`, and apps sleeping it out serialize across topics (three at
   10 Hz → 3.3 Hz each). A per-subscriber `wdog_s` armed in `sensor_poll()`
   paces each at its own interval. A watchdog rather than a work item keeps
   this off the work queue, which is what `fetch()` exists to avoid: it runs
   in timer context and needs no lock, so teardown just cancels it where it
   clears `fds`, and `sensor_close()` needs nothing of its own.

## Impact

Any `fetch()`-only uORB sensor (on-demand I2C/SPI, no interrupt) now
works with `poll()`/`read()` without the app forcing `O_NONBLOCK`, and
pacing costs no thread and no work queue — it needs no `CONFIG_` option
at all, where the earlier work-queue revision of this PR silently did
nothing without `CONFIG_SCHED_LPWORK`. Every interrupt-driven sensor,
including l3gd20 after commit 1, keeps blocking correctly until real new
data arrives; push semantics are unchanged, verified on both paths
(Testing).

## Testing

Host: Ubuntu 24.04.3 LTS. `checkpatch.sh` (style + `-m` commit messages)
clean on all 3 commits.

**Compiles clean** on 3 architectures touching the changed
`drivers/sensors/sensor.c`: xtensa-esp-elf-gcc 14.2.0 (`esp32s3-devkit`),
arm-none-eabi-gcc 13.2.1 (`stm32f4discovery`), and `sim` (x86_64).

### fetch()-only path — ESP32-S3-DevKitC + MPU6050 (GY-521) on I2C0

`fetch()`-only with no interrupt line, no `O_NONBLOCK` anywhere in the
unmodified `apps/system/uorb/listener.c`. Note this configuration does
**not** enable `CONFIG_SCHED_LPWORK`, so it is also the case the previous
work-queue revision could not have paced at all:

```
nsh> uorb_listener -n 5 -r 10 sensor_accel0
Monitor objects num:1
object_name:sensor_accel, object_instance:0
sensor_accel(now:25470000):timestamp:25470000,x:-0.160412,y:-0.191536,z:10.292673,temperature:24.106468
sensor_accel(now:25580000):timestamp:25580000,x:-0.134075,y:-0.093373,z:10.297462,temperature:24.012352
sensor_accel(now:25690000):timestamp:25690000,x:-0.138864,y:-0.134075,z:10.192117,temperature:23.918234
sensor_accel(now:25800000):timestamp:25800000,x:-0.105345,y:-0.155623,z:10.362105,temperature:24.012352
sensor_accel(now:25910000):timestamp:25910000,x:-0.124498,y:-0.148441,z:10.285490,temperature:24.012352
Object name:sensor_accel0, received:5
Total number of received Message:5/5
```

110 ms apart, the requested 10 Hz.

**Per-subscriber pacing**: two `uorb_listener` processes on the same
`sensor_accel0` at once, `-r 20` and `-r 5`. Their samples landed ~60 ms
and ~210 ms apart respectively — each paced at its own interval, not at
the minimum across both.

**Teardown under stress**: 10 rounds of `uorb_listener -r 5 sensor_accel0 &`
followed by `SIGINT` mid-poll. `ps` afterward shows no leaked task and no
armed timer, and `uorb_listener -n 3 sensor_accel0` right after still
completes 3/3.

### push path — sim, exercising the `buffersem` removal

`sim:baromonitor`, with `uorb_generator` as the publisher: `orb_publish()`
→ `write()` → `sensor_write()` → `sensor_push_event()`, which is exactly
where the `nxsem_post(&user->buffersem)` was removed.

```
nsh> uorb_generator -n 100 -r 5 -s -t sensor_baro0 timestamp:23191100,pressure:999.12,temperature:26.34 &
nsh> uorb_listener -n 5 sensor_baro0
Monitor objects num:1
object_name:sensor_baro, object_instance:0
sensor_baro(now:9070000):timestamp:8940000,pressure:999.119995,temperature:26.340000
sensor_baro(now:9150000):timestamp:9150000,pressure:999.119995,temperature:26.340000
sensor_baro(now:9360000):timestamp:9360000,pressure:999.119995,temperature:26.340000
sensor_baro(now:9570000):timestamp:9570000,pressure:999.119995,temperature:26.340000
sensor_baro(now:9780000):timestamp:9780000,pressure:999.119995,temperature:26.340000
Object name:sensor_baro0, received:5
Total number of received Message:5/5
```

The ~210 ms deltas track the publisher's 5 Hz, so the subscriber is being
woken by each push rather than spinning or stalling.

Two subscribers at once against a 10 Hz publisher, one of them rate
limited: the plain one got 6/6 ~110 ms apart, the `-r 2` one got 4/4
~500 ms apart — both notified from the same `sensor_push_event()` loop,
and the push-side rate gating in `sensor_is_updated()` is unaffected.

Six sequential subscribe/teardown cycles on that topic all completed and
exited cleanly, with no leaked task. That also covers an edge case of
commit 3: a push sensor never takes the branch that arms the watchdog, so
teardown's `wd_cancel()` always runs on a never-armed `wdog_s`. It is safe
by construction (`WDOG_ISACTIVE` tests `func != NULL`, and `user` comes
from `kmm_zalloc`), and this confirms it at runtime.
