### PR TITLE
{bp-19464} cmake: Sanitize NAME for _main symbol generation

### DIFF
--- a/cmake/nuttx_add_application.cmake
+++ b/cmake/nuttx_add_application.cmake
@@ -111,6 +111,8 @@ function(nuttx_add_application)
     return()
   endif()
 
+  string(REPLACE "-" "_" NAME_SYM "${NAME}")
+
   # check if SRCS exist
   if(SRCS)
     file(GLOB SRCS_EXIST ${SRCS})
@@ -231,7 +233,7 @@ function(nuttx_add_application)
         set_property(
           SOURCE ${MAIN_SRC}
           APPEND
-          PROPERTY COMPILE_DEFINITIONS main=${NAME}_main)
+          PROPERTY COMPILE_DEFINITIONS main=${NAME_SYM}_main)
       endif()
     endif()
 
@@ -249,7 +251,7 @@ function(nuttx_add_application)
 
   # store parameters into properties (used during builtin list generation)
 
-  set_target_properties(${TARGET} PROPERTIES APP_MAIN ${NAME}_main)
+  set_target_properties(${TARGET} PROPERTIES APP_MAIN ${NAME_SYM}_main)
   set_target_properties(${TARGET} PROPERTIES APP_NAME ${NAME})
 
   if(PRIORITY)


### PR DESCRIPTION
## Summary

Program names containing '-' (for example, renaming hello to hello-world via PROGNAME) previously generated an invalid identifier <NAME>_main when constructing the main= compiler definition and the APP_MAIN target property used during builtin list generation. This caused the CMake build to fail because '-' is not a valid character in a C identifier.

This mirrors the Make-based fix (Application.mk's PROGSYM) for the traditional build.

Introduce NAME_SYM, a sanitized copy of NAME with '-' replaced by '_', and use it only where an internal C identifier is required: the main= COMPILE_DEFINITIONS property and the APP_MAIN target property. Leave NAME unchanged everywhere else, including CMake target/output names and the APP_NAME property, where hyphens are valid.

The standalone/loadable executable path (MODULE/DYNLIB/kernel build) does not rename main() and therefore requires no sanitization because each executable is linked independently rather than merged into a shared builtin image.

Testing (WSL2 Ubuntu, x86_64):
- BOARD_CONFIG=sim/nsh, CONFIG_EXAMPLES_HELLO_PROGNAME="hello-world": clean CMake configure/build; 'hello-world' runs and prints 'Hello, World!!'
- Reverted to CONFIG_EXAMPLES_HELLO_PROGNAME="hello": reconfigured and rebuilt; 'hello' runs and prints 'Hello, World!!' (no regression)

Fixes #19447

## Impact

RELEASE

## Testing

CI