### PR TITLE
Feature/mpu6050 drdy interrupt

### DIFF
--- a/Documentation/components/drivers/special/sensors/mpu6050.rst
+++ b/Documentation/components/drivers/special/sensors/mpu6050.rst
@@ -33,24 +33,62 @@ Where ``n`` is the device number passed during device registration (e.g., 0).
 
    /* Example uORB sensor registration on I2C bus 0 at default address 0x68 */
 
-   int err = mpu6050_register(0, i2c_master, MPU6050_ADDR_LOW);
+   int err = mpu6050_register(0, i2c_master, MPU6050_ADDR_LOW, NULL);
    if (err < 0)
      {
        syslog(LOG_ERR, "Failed to register MPU6050: %d\n", err);
      }
 
+The device samples at 100 Hz.
+
+Acquisition Modes
+=================
+
+The driver reads the device on demand by default: a sample is taken when the
+application reads the topic, and is timestamped at that moment.
+
+With ``CONFIG_SENSORS_MPU6050_INT`` the device drives the acquisition instead,
+through its data ready interrupt. Samples are then timestamped when they were
+measured rather than when they were asked for, and both topics are published
+from a single read, so accelerometer and gyroscope share one timestamp. This
+requires the INT pin to be wired, and the board to pass a
+``struct mpu6050_config_s`` whose ``attach`` member connects that pin to the
+driver:
+
+.. code-block:: c
+
+   static int board_mpu6050_attach(FAR const struct mpu6050_config_s *config,
+                                   xcpt_t isr, FAR void *arg)
+   {
+     /* Configure the GPIO for a rising edge and attach isr to it */
+   }
+
+   static const struct mpu6050_config_s g_mpu6050_config =
+   {
+     .attach = board_mpu6050_attach,
+   };
+
+   int err = mpu6050_register(0, i2c_master, MPU6050_ADDR_LOW,
+                              &g_mpu6050_config);
+
+Registration fails with ``-EINVAL`` if the option is enabled and no ``attach``
+is supplied, since the interrupt is the only source of samples in that build.
+
 Configuration Options
 =====================
 
 - ``CONFIG_SENSORS_MPU6050`` - Enables uORB driver support for the InvenSense MPU6050 6-axis MotionTracker over I2C.
+- ``CONFIG_SENSORS_MPU6050_INT`` - Takes samples from the data ready interrupt instead of reading the device on demand. Requires board support, see `Acquisition Modes`_.
 
 Supported Operations
 ====================
 
-The MPU6050 uORB driver supports standard sensor operations (`activate`, `fetch`,
-`set_interval`, `batch`, and `control`). It acquires simultaneous 3-axis accelerometer
-and 3-axis gyroscope samples, applies appropriate scale conversions, and publishes them
-to their respective uORB topics.
+The MPU6050 uORB driver supports standard sensor operations (`activate`,
+`set_interval`, `batch`, and `control`), plus `fetch` when reading on demand.
+An instance provides either `fetch` or interrupt driven delivery, never both.
+It acquires simultaneous 3-axis accelerometer and 3-axis gyroscope samples,
+applies appropriate scale conversions, and publishes them to their respective
+uORB topics.
 
 Example Usage (`uorb_listener`)
 -------------------------------

--- a/drivers/sensors/Kconfig
+++ b/drivers/sensors/Kconfig
@@ -1573,6 +1573,20 @@ config SENSORS_MPU6050
 	---help---
 		Enable uORB driver support for Invensense MPU6050 6-axis MotionTracker device over I2C.
 
+if SENSORS_MPU6050
+
+config SENSORS_MPU6050_INT
+	bool "Deliver samples from the data ready interrupt"
+	default n
+	select SCHED_HPWORK
+	---help---
+		Take samples from the MPU6050 INT pin instead of reading the device
+		on demand, which timestamps them when they were actually measured.
+		The board must wire that pin and supply mpu6050_config_s::attach;
+		registration fails with -EINVAL otherwise.
+
+endif # SENSORS_MPU6050
+
 config SENSORS_MPU9250
 	bool "Invensense MPU9250 Sensor support"
 	default n

--- a/drivers/sensors/mpu6050_uorb.c
+++ b/drivers/sensors/mpu6050_uorb.c
@@ -39,6 +39,9 @@
 #include <nuttx/mutex.h>
 #include <nuttx/sensors/mpu6050.h>
 #include <nuttx/sensors/sensor.h>
+#ifdef CONFIG_SENSORS_MPU6050_INT
+#  include <nuttx/wqueue.h>
+#endif
 
 #ifdef CONFIG_SENSORS_MPU6050
 
@@ -111,6 +114,10 @@ struct mpu6050_uorb_dev_s
   struct mpu6050_dev_s base;
   struct mpu6050_sensor_s accel;
   struct mpu6050_sensor_s gyro;
+#ifdef CONFIG_SENSORS_MPU6050_INT
+  struct work_s work;    /* Bottom half: the I2C read cannot run in the ISR */
+  uint64_t timestamp;    /* When the sample became ready, taken in the ISR */
+#endif
 };
 
 /****************************************************************************
@@ -119,22 +126,34 @@ struct mpu6050_uorb_dev_s
 
 static int mpu6050_activate(FAR struct sensor_lowerhalf_s *lower,
                             FAR struct file *filep, bool enable);
-static int mpu6050_fetch(FAR struct sensor_lowerhalf_s *lower,
-                         FAR struct file *filep,
-                         FAR char *buffer, size_t buflen);
 static int mpu6050_control(FAR struct sensor_lowerhalf_s *lower,
                            FAR struct file *filep,
                            int cmd, unsigned long arg);
+#ifdef CONFIG_SENSORS_MPU6050_INT
+static int mpu6050_interrupt(int irq, FAR void *context, FAR void *arg);
+static void mpu6050_worker(FAR void *arg);
+#else
+static int mpu6050_fetch(FAR struct sensor_lowerhalf_s *lower,
+                         FAR struct file *filep,
+                         FAR char *buffer, size_t buflen);
+#endif
 
 /****************************************************************************
  * Private Data
  ****************************************************************************/
 
+/* With the INT pin wired the device pushes samples on its own, so fetch()
+ * is deliberately absent: a lower half implements one model or the other,
+ * never both.
+ */
+
 static const struct sensor_ops_s g_mpu6050_ops =
 {
   .activate = mpu6050_activate,
-  .fetch    = mpu6050_fetch,
   .control  = mpu6050_control,
+#ifndef CONFIG_SENSORS_MPU6050_INT
+  .fetch    = mpu6050_fetch,
+#endif
 };
 
 /****************************************************************************
@@ -227,6 +246,10 @@ static int mpu6050_activate(FAR struct sensor_lowerhalf_s *lower,
 {
   FAR struct mpu6050_sensor_s *priv = (FAR struct mpu6050_sensor_s *)lower;
   FAR struct mpu6050_dev_s *dev = priv->dev;
+#ifdef CONFIG_SENSORS_MPU6050_INT
+  FAR struct mpu6050_uorb_dev_s *udev = (FAR struct mpu6050_uorb_dev_s *)dev;
+  bool other;
+#endif
   int ret;
 
   ret = nxmutex_lock(&dev->dev_lock);
@@ -235,14 +258,26 @@ static int mpu6050_activate(FAR struct sensor_lowerhalf_s *lower,
       return ret;
     }
 
-  if (enable)
+#ifdef CONFIG_SENSORS_MPU6050_INT
+
+  /* The data ready interrupt drives delivery here, so it stays enabled
+   * while either of the two sensors is still subscribed.
+   */
+
+  other = (priv == &udev->accel) ? udev->gyro.enabled : udev->accel.enabled;
+  if (enable || !other)
     {
-      ret = mpu6050_write_reg(dev, MPU6050_PWR_MGMT_1, 0x00);
+      ret = mpu6050_write_reg(dev, MPU6050_PWR_MGMT_1,
+                              enable ? 0x00 : 0x40);
+      if (ret >= 0)
+        {
+          ret = mpu6050_write_reg(dev, MPU6050_INT_ENABLE,
+                                  enable ? 0x01 : 0x00);
+        }
     }
-  else
-    {
-      ret = mpu6050_write_reg(dev, MPU6050_PWR_MGMT_1, 0x40);
-    }
+#else
+  ret = mpu6050_write_reg(dev, MPU6050_PWR_MGMT_1, enable ? 0x00 : 0x40);
+#endif
 
   if (ret >= 0)
     {
@@ -252,6 +287,85 @@ static int mpu6050_activate(FAR struct sensor_lowerhalf_s *lower,
   nxmutex_unlock(&dev->dev_lock);
   return ret;
 }
+
+#ifdef CONFIG_SENSORS_MPU6050_INT
+
+/****************************************************************************
+ * Name: mpu6050_interrupt
+ ****************************************************************************/
+
+static int mpu6050_interrupt(int irq, FAR void *context, FAR void *arg)
+{
+  FAR struct mpu6050_uorb_dev_s *dev = arg;
+
+  /* Timestamp here, where the sample really became ready.  The read itself
+   * needs I2C, which may block, so it is deferred to the worker.
+   */
+
+  dev->timestamp = sensor_get_timestamp();
+  return work_queue(HPWORK, &dev->work, mpu6050_worker, dev, 0);
+}
+
+/****************************************************************************
+ * Name: mpu6050_worker
+ ****************************************************************************/
+
+static void mpu6050_worker(FAR void *arg)
+{
+  FAR struct mpu6050_uorb_dev_s *dev = arg;
+  struct sensor_accel accel;
+  struct sensor_gyro gyro;
+  uint8_t buf[14];
+  float temp_c;
+  int ret;
+
+  if (nxmutex_lock(&dev->base.dev_lock) < 0)
+    {
+      return;
+    }
+
+  ret = mpu6050_read_regs(&dev->base, MPU6050_ACCEL_XOUT_H, buf, 14);
+  nxmutex_unlock(&dev->base.dev_lock);
+
+  if (ret < 0)
+    {
+      snerr("ERROR: Failed to read measurement: %d\n", ret);
+      return;
+    }
+
+  temp_c = ((float)(int16_t)((buf[6] << 8) | buf[7]) / 340.0f) + 36.53f;
+
+  if (dev->accel.enabled)
+    {
+      accel.timestamp   = dev->timestamp;
+      accel.x           = (float)(int16_t)((buf[0] << 8) | buf[1]) *
+                          dev->accel.scale;
+      accel.y           = (float)(int16_t)((buf[2] << 8) | buf[3]) *
+                          dev->accel.scale;
+      accel.z           = (float)(int16_t)((buf[4] << 8) | buf[5]) *
+                          dev->accel.scale;
+      accel.temperature = temp_c;
+
+      dev->accel.lower.push_event(dev->accel.lower.priv, &accel,
+                                  sizeof(accel));
+    }
+
+  if (dev->gyro.enabled)
+    {
+      gyro.timestamp   = dev->timestamp;
+      gyro.x           = (float)(int16_t)((buf[8] << 8) | buf[9]) *
+                         dev->gyro.scale;
+      gyro.y           = (float)(int16_t)((buf[10] << 8) | buf[11]) *
+                         dev->gyro.scale;
+      gyro.z           = (float)(int16_t)((buf[12] << 8) | buf[13]) *
+                         dev->gyro.scale;
+      gyro.temperature = temp_c;
+
+      dev->gyro.lower.push_event(dev->gyro.lower.priv, &gyro, sizeof(gyro));
+    }
+}
+
+#else
 
 /**
  * Name: mpu6050_fetch
@@ -333,6 +447,8 @@ static int mpu6050_fetch(FAR struct sensor_lowerhalf_s *lower,
 
   return -EINVAL;
 }
+
+#endif
 
 /**
  * Name: mpu6050_control
@@ -430,7 +546,8 @@ static int mpu6050_control(FAR struct sensor_lowerhalf_s *lower,
  * Name: mpu6050_register
  */
 
-int mpu6050_register(int devno, FAR struct i2c_master_s *i2c, uint8_t addr)
+int mpu6050_register(int devno, FAR struct i2c_master_s *i2c, uint8_t addr,
+                     FAR const struct mpu6050_config_s *config)
 {
   FAR struct mpu6050_uorb_dev_s *dev;
   FAR struct mpu6050_sensor_s *sensor;
@@ -439,6 +556,18 @@ int mpu6050_register(int devno, FAR struct i2c_master_s *i2c, uint8_t addr)
   int ret;
 
   DEBUGASSERT(i2c != NULL);
+
+#ifdef CONFIG_SENSORS_MPU6050_INT
+  /* The interrupt is the only source of samples in this build, so a board
+   * that did not wire it up is misconfigured rather than merely limited.
+   */
+
+  if (config == NULL || config->attach == NULL)
+    {
+      snerr("ERROR: CONFIG_SENSORS_MPU6050_INT needs config->attach\n");
+      return -EINVAL;
+    }
+#endif
 
   dev = (FAR struct mpu6050_uorb_dev_s *)
     kmm_zalloc(sizeof(struct mpu6050_uorb_dev_s));
@@ -470,6 +599,13 @@ int mpu6050_register(int devno, FAR struct i2c_master_s *i2c, uint8_t addr)
   /* Initialize MPU6050 */
 
   mpu6050_write_reg(&dev->base, MPU6050_PWR_MGMT_1, 0x00);   /* Wake up */
+
+  /* DLPF_CFG 1 puts the gyroscope output at 1 kHz, which is what the
+   * divider below assumes.  Left at its 0 reset value that output is 8 kHz
+   * and the device samples at 800 Hz instead.
+   */
+
+  mpu6050_write_reg(&dev->base, MPU6050_CONFIG, 0x01);
   mpu6050_write_reg(&dev->base, MPU6050_SMPLRT_DIV, 9);      /* 100 Hz */
   mpu6050_write_reg(&dev->base, MPU6050_ACCEL_CONFIG, 0x00); /* ±2g */
   mpu6050_write_reg(&dev->base, MPU6050_GYRO_CONFIG, 0x00);  /* ±250°/s */
@@ -510,6 +646,15 @@ int mpu6050_register(int devno, FAR struct i2c_master_s *i2c, uint8_t addr)
       syslog(LOG_ERR, "MPU6050: Failed to register gyro: %d\n", ret);
       goto errout;
     }
+
+#ifdef CONFIG_SENSORS_MPU6050_INT
+  ret = config->attach(config, mpu6050_interrupt, dev);
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "MPU6050: Failed to attach interrupt: %d\n", ret);
+      goto errout;
+    }
+#endif
 
   syslog(LOG_INFO, "MPU6050: uORB driver registered successfully\n");
   return OK;

--- a/include/nuttx/sensors/mpu6050.h
+++ b/include/nuttx/sensors/mpu6050.h
@@ -46,6 +46,18 @@
 
 struct i2c_master_s;
 
+/* Board specific configuration.  With CONFIG_SENSORS_MPU6050_INT the board
+ * must supply attach(), which wires the MPU6050 INT pin to the given
+ * handler; the driver then delivers samples from that interrupt instead of
+ * reading the device on demand.
+ */
+
+struct mpu6050_config_s
+{
+  CODE int (*attach)(FAR const struct mpu6050_config_s *config,
+                     xcpt_t isr, FAR void *arg);
+};
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
@@ -63,17 +75,19 @@ extern "C"
  *   sensor framework.
  *
  * Input Parameters:
- *   devno - Device number for sensor registration (e.g. 0)
- *   i2c   - Pointer to the I2C master interface
- *   addr  - I2C slave address of the MPU6050 device
+ *   devno  - Device number for sensor registration (e.g. 0)
+ *   i2c    - Pointer to the I2C master interface
+ *   addr   - I2C slave address of the MPU6050 device
+ *   config - Board configuration, required with CONFIG_SENSORS_MPU6050_INT
+ *            and otherwise unused; may be NULL
  *
  * Returned Value:
  *   Zero (OK) on success; a negated errno value on failure.
  *
  ****************************************************************************/
 
-int mpu6050_register(int devno, FAR struct i2c_master_s *i2c,
-                     uint8_t addr);
+int mpu6050_register(int devno, FAR struct i2c_master_s *i2c, uint8_t addr,
+                     FAR const struct mpu6050_config_s *config);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
## Summary

The MPU6050 driver only implemented `fetch()`, so samples were read on
demand: timestamped when the application asked rather than when the device
measured, with the scheduler's jitter baked in, and with accelerometer and
gyroscope coming from two separate I2C reads so the two topics were never
sampled at the same instant. The part has an INT pin and a data ready
interrupt; nothing used them.

Two commits:

1. **Push mode behind `CONFIG_SENSORS_MPU6050_INT`, plus a DLPF fix.** The
   board supplies `mpu6050_config_s::attach` to wire the INT pin; the
   handler timestamps and defers to HPWORK, and the worker reads the device
   once and pushes both topics from that single sample. The I2C read cannot
   run in the interrupt, hence the work queue. The mode is chosen at build
   time, so `fetch()` is simply left out of the ops table and out of the
   build when the option is set: an instance uses one model or the other,
   never the mixture that made `poll()` unusable on l3gd20 (#19596). A board
   that enables the option without supplying `attach` is misconfigured, so
   registration fails with `-EINVAL` rather than silently falling back.

   The same commit sets `CONFIG` so the DLPF is on. The sample rate is the
   gyroscope output rate divided by `1 + SMPLRT_DIV`, and that output is
   1 kHz only while the DLPF is enabled. `CONFIG` was left at its 0 reset
   value, which disables the DLPF and puts the output at 8 kHz, so the
   divider of 9 gave 800 Hz rather than the intended 100 Hz. `fetch()` hid
   this because the application set the pace and simply read the most recent
   sample; the interrupt made the real rate visible.
2. **Update the driver documentation** for the new registration signature
   and the two acquisition modes.

## Impact

Boards that wire the INT pin get samples timestamped at acquisition, both
topics sampled from the same read, and one I2C transaction per sample
instead of one per `read()`. Boards that do not wire it are unaffected:
the option defaults to `n` and the `fetch()` path is unchanged. The DLPF
fix applies to both modes and corrects the configured rate to the 100 Hz
the code already documented, additionally giving the anti-alias filtering
that a 100 Hz sampler should have.

## Testing

Host: Ubuntu 24.04.3 LTS. `checkpatch.sh` (style + `-m` commit messages)
clean on all four commits.

**Compiles clean** in both modes — `sim` (x86_64) with
`CONFIG_SENSORS_MPU6050_INT` on and off, and xtensa-esp-elf-gcc 14.2.0 for
the hardware runs below. The refactor was re-verified on hardware after the
fact: same 101 Hz and no duplicates, so it is behaviour neutral as claimed.

**On hardware** — ESP32-S3-DevKitC + MPU6050 (GY-521), I2C0 on
SDA GPIO5 / SCL GPIO4, INT on GPIO6. The board glue providing `attach()`
for that target is not part of this PR.

Sample rate, measured over 100 samples of `uorb_listener sensor_accel0`,
before and after the DLPF commit:

| | rate | consecutive duplicate samples |
|---|---|---|
| before | 833 Hz | 36 of 100 |
| after | 101 Hz | 0 of 100 |

The duplicates before the fix are the worker being re-triggered faster than
the device produced new data. After it, every interrupt yields a fresh
sample at the intended rate.

Both topics from one interrupt, note the shared timestamp:

```
nsh> uorb_listener -n 6 sensor_accel0,sensor_gyro0
Monitor objects num:2
object_name:sensor_gyro, object_instance:0
object_name:sensor_accel, object_instance:0
sensor_gyro(now:72560000):timestamp:72560000,x:2.424675,y:0.108184,z:0.039836,temperature:22.394705
sensor_accel(now:72560000):timestamp:72560000,x:0.790087,y:1.301249,z:10.234015,temperature:22.394705
sensor_gyro(now:72570000):timestamp:72570000,x:-0.380109,y:0.310962,z:0.613530,temperature:23.668234
sensor_accel(now:72570000):timestamp:72570000,x:0.776918,y:1.278504,z:10.190920,temperature:23.668234
sensor_gyro(now:72580000):timestamp:72580000,x:-0.024781,y:0.089131,z:0.303501,temperature:23.682940
sensor_accel(now:72580000):timestamp:72580000,x:0.785298,y:1.274912,z:10.144233,temperature:23.682940
Object name:sensor_gyro0, received:3
Object name:sensor_accel0, received:3
Total number of received Message:6/6
```

**Teardown**: 8 rounds of `uorb_listener -r 5 sensor_accel0 &` followed by
`SIGINT` mid-poll. `ps` afterward shows no leaked task and an idle `hpwork`
thread, and `uorb_listener -n 3 sensor_accel0` right after still completes
3/3 — the interrupt is disabled when the last subscriber leaves and
re-enabled when one returns.
