### PR TITLE
{bp-19419} drivers/contactless: fix uninitialized uid leak in mfrc522_read

### DIFF
--- a/drivers/contactless/mfrc522.c
+++ b/drivers/contactless/mfrc522.c
@@ -1480,6 +1480,7 @@ static ssize_t mfrc522_read(FAR struct file *filep, FAR char *buffer,
   FAR struct inode *inode;
   FAR struct mfrc522_dev_s *dev;
   FAR struct picc_uid_s uid;
+  int ret;
 
   inode = filep->f_inode;
 
@@ -1496,7 +1497,13 @@ static ssize_t mfrc522_read(FAR struct file *filep, FAR char *buffer,
 
   /* Now read the UID */
 
-  mfrc522_picc_select(dev, &uid, 0);
+  memset(&uid, 0, sizeof(uid));
+  ret = mfrc522_picc_select(dev, &uid, 0);
+  if (ret < 0)
+    {
+      ctlserr("Failed to select PICC: %d\n", ret);
+      return ret;
+    }
 
   if (uid.sak != PICC_TYPE_NOT_COMPLETE)
     {


### PR DESCRIPTION
## Summary

Fix security issue where uninitialized kernel stack contents could be leaked to userspace when mfrc522_picc_select() fails.

In mfrc522_read(), the local variable 'uid' was not initialized before being passed to mfrc522_picc_select(). If the function fails (e.g., due to bad data on the SPI bus), the uninitialized uid.sak value could pass the PICC_TYPE_NOT_COMPLETE check, causing snprintf() to copy uninitialized kernel stack data to the userspace buffer.

Fixes #19417

## Impact

RELEASE

## Testing

CI