### PR TITLE
net: Fix fragment forwarding and IPv6 reassembly keys

### DIFF
--- a/net/ipforward/ipv4_forward.c
+++ b/net/ipforward/ipv4_forward.c
@@ -549,6 +549,17 @@ drop:
   ipv4_dropstats(ipv4);
 
 #if defined(CONFIG_NET_ICMP) && !defined(CONFIG_NET_ICMP_NO_STACK)
+  /* ICMP errors are only generated for unfragmented packets or fragment
+   * zero.  Non-initial fragments do not carry enough context for a useful
+   * ICMP error payload.
+   */
+
+  if ((ipv4->ipoffset[0] & 0x1f) != 0 || ipv4->ipoffset[1] != 0)
+    {
+      dev->d_len = 0;
+      return ret;
+    }
+
   /* Reply ICMP to the sender for particular errors. */
 
   switch (ret)

--- a/net/ipfrag/ipfrag.c
+++ b/net/ipfrag/ipfrag.c
@@ -153,6 +153,9 @@ static void ip_fragin_check(FAR struct ip_fragsnode_s *fragsnode);
 static void ip_fragin_cachemonitor(FAR struct ip_fragsnode_s *curnode);
 static inline FAR struct iob_s *
 ip_fragout_allocfragbuf(FAR struct iob_queue_s *fragq);
+static bool ip_fragin_match(FAR struct net_driver_s *dev,
+                            FAR struct ip_fragsnode_s *node,
+                            FAR struct ip_fraglink_s *fraglink);
 
 /****************************************************************************
  * Private Functions
@@ -507,6 +510,35 @@ ip_fragout_allocfragbuf(FAR struct iob_queue_s *fragq)
 }
 
 /****************************************************************************
+ * Name: ip_fragin_match
+ *
+ * Description:
+ *   Check whether a fragment belongs to an existing reassembly node.
+ *
+ ****************************************************************************/
+
+static bool ip_fragin_match(FAR struct net_driver_s *dev,
+                            FAR struct ip_fragsnode_s *node,
+                            FAR struct ip_fraglink_s *fraglink)
+{
+  if (dev != node->dev || fraglink->isipv4 != node->isipv4 ||
+      fraglink->ipid != node->ipid)
+    {
+      return false;
+    }
+
+#ifdef CONFIG_NET_IPv6
+  if (!fraglink->isipv4)
+    {
+      return net_ipv6addr_cmp(fraglink->srcipaddr, node->srcipaddr) &&
+             net_ipv6addr_cmp(fraglink->destipaddr, node->destipaddr);
+    }
+#endif
+
+  return true;
+}
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -575,9 +607,13 @@ bool ip_fragin_enqueue(FAR struct net_driver_s *dev,
     {
       node = (struct ip_fragsnode_s *)entry;
 
-      if (dev == node->dev && curfraglink->ipid <= node->ipid)
+      if (dev == node->dev)
         {
-          break;
+          if (ip_fragin_match(dev, node, curfraglink) ||
+              curfraglink->ipid < node->ipid)
+            {
+              break;
+            }
         }
 
       entrylast = entry;
@@ -586,7 +622,7 @@ bool ip_fragin_enqueue(FAR struct net_driver_s *dev,
 
   node = (FAR struct ip_fragsnode_s *)entry;
 
-  if (node != NULL && curfraglink->ipid == node->ipid)
+  if (node != NULL && ip_fragin_match(dev, node, curfraglink))
     {
       FAR struct ip_fraglink_s *fraglink;
       FAR struct ip_fraglink_s *lastlink = NULL;
@@ -688,6 +724,7 @@ bool ip_fragin_enqueue(FAR struct net_driver_s *dev,
       node->flink      = NULL;
       node->flinkat    = NULL;
       node->dev        = dev;
+      node->isipv4     = curfraglink->isipv4;
       node->ipid       = curfraglink->ipid;
       node->frags      = curfraglink;
       node->tick       = clock_systime_ticks();
@@ -695,6 +732,14 @@ bool ip_fragin_enqueue(FAR struct net_driver_s *dev,
       g_bufoccupy     += IOBUF_CNT(curfraglink->frag);
       node->verifyflag = 0;
       node->outgoframe = NULL;
+
+#ifdef CONFIG_NET_IPv6
+      if (!curfraglink->isipv4)
+        {
+          net_ipv6addr_copy(node->srcipaddr, curfraglink->srcipaddr);
+          net_ipv6addr_copy(node->destipaddr, curfraglink->destipaddr);
+        }
+#endif
 
       /* Insert this new node into linked list identified by
        * g_assemblyhead_ipid with correct position

--- a/net/ipfrag/ipfrag.h
+++ b/net/ipfrag/ipfrag.h
@@ -73,7 +73,7 @@ enum ip_fragverify_e
 struct ip_fraglink_s
 {
   /* This link is used to maintain a single-linked list of ip_fraglink_s,
-   * it links all framgents with the same IP ID
+   * it links all fragments with the same reassembly key.
    */
 
   FAR struct ip_fraglink_s  *flink;
@@ -84,6 +84,11 @@ struct ip_fraglink_s
   uint16_t                   fragoff;   /* Fragment offset */
   uint16_t                   fraglen;   /* Payload length */
   uint16_t                   morefrags; /* The more frag flag */
+
+#ifdef CONFIG_NET_IPv6
+  net_ipv6addr_t             srcipaddr;  /* IPv6 source address */
+  net_ipv6addr_t             destipaddr; /* IPv6 destination address */
+#endif
 
   /* The identification field is 16 bits in IPv4 header but 32 bits in IPv6
    * fragment header
@@ -109,12 +114,18 @@ struct ip_fragsnode_s
   /* Interface understood by the network */
 
   FAR struct net_driver_s   *dev;
+  uint8_t                    isipv4;     /* IPv4 or IPv6 */
 
   /* IP Identification (IP ID) field defined in ipv4 header or in ipv6
    * fragment header.
    */
 
   uint32_t                   ipid;
+
+#ifdef CONFIG_NET_IPv6
+  net_ipv6addr_t             srcipaddr;  /* IPv6 source address */
+  net_ipv6addr_t             destipaddr; /* IPv6 destination address */
+#endif
 
   /* Count ticks, used by ressembly timer */
 
@@ -128,7 +139,7 @@ struct ip_fragsnode_s
 
   uint32_t                   bufcnt;
 
-  /* Linked all fragments with the same IP ID. */
+  /* Linked all fragments with the same reassembly key. */
 
   FAR struct ip_fraglink_s  *frags;
 

--- a/net/ipfrag/ipv6_frag.c
+++ b/net/ipfrag/ipv6_frag.c
@@ -145,6 +145,8 @@ static int32_t ipv6_fragin_getinfo(FAR struct iob_s *iob,
       fraglink->ipid      = NTOHL(
         ((uint32_t)(*(FAR uint16_t *)(&fraghdr->id[0])) << 16) +
          (uint32_t)(*(FAR uint16_t *)(&fraghdr->id[2])));
+      net_ipv6addr_copy(fraglink->srcipaddr, ipv6->srcipaddr);
+      net_ipv6addr_copy(fraglink->destipaddr, ipv6->destipaddr);
 
       fraglink->frag      = iob;
 


### PR DESCRIPTION
## Summary
- suppress ICMP errors for IPv4 non-initial fragments during forwarding failures
- include IPv6 source/destination addresses in fragment reassembly matching

## Risk without this change
- IPv6 reassembly can mix fragments from different packets when they arrive on the same interface with the same Fragment Identification value.
- A mixed reassembly can corrupt payload data by combining fragment zero from one IPv6 flow with later fragments from another flow.
- NAT66 and IP filter paths reassemble fragments before processing, so a corrupted reassembled packet can lead to wrong NAT/filter decisions.
- Legitimate fragmented traffic can be dropped or timed out if another packet poisons its reassembly node.
- An attacker able to inject IPv6 fragments with a chosen or guessed Fragment Identification value can interfere with another fragmented flow on the same interface.
- Tracking the IP family in the reassembly key also avoids accidental IPv4/IPv6 node matching on the same interface and identification value.

## Testing
- git diff --check HEAD~2..HEAD
- tools/nxstyle net/ipforward/ipv4_forward.c
- tools/nxstyle net/ipfrag/ipfrag.c
- tools/nxstyle net/ipfrag/ipfrag.h
- tools/nxstyle net/ipfrag/ipv6_frag.c