### PR TITLE
net/ipv6: Forward reassembled fragments through fragout

### DIFF
--- a/include/nuttx/net/netdev.h
+++ b/include/nuttx/net/netdev.h
@@ -442,6 +442,7 @@ struct net_driver_s
   /* Remember the outgoing fragments waiting to be sent */
 
 #ifdef CONFIG_NET_IPFRAG
+  uint8_t d_ipfrag_reassembled; /* Current packet is reassembled by IPFRAG */
   struct iob_queue_s d_fragout;
 #endif
 

--- a/net/ipforward/ipv6_forward.c
+++ b/net/ipforward/ipv6_forward.c
@@ -390,11 +390,17 @@ static int ipv6_dev_forward(FAR struct net_driver_s *dev,
     }
   else if (ret == PACKET_NOT_FORWARDED)
     {
-      /* Verify that the full packet will fit within the forwarding devices
-       * MTU.  We provide no support for fragmenting forwarded packets.
+      /* Verify that the full packet will fit within the forwarding device's
+       * MTU.  Normal IPv6 forwarding does not fragment oversized packets,
+       * but packets reassembled locally for NAT66/IPFILTER may be split
+       * again by the egress IPFRAG path.
        */
 
-      if (NET_LL_HDRLEN(fwddev) + dev->d_len > NETDEV_PKTSIZE(fwddev))
+      if (NET_LL_HDRLEN(fwddev) + dev->d_len > NETDEV_PKTSIZE(fwddev)
+#ifdef CONFIG_NET_IPFRAG
+          && !dev->d_ipfrag_reassembled
+#endif
+         )
         {
           nwarn("WARNING: Packet > MTU... Dropping\n");
           ret = -EFBIG;

--- a/net/ipfrag/ipv6_frag.c
+++ b/net/ipfrag/ipv6_frag.c
@@ -469,6 +469,8 @@ int32_t ipv6_fragin(FAR struct net_driver_s *dev)
   FAR struct ip_fragsnode_s *node = NULL;
   FAR struct ip_fraglink_s *fraginfo = NULL;
   bool restartwdog;
+  uint8_t reassembled;
+  int32_t ret;
 
   if (dev->d_len != dev->d_iob->io_pktlen)
     {
@@ -521,7 +523,12 @@ int32_t ipv6_fragin(FAR struct net_driver_s *dev)
 
       kmm_free(node);
 
-      return ipv6_input(dev);
+      reassembled = dev->d_ipfrag_reassembled;
+      dev->d_ipfrag_reassembled = true;
+      ret = ipv6_input(dev);
+      dev->d_ipfrag_reassembled = reassembled;
+
+      return ret;
     }
 
   nxmutex_unlock(&g_ipfrag_lock);

--- a/net/netdev/netdev_register.c
+++ b/net/netdev/netdev_register.c
@@ -427,6 +427,10 @@ int netdev_register(FAR struct net_driver_s *dev, enum net_lltype_e lltype)
 
       dev->d_polltype = 0;
 
+#ifdef CONFIG_NET_IPFRAG
+      dev->d_ipfrag_reassembled = false;
+#endif
+
       nxrmutex_init(&dev->d_lock);
 
       /* We need exclusive access for the following operations */


### PR DESCRIPTION
## Summary
- track IPv6 packets produced by local fragment reassembly
- allow only those reassembled packets to bypass the IPv6 forwarding MTU drop when CONFIG_NET_IPFRAG is enabled
- keep normal oversized IPv6 forwarding on the Packet Too Big path

## Why
NAT66 and IPFILTER may reassemble IPv6 fragments before forwarding so they can inspect the full packet. If the reassembled transit packet is larger than the egress MTU, ipv6_dev_forward() drops it before the existing egress ip_fragout() path can split it again.

## Behavior
Normal unfragmented IPv6 packets are still not fragmented by the router. The exception is limited to packets that were already fragmented on ingress and were reassembled inside the stack before forwarding.

## Testing
Style/build checks:
- `git diff --check HEAD~1..HEAD`
- `make -C tools -f Makefile.host nxstyle`
- `tools/nxstyle include/nuttx/net/netdev.h`
- `tools/nxstyle net/ipforward/ipv6_forward.c`
- `tools/nxstyle net/ipfrag/ipv6_frag.c`
- `tools/nxstyle net/netdev/netdev_register.c`
- `make -j8` with `sim:dynconns`

Functional emulator method:
- Configure `sim:dynconns` with two simulator network devices and IPv6/IPFRAG/IPFILTER enabled.
- Run NuttX with two TAP-backed interfaces connected to two Linux namespaces.
- Topology: `nuttxfrag-a` (`2001:db8:1::2/64`) -> NuttX `eth0` (`2001:db8:1::1/64`) -> NuttX `eth1` (`2001:db8:2::1/64`) -> `nuttxfrag-b` (`2001:db8:2::2/64`).
- Send a 2400-byte IPv6 echo request from namespace A to namespace B.
- Capture IPv6 Fragment headers on namespace B egress with `tcpdump`.
- Pass condition: namespace B captures the re-forwarded packet as IPv6 fragments after NuttX local reassembly.

Functional emulator log:
```text
$ git diff --check HEAD~1..HEAD
<no output>

$ tools/nxstyle include/nuttx/net/netdev.h
$ tools/nxstyle net/ipforward/ipv6_forward.c
$ tools/nxstyle net/ipfrag/ipv6_frag.c
$ tools/nxstyle net/netdev/netdev_register.c
<no output>

$ sudo -E /home/hma/misc/misc_tools/bugs/ipfrag/test_ipv6_reassembled_forward_fragout.sh --keep
Captured egress IPv6 fragments: 2

$ tcpdump -n -vv -r /tmp/nuttx-ipfrag-forward/egress-fragments.pcap
11:34:07.152749 IP6 (flowlabel 0xcf7c5, hlim 63, next-header Fragment (44) payload length: 1456) 2001:db8:1::2 > 2001:db8:2::2: frag (0x00000001:0|1448) ICMP6, echo request, id 64993, seq 1
11:34:07.152809 IP6 (flowlabel 0xcf7c5, hlim 63, next-header Fragment (44) payload length: 968) 2001:db8:1::2 > 2001:db8:2::2: frag (0x00000001:1448|960)
```
