### PR TITLE
{bp-19487} sched: avoid dumping raw memory at address 0 for tasks without kstack

### DIFF
--- a/sched/misc/assert.c
+++ b/sched/misc/assert.c
@@ -325,7 +325,11 @@ static void dump_stacks(FAR struct tcb_s *rtcb, uintptr_t sp)
 #endif
 
 #ifdef CONFIG_ARCH_KERNEL_STACK
-  if (kernelstack_sp != 0 || force)
+  /* kernelstack_base is NULL for tasks with no kernel stack (e.g. idle).
+   * dump_stackinfo() would then dump raw memory starting at address 0.
+   */
+
+  if (kernelstack_base != 0 && (kernelstack_sp != 0 || force))
     {
       dump_stackinfo("Kernel",
                      kernelstack_sp,


### PR DESCRIPTION
## Summary

dump_stacks() only checked kernelstack_sp != 0 || force, so for tasks with no kernel stack (e.g. idle, kernelstack_base == 0) the force path passed base 0 to dump_stackinfo() and dumped raw memory from address 0, triggering a secondary fault that truncated the panic log.  Guard with kernelstack_base != 0.

## Impact

RELEASE

## Testing

CI