### PR TITLE
drivers/mmcsd/mmcsd_sdio.c: Fix finfo print modifier

### DIFF
--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -1024,9 +1024,9 @@ static void mmcsd_decode_cid(FAR struct mmcsd_state_s *priv, uint32_t cid[4])
   decoded.mdt    = (cid[3] >> 8) & 0xff;
   decoded.crc    = (cid[3] >> 1) & 0x7f;
 
-  finfo("mid: %02x cbx: %01x oid: %01x pnm: %s prv: %d psn: %08x mdt: %02x\
-         crc: %02x\n", decoded.mid, decoded.cbx, decoded.oid, decoded.pnm,
-         decoded.prv, (unsigned long)decoded.psn, decoded.mdt, decoded.crc);
+  finfo("mid: %02x cbx: %01x oid: %01x pnm: %s prv: %d psn: %08" PRIx32
+        " mdt: %02x crc: %02x\n", decoded.mid, decoded.cbx, decoded.oid,
+        decoded.pnm, decoded.prv, decoded.psn, decoded.mdt, decoded.crc);
 }
 #endif
 


### PR DESCRIPTION
## Summary

A small compilation fix for 64-bit targets defining CONFIG_DEBUG_FS_INFO=y. The "decoded.psn" is uint32_t, not unsigned long, so use PRIx32 instead of cast.

## Impact

Removes compilation error on platforms where "unsigned long" is not 32 bits wide. No functional change.

## Testing

Tested on compiling with imx93-evk:nsh by adding debug info for FS.
