### PR TITLE
{bp-19438} arch/common: fix host_flags_to_mode() O_RDONLY sentinel collision

### DIFF
--- a/arch/arm/src/common/arm_hostfs.c
+++ b/arch/arm/src/common/arm_hostfs.c
@@ -31,6 +31,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <string.h>
+#include <sys/param.h>
 #include <syscall.h>
 #include <unistd.h>
 
@@ -94,11 +95,10 @@ static int host_flags_to_mode(int flags)
     O_WRONLY | O_CREAT | O_APPEND,
     O_RDWR | O_CREAT | O_APPEND | O_TEXT,
     O_RDWR | O_CREAT | O_APPEND,
-    0,
   };
 
   int i;
-  for (i = 0; modeflags[i] != 0; i++)
+  for (i = 0; i < nitems(modeflags); i++)
     {
       if ((modemasks & flags) == modeflags[i])
         {

--- a/arch/arm64/src/common/arm64_hostfs.c
+++ b/arch/arm64/src/common/arm64_hostfs.c
@@ -31,6 +31,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <string.h>
+#include <sys/param.h>
 #include <syscall.h>
 #include <unistd.h>
 
@@ -94,11 +95,10 @@ static int host_flags_to_mode(int flags)
     O_WRONLY | O_CREAT | O_APPEND,
     O_RDWR | O_CREAT | O_APPEND | O_TEXT,
     O_RDWR | O_CREAT | O_APPEND,
-    0,
   };
 
   int i;
-  for (i = 0; modeflags[i] != 0; i++)
+  for (i = 0; i < nitems(modeflags); i++)
     {
       if ((modemasks & flags) == modeflags[i])
         {

--- a/arch/risc-v/src/common/riscv_hostfs.c
+++ b/arch/risc-v/src/common/riscv_hostfs.c
@@ -31,6 +31,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <string.h>
+#include <sys/param.h>
 #include <syscall.h>
 #include <unistd.h>
 
@@ -94,11 +95,10 @@ static int host_flags_to_mode(int flags)
     O_WRONLY | O_CREAT | O_APPEND,
     O_RDWR | O_CREAT | O_APPEND | O_TEXT,
     O_RDWR | O_CREAT | O_APPEND,
-    0,
   };
 
   int i;
-  for (i = 0; modeflags[i] != 0; i++)
+  for (i = 0; i < nitems(modeflags); i++)
     {
       if ((modemasks & flags) == modeflags[i])
         {


### PR DESCRIPTION
## Summary

host_flags_to_mode() used a trailing 0 entry in modeflags[] as the loop-termination sentinel. O_RDONLY is defined as 0 and is exactly modeflags[1], so the loop's termination check fired before ever comparing that entry, and a bare O_RDONLY open always fell through to -EINVAL.

Bound the loop by array size (nitems()) instead of a value sentinel.

## Impact

RELEASE

## Testing

CI