### PR TITLE
imxrt/flexcan: Fix uninitialized union and allow BRS

### DIFF
--- a/arch/arm/src/imx9/imx9_flexcan.c
+++ b/arch/arm/src/imx9/imx9_flexcan.c
@@ -690,6 +690,7 @@ static int imx9_transmit(struct imx9_driver_s *priv)
     (peak_tx_mailbox_index_ > mbi ? peak_tx_mailbox_index_ : mbi);
 
   union cs_e cs;
+  cs.cs = 0;
   cs.code = CAN_TXMB_DATAORREMOTE;
   struct mb_s *mb = flexcan_get_mb(priv, mbi);
   mb->cs.code = CAN_TXMB_INACTIVE;
@@ -732,6 +733,7 @@ static int imx9_transmit(struct imx9_driver_s *priv)
         }
 
       cs.rtr = frame->can_id & FLAGRTR ? 1 : 0;
+      cs.brs = frame->flags & CANFD_BRS ? 1 : 0;
 
       cs.dlc = g_len_to_can_dlc[frame->len];
 

--- a/arch/arm/src/imxrt/imxrt_flexcan.c
+++ b/arch/arm/src/imxrt/imxrt_flexcan.c
@@ -656,6 +656,7 @@ static int imxrt_transmit(struct imxrt_driver_s *priv)
     (peak_tx_mailbox_index_ > mbi ? peak_tx_mailbox_index_ : mbi);
 
   union cs_e cs;
+  cs.cs = 0;
   cs.code = CAN_TXMB_DATAORREMOTE;
   struct mb_s *mb = flexcan_get_mb(priv, mbi);
   mb->cs.code = CAN_TXMB_INACTIVE;
@@ -698,6 +699,7 @@ static int imxrt_transmit(struct imxrt_driver_s *priv)
         }
 
       cs.rtr = frame->can_id & FLAGRTR ? 1 : 0;
+      cs.brs = frame->flags & CANFD_BRS ? 1 : 0;
 
       cs.dlc = g_len_to_can_dlc[frame->len];
 

--- a/arch/arm/src/kinetis/kinetis_flexcan.c
+++ b/arch/arm/src/kinetis/kinetis_flexcan.c
@@ -683,6 +683,7 @@ static int kinetis_transmit(struct kinetis_driver_s *priv)
     (peak_tx_mailbox_index_ > mbi ? peak_tx_mailbox_index_ : mbi);
 
   union cs_e cs;
+  cs.cs = 0;
   cs.code = CAN_TXMB_DATAORREMOTE;
   struct mb_s *mb = &priv->tx[mbi];
   mb->cs.code = CAN_TXMB_INACTIVE;
@@ -725,6 +726,7 @@ static int kinetis_transmit(struct kinetis_driver_s *priv)
         }
 
       cs.rtr = frame->can_id & FLAGRTR ? 1 : 0;
+      cs.brs = frame->flags & CANFD_BRS ? 1 : 0;
 
       cs.dlc = g_len_to_can_dlc[frame->len];
 

--- a/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
@@ -685,6 +685,7 @@ static int s32k1xx_transmit(struct s32k1xx_driver_s *priv)
     (peak_tx_mailbox_index_ > mbi ? peak_tx_mailbox_index_ : mbi);
 
   union cs_e cs;
+  cs.cs = 0;
   cs.code = CAN_TXMB_DATAORREMOTE;
   struct mb_s *mb = &priv->tx[mbi];
   mb->cs.code = CAN_TXMB_INACTIVE;
@@ -729,6 +730,7 @@ static int s32k1xx_transmit(struct s32k1xx_driver_s *priv)
         }
 
       cs.rtr = frame->can_id & FLAGRTR ? 1 : 0;
+      cs.brs = frame->flags & CANFD_BRS ? 1 : 0;
 
       cs.dlc = g_len_to_can_dlc[frame->len];
 

--- a/arch/arm/src/s32k3xx/s32k3xx_flexcan.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_flexcan.c
@@ -845,6 +845,7 @@ static int s32k3xx_transmit(struct s32k3xx_driver_s *priv)
     (peak_tx_mailbox_index_ > mbi ? peak_tx_mailbox_index_ : mbi);
 
   union cs_e cs;
+  cs.cs = 0;
   cs.code = CAN_TXMB_DATAORREMOTE;
   struct mb_s *mb = &priv->tx[mbi];
   mb->cs.code = CAN_TXMB_INACTIVE;
@@ -889,6 +890,7 @@ static int s32k3xx_transmit(struct s32k3xx_driver_s *priv)
         }
 
       cs.rtr = frame->can_id & FLAGRTR ? 1 : 0;
+      cs.brs = frame->flags & CANFD_BRS ? 1 : 0;
 
       cs.dlc = g_len_to_can_dlc[frame->len];
 


### PR DESCRIPTION
## Summary

There is stack-uninitialized union in `imxrt_transmit()`.
Every frame transmitted has random IDE/SRR/ESI/BRS bits.
BRS is usually zero meaning CAN FD speedup in data phase does not happen.
Fix:

- Zero initialize the union
- Allow setting BRS bit from `frame->flags`

## Impact

- imxrt flexcan transmit path

## Testing

px4 on custom board sending data over CAN FD to Linux PC using Kvaser USBcan Pro 2xHS v2

Setup:
- nominal 500 kbit/s / data 1 Mbit/s
- two CAN FD frames sent
  - ID 0x10 (12 bytes), payload all 0x00
  - ID 0x20 (32 bytes), payload all 0x00
- Probe on CAN_L to GND, 50 µs/div.
- Each capture shows the full 0x10 frame followed by the start of 0x20 (truncated at the right edge of the record).

<img width="1025" height="1264" alt="image" src="https://github.com/user-attachments/assets/f3e53d12-6911-4ec1-94be-0153f46a17a2" />

- **Before fix:** the entire frame is transmitted at one bit rate —
  uniform ~2 µs bit widths from SOF through ACK. The 0x10 frame takes ~336 µs,
  which is exactly 168 bits (147 frame bits + 21 stuff bits for the all-zero
  payload) at 500 kbit/s. No bit-rate switch occurs, i.e. BRS is going out
  dominant (0).

- **After fix:** the frame starts identically (same ID pattern,
  same ~2 µs bits through the arbitration/control field), then the bit width
  halves exactly at the BRS bit position (SOF + 18 bits). The data phase runs at
  1 Mbit/s and returns to nominal at the CRC delimiter for ACK/EOF. The same
  frame now completes in ~188 µs, matching the bit-exact prediction for BRS = 1
  at this timing configuration.

The two captures are identical up to the BRS bit and the portion after it runs
exactly 2.0× faster, matching the configured 500k:1M ratio — so the only change
on the wire is BRS: dominant before the fix, recessive after. Frames are ACKed
normally in both captures (inter-frame gap = 11 bit times, no error frames).
