### PR TITLE
{bp-19559} arch/x86_64: six fixes to make BUILD_KERNEL and the HPET alarm work

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -151,6 +151,7 @@ config ARCH_X86_64
 	select ARCH_HAVE_SETJMP
 	select ARCH_HAVE_PERF_EVENTS
 	select ARCH_HAVE_POWEROFF
+	select ARCH_HAVE_SYSCALL if LIB_SYSCALL
 	---help---
 		x86-64 architectures.
 
@@ -610,6 +611,12 @@ config ARCH_HAVE_FETCHADD
 config ARCH_HAVE_RTC_SUBSECONDS
 	bool
 	default n
+
+config ARCH_HAVE_SYSCALL
+	bool
+	default n
+	---help---
+		Indicates that the architecture provides the system call interface.
 
 config ARCH_HAVE_SYSCALL_HOOKS
 	bool

--- a/arch/x86_64/src/common/x86_64_addrenv.c
+++ b/arch/x86_64/src/common/x86_64_addrenv.c
@@ -70,6 +70,8 @@
 
 #include <nuttx/spinlock.h>
 
+#include <arch/arch.h>
+
 #include "addrenv.h"
 #include "pgalloc.h"
 #include "x86_64_mmu.h"
@@ -192,10 +194,18 @@ static int create_spgtables(arch_addrenv_t *addrenv)
 static void copy_kernel_mappings(arch_addrenv_t *addrenv)
 {
   uintptr_t *pdpt = (uintptr_t *)x86_64_pgvaddr(addrenv->spgtables[1]);
+  int        i;
 
   /* Kernel mapping - lower 1GB maps to 4GB-5GB */
 
   pdpt[4] = X86_PDPT_KERNEL_MAP;
+
+  /* Inherit the boot identity mapping of the low 4GB. */
+
+  for (i = 0; i < X86_MMU_LOWMEM_PDPTS; i++)
+    {
+      pdpt[i] = g_pdpt[i];
+    }
 }
 
 /****************************************************************************

--- a/arch/x86_64/src/common/x86_64_mmu.h
+++ b/arch/x86_64/src/common/x86_64_mmu.h
@@ -57,6 +57,10 @@
 #define X86_MMU_VADDR_INDEX(vaddr, ptlevel) \
   ((vaddr >> X86_MMU_VADDR_SHIFT(ptlevel)) & X86_MMU_VPN_MASK)
 
+/* Number of PDPT entries in the boot low-memory identity mapping. */
+
+#define X86_MMU_LOWMEM_PDPTS    4
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/

--- a/arch/x86_64/src/intel64/Kconfig
+++ b/arch/x86_64/src/intel64/Kconfig
@@ -70,6 +70,10 @@ config ARCH_INTEL64_TSC
 
 config ARCH_INTEL64_HPET_ALARM
 	bool "HPET timer alarm support"
+	select INTEL64_ONESHOT
+	select ONESHOT
+	select ONESHOT_COUNT
+	select ONESHOT_FAST_DIVISION
 	select ALARM_ARCH
 	---help---
 		With this option you can enable ALARM_ARCH features that works on top of

--- a/arch/x86_64/src/intel64/intel64_freq.c
+++ b/arch/x86_64/src/intel64/intel64_freq.c
@@ -150,10 +150,12 @@ void x86_64_timer_calibrate_freq(void)
   g_x86_64_timer_freq = CONFIG_ARCH_INTEL64_APIC_FREQ_KHZ * 1000ul;
 #endif
 
+#ifdef CONFIG_ARCH_INTEL64_HAVE_TSC
   if (g_x86_64_timer_freq == 0)
     {
       /* The TSC frequency is not available */
 
       PANIC();
     }
+#endif
 }

--- a/arch/x86_64/src/intel64/intel64_oneshot_lower.c
+++ b/arch/x86_64/src/intel64/intel64_oneshot_lower.c
@@ -149,9 +149,13 @@ static void intel64_timer_start_absolute(struct oneshot_lowerhalf_s *lower,
     (struct intel64_oneshot_lowerhalf_s *)lower;
   irqstate_t flags    = spin_lock_irqsave(&g_oneshotlow_spin);
   int        ret      = intel64_oneshot_current(&priv->oneshot, &current_us);
-  uint64_t   delta_us = expected - current_us;
+  uint64_t   delta_us;
 
   DEBUGASSERT(ret == OK);
+
+  /* Use the shortest delay when the deadline has passed. */
+
+  delta_us = expected > current_us ? expected - current_us : 0;
 
   ts.tv_sec  = delta_us / USEC_PER_SEC;
   ts.tv_nsec = delta_us % USEC_PER_SEC * 1000ull;

--- a/arch/x86_64/src/intel64/intel64_pgalloc.c
+++ b/arch/x86_64/src/intel64/intel64_pgalloc.c
@@ -61,15 +61,17 @@ void up_allocate_pgheap(void **heap_start, size_t *heap_size)
 {
   DEBUGASSERT(heap_start && heap_size);
 
+  /* The page allocator uses physical addresses. */
+
 #ifndef CONFIG_ARCH_PGPOOL_MAPPING
   /* pgheap at the end of RAM */
 
-  *heap_start = (void *)(X86_64_PGPOOL_BASE + X86_64_LOAD_OFFSET);
+  *heap_start = (void *)X86_64_PGPOOL_BASE;
   *heap_size  = (size_t)X86_64_PGPOOL_SIZE;
 #else
   /* pgheap defined with Kconfig options */
 
-  *heap_start = (void *)CONFIG_ARCH_PGPOOL_VBASE;
+  *heap_start = (void *)CONFIG_ARCH_PGPOOL_PBASE;
   *heap_size  = (size_t)CONFIG_ARCH_PGPOOL_SIZE;
 #endif
 }


### PR DESCRIPTION
## Summary

<p dir="auto">Six independent x86_64 bugs. Each is a separate commit; together they are what<br>
had to be fixed before an x86_64 target could be built and run at all.</p>
<markdown-accessiblity-table data-catalyst="">
  | Commit | Area | What it breaks
-- | -- | -- | --
1 | make ARCH_INTEL64_HPET_ALARM buildable | Kconfig | anything selecting the HPET
2 | do not demand a TSC frequency for a clock that has none | boot | anything selecting the HPET
3 | define the missing CONFIG_ARCH_HAVE_SYSCALL | Kconfig | knsh_romfs, knsh_romfs_pci
4 | give the page allocator the physical page pool base | addrenv | knsh_romfs, knsh_romfs_pci
5 | inherit the kernel low memory mapping in an address environment | addrenv | knsh_romfs, knsh_romfs_pci
6 | do not wrap the HPET oneshot on a deadline that has passed | timer | anything selecting the HPET

</markdown-accessiblity-table>
<p dir="auto">There is a reason there are six of them, and it is bug 3: <code class="notranslate">CONFIG_BUILD_KERNEL</code><br>
on x86_64 has been unbuildable since May 2025, so nothing behind it has been<br>
exercised in a year, and the HPET alarm looks like it has never been exercised<br>
at all.</p>
<h2 dir="auto"></h2>

## Impact

RELEASE

## Testing

CI