### PR TITLE
{bp-19520} stm32: Detach GPIO IRQ callbacks upon clearing "setevent" - #19520

### DIFF
--- a/arch/arm/src/common/stm32/stm32_exti_gpio_m0_v1.c
+++ b/arch/arm/src/common/stm32/stm32_exti_gpio_m0_v1.c
@@ -221,6 +221,7 @@ int stm32_gpiosetevent(uint32_t pinset, bool risingedge, bool fallingedge,
   xcpt_t   handler;
   int      nshared;
   int      i;
+  int      ret;
 
   /* Select the interrupt handler for this EXTI pin */
 
@@ -274,6 +275,16 @@ int stm32_gpiosetevent(uint32_t pinset, bool risingedge, bool fallingedge,
 
       if (i == nshared)
         {
+          /* remove any leftover callback */
+
+          ret = irq_detach(irq);
+          if (ret < 0)
+            {
+              return ret;
+            }
+
+          /* disable the interrupt */
+
           up_disable_irq(irq);
         }
     }

--- a/arch/arm/src/common/stm32/stm32_exti_gpio_m3m4_v1v2.c
+++ b/arch/arm/src/common/stm32/stm32_exti_gpio_m3m4_v1v2.c
@@ -259,6 +259,7 @@ int stm32_gpiosetevent(uint32_t pinset, bool risingedge, bool fallingedge,
   xcpt_t   handler;
   int      nshared;
   int      i;
+  int      ret;
 
   /* Select the interrupt handler for this EXTI pin */
 
@@ -333,6 +334,16 @@ int stm32_gpiosetevent(uint32_t pinset, bool risingedge, bool fallingedge,
 
       if (i == nshared)
         {
+          /* remove any leftover callback */
+
+          ret = irq_detach(irq);
+          if (ret < 0)
+            {
+              return ret;
+            }
+
+          /* disable the interrupt */
+
           up_disable_irq(irq);
         }
     }

--- a/arch/arm/src/stm32f7/stm32_exti_gpio.c
+++ b/arch/arm/src/stm32f7/stm32_exti_gpio.c
@@ -266,6 +266,7 @@ int stm32_gpiosetevent(uint32_t pinset, bool risingedge, bool fallingedge,
   xcpt_t   handler;
   int      nshared;
   int      i;
+  int      ret;
 
   /* Select the interrupt handler for this EXTI pin */
 
@@ -340,6 +341,16 @@ int stm32_gpiosetevent(uint32_t pinset, bool risingedge, bool fallingedge,
 
       if (i == nshared)
         {
+          /* remove any leftover callback */
+
+          ret = irq_detach(irq);
+          if (ret < 0)
+            {
+              return ret;
+            }
+
+          /* disable the interrupt */
+
           up_disable_irq(irq);
         }
     }

--- a/arch/arm/src/stm32h7/stm32_exti_gpio.c
+++ b/arch/arm/src/stm32h7/stm32_exti_gpio.c
@@ -268,6 +268,7 @@ int stm32_gpiosetevent(uint32_t pinset, bool risingedge, bool fallingedge,
   xcpt_t   handler;
   int      nshared;
   int      i;
+  int      ret;
 
   /* Select the interrupt handler for this EXTI pin */
 
@@ -342,6 +343,16 @@ int stm32_gpiosetevent(uint32_t pinset, bool risingedge, bool fallingedge,
 
       if (i == nshared)
         {
+          /* remove any leftover callback */
+
+          ret = irq_detach(irq);
+          if (ret < 0)
+            {
+              return ret;
+            }
+
+          /* disable the interrupt */
+
           up_disable_irq(irq);
         }
     }

--- a/arch/arm/src/stm32l4/stm32l4_exti_gpio.c
+++ b/arch/arm/src/stm32l4/stm32l4_exti_gpio.c
@@ -262,6 +262,7 @@ int stm32_gpiosetevent(uint32_t pinset, bool risingedge, bool fallingedge,
   xcpt_t   handler;
   int      nshared;
   int      i;
+  int      ret;
 
   /* Select the interrupt handler for this EXTI pin */
 
@@ -336,6 +337,16 @@ int stm32_gpiosetevent(uint32_t pinset, bool risingedge, bool fallingedge,
 
       if (i == nshared)
         {
+          /* remove any leftover callback */
+
+          ret = irq_detach(irq);
+          if (ret < 0)
+            {
+              return ret;
+            }
+
+          /* disable the interrupt */
+
           up_disable_irq(irq);
         }
     }

--- a/arch/arm/src/stm32l5/stm32l5_exti_gpio.c
+++ b/arch/arm/src/stm32l5/stm32l5_exti_gpio.c
@@ -126,6 +126,7 @@ int stm32_gpiosetevent(uint32_t pinset, bool risingedge, bool fallingedge,
   uint32_t pin = pinset & GPIO_PIN_MASK;
   uint32_t exti = 1 << pin;
   int      irq = STM32_IRQ_EXTI0 + pin;
+  int      ret;
 
   g_gpio_handlers[pin].callback = func;
   g_gpio_handlers[pin].arg      = arg;
@@ -139,6 +140,16 @@ int stm32_gpiosetevent(uint32_t pinset, bool risingedge, bool fallingedge,
     }
   else
     {
+      /* remove any leftover callback */
+
+      ret = irq_detach(irq);
+      if (ret < 0)
+        {
+          return ret;
+        }
+
+      /* disable the interrupt */
+
       up_disable_irq(irq);
     }
 

--- a/arch/arm/src/stm32u5/stm32_exti_gpio.c
+++ b/arch/arm/src/stm32u5/stm32_exti_gpio.c
@@ -126,6 +126,7 @@ int stm32_gpiosetevent(uint32_t pinset, bool risingedge, bool fallingedge,
   uint32_t pin = pinset & GPIO_PIN_MASK;
   uint32_t exti = 1 << pin;
   int      irq = STM32_IRQ_EXTI0 + pin;
+  int      ret;
 
   g_gpio_handlers[pin].callback = func;
   g_gpio_handlers[pin].arg      = arg;
@@ -139,6 +140,16 @@ int stm32_gpiosetevent(uint32_t pinset, bool risingedge, bool fallingedge,
     }
   else
     {
+      /* remove any leftover callback */
+
+      ret = irq_detach(irq);
+      if (ret < 0)
+        {
+          return ret;
+        }
+
+      /* disable the interrupt */
+
       up_disable_irq(irq);
     }
 

--- a/arch/arm/src/stm32wb/stm32wb_exti_gpio.c
+++ b/arch/arm/src/stm32wb/stm32wb_exti_gpio.c
@@ -260,6 +260,7 @@ int stm32_gpiosetevent(uint32_t pinset, bool risingedge, bool fallingedge,
   xcpt_t   handler;
   int      nshared;
   int      i;
+  int      ret;
 
   /* Select the interrupt handler for this EXTI pin */
 
@@ -334,6 +335,16 @@ int stm32_gpiosetevent(uint32_t pinset, bool risingedge, bool fallingedge,
 
       if (i == nshared)
         {
+          /* remove any leftover callback */
+
+          ret = irq_detach(irq);
+          if (ret < 0)
+            {
+              return ret;
+            }
+
+          /* disable the interrupt */
+
           up_disable_irq(irq);
         }
     }

--- a/arch/arm/src/stm32wl5/stm32wl5_exti_gpio.c
+++ b/arch/arm/src/stm32wl5/stm32wl5_exti_gpio.c
@@ -262,6 +262,7 @@ int stm32_gpiosetevent(uint32_t pinset, bool risingedge, bool fallingedge,
   xcpt_t   handler;
   int      nshared;
   int      i;
+  int      ret;
 
   /* Select the interrupt handler for this EXTI pin */
 
@@ -336,6 +337,16 @@ int stm32_gpiosetevent(uint32_t pinset, bool risingedge, bool fallingedge,
 
       if (i == nshared)
         {
+          /* remove any leftover callback */
+
+          ret = irq_detach(irq);
+          if (ret < 0)
+            {
+              return ret;
+            }
+
+          /* disable the interrupt */
+
           up_disable_irq(irq);
         }
     }


### PR DESCRIPTION
## Summary

When the interrupts get disabled, the callback(s) are still attached. That structure is never cleared, causing several calls to attach/detach to eventually fail as the callback queue gets full.

When the error occurs, the registration fails with error 12 (ENOMEM). By detaching the IRQ and clearing the callbacks, this error doesn't happen again

## Impact

RELEASE

## Testing

CI