### PR TITLE
{bp-19477} tools/Zig.defs: Fix Zig builds on sim:x86_64

### DIFF
--- a/tools/Zig.defs
+++ b/tools/Zig.defs
@@ -36,7 +36,13 @@ else ifeq ($(CONFIG_ARCH_RISCV),y)
   ZIGFLAGS += -mcmodel=medium
 
 else 
-  ZIGFLAGS := -target $(LLVM_ARCHTYPE)-freestanding-$(LLVM_ABITYPE)
+  ifeq ($(LLVM_ABITYPE),sysv)
+    ZIG_ABITYPE := gnu
+  else
+    ZIG_ABITYPE := $(LLVM_ABITYPE)
+  endif
+
+  ZIGFLAGS := -target $(LLVM_ARCHTYPE)-freestanding-$(ZIG_ABITYPE)
 endif
 
 # Convert cortex-xxx/sifive-exx to cortex_xxx/sifive_exx
@@ -44,3 +50,5 @@ endif
 ifneq ($(LLVM_CPUTYPE),)
 ZIGFLAGS += -mcpu $(subst -,_,$(LLVM_CPUTYPE))
 endif
+
+ZIGFLAGS += -fcompiler-rt


### PR DESCRIPTION
## Summary

Building Zig applications on sim:x86_64 with Zig 0.13.0 fails because the generated target "x86_64-freestanding-sysv" is not recognized by Zig. Introduce a Zig-specific ABI mapping that translates "sysv" to "gnu" without affecting other toolchains.

After correcting the target ABI, linking still fails due to unresolved references to __zig_probe_stack. Add -fcompiler-rt so Zig includes the required compiler runtime during linking.

Verified on sim:nsh with CONFIG_EXAMPLES_HELLO_ZIG=y:

  nsh> hello_zig
  [sim]: Hello, Zig!

Fixes #19475

## Impact

RELEASE

## Testing

CI