### PR TITLE
{bp-19574} rp2040/rp23xx: order the USB BUFF_STATUS clear before the AVAILABLE re-arm

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -381,6 +381,7 @@ config ARCH_CHIP_RP2040
 	select ARM_HAVE_WFE_SEV
 	select ARCH_BOARD_COMMON
 	select ARCH_HAVE_CUSTOM_TESTSET
+	select ARCH_USBDEV_STALLQUEUE if USBDEV
 	---help---
 		Raspberry Pi RP2040 architectures (ARM dual Cortex-M0+).
 
@@ -395,6 +396,7 @@ config ARCH_CHIP_RP23XX
 	select ARCH_HAVE_FPU
 	select ARCH_HAVE_CUSTOM_TESTSET
 	select ARCH_BOARD_COMMON
+	select ARCH_USBDEV_STALLQUEUE if USBDEV
 	---help---
 		Raspberry Pi RP23XX architectures (ARM dual Cortex-M33 or RISC-V).
 

--- a/arch/arm/src/rp2040/rp2040_usbdev.c
+++ b/arch/arm/src/rp2040/rp2040_usbdev.c
@@ -536,6 +536,20 @@ static int rp2040_epread(struct rp2040_ep_s *privep, uint16_t nbytes)
   uint32_t val;
   irqstate_t flags;
 
+  /* The hardware receives a single USB packet into the buffer, and the
+   * buffer-control LEN field is only 10 bits wide.  Arm the buffer for at
+   * most one maximum-size packet; rp2040_rxcomplete accumulates the request
+   * across multiple packets and re-arms until it is satisfied or a short
+   * packet arrives.  Passing the full (possibly multi-kByte) request length
+   * would overflow LEN and corrupt the neighbouring control bits, making the
+   * transfer complete immediately with zero bytes.
+   */
+
+  if (nbytes > privep->ep.maxpacket)
+    {
+      nbytes = privep->ep.maxpacket;
+    }
+
   val = nbytes |
         RP2040_USBCTRL_DPSRAM_EP_BUFF_CTRL_AVAIL |
         (privep->next_pid ?

--- a/arch/arm/src/rp2040/rp2040_usbdev.c
+++ b/arch/arm/src/rp2040/rp2040_usbdev.c
@@ -2184,8 +2184,17 @@ int usbdev_register(struct usbdevclass_driver_s *driver)
 
   /* Enable interrupt */
 
-  putreg32(RP2040_USBCTRL_REGS_SIE_CTRL_EP0_INT_1BUF,
-           RP2040_USBCTRL_REGS_SIE_CTRL);
+  /* Use setbits, NOT putreg32: CLASS_BIND above ends with DEV_CONNECT
+   * (composite_bind/cdcacm_bind), which sets SIE_CTRL.PULLUP_EN.  A
+   * wholesale write here clobbers that pull-up microseconds after it was
+   * asserted; enumeration then only succeeds if the host happened to
+   * latch the short pull-up blip and issues a bus reset (whose handler
+   * re-arms the pull-up).  A cold-plugged host port misses the blip and
+   * the device stays disconnected forever.
+   */
+
+  setbits_reg32(RP2040_USBCTRL_REGS_SIE_CTRL_EP0_INT_1BUF,
+                RP2040_USBCTRL_REGS_SIE_CTRL);
   putreg32(RP2040_USBCTRL_REGS_INTR_BUFF_STATUS |
            RP2040_USBCTRL_REGS_INTR_BUS_RESET |
            RP2040_USBCTRL_REGS_INTR_SETUP_REQ,

--- a/arch/arm/src/rp2040/rp2040_usbdev.c
+++ b/arch/arm/src/rp2040/rp2040_usbdev.c
@@ -473,6 +473,7 @@ static void rp2040_update_buffer_control(struct rp2040_ep_s *privep,
                                          uint32_t or_mask)
 {
   uint32_t value = 0;
+  int i;
 
   if (and_mask)
     {
@@ -482,6 +483,24 @@ static void rp2040_update_buffer_control(struct rp2040_ep_s *privep,
   if (or_mask)
     {
       value |= or_mask;
+
+      if (or_mask & RP2040_USBCTRL_DPSRAM_EP_BUFF_CTRL_AVAIL)
+        {
+          /* RP2040 datasheet 4.1.2.5.1: the AVAILABLE bit must be set
+           * after the rest of the buffer control register has been
+           * written and had time to settle across the clock domain
+           * crossing, or the controller may act on a stale length/PID.
+           * 12 CPU cycles covers system clocks up to 12x clk_usb.
+           */
+
+          putreg32(value & ~RP2040_USBCTRL_DPSRAM_EP_BUFF_CTRL_AVAIL,
+                   privep->buf_ctrl);
+
+          for (i = 0; i < 12; i++)
+            {
+              __asm__ volatile("nop");
+            }
+        }
     }
 
   putreg32(value, privep->buf_ctrl);

--- a/arch/arm/src/rp2040/rp2040_usbdev.c
+++ b/arch/arm/src/rp2040/rp2040_usbdev.c
@@ -218,6 +218,7 @@ struct rp2040_req_s
 {
   struct usbdev_req_s req;        /* Standard USB request */
   struct rp2040_req_s *flink;     /* Supports a singly linked list */
+  bool armed;                     /* Hardware buffer armed for this request */
 };
 
 /* This is the internal representation of an endpoint */
@@ -647,6 +648,7 @@ static void rp2040_reqcomplete(struct rp2040_ep_s *privep, int16_t result)
 static void rp2040_txcomplete(struct rp2040_ep_s *privep)
 {
   struct rp2040_req_s *privreq;
+  bool completed = false;
 
   privreq = rp2040_rqpeek(privep);
   if (!privreq)
@@ -663,10 +665,31 @@ static void rp2040_txcomplete(struct rp2040_ep_s *privep)
           usbtrace(TRACE_COMPLETE(privep->epphy), privreq->req.xfrd);
           privep->txnullpkt = 0;
           rp2040_reqcomplete(privep, OK);
+          completed = true;
         }
     }
 
-  rp2040_wrrequest(privep);
+  if (completed)
+    {
+      /* Start the next queued request -- unless it was already armed.  The
+       * completion callback above may have submitted a new request on the
+       * now idle endpoint; epsubmit then armed the hardware buffer itself,
+       * and arming it a second time here would toggle the data PID twice
+       * and make the host silently discard the packet as a retransmission.
+       */
+
+      privreq = rp2040_rqpeek(privep);
+      if (privreq && !privreq->armed)
+        {
+          rp2040_wrrequest(privep);
+        }
+    }
+  else if (privreq)
+    {
+      /* Continue with the next packet of the in-progress request */
+
+      rp2040_wrrequest(privep);
+    }
 }
 
 /****************************************************************************
@@ -699,6 +722,7 @@ static int rp2040_wrrequest(struct rp2040_ep_s *privep)
     {
       if (privep->epphy == 0)
         {
+          privreq->armed = true;
           rp2040_epwrite(privep, NULL, 0);
         }
       else
@@ -724,6 +748,7 @@ static int rp2040_wrrequest(struct rp2040_ep_s *privep)
        * bytes to send.
        */
 
+      privreq->armed = true;
       privep->txnullpkt = 0;
       if (bytesleft > privep->ep.maxpacket)
         {
@@ -779,6 +804,16 @@ static void rp2040_rxcomplete(struct rp2040_ep_s *privep)
     {
       usbtrace(TRACE_COMPLETE(privep->epphy), privreq->req.xfrd);
       rp2040_reqcomplete(privep, OK);
+
+      /* Re-arm only if the completion callback didn't already do it by
+       * resubmitting a request (see rp2040_txcomplete).
+       */
+
+      privreq = rp2040_rqpeek(privep);
+      if (privreq && privreq->armed)
+        {
+          return;
+        }
     }
 
   rp2040_rdrequest(privep);
@@ -809,6 +844,7 @@ static int rp2040_rdrequest(struct rp2040_ep_s *privep)
 
   usbtrace(TRACE_READ(privep->epphy), privreq->req.len);
 
+  privreq->armed = true;
   return rp2040_epread(privep, privreq->req.len);
 }
 
@@ -1635,6 +1671,7 @@ static int rp2040_epsubmit(struct usbdev_ep_s *ep,
 
   req->result = -EINPROGRESS;
   req->xfrd = 0;
+  privreq->armed = false;
 
   flags = enter_critical_section();
 

--- a/arch/arm/src/rp2040/rp2040_usbdev.c
+++ b/arch/arm/src/rp2040/rp2040_usbdev.c
@@ -38,6 +38,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
 #include <nuttx/kmalloc.h>
+#include <arch/barriers.h>
 #include <nuttx/usb/usb.h>
 #include <nuttx/usb/usbdev.h>
 #include <nuttx/usb/usbdev_trace.h>
@@ -483,6 +484,18 @@ static void rp2040_update_buffer_control(struct rp2040_ep_s *privep,
 
       if (or_mask & RP2040_USBCTRL_DPSRAM_EP_BUFF_CTRL_AVAIL)
         {
+          /* Order the preceding BUFF_STATUS clear (in the USB controller
+           * register block) ahead of the AVAILABLE re-arm (in DPSRAM):
+           * these are two different peripheral regions whose stores the
+           * bus fabric may reorder.  Without the barrier the controller
+           * can observe the re-arm before the clear, transmit the next IN
+           * packet and latch its completion in BUFF_STATUS, then have that
+           * bit wiped by the late-landing clear -- the lost completion
+           * stops all further buffer interrupts and TX wedges.
+           */
+
+          UP_DMB();
+
           /* RP2040 datasheet 4.1.2.5.1: the AVAILABLE bit must be set
            * after the rest of the buffer control register has been
            * written and had time to settle across the clock domain

--- a/arch/arm/src/rp2040/rp2040_usbdev.c
+++ b/arch/arm/src/rp2040/rp2040_usbdev.c
@@ -318,9 +318,6 @@ static void rp2040_update_buffer_control(struct rp2040_ep_s *privep,
 static int rp2040_epwrite(struct rp2040_ep_s *privep, uint8_t *buf,
                           uint16_t nbytes);
 static int rp2040_epread(struct rp2040_ep_s *privep, uint16_t nbytes);
-static void rp2040_abortrequest(struct rp2040_ep_s *privep,
-                                struct rp2040_req_s *privreq,
-                                int16_t result);
 static void rp2040_reqcomplete(struct rp2040_ep_s *privep, int16_t result);
 static void rp2040_txcomplete(struct rp2040_ep_s *privep);
 static int rp2040_wrrequest(struct rp2040_ep_s *privep);
@@ -584,30 +581,6 @@ static int rp2040_epread(struct rp2040_ep_s *privep, uint16_t nbytes)
   spin_unlock_irqrestore(&priv->lock, flags);
 
   return OK;
-}
-
-/****************************************************************************
- * Name: rp2040_abortrequest
- *
- * Description:
- *   Discard a request
- *
- ****************************************************************************/
-
-static void rp2040_abortrequest(struct rp2040_ep_s *privep,
-                                struct rp2040_req_s *privreq,
-                                int16_t result)
-{
-  usbtrace(TRACE_DEVERROR(RP2040_TRACEERR_REQABORTED),
-          (uint16_t)privep->epphy);
-
-  /* Save the result in the request structure */
-
-  privreq->req.result = result;
-
-  /* Callback to the request completion handler */
-
-  privreq->req.callback(&privep->ep, &privreq->req);
 }
 
 /****************************************************************************
@@ -1052,6 +1025,11 @@ static void rp2040_ep0setup(struct rp2040_usbdev_s *priv)
                 }
               else
                 {
+                  uint8_t response[2];
+
+                  response[0] = 0;
+                  response[1] = 0;
+
                   switch (priv->ctrl.type & USB_REQ_RECIPIENT_MASK)
                     {
                       case USB_REQ_RECIPIENT_ENDPOINT:
@@ -1068,10 +1046,23 @@ static void rp2040_ep0setup(struct rp2040_usbdev_s *priv)
                                 priv->ctrl.type);
                               priv->stalled = true;
                             }
+                          else if (privep->stalled)
+                            {
+                              response[0] = 1; /* Endpoint HALTed */
+                            }
                         }
                         break;
 
                       case USB_REQ_RECIPIENT_DEVICE:
+                        usbtrace(TRACE_INTDECODE(
+                                 RP2040_TRACEINTID_GETIFDEV),
+                                 0);
+                        if (priv->selfpowered)
+                          {
+                            response[0] = 1 << USB_FEATURE_SELFPOWERED;
+                          }
+                        break;
+
                       case USB_REQ_RECIPIENT_INTERFACE:
                         usbtrace(TRACE_INTDECODE(
                                  RP2040_TRACEINTID_GETIFDEV),
@@ -1086,6 +1077,17 @@ static void rp2040_ep0setup(struct rp2040_usbdev_s *priv)
                           priv->stalled = true;
                         }
                         break;
+                    }
+
+                  /* Send the two-byte endpoint status.  Without a data
+                   * stage EP0 NAKs the host's IN forever; macOS queries
+                   * GET_STATUS on a halted bulk pipe during Bulk-Only reset
+                   * recovery, so this is required for MSC error recovery.
+                   */
+
+                  if (!priv->stalled)
+                    {
+                      rp2040_epwrite(ep0, response, 2);
                     }
                 }
             }
@@ -1394,7 +1396,15 @@ static bool rp2040_usbintr_buffstat(struct rp2040_usbdev_s *priv)
 
               if (privep->in)
                 {
-                  if (!rp2040_rqempty(privep))
+                  if (privep->epphy != 0 && privep->stalled)
+                    {
+                      /* Completion latched for a transfer the halt already
+                       * aborted (canceled by rp2040_epstall); don't
+                       * attribute the stale buffer event to post-halt
+                       * requests.
+                       */
+                    }
+                  else if (!rp2040_rqempty(privep))
                     {
                       rp2040_txcomplete(privep);
                     }
@@ -1694,24 +1704,22 @@ static int rp2040_epsubmit(struct usbdev_ep_s *ep,
 
   flags = enter_critical_section();
 
-  if (privep->stalled && privep->in)
-    {
-      rp2040_abortrequest(privep, privreq, -EBUSY);
-      ret = -EBUSY;
-    }
-
   /* Handle IN (device-to-host) requests */
 
-  else if (privep->in)
+  if (privep->in)
     {
-      /* Add the new request to the request queue for the IN endpoint */
+      /* Queue the request on the IN endpoint.  If halted, only queue it;
+       * it is armed when the halt clears (rp2040_epstall).  MSC relies on
+       * this: the CSW is submitted while the bulk IN is still halted
+       * (ARCH_USBDEV_STALLQUEUE).
+       */
 
       bool empty = rp2040_rqempty(privep);
 
       rp2040_rqenqueue(privep, privreq);
       usbtrace(TRACE_INREQQUEUED(privep->epphy), privreq->req.len);
 
-      if (empty)
+      if (empty && !privep->stalled)
         {
           rp2040_wrrequest(privep);
         }
@@ -1721,7 +1729,9 @@ static int rp2040_epsubmit(struct usbdev_ep_s *ep,
 
   else
     {
-      /* Add the new request to the request queue for the OUT endpoint */
+      /* Queue on the OUT endpoint.  As for IN, don't arm while halted:
+       * arming rewrites the buffer control word and clears the STALL bit.
+       */
 
       bool empty = rp2040_rqempty(privep);
 
@@ -1731,7 +1741,7 @@ static int rp2040_epsubmit(struct usbdev_ep_s *ep,
 
       /* This there a incoming data pending the availability of a request? */
 
-      if (empty)
+      if (empty && !privep->stalled)
         {
           ret = rp2040_rdrequest(privep);
         }
@@ -1829,14 +1839,17 @@ static int rp2040_epstall(struct usbdev_ep_s *ep, bool resume)
 {
   struct rp2040_ep_s *privep = (struct rp2040_ep_s *)ep;
   struct rp2040_usbdev_s *priv = privep->dev;
+  irqstate_t irqflags;
   irqstate_t flags;
 
+  irqflags = enter_critical_section();
   flags = spin_lock_irqsave(&priv->lock);
 
   if (resume)
     {
       usbtrace(TRACE_EPRESUME, privep->epphy);
       privep->stalled = false;
+      privep->pending_stall = false;
       if (privep->epphy == 0)
         {
           clrbits_reg32(privep->in ?
@@ -1849,8 +1862,29 @@ static int rp2040_epstall(struct usbdev_ep_s *ep, bool resume)
                         ~(RP2040_USBCTRL_DPSRAM_EP_BUFF_CTRL_STALL),
                         0);
 
+      /* Halt clearing resets the data toggle to DATA0 (USB 2.0 9.4.5) */
+
       privep->next_pid = 0;
       priv->zlp_stat = RP2040_ZLP_NONE;
+
+      spin_unlock_irqrestore(&priv->lock, flags);
+
+      /* Restart any requests that were queued (but not armed) while the
+       * endpoint was halted -- e.g. the mass storage CSW that concludes
+       * a failed command (ARCH_USBDEV_STALLQUEUE).
+       */
+
+      if (privep->epphy != 0 && !rp2040_rqempty(privep))
+        {
+          if (privep->in)
+            {
+              rp2040_wrrequest(privep);
+            }
+          else
+            {
+              rp2040_rdrequest(privep);
+            }
+        }
     }
   else
     {
@@ -1861,18 +1895,31 @@ static int rp2040_epstall(struct usbdev_ep_s *ep, bool resume)
           /* EP0 IN Transfer ongoing : postpone the stall until the end */
 
           privep->pending_stall = true;
+          priv->zlp_stat = RP2040_ZLP_NONE;
+          spin_unlock_irqrestore(&priv->lock, flags);
         }
       else
         {
           /* Stall immediately */
 
           rp2040_epstall_exec_nolock(ep);
-        }
+          priv->zlp_stat = RP2040_ZLP_NONE;
+          spin_unlock_irqrestore(&priv->lock, flags);
 
-      priv->zlp_stat = RP2040_ZLP_NONE;
+          /* Terminate the IN transfer the halt aborted: its buffer was
+           * disarmed by the STALL write above and would never complete.
+           * Anything the class resubmits stays queued until the halt
+           * clears.
+           */
+
+          if (privep->epphy != 0 && privep->in && !rp2040_rqempty(privep))
+            {
+              rp2040_cancelrequests(privep);
+            }
+        }
     }
 
-  spin_unlock_irqrestore(&priv->lock, flags);
+  leave_critical_section(irqflags);
 
   return OK;
 }

--- a/arch/arm/src/rp23xx/rp23xx_usbdev.c
+++ b/arch/arm/src/rp23xx/rp23xx_usbdev.c
@@ -2176,8 +2176,17 @@ int usbdev_register(struct usbdevclass_driver_s *driver)
 
   /* Enable interrupt */
 
-  putreg32(RP23XX_USBCTRL_REGS_SIE_CTRL_EP0_INT_1BUF,
-           RP23XX_USBCTRL_REGS_SIE_CTRL);
+  /* Use setbits, NOT putreg32: CLASS_BIND above ends with DEV_CONNECT
+   * (composite_bind/cdcacm_bind), which sets SIE_CTRL.PULLUP_EN.  A
+   * wholesale write here clobbers that pull-up microseconds after it was
+   * asserted; enumeration then only succeeds if the host happened to
+   * latch the short pull-up blip and issues a bus reset (whose handler
+   * re-arms the pull-up).  A cold-plugged host port misses the blip and
+   * the device stays disconnected forever.
+   */
+
+  setbits_reg32(RP23XX_USBCTRL_REGS_SIE_CTRL_EP0_INT_1BUF,
+                RP23XX_USBCTRL_REGS_SIE_CTRL);
   putreg32(RP23XX_USBCTRL_REGS_INTR_BUFF_STATUS |
            RP23XX_USBCTRL_REGS_INTR_BUS_RESET |
            RP23XX_USBCTRL_REGS_INTR_SETUP_REQ,

--- a/arch/arm/src/rp23xx/rp23xx_usbdev.c
+++ b/arch/arm/src/rp23xx/rp23xx_usbdev.c
@@ -218,6 +218,7 @@ struct rp23xx_req_s
 {
   struct usbdev_req_s req;        /* Standard USB request */
   struct rp23xx_req_s *flink;     /* Supports a singly linked list */
+  bool armed;                     /* Hardware buffer armed for this request */
 };
 
 /* This is the internal representation of an endpoint */
@@ -472,6 +473,7 @@ static void rp23xx_update_buffer_control(struct rp23xx_ep_s *privep,
                                          uint32_t or_mask)
 {
   uint32_t value = 0;
+  int i;
 
   if (and_mask)
     {
@@ -481,6 +483,25 @@ static void rp23xx_update_buffer_control(struct rp23xx_ep_s *privep,
   if (or_mask)
     {
       value |= or_mask;
+
+      if (or_mask & RP23XX_USBCTRL_DPSRAM_EP_BUFF_CTRL_AVAIL)
+        {
+          /* The AVAILABLE bit must be set after the rest of the buffer
+           * control register has been written and had time to settle
+           * across the clock domain crossing, or the controller may act
+           * on a stale length/PID (RP2350 datasheet, USB buffer control;
+           * same semantics as RP2040 datasheet 4.1.2.5.1).  12 CPU cycles
+           * covers system clocks up to 12x clk_usb.
+           */
+
+          putreg32(value & ~RP23XX_USBCTRL_DPSRAM_EP_BUFF_CTRL_AVAIL,
+                   privep->buf_ctrl);
+
+          for (i = 0; i < 12; i++)
+            {
+              __asm__ volatile("nop");
+            }
+        }
     }
 
   putreg32(value, privep->buf_ctrl);
@@ -533,6 +554,20 @@ static int rp23xx_epread(struct rp23xx_ep_s *privep, uint16_t nbytes)
 {
   uint32_t val;
   irqstate_t flags;
+
+  /* The hardware receives a single USB packet into the buffer, and the
+   * buffer-control LEN field is only 10 bits wide.  Arm the buffer for at
+   * most one maximum-size packet; rp23xx_rxcomplete accumulates the request
+   * across multiple packets and re-arms until it is satisfied or a short
+   * packet arrives.  Passing the full (possibly multi-kByte) request length
+   * would overflow LEN and corrupt the neighbouring control bits, making the
+   * transfer complete immediately with zero bytes.
+   */
+
+  if (nbytes > privep->ep.maxpacket)
+    {
+      nbytes = privep->ep.maxpacket;
+    }
 
   val = nbytes |
         RP23XX_USBCTRL_DPSRAM_EP_BUFF_CTRL_AVAIL |
@@ -631,6 +666,7 @@ static void rp23xx_reqcomplete(struct rp23xx_ep_s *privep, int16_t result)
 static void rp23xx_txcomplete(struct rp23xx_ep_s *privep)
 {
   struct rp23xx_req_s *privreq;
+  bool completed = false;
 
   privreq = rp23xx_rqpeek(privep);
   if (!privreq)
@@ -647,10 +683,31 @@ static void rp23xx_txcomplete(struct rp23xx_ep_s *privep)
           usbtrace(TRACE_COMPLETE(privep->epphy), privreq->req.xfrd);
           privep->txnullpkt = 0;
           rp23xx_reqcomplete(privep, OK);
+          completed = true;
         }
     }
 
-  rp23xx_wrrequest(privep);
+  if (completed)
+    {
+      /* Start the next queued request -- unless it was already armed.  The
+       * completion callback above may have submitted a new request on the
+       * now idle endpoint; epsubmit then armed the hardware buffer itself,
+       * and arming it a second time here would toggle the data PID twice
+       * and make the host silently discard the packet as a retransmission.
+       */
+
+      privreq = rp23xx_rqpeek(privep);
+      if (privreq && !privreq->armed)
+        {
+          rp23xx_wrrequest(privep);
+        }
+    }
+  else if (privreq)
+    {
+      /* Continue with the next packet of the in-progress request */
+
+      rp23xx_wrrequest(privep);
+    }
 }
 
 /****************************************************************************
@@ -683,6 +740,7 @@ static int rp23xx_wrrequest(struct rp23xx_ep_s *privep)
     {
       if (privep->epphy == 0)
         {
+          privreq->armed = true;
           rp23xx_epwrite(privep, NULL, 0);
         }
       else
@@ -708,6 +766,7 @@ static int rp23xx_wrrequest(struct rp23xx_ep_s *privep)
        * bytes to send.
        */
 
+      privreq->armed = true;
       privep->txnullpkt = 0;
       if (bytesleft > privep->ep.maxpacket)
         {
@@ -763,6 +822,16 @@ static void rp23xx_rxcomplete(struct rp23xx_ep_s *privep)
     {
       usbtrace(TRACE_COMPLETE(privep->epphy), privreq->req.xfrd);
       rp23xx_reqcomplete(privep, OK);
+
+      /* Re-arm only if the completion callback didn't already do it by
+       * resubmitting a request (see rp23xx_txcomplete).
+       */
+
+      privreq = rp23xx_rqpeek(privep);
+      if (privreq && privreq->armed)
+        {
+          return;
+        }
     }
 
   rp23xx_rdrequest(privep);
@@ -793,6 +862,7 @@ static int rp23xx_rdrequest(struct rp23xx_ep_s *privep)
 
   usbtrace(TRACE_READ(privep->epphy), privreq->req.len);
 
+  privreq->armed = true;
   return rp23xx_epread(privep, privreq->req.len);
 }
 
@@ -1622,6 +1692,7 @@ static int rp23xx_epsubmit(struct usbdev_ep_s *ep,
 
   req->result = -EINPROGRESS;
   req->xfrd = 0;
+  privreq->armed = false;
 
   flags = enter_critical_section();
 

--- a/arch/arm/src/rp23xx/rp23xx_usbdev.c
+++ b/arch/arm/src/rp23xx/rp23xx_usbdev.c
@@ -38,6 +38,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/spinlock.h>
 #include <nuttx/kmalloc.h>
+#include <arch/barriers.h>
 #include <nuttx/usb/usb.h>
 #include <nuttx/usb/usbdev.h>
 #include <nuttx/usb/usbdev_trace.h>
@@ -483,6 +484,18 @@ static void rp23xx_update_buffer_control(struct rp23xx_ep_s *privep,
 
       if (or_mask & RP23XX_USBCTRL_DPSRAM_EP_BUFF_CTRL_AVAIL)
         {
+          /* Order the preceding BUFF_STATUS clear (in the USB controller
+           * register block) ahead of the AVAILABLE re-arm (in DPSRAM):
+           * these are two different peripheral regions whose stores the
+           * Cortex-M33 bus fabric may reorder.  Without the barrier the
+           * controller can observe the re-arm before the clear, transmit
+           * the next IN packet and latch its completion in BUFF_STATUS,
+           * then have that bit wiped by the late-landing clear -- the lost
+           * completion stops all further buffer interrupts and TX wedges.
+           */
+
+          UP_DMB();
+
           /* The AVAILABLE bit must be set after the rest of the buffer
            * control register has been written and had time to settle
            * across the clock domain crossing, or the controller may act

--- a/arch/arm/src/rp23xx/rp23xx_usbdev.c
+++ b/arch/arm/src/rp23xx/rp23xx_usbdev.c
@@ -318,9 +318,6 @@ static void rp23xx_update_buffer_control(struct rp23xx_ep_s *privep,
 static int rp23xx_epwrite(struct rp23xx_ep_s *privep, uint8_t *buf,
                           uint16_t nbytes);
 static int rp23xx_epread(struct rp23xx_ep_s *privep, uint16_t nbytes);
-static void rp23xx_abortrequest(struct rp23xx_ep_s *privep,
-                                struct rp23xx_req_s *privreq,
-                                int16_t result);
 static void rp23xx_reqcomplete(struct rp23xx_ep_s *privep, int16_t result);
 static void rp23xx_txcomplete(struct rp23xx_ep_s *privep);
 static int rp23xx_wrrequest(struct rp23xx_ep_s *privep);
@@ -583,30 +580,6 @@ static int rp23xx_epread(struct rp23xx_ep_s *privep, uint16_t nbytes)
   spin_unlock_irqrestore(&g_usbdev.lock, flags);
 
   return OK;
-}
-
-/****************************************************************************
- * Name: rp23xx_abortrequest
- *
- * Description:
- *   Discard a request
- *
- ****************************************************************************/
-
-static void rp23xx_abortrequest(struct rp23xx_ep_s *privep,
-                                struct rp23xx_req_s *privreq,
-                                int16_t result)
-{
-  usbtrace(TRACE_DEVERROR(RP23XX_TRACEERR_REQABORTED),
-          (uint16_t)privep->epphy);
-
-  /* Save the result in the request structure */
-
-  privreq->req.result = result;
-
-  /* Callback to the request completion handler */
-
-  privreq->req.callback(&privep->ep, &privreq->req);
 }
 
 /****************************************************************************
@@ -1051,6 +1024,11 @@ static void rp23xx_ep0setup(struct rp23xx_usbdev_s *priv)
                 }
               else
                 {
+                  uint8_t response[2];
+
+                  response[0] = 0;
+                  response[1] = 0;
+
                   switch (priv->ctrl.type & USB_REQ_RECIPIENT_MASK)
                     {
                       case USB_REQ_RECIPIENT_ENDPOINT:
@@ -1067,10 +1045,23 @@ static void rp23xx_ep0setup(struct rp23xx_usbdev_s *priv)
                                 priv->ctrl.type);
                               priv->stalled = true;
                             }
+                          else if (privep->stalled)
+                            {
+                              response[0] = 1; /* Endpoint HALTed */
+                            }
                         }
                         break;
 
                       case USB_REQ_RECIPIENT_DEVICE:
+                        usbtrace(TRACE_INTDECODE(
+                                 RP23XX_TRACEINTID_GETIFDEV),
+                                 0);
+                        if (priv->selfpowered)
+                          {
+                            response[0] = 1 << USB_FEATURE_SELFPOWERED;
+                          }
+                        break;
+
                       case USB_REQ_RECIPIENT_INTERFACE:
                         usbtrace(TRACE_INTDECODE(
                                  RP23XX_TRACEINTID_GETIFDEV),
@@ -1085,6 +1076,17 @@ static void rp23xx_ep0setup(struct rp23xx_usbdev_s *priv)
                           priv->stalled = true;
                         }
                         break;
+                    }
+
+                  /* Send the two-byte endpoint status.  Without a data
+                   * stage EP0 NAKs the host's IN forever; macOS queries
+                   * GET_STATUS on a halted bulk pipe during Bulk-Only reset
+                   * recovery, so this is required for MSC error recovery.
+                   */
+
+                  if (!priv->stalled)
+                    {
+                      rp23xx_epwrite(ep0, response, 2);
                     }
                 }
             }
@@ -1394,7 +1396,15 @@ static bool rp23xx_usbintr_buffstat(struct rp23xx_usbdev_s *priv)
 
               if (privep->in)
                 {
-                  if (!rp23xx_rqempty(privep))
+                  if (privep->epphy != 0 && privep->stalled)
+                    {
+                      /* Completion latched for a transfer the halt already
+                       * aborted (canceled by rp23xx_epstall); don't
+                       * attribute the stale buffer event to post-halt
+                       * requests.
+                       */
+                    }
+                  else if (!rp23xx_rqempty(privep))
                     {
                       rp23xx_txcomplete(privep);
                     }
@@ -1696,24 +1706,22 @@ static int rp23xx_epsubmit(struct usbdev_ep_s *ep,
 
   flags = enter_critical_section();
 
-  if (privep->stalled && privep->in)
-    {
-      rp23xx_abortrequest(privep, privreq, -EBUSY);
-      ret = -EBUSY;
-    }
-
   /* Handle IN (device-to-host) requests */
 
-  else if (privep->in)
+  if (privep->in)
     {
-      /* Add the new request to the request queue for the IN endpoint */
+      /* Queue the request on the IN endpoint.  If halted, only queue it;
+       * it is armed when the halt clears (rp23xx_epstall).  MSC relies on
+       * this: the CSW is submitted while the bulk IN is still halted
+       * (ARCH_USBDEV_STALLQUEUE).
+       */
 
       bool empty = rp23xx_rqempty(privep);
 
       rp23xx_rqenqueue(privep, privreq);
       usbtrace(TRACE_INREQQUEUED(privep->epphy), privreq->req.len);
 
-      if (empty)
+      if (empty && !privep->stalled)
         {
           rp23xx_wrrequest(privep);
         }
@@ -1723,7 +1731,9 @@ static int rp23xx_epsubmit(struct usbdev_ep_s *ep,
 
   else
     {
-      /* Add the new request to the request queue for the OUT endpoint */
+      /* Queue on the OUT endpoint.  As for IN, don't arm while halted:
+       * arming rewrites the buffer control word and clears the STALL bit.
+       */
 
       bool empty = rp23xx_rqempty(privep);
 
@@ -1733,7 +1743,7 @@ static int rp23xx_epsubmit(struct usbdev_ep_s *ep,
 
       /* This there a incoming data pending the availability of a request? */
 
-      if (empty)
+      if (empty && !privep->stalled)
         {
           ret = rp23xx_rdrequest(privep);
         }
@@ -1818,14 +1828,17 @@ static int rp23xx_epstall(struct usbdev_ep_s *ep, bool resume)
 {
   struct rp23xx_ep_s *privep = (struct rp23xx_ep_s *)ep;
   struct rp23xx_usbdev_s *priv = privep->dev;
+  irqstate_t irqflags;
   irqstate_t flags;
 
+  irqflags = enter_critical_section();
   flags = spin_lock_irqsave(&g_usbdev.lock);
 
   if (resume)
     {
       usbtrace(TRACE_EPRESUME, privep->epphy);
       privep->stalled = false;
+      privep->pending_stall = false;
       if (privep->epphy == 0)
         {
           clrbits_reg32(privep->in ?
@@ -1838,8 +1851,29 @@ static int rp23xx_epstall(struct usbdev_ep_s *ep, bool resume)
                         ~(RP23XX_USBCTRL_DPSRAM_EP_BUFF_CTRL_STALL),
                         0);
 
+      /* Halt clearing resets the data toggle to DATA0 (USB 2.0 9.4.5) */
+
       privep->next_pid = 0;
       priv->zlp_stat = RP23XX_ZLP_NONE;
+
+      spin_unlock_irqrestore(&g_usbdev.lock, flags);
+
+      /* Restart any requests that were queued (but not armed) while the
+       * endpoint was halted -- e.g. the mass storage CSW that concludes
+       * a failed command (ARCH_USBDEV_STALLQUEUE).
+       */
+
+      if (privep->epphy != 0 && !rp23xx_rqempty(privep))
+        {
+          if (privep->in)
+            {
+              rp23xx_wrrequest(privep);
+            }
+          else
+            {
+              rp23xx_rdrequest(privep);
+            }
+        }
     }
   else
     {
@@ -1850,18 +1884,31 @@ static int rp23xx_epstall(struct usbdev_ep_s *ep, bool resume)
           /* EP0 IN Transfer ongoing : postpone the stall until the end */
 
           privep->pending_stall = true;
+          priv->zlp_stat = RP23XX_ZLP_NONE;
+          spin_unlock_irqrestore(&g_usbdev.lock, flags);
         }
       else
         {
           /* Stall immediately */
 
           rp23xx_epstall_exec(ep);
-        }
+          priv->zlp_stat = RP23XX_ZLP_NONE;
+          spin_unlock_irqrestore(&g_usbdev.lock, flags);
 
-      priv->zlp_stat = RP23XX_ZLP_NONE;
+          /* Terminate the IN transfer the halt aborted: its buffer was
+           * disarmed by the STALL write above and would never complete.
+           * Anything the class resubmits stays queued until the halt
+           * clears.
+           */
+
+          if (privep->epphy != 0 && privep->in && !rp23xx_rqempty(privep))
+            {
+              rp23xx_cancelrequests(privep);
+            }
+        }
     }
 
-  spin_unlock_irqrestore(&g_usbdev.lock, flags);
+  leave_critical_section(irqflags);
 
   return OK;
 }


### PR DESCRIPTION
## Summary

rp2040_update_buffer_control() / rp23xx_update_buffer_control() re-arm an
endpoint buffer by setting the AVAILABLE bit in the buffer-control word,
which lives in DPSRAM. When a buffer is re-armed from the completion path
(rp2040_usbintr_buffstat / rp23xx_usbintr_buffstat), that runs right after
the handler clears the endpoint's bit in BUFF_STATUS, which lives in the
USB controller register block — a different peripheral region.

The bus fabric may reorder those two stores. If the controller observes the
AVAILABLE re-arm before the BUFF_STATUS clear lands, it can transmit the
next IN packet and latch its completion in BUFF_STATUS before the clear
arrives; the late clear then wipes that just-set completion bit. The lost
completion edge stops all further buffer interrupts for the endpoint, so the
class driver's write-complete callback never runs and TX wedges permanently.

The fix adds a UP_DMB() at the top of the AVAILABLE re-arm so the preceding
BUFF_STATUS clear is ordered ahead of it. (Non-SMP builds reduce
spin_lock_irqsave to a barrier-free up_irq_save, so nothing else orders
these two stores.)

This is the hardware-ordering issue tracked in #19472. The recently merged
#19470 fixed the cdcncm-layer write-buffer handling; this is the companion
controller-level fix it referenced, needed for full TX stability on RP2350
under maximal IN density.

Includes:
https://github.com/apache/nuttx/pull/19378
https://github.com/apache/nuttx/pull/19450
https://github.com/apache/nuttx/pull/19452

## Impact

RELEASE

## Testing

CI