### PR TITLE
libc/dlfcn: Count opens so a library can be shared

### DIFF
--- a/Documentation/implementation/kernel_modules_vs_shared_libraries.rst
+++ b/Documentation/implementation/kernel_modules_vs_shared_libraries.rst
@@ -67,12 +67,15 @@ of a shared library in that environment.
 In this case kernel modules really only differ from shared
 libraries in their usage semantics:
 
-For the FLAT build, I have added the standard ``include/dllfcn.h``
-and have implemented the FLAT shared library support as a thin wrapper
-around the kernel module support:
+For the FLAT build, the standard ``include/dlfcn.h`` interfaces are
+implemented as a thin wrapper around the same module library that the kernel
+module support uses:
 
-* ``dlopen()`` maps to ``insmod()``.
-* ``dlclose()`` maps to ``rmmod()``.
+* ``dlopen()`` loads the library, or takes an additional reference on it if
+  it is already loaded, and returns a handle to it. See
+  `Opening a Library More Than Once`_.
+* ``dlclose()`` releases one reference. The library is unloaded, as
+  ``rmmod()`` would, only when the last handle is closed.
 * ``dlsym()`` maps to ``modsym()``.
 * ``dlerror()`` is only a stub at the present time.
 
@@ -101,6 +104,43 @@ The shared library functions no longer call the kernel module logic but rather
 implement their one top-level management logic using the lower-level routines
 in the module library.
 
+The user space copy of the module library keeps the name of each loaded
+library whenever ``CONFIG_LIBC_DLFCN`` is enabled, since the name is the only
+way to tell that a library is already loaded. This costs ``NAME_MAX`` bytes
+per loaded library, but it makes ``dlopen()`` behave exactly as it does in the
+FLAT build.
+
+
+Opening a Library More Than Once
+================================
+
+In the FLAT and PROTECTED builds, ``dlopen()`` of a library that is already
+loaded does not load a second copy and does not fail. It returns a handle to
+the library that is already loaded and takes an additional reference on it.
+Each successful ``dlopen()`` must be matched by a ``dlclose()``; the library
+is unloaded only when the last handle is closed. Up to 255 handles may be
+outstanding on one library; beyond that ``dlopen()`` fails with ``EMFILE``.
+
+Some consequences worth keeping in mind:
+
+* A library is identified by the *basename* of the path passed to
+  ``dlopen()``. Two files with the same basename in different directories
+  are treated as the same library, and the second ``dlopen()`` will return
+  the first one.
+* There is only one instance of the library's ``.data`` and ``.bss``. Global
+  and static data are shared by every user of the library, and by every task
+  group in the system.
+* Constructors in ``.init_array`` run once, when the library is first loaded,
+  and destructors in ``.fini_array`` run once, when the last handle is
+  closed. They do not run per ``dlopen()``/``dlclose()`` pair.
+* Symbols obtained with ``dlsym()`` remain valid until the last handle is
+  closed, not until the caller's own handle is closed.
+
+Kernel modules deliberately behave differently: ``insmod()`` fails with
+``EEXIST`` if a module of that name is already installed, and ``rmmod()``
+removes it immediately. A kernel module is a singleton and is not reference
+counted.
+
 
 Better FLAT and PROTECTED Mode Shared Libraries
 ===============================================
@@ -112,7 +152,7 @@ for each NuttX task group.
 A task group is the moral equivalent of a Unix process.
 That is how a shared library would have to work in uClinux, for example.
 But that would be a substantial effort! For example, since each
-``.bss``/``.data`` would lie at a different physical addres,
+``.bss``/``.data`` would lie at a different physical address,
 the ``.text`` section logic would need support
 Position-Independent-Data (PID).
 Embedded PID support, however, is pretty much broken on all current GCC
@@ -174,3 +214,6 @@ are loaded into memory before the programs ``main()`` logic is called.
 .. note:: There is not yet any shared library support in the KERNEL build mode.
           This would be quite a large effort and not on the plan of record
           at the present time.
+          ``dlopen()`` always fails and returns ``NULL`` in the KERNEL build,
+          so none of the reference counting behaviour described above applies
+          there.

--- a/include/nuttx/lib/elf.h
+++ b/include/nuttx/lib/elf.h
@@ -79,7 +79,12 @@
  *   portion of the build
  */
 
-#if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__)
+/* dlopen() needs a name too: it is the only way to tell that a library is
+ * already loaded.
+ */
+
+#if defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__) || \
+    defined(CONFIG_LIBC_DLFCN)
 #  define HAVE_LIBC_ELF_NAMES
 #  define LIBC_ELF_NAMEMAX NAME_MAX
 #endif
@@ -173,6 +178,12 @@ struct module_s
   size_t textsize;                     /* Size of the kernel .text memory allocation */
   size_t datasize;                     /* Size of the kernel .bss/.data memory allocation */
 #endif
+
+  uint8_t nopen;                       /* Outstanding references: insmod()
+                                        * and dlopen() each take one, rmmod()
+                                        * and dlclose() give one back, and the
+                                        * module goes when the last does
+                                        */
 
 #if CONFIG_LIBC_ELF_MAXDEPEND > 0
   uint8_t dependents;                  /* Number of modules that depend on this module */

--- a/libs/libc/dlfcn/lib_dlclose.c
+++ b/libs/libc/dlfcn/lib_dlclose.c
@@ -82,6 +82,7 @@
 int dlclose(FAR void *handle)
 {
 #if defined(CONFIG_BUILD_FLAT) || defined(CONFIG_BUILD_PROTECTED)
+
   /* In the FLAT build, a shared library is essentially the same as a kernel
    * module.
    *
@@ -91,6 +92,10 @@ int dlclose(FAR void *handle)
    * using the user space symbol table.
    *
    * dlremove() is essentially a clone of rmmod().
+   */
+
+  /* libelf_remove() gives back a reference and unloads only when the last
+   * one goes, so closing one of two handles leaves the other usable.
    */
 
   return libelf_remove(handle);

--- a/libs/libc/dlfcn/lib_dlopen.c
+++ b/libs/libc/dlfcn/lib_dlopen.c
@@ -26,8 +26,10 @@
 
 #include <nuttx/config.h>
 
-#include <libgen.h>
 #include <dlfcn.h>
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
 
 #include <nuttx/envpath.h>
 #include <nuttx/lib/elf.h>
@@ -82,24 +84,21 @@
 
 static inline FAR void *dlinsert(FAR const char *filename)
 {
-  FAR void *handle;
-  FAR char *name;
+  FAR const char *modname;
 
   DEBUGASSERT(filename != NULL);
 
-  name = strdup(filename);
-  if (name == NULL)
-    {
-      return NULL;
-    }
+  /* The module name is the basename of the file */
 
-  /* Then install the file using the basename of the file as the module
-   * name.
+  modname = strrchr(filename, '/');
+  modname = modname != NULL ? modname + 1 : filename;
+
+  /* libelf_insert() returns the module already loaded under this name,
+   * with another reference taken, so a library opened twice is one
+   * instance shared by both callers.
    */
 
-  handle = libelf_insert(filename, basename(name));
-  lib_free(name);
-  return handle;
+  return libelf_insert(filename, modname);
 }
 #else /* if defined(CONFIG_BUILD_KERNEL) */
 /* The KERNEL build is considerably more complex:  In order to be shared,

--- a/libs/libc/elf/elf_insert.c
+++ b/libs/libc/elf/elf_insert.c
@@ -307,14 +307,26 @@ FAR void *libelf_insert(FAR const char *filename, FAR const char *modname)
 
   libelf_registry_lock();
 
-  /* Check if this module is already installed */
+  /* Already installed?  Take another reference rather than load a second
+   * copy: there is one instance of a module per name, and every caller
+   * shares it.  The count is kept here so that insmod()/rmmod() and
+   * dlopen()/dlclose() get the same behaviour from the same code.
+   */
 
 #ifdef HAVE_LIBC_ELF_NAMES
-  if (libelf_registry_find(modname) != NULL)
+  modp = libelf_registry_find(modname);
+  if (modp != NULL)
     {
+      if (modp->nopen == UINT8_MAX)
+        {
+          libelf_registry_unlock();
+          set_errno(EMFILE);
+          return NULL;
+        }
+
+      modp->nopen++;
       libelf_registry_unlock();
-      set_errno(EEXIST);
-      return NULL;
+      return modp;
     }
 #endif
 
@@ -342,6 +354,7 @@ FAR void *libelf_insert(FAR const char *filename, FAR const char *modname)
   /* Save the module name in the registry entry */
 
   strlcpy(modp->modname, modname, sizeof(modp->modname));
+  modp->nopen = 1;
 #endif
 
   /* Load the program binary */

--- a/libs/libc/elf/elf_remove.c
+++ b/libs/libc/elf/elf_remove.c
@@ -205,6 +205,20 @@ int libelf_remove(FAR void *handle)
       goto errout_with_lock;
     }
 
+  /* Give back a reference.  The module goes only when the last one does,
+   * so an rmmod() cannot pull a module out from under a dlopen() that is
+   * still holding it.
+   */
+
+  if (modp->nopen > 1)
+    {
+      modp->nopen--;
+      libelf_registry_unlock();
+      return OK;
+    }
+
+  modp->nopen = 0;
+
   ret = libelf_uninit(modp);
   if (ret < 0)
     {

--- a/sched/module/mod_insmod.c
+++ b/sched/module/mod_insmod.c
@@ -26,6 +26,8 @@
 
 #include <nuttx/config.h>
 
+#include <errno.h>
+
 #include <nuttx/module.h>
 #include <nuttx/lib/elf.h>
 
@@ -63,6 +65,17 @@
 
 FAR void *insmod(FAR const char *filename, FAR const char *modname)
 {
+  /* A duplicate name is an error here, where it has always been.
+   * libelf_insert() would take a reference instead, which is what
+   * dlopen() wants and insmod() does not.
+   */
+
+  if (libelf_gethandle(modname) != NULL)
+    {
+      set_errno(EEXIST);
+      return NULL;
+    }
+
   return libelf_insert(filename, modname);
 }
 


### PR DESCRIPTION
## Summary

`dlopen()` of a library that is already loaded fails. `libelf_insert()` rejects a name already in the module registry with `EEXIST` and `dlinsert()` passes that straight out, so the second caller gets `NULL`. POSIX says `dlopen()` shall return a handle to the object, and today there is no way for two modules to hold the same library at once — which is what a shared library is for.

`dlopen()` now takes another reference on a library that is already loaded, and `dlclose()` tears it down only when the last handle goes.

The count lives in `libelf_insert()` and `libelf_remove()`, so `dlopen()`/`dlclose()` and `insmod()`/`rmmod()` get it from the same code: `libelf_insert()` looks the name up in the registry first and takes a reference on what is already there rather than loading a second copy, and `libelf_remove()` only tears the module down when the last reference goes. `dlopen()` and `dlclose()` are one line each.

`insmod()` keeps its own behaviour on top of that. A second `insmod` of the same name still fails with `EEXIST`, which is right for a kernel module, so it checks the registry before calling `libelf_insert()` — letting it take a silent reference would turn a long-standing error into success, and would then need as many `rmmod()`s as `insmod()`s before the module actually unloaded.

## Module names in a PROTECTED build

The module name is what makes any of this possible, and a PROTECTED build did not have one.

Names were defined for `CONFIG_BUILD_FLAT` or the kernel side of a split build, on the reasoning that only the kernel needed them. That predates `dlopen()` being usable from user space. Without a name the user-space copy of libelf cannot recognise a second open, cannot count opens, and cannot make `dlclose()` mean anything — two `dlopen()`s there produce two independent copies of the library and lose track of the first.

Names are therefore defined wherever `CONFIG_LIBC_DLFCN` is, which costs `NAME_MAX` per loaded module in that configuration and nothing otherwise.

## Impact

No change for a configuration without `CONFIG_LIBC_DLFCN`.

`insmod`/`rmmod` are unaffected.

`BUILD_KERNEL` is deliberately untouched: `dlopen()` returns `NULL` there unconditionally, because `dlinsert()` is a stub. Sharing a library between processes with separate address spaces needs the text in a shared region and each process's data at a matching virtual address, which is a different problem from this one.

## Testing

Tested by apache/nuttx-apps#3691, which opens a library twice, closes one handle and checks the library is still usable through the other. That test fails on master and passes with this change.

Built `mps3-an547:picostest` with and without `CONFIG_LIBC_DLFCN`.

Built `stm32f4discovery:kostest`, a `CONFIG_BUILD_PROTECTED=y` configuration, with `CONFIG_LIBC_DLFCN` enabled — this is the case the name change is for.

Built with `CONFIG_MODULE` and no `CONFIG_LIBC_DLFCN`, and the other way round, since the counting is now on the path both reach.

Runtime on a second architecture: ESP32-S3 (xtensa LX7, WROOM-2-N32R8V), `esp32s3-devkit:elf` with `CONFIG_LIBC_DLFCN` and `apps/examples/sotest`. `examples/elf` loads and runs its eleven modules, C++ included, with heap usage back to its starting value at the end; `sotest` opens its library twice through the counting added here — one `module_initialize`, both handles usable, one `module_uninitialize` when the last one closes.

Runtime on hardware, on a Pimoroni Pico Plus 2 (RP2350, Cortex-M33). Stacked under apache/nuttx#19673, which is what makes a `DT_NEEDED` library go through `dlopen()`, the whole `apps/testing/fs/xipfs` suite passes 131 of 131 — including two modules that name the same library, where the second open takes a reference to what the first loaded: one copy in flash, pinned once, one set of constructors, and the destructors running at the last close.

`tools/checkpatch.sh -c -u -m -g` passes.


