### PR TITLE
{bp-19495} arch/arm/stm32h7: fix MDIO RDA field in c22 write

### DIFF
--- a/arch/arm/src/stm32h7/stm32_mdio.c
+++ b/arch/arm/src/stm32h7/stm32_mdio.c
@@ -179,7 +179,7 @@ static int stm32_c22_write(struct mdio_lowerhalf_s *dev, uint8_t phydev,
 
   regval |= (((uint32_t)phydev << ETH_MACMDIOAR_PA_SHIFT) &
             ETH_MACMDIOAR_PA_MASK);
-  regval |= (((uint32_t)phydev << ETH_MACMDIOAR_RDA_SHIFT) &
+  regval |= (((uint32_t)regaddr << ETH_MACMDIOAR_RDA_SHIFT) &
             ETH_MACMDIOAR_RDA_MASK);
   regval |= (ETH_MACMDIOAR_MB | ETH_MACMDIOAR_GOC_WRITE);
 


### PR DESCRIPTION
## Summary

Use correct register

## Impact

RELEASE

## Testing

CI