### PR TITLE
{bp-19444} libs/libc: Fix divide-by-zero in stat() with large filesystem block sizes

### DIFF
--- a/arch/arm/src/lc823450/lc823450_mmcl.c
+++ b/arch/arm/src/lc823450/lc823450_mmcl.c
@@ -205,7 +205,7 @@ static int mmcl_geometry(struct inode *inode, struct geometry *geometry)
       finfo("available: true mediachanged: false writeenabled: %s\n",
             geometry->geo_writeenabled ? "true" : "false");
 
-      finfo("nsectors: %" PRIuOFF " sectorsize: %" PRIi16 "\n",
+      finfo("nsectors: %" PRIuOFF " sectorsize: %" PRId32 "\n",
             geometry->geo_nsectors, geometry->geo_sectorsize);
 
       return OK;

--- a/arch/arm/src/s32k1xx/s32k1xx_eeeprom.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_eeeprom.c
@@ -304,7 +304,7 @@ static int eeed_geometry(struct inode *inode, struct geometry *geometry)
 
       finfo("available: true mediachanged: false writeenabled: %s\n",
             geometry->geo_writeenabled ? "true" : "false");
-      finfo("nsectors: %" PRIuOFF " sectorsize: %" PRIu16 "\n",
+      finfo("nsectors: %" PRIuOFF " sectorsize: %" PRId32 "\n",
             geometry->geo_nsectors, geometry->geo_sectorsize);
 
       return OK;

--- a/arch/sim/src/sim/posix/sim_hostfs.c
+++ b/arch/sim/src/sim/posix/sim_hostfs.c
@@ -445,6 +445,8 @@ int host_readdir(void *dirp, struct nuttx_dirent_s *entry)
       strncpy(entry->d_name, ent->d_name, sizeof(entry->d_name) - 1);
       entry->d_name[sizeof(entry->d_name) - 1] = 0;
 
+      entry->d_ino = ent->d_ino;
+
       /* Map the type */
 
       if (ent->d_type == DT_REG)

--- a/drivers/misc/ramdisk.c
+++ b/drivers/misc/ramdisk.c
@@ -324,7 +324,7 @@ static int rd_geometry(FAR struct inode *inode,
 
       finfo("available: true mediachanged: false writeenabled: %s\n",
             geometry->geo_writeenabled ? "true" : "false");
-      finfo("nsectors: %" PRIuOFF " sectorsize: %" PRIi16 "\n",
+      finfo("nsectors: %" PRIuOFF " sectorsize: %" PRId32 "\n",
             geometry->geo_nsectors, geometry->geo_sectorsize);
 
       return OK;

--- a/drivers/mmcsd/mmcsd_sdio.c
+++ b/drivers/mmcsd/mmcsd_sdio.c
@@ -2591,7 +2591,7 @@ static int mmcsd_geometry(FAR struct inode *inode, struct geometry *geometry)
           finfo("available: true mediachanged: %s writeenabled: %s\n",
                  geometry->geo_mediachanged ? "true" : "false",
                  geometry->geo_writeenabled ? "true" : "false");
-          finfo("nsectors: %" PRIuOFF " sectorsize: %" PRIi16 "\n",
+          finfo("nsectors: %" PRIuOFF " sectorsize: %" PRId32 "\n",
                  geometry->geo_nsectors,
                  geometry->geo_sectorsize);
 

--- a/drivers/mmcsd/mmcsd_spi.c
+++ b/drivers/mmcsd/mmcsd_spi.c
@@ -1649,7 +1649,7 @@ static int mmcsd_geometry(FAR struct inode *inode,
   finfo("geo_mediachanged:  %d\n", geometry->geo_mediachanged);
   finfo("geo_writeenabled:  %d\n", geometry->geo_writeenabled);
   finfo("geo_nsectors:      %" PRIuOFF "\n", geometry->geo_nsectors);
-  finfo("geo_sectorsize:    %" PRIi16 "\n", geometry->geo_sectorsize);
+  finfo("geo_sectorsize:    %" PRId32 "\n", geometry->geo_sectorsize);
 
   return OK;
 }

--- a/drivers/mtd/ftl.c
+++ b/drivers/mtd/ftl.c
@@ -833,7 +833,7 @@ static int ftl_geometry(FAR struct inode *inode,
 
       finfo("available: true mediachanged: false writeenabled: %s\n",
             geometry->geo_writeenabled ? "true" : "false");
-      finfo("nsectors: %" PRIuOFF " sectorsize: %u\n",
+      finfo("nsectors: %" PRIuOFF " sectorsize: %" PRId32 "\n",
             geometry->geo_nsectors, geometry->geo_sectorsize);
 
       return OK;

--- a/drivers/mtd/smart.c
+++ b/drivers/mtd/smart.c
@@ -1074,7 +1074,7 @@ static int smart_geometry(FAR struct inode *inode,
 
       finfo("available: true mediachanged: false writeenabled: %s\n",
             geometry->geo_writeenabled ? "true" : "false");
-      finfo("nsectors: %" PRIuOFF " sectorsize: %" PRIi16 "\n",
+      finfo("nsectors: %" PRIuOFF " sectorsize: %" PRId32 "\n",
             geometry->geo_nsectors, geometry->geo_sectorsize);
 
       return OK;

--- a/drivers/usbhost/usbhost_storage.c
+++ b/drivers/usbhost/usbhost_storage.c
@@ -2235,7 +2235,7 @@ static int usbhost_geometry(FAR struct inode *inode,
           geometry->geo_sectorsize    = priv->blocksize;
           nxmutex_unlock(&priv->lock);
 
-          uinfo("nsectors: %" PRIdOFF " sectorsize: %" PRIi16 "\n",
+          uinfo("nsectors: %" PRIdOFF " sectorsize: %" PRId32 "\n",
                 geometry->geo_nsectors, geometry->geo_sectorsize);
         }
     }

--- a/fs/driver/fs_blockmerge.c
+++ b/fs/driver/fs_blockmerge.c
@@ -126,7 +126,7 @@ static int merge_open(FAR struct inode *inode)
           goto err_with_inode;
         }
 
-      finfo("[%s] nsectors: %" PRIuOFF " sectorsize:%u\n",
+      finfo("[%s] nsectors: %" PRIuOFF " sectorsize:%" PRId32 "\n",
             priv->part[i].path, priv->part[i].geo.geo_nsectors,
             priv->part[i].geo.geo_sectorsize);
     }
@@ -260,7 +260,7 @@ static int merge_geometry(FAR struct inode *inode,
           geometry->geo_nsectors += priv->part[i].geo.geo_nsectors;
         }
 
-      finfo("nsectors: %" PRIuOFF " sectorsize:%u\n",
+      finfo("nsectors: %" PRIuOFF " sectorsize:%" PRId32 "\n",
             geometry->geo_nsectors, geometry->geo_sectorsize);
       return OK;
     }

--- a/fs/rpmsgfs/rpmsgfs.h
+++ b/fs/rpmsgfs/rpmsgfs.h
@@ -166,6 +166,7 @@ begin_packed_struct struct rpmsgfs_readdir_s
 {
   struct rpmsgfs_header_s header;
   int32_t                 fd;
+  uint32_t                ino;
   uint32_t                type;
   char                    name[0];
 } end_packed_struct;

--- a/fs/rpmsgfs/rpmsgfs.h
+++ b/fs/rpmsgfs/rpmsgfs.h
@@ -123,8 +123,7 @@ begin_packed_struct struct rpmsgfs_stat_priv_s
   uint32_t dev;       /* Device ID of device containing file */
   uint32_t mode;      /* File type, attributes, and access mode bits */
   uint32_t rdev;      /* Device ID (if file is character or block special) */
-  uint16_t ino;       /* File serial number */
-  uint16_t nlink;     /* Number of hard links to the file */
+  uint32_t ino;       /* File serial number */
   int64_t  size;      /* Size of file/directory, in bytes */
   int64_t  atim_sec;  /* Time of last access, seconds */
   int64_t  atim_nsec; /* Time of last access, nanoseconds */
@@ -136,7 +135,7 @@ begin_packed_struct struct rpmsgfs_stat_priv_s
   int16_t  uid;       /* User ID of file */
   int16_t  gid;       /* Group ID of file */
   int16_t  blksize;   /* Block size used for filesystem I/O */
-  uint16_t reserved;  /* Reserved space */
+  uint16_t nlink;     /* Number of hard links to the file */
 } end_packed_struct;
 
 begin_packed_struct struct rpmsgfs_fstat_s

--- a/fs/rpmsgfs/rpmsgfs_client.c
+++ b/fs/rpmsgfs/rpmsgfs_client.c
@@ -209,6 +209,7 @@ static int rpmsgfs_readdir_handler(FAR struct rpmsg_endpoint *ept,
     {
       strlcpy(entry->d_name, rsp->name, sizeof(entry->d_name));
       entry->d_type = rsp->type;
+      entry->d_ino = rsp->ino;
     }
 
   rpmsg_post(ept, &cookie->sem);

--- a/fs/rpmsgfs/rpmsgfs_server.c
+++ b/fs/rpmsgfs/rpmsgfs_server.c
@@ -622,6 +622,7 @@ static int rpmsgfs_readdir_handler(FAR struct rpmsg_endpoint *ept,
           size = MIN(size - len, strlen(entry->d_name) + 1);
           msg->type = entry->d_type;
           strlcpy(msg->name, entry->d_name, size);
+          msg->ino = entry->d_ino;
           len += size;
           ret = 0;
         }

--- a/fs/vfs/fs_dir.c
+++ b/fs/vfs/fs_dir.c
@@ -376,6 +376,8 @@ static int read_pseudodir(FAR struct fs_dirent_s *dir,
       entry->d_type = DTYPE_DIRECTORY;
     }
 
+  entry->d_ino = pdir->next->i_ino;
+
   /* Now get the inode to visit next time that readdir() is called */
 
   inode_lock();

--- a/include/dirent.h
+++ b/include/dirent.h
@@ -107,11 +107,12 @@
  * of char containing at least {NAME_MAX} plus one elements.
  *
  * POSIX also requires the field d_ino (type ino_t) that provides the file
- * serial number.  This functionality is not implemented in NuttX.
+ * serial number.
  */
 
 struct dirent
 {
+  ino_t    d_ino;                 /* File serial number */
   uint8_t  d_type;                /* Type of file */
   char     d_name[NAME_MAX + 1];  /* File name */
 };

--- a/include/nuttx/fs/hostfs.h
+++ b/include/nuttx/fs/hostfs.h
@@ -123,7 +123,7 @@
 
 /* These must match the definitions in include/sys/types.h */
 
-typedef int16_t      nuttx_blksize_t;
+typedef int32_t      nuttx_blksize_t;
 
 #  ifdef CONFIG_SMALL_MEMORY
 typedef uint16_t     nuttx_size_t;

--- a/include/nuttx/fs/hostfs.h
+++ b/include/nuttx/fs/hostfs.h
@@ -164,6 +164,7 @@ struct nuttx_timespec
 
 struct nuttx_dirent_s
 {
+  nuttx_ino_t  d_ino;
   uint8_t      d_type;                      /* type of file */
   char         d_name[CONFIG_NAME_MAX + 1]; /* filename */
 };

--- a/include/nuttx/fs/hostfs.h
+++ b/include/nuttx/fs/hostfs.h
@@ -136,7 +136,7 @@ typedef intptr_t     nuttx_ssize_t;
 typedef unsigned int nuttx_gid_t;
 typedef unsigned int nuttx_uid_t;
 typedef uint32_t     nuttx_dev_t;
-typedef uint16_t     nuttx_ino_t;
+typedef uint32_t     nuttx_ino_t;
 typedef uint16_t     nuttx_nlink_t;
 
 #  ifdef CONFIG_FS_LARGEFILE

--- a/include/nuttx/fs/hostfs.h
+++ b/include/nuttx/fs/hostfs.h
@@ -124,20 +124,21 @@
 /* These must match the definitions in include/sys/types.h */
 
 typedef int16_t      nuttx_blksize_t;
+
 #  ifdef CONFIG_SMALL_MEMORY
-typedef int16_t      nuttx_gid_t;
-typedef int16_t      nuttx_uid_t;
 typedef uint16_t     nuttx_size_t;
 typedef int16_t      nuttx_ssize_t;
 #  else /* CONFIG_SMALL_MEMORY */
-typedef unsigned int nuttx_gid_t;
-typedef unsigned int nuttx_uid_t;
 typedef uintptr_t    nuttx_size_t;
 typedef intptr_t     nuttx_ssize_t;
 #  endif /* CONFIG_SMALL_MEMORY */
+
+typedef unsigned int nuttx_gid_t;
+typedef unsigned int nuttx_uid_t;
 typedef uint32_t     nuttx_dev_t;
 typedef uint16_t     nuttx_ino_t;
 typedef uint16_t     nuttx_nlink_t;
+
 #  ifdef CONFIG_FS_LARGEFILE
 typedef int64_t      nuttx_off_t;
 typedef uint64_t     nuttx_blkcnt_t;
@@ -145,6 +146,7 @@ typedef uint64_t     nuttx_blkcnt_t;
 typedef int32_t      nuttx_off_t;
 typedef uint32_t     nuttx_blkcnt_t;
 #  endif
+
 typedef unsigned int nuttx_mode_t;
 typedef int          nuttx_fsid_t[2];
 

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -229,7 +229,7 @@ typedef off_t        loff_t;
 
 /* blksize_t is a signed integer value used for file block sizes */
 
-typedef int16_t      blksize_t;
+typedef int32_t      blksize_t;
 
 /* Network related */
 

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -123,18 +123,13 @@ typedef uint16_t     size_t;
 typedef int16_t      ssize_t;
 typedef uint16_t     rsize_t;
 
-/* uid_t is used for user IDs
- * gid_t is used for group IDs.
- */
-
-typedef int16_t      uid_t;
-typedef int16_t      gid_t;
-
 #else /* CONFIG_SMALL_MEMORY */
 
 typedef _size_t      size_t;
 typedef _ssize_t     ssize_t;
 typedef _size_t      rsize_t;
+
+#endif /* CONFIG_SMALL_MEMORY */
 
 /* uid_t is used for user IDs
  * gid_t is used for group IDs.
@@ -142,8 +137,6 @@ typedef _size_t      rsize_t;
 
 typedef unsigned int uid_t;
 typedef unsigned int gid_t;
-
-#endif /* CONFIG_SMALL_MEMORY */
 
 /* dev_t is used for device IDs */
 

--- a/include/sys/types.h
+++ b/include/sys/types.h
@@ -144,7 +144,7 @@ typedef uint32_t     dev_t;
 
 /* ino_t is used for file serial numbers */
 
-typedef uint16_t     ino_t;
+typedef uint32_t     ino_t;
 
 /* nlink_t is used for link counts */
 


### PR DESCRIPTION
## Summary

This change fixes a divide-by-zero in stat() caused by overflow of st_blksize when a filesystem reports a block size larger than can be represented by blksize_t. As reported in #19432, this can occur with LittleFS configurations using large block sizes, where blksize_t is currently defined as int16_t. When the filesystem block size exceeds the range of int16_t, st_blksize is truncated to zero, causing an integer divide-by-zero when st_blocks is calculated.

This patch widens blksize_t from int16_t to int32_t in include/sys/types.h and updates the corresponding nuttx_blksize_t definition in include/nuttx/fs/hostfs.h so the two definitions remain consistent.

Fixes #19432

Includes:
https://github.com/apache/nuttx/pull/19179

## Impact

RELEASE

## Testing

CI