### PR TITLE
{bp-19565} arch/arm: carry CONTROL over to the fork child on Cortex-M

### DIFF
--- a/arch/arm/src/common/arm_fork.c
+++ b/arch/arm/src/common/arm_fork.c
@@ -228,6 +228,14 @@ pid_t arm_fork(const struct fork_s *context)
 
           child->xcp.syscall[index].excreturn =
             parent->xcp.syscall[index].excreturn;
+
+          /* CONTROL too:  SYS_syscall_return restores it from ctrlreturn,
+           * and the child's zeroed TCB would return it to user space with
+           * CONTROL == 0 -- nPRIV clear, i.e. privileged.
+           */
+
+          child->xcp.syscall[index].ctrlreturn =
+            parent->xcp.syscall[index].ctrlreturn;
 #else
 #  error Missing logic
 #endif


### PR DESCRIPTION
## Summary

In a protected build arm_svcall.c treats the caller's CONTROL as part of the saved system call state: it stores it in xcp.syscall[].ctrlreturn on entry and restores it from there on SYS_syscall_return.  All three Cortex-M profiles do this -- armv6-m, armv7-m and armv8-m each define the field in arch/arm/include/<arch>/irq.h and use it symmetrically.

arm_fork_direct() copied sysreturn and excreturn to the child but not ctrlreturn.  The child's TCB comes from kmm_zalloc(), so the field was zero, and CONTROL == 0 is nPRIV clear: the child returned to user space privileged while its parent returned unprivileged.  The child ran out its life with the MPU restrictions its parent is under silently lifted, which is the isolation BUILD_PROTECTED exists to provide.

Nothing faults, and that is why this survived.  CONTROL == 0 also selects MSP, which sounds like it should crash immediately, but NuttX already runs Cortex-M threads on MSP -- the parent's saved value is 0x1, nPRIV set and SPSEL clear -- so the two differ only in the privilege bit and there is no stack change to trip over.  Privileged code then passes every test unprivileged code passes, so ostest cannot see it either.

Measured on an RP2350 (Cortex-M33) in BUILD_PROTECTED, breaking at the nxtask_start_fork() call in arm_fork_direct() during task_fork_test: parent ctrlreturn 0x00000001, child ctrlreturn 0x00000000.  With this change both read 0x00000001.

BUILD_FLAT is unaffected: without CONFIG_LIB_SYSCALL, nsyscalls is 0 and the whole block is skipped.  armv7-a and armv7-r are unaffected too; they carry cpsr instead, and that is already copied.

## Impact

RELEASE

## Testing

CI