### PR TITLE
{bp-19513} libs/libbuiltin/compiler-rt: skip unsupported Arm VFP builtins asm

### DIFF
--- a/libs/libbuiltin/compiler-rt/CMakeLists.txt
+++ b/libs/libbuiltin/compiler-rt/CMakeLists.txt
@@ -114,6 +114,45 @@ if(CONFIG_BUILTIN_COMPILER_RT)
     list(REMOVE_ITEM RT_BUILTINS_SRCS ${x86_80_BIT_SOURCES})
   endif()
 
+  # The Arm builtins ship hand-written VFP assembly whose FPU requirements the
+  # globs above ignore, so assemble only the files the configured FPU supports
+  # (upstream compiler-rt selects them conditionally).  chkstk.S and chkstk2.S
+  # are Windows/MinGW-only stack probes; every *vfp.S needs a hardware FPU; and
+  # the double-precision *df*vfp.S routines additionally need a double-precision
+  # FPU.  Without this, single-precision-FPU targets such as Cortex-M33
+  # (fpv5-sp-d16) fail with "selected FPU does not support instruction".  See
+  # apache/nuttx#17386.
+  if(CONFIG_ARCH_ARM)
+    set(RT_BUILTINS_ARM_EXCLUDE ${BUILTINS_DIR}/arm/chkstk.S
+                                ${BUILTINS_DIR}/arm/chkstk2.S)
+    if(NOT CONFIG_ARCH_FPU)
+      file(GLOB RT_BUILTINS_ARM_VFP ${BUILTINS_DIR}/arm/*vfp.S)
+      list(APPEND RT_BUILTINS_ARM_EXCLUDE ${RT_BUILTINS_ARM_VFP})
+    elseif(NOT CONFIG_ARCH_DPFPU)
+      list(
+        APPEND
+        RT_BUILTINS_ARM_EXCLUDE
+        ${BUILTINS_DIR}/arm/adddf3vfp.S
+        ${BUILTINS_DIR}/arm/divdf3vfp.S
+        ${BUILTINS_DIR}/arm/eqdf2vfp.S
+        ${BUILTINS_DIR}/arm/extendsfdf2vfp.S
+        ${BUILTINS_DIR}/arm/fixdfsivfp.S
+        ${BUILTINS_DIR}/arm/fixunsdfsivfp.S
+        ${BUILTINS_DIR}/arm/floatsidfvfp.S
+        ${BUILTINS_DIR}/arm/floatunssidfvfp.S
+        ${BUILTINS_DIR}/arm/gedf2vfp.S
+        ${BUILTINS_DIR}/arm/gtdf2vfp.S
+        ${BUILTINS_DIR}/arm/ledf2vfp.S
+        ${BUILTINS_DIR}/arm/ltdf2vfp.S
+        ${BUILTINS_DIR}/arm/muldf3vfp.S
+        ${BUILTINS_DIR}/arm/nedf2vfp.S
+        ${BUILTINS_DIR}/arm/subdf3vfp.S
+        ${BUILTINS_DIR}/arm/truncdfsf2vfp.S
+        ${BUILTINS_DIR}/arm/unorddf2vfp.S)
+    endif()
+    list(REMOVE_ITEM RT_BUILTINS_SRCS ${RT_BUILTINS_ARM_EXCLUDE})
+  endif()
+
   if(NOT CONFIG_COVERAGE_NONE)
     target_compile_options(rt.builtins PRIVATE -fno-profile-instr-generate
                                                -fno-coverage-mapping)

--- a/libs/libbuiltin/compiler-rt/Make.defs
+++ b/libs/libbuiltin/compiler-rt/Make.defs
@@ -108,6 +108,33 @@ ifeq ($(CONFIG_ARCH_X86_64),)
   CSRCS := $(filter-out $(x86_80_BIT_SOURCES), $(CSRCS))
 endif
 
+# The Arm builtins ship hand-written VFP assembly whose FPU requirements the
+# wildcard glob above ignores.  Upstream compiler-rt selects these files
+# conditionally, so assemble only the ones the configured FPU supports;
+# otherwise single-precision-FPU targets (e.g. Cortex-M33, fpv5-sp-d16) fail
+# with "selected FPU does not support instruction".  See apache/nuttx#17386.
+#   - chkstk.S / chkstk2.S are Windows/MinGW-only stack probes;
+#   - every *vfp.S needs a hardware FPU;
+#   - the double-precision *df*vfp.S routines additionally need a
+#     double-precision FPU.
+
+ifeq ($(CONFIG_ARCH_ARM),y)
+  COMPILER_RT_ARM_EXCLUDE := chkstk.S chkstk2.S
+ifneq ($(CONFIG_ARCH_FPU),y)
+  COMPILER_RT_ARM_EXCLUDE += $(notdir \
+    $(wildcard compiler-rt/compiler-rt/lib/builtins/arm/*vfp.S))
+else ifneq ($(CONFIG_ARCH_DPFPU),y)
+  COMPILER_RT_ARM_EXCLUDE += adddf3vfp.S divdf3vfp.S eqdf2vfp.S extendsfdf2vfp.S
+  COMPILER_RT_ARM_EXCLUDE += fixdfsivfp.S fixunsdfsivfp.S floatsidfvfp.S
+  COMPILER_RT_ARM_EXCLUDE += floatunssidfvfp.S gedf2vfp.S gtdf2vfp.S ledf2vfp.S
+  COMPILER_RT_ARM_EXCLUDE += ltdf2vfp.S muldf3vfp.S nedf2vfp.S subdf3vfp.S
+  COMPILER_RT_ARM_EXCLUDE += truncdfsf2vfp.S unorddf2vfp.S
+endif
+  ASRCS := $(filter-out $(addprefix \
+    compiler-rt/compiler-rt/lib/builtins/arm/, $(COMPILER_RT_ARM_EXCLUDE)), \
+    $(ASRCS))
+endif
+
 endif
 
 ################# Profile Library #################


### PR DESCRIPTION
## Summary

The compiler-rt builtins build globs every arm/*.S source, but several of those hand-written assembly files require FPU features the target may not have.  Upstream compiler-rt selects them conditionally; NuttX did not, so BUILTIN_COMPILER_RT builds for single-precision-FPU Arm targets (e.g. Cortex-M33, -mfpu=fpv5-sp-d16) failed to assemble with errors such as "selected FPU does not support instruction -- vadd.f64".

Filter the source list to match the configured FPU, in both the Makefile and CMake builds:
  - chkstk.S / chkstk2.S are Windows/MinGW-only stack probes, always dropped;
  - with no hardware FPU (!CONFIG_ARCH_FPU) all arm/*vfp.S are dropped;
  - with a single-precision FPU (!CONFIG_ARCH_DPFPU) the double-precision *df*vfp.S routines are dropped.

Reproduced against compiler-rt 17.0.1 with arm-none-eabi-gcc 14.2 using the Cortex-M33 single-precision flags: 18 of 86 arm/*.S files failed to assemble (17 double-precision *df*vfp.S plus chkstk.S); after the filter all remaining 68 files assemble cleanly.

Fixes: https://github.com/apache/nuttx/issues/17386

## Impact

RELEASE

## Testing

CI