### PR TITLE
{bp-19497} lib/math32: Avoid __uint128_t casts for LDC ImportC

### DIFF
--- a/include/nuttx/lib/math32.h
+++ b/include/nuttx/lib/math32.h
@@ -495,7 +495,8 @@ static inline_function uint64_t invdiv_umulh64(uint64_t a, uint64_t b)
    * the inline assembly.
    */
 
-  __uint128_t res128 = (__uint128_t)a * b;
+  __uint128_t a128 = a;
+  __uint128_t res128 = a128 * b;
   return res128 >> 64;
 #endif
 }
@@ -542,7 +543,8 @@ void invdiv_init_param64(uint64_t d, FAR invdiv_param64_t *param)
 
   param->mult = q[0] + 1;
 #else
-  param->mult  = ((__uint128_t)1 << 64) * t / d + 1;
+  __uint128_t one128 = 1;
+  param->mult = (one128 << 64) * t / d + 1;
 #endif
   param->shift = l - 1;
 }


### PR DESCRIPTION
## Summary

Building the hello_d example with LDC ImportC fails because ImportC does not correctly handle direct __uint128_t C-style casts such as (__uint128_t)a and (__uint128_t)1.

Replace the direct casts with equivalent typed temporaries, preserving the existing behavior while allowing hello_d to build successfully with LDC ImportC.

Verified on sim:nsh with CONFIG_EXAMPLES_HELLO_D=y:

  nsh> hello_d
  Hello World, [skylake]!
  DHelloWorld.HelloWorld: Hello, World!!

## Impact

RELEASE

## Testing

CI