### PR TITLE
{bp-19566} tools/mkallsyms.py: let the dependency error actually reach the user

### DIFF
--- a/tools/mkallsyms.py
+++ b/tools/mkallsyms.py
@@ -23,7 +23,6 @@
 
 import argparse
 import errno
-import os
 import re
 import sys
 
@@ -36,7 +35,7 @@ try:
 except ModuleNotFoundError:
     print("Please execute the following command to install dependencies:")
     print("pip install pyelftools cxxfilt")
-    os._exit(errno.EINVAL)
+    sys.exit(errno.EINVAL)
 
 
 class SymbolTables(object):
@@ -126,7 +125,7 @@ def usage():
     print(
         "Usage: mkallsyms.py [noconst] <ELFBIN> [output file] [order symbols by name]"
     )
-    os._exit(errno.ENOENT)
+    sys.exit(errno.ENOENT)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

mkallsyms.py prints "Please execute the following command to install dependencies: pip install pyelftools cxxfilt" and then calls os._exit(errno.EINVAL).  os._exit() terminates without flushing stdio, so when stdout is a pipe -- which it always is under make -- the message sits in the buffer and is discarded.  What the developer sees is:

  make[1]: *** [Makefile:65: nuttx] Error 22

with no indication of the cause anywhere in the build output.  Error 22 is just errno.EINVAL leaking out as an exit status.  The same applies to usage(), which exits ENOENT the same way.

Use sys.exit() in both places, which raises SystemExit and lets the interpreter flush on the way out.  Nothing else changes:  the exit statuses are the same, and os is no longer referenced, so the import goes too.

## Impact

RELEASE

## Testing

CI