### PR TITLE
{bp-19567} arch/x86: default CROSSDEV on a macOS host

### DIFF
--- a/arch/x86/src/common/Toolchain.defs
+++ b/arch/x86/src/common/Toolchain.defs
@@ -44,11 +44,16 @@ ARCHCPUFLAGS += -m32
 LDFLAGS += -m elf_i386
 endif
 
-# We have to use a cross-development toolchain under Cygwin because the native
-# Cygwin toolchains don't generate ELF binaries.
+# A cross-development toolchain is required under Cygwin, whose native
+# toolchains don't generate ELF binaries, and on macOS, which has no i386 host
+# compiler at all -- Apple clang cannot target i386 on Apple Silicon.
+# arch/x86_64 defaults CROSSDEV the same way.  Note that a 64-bit toolchain
+# with -m32 is not a substitute unless it was built with multilib.
 
 ifeq ($(CONFIG_WINDOWS_CYGWIN),y)
-CROSSDEV = i486-nuttx-elf-
+CROSSDEV ?= i486-nuttx-elf-
+else ifeq ($(CONFIG_HOST_MACOS),y)
+CROSSDEV ?= i686-elf-
 endif
 
 CC = $(CROSSDEV)gcc


### PR DESCRIPTION
## Summary

arch/x86 set CROSSDEV only under Cygwin, so everywhere else the build used the bare tool names and got the host compiler.  On Linux that is a native gcc which can produce i486 ELF objects, which is what the board README assumes.  On macOS it is Apple clang, and on Apple Silicon that cannot target i386 in any form -- so there is no configuration in which the default works and a cross toolchain is not optional.

Default it to i686-elf-, which Homebrew packages and which accepts the -march=i486 -mtune=i486 already in ARCHCPUFLAGS.  arch/x86_64 has had exactly this stanza for its own toolchain all along; this is the same shape.

The Cygwin assignment becomes ?= to match, so that a CROSSDEV passed in from the environment or the command line is honoured rather than overridden.

Note for anyone tempted by the toolchain they already have: a 64-bit x86 compiler with -m32 is not a substitute unless it was built with multilib. Homebrew's x86_64-elf-gcc compiles 32-bit objects perfectly happily and has no 32-bit libgcc to link them against, so the entire build succeeds and only the final link fails, on __udivdi3, __divdi3, __moddi3 and __udivmoddi4. `x86_64-elf-gcc -print-multi-lib' prints just `.;', which is the toolchain saying so up front.

## Impact

RELEASE

## Testing

CI