### PR TITLE
{bp-19415} drivers/spi/ice40: fix operator precedence in final clock cycle count

### DIFF
--- a/drivers/spi/ice40.c
+++ b/drivers/spi/ice40.c
@@ -269,7 +269,7 @@ ice40_endwrite(FAR struct ice40_dev_s *dev)
 
   dev->ops->select(dev, false);
 
-  for (size_t i = 0; i < ICE40_SPI_FINAL_CLK_CYCLES + 7 / 8; i++)
+  for (size_t i = 0; i < (ICE40_SPI_FINAL_CLK_CYCLES + 7) / 8; i++)
     {
       SPI_SEND(dev->spi, 0xff);
     }


### PR DESCRIPTION
## Summary

ice40_endwrite() computes how many dummy SPI bytes to clock out after the bitstream to finish FPGA configuration with:

    for (size_t i = 0; i < ICE40_SPI_FINAL_CLK_CYCLES + 7 / 8; i++)

`/` binds tighter than `+` in C, so this parses as ICE40_SPI_FINAL_CLK_CYCLES + (7 / 8) = 160 + 0 = 160, i.e. the "+ 7 / 8" is a silent no-op. The macro name and the classic `(n + 7) / 8` ceiling-division idiom (used elsewhere in embedded code to convert a bit/cycle count into a byte count) make clear the intent was to send ceil(ICE40_SPI_FINAL_CLK_CYCLES / 8) = 20 bytes (160 SPI clock cycles, matching the macro name). Instead the unmodified code sends 160 bytes, i.e. 1280 clock cycles - 8x more than intended.

Fix by parenthesizing the ceiling-division: (ICE40_SPI_FINAL_CLK_CYCLES
+ 7) / 8, which evaluates to 20, restoring the intended 160-clock-cycle finalization sequence.

Fixes #19367

## Impact

RELEASE

## Testing

CI