### PR TITLE
{bp-19516} libc/time: Fix POSIX timezone string parsing.

### DIFF
--- a/libs/libc/time/lib_localtime.c
+++ b/libs/libc/time/lib_localtime.c
@@ -2751,8 +2751,8 @@ static int zoneinit(FAR const char *name)
       int err;
 
       err = tzload(name, g_lcl_ptr, TRUE);
-      if (err != 0 && name != NULL && name[0] == ':' &&
-          tzparse(name, g_lcl_ptr, NULL) != 0)
+      if (err != 0 && name != NULL && name[0] != ':' &&
+          tzparse(name, g_lcl_ptr, NULL) == 0)
         {
           err = 0;
         }


### PR DESCRIPTION
## Summary

When loading a zoneinfo file fails, parse a non-colon-prefixed TZ value as a POSIX timezone string. Treat a successful tzparse() result as success while preserving the leading-colon file-only behavior.

## Impact

RELEASE

## Testing

CI