### PR TITLE
{bp-19581} mm/ubsan: fix signed inline value decoding

### DIFF
--- a/mm/ubsan/ubsan.c
+++ b/mm/ubsan/ubsan.c
@@ -158,10 +158,11 @@ static int64_t get_signed_val(FAR struct type_descriptor *type,
   if (is_inline_int(type))
     {
       unsigned bits = type_bit_width(type);
-      uint64_t mask = (1llu << bits) - 1;
+      uint64_t mask = UINT64_MAX >> (sizeof(uint64_t) * 8 - bits);
       uint64_t ret = (uintptr_t)val & mask;
 
-      return ret & (1llu << (bits - 1)) != 0 ? ret | ~mask : ret;
+      return (int64_t)(((ret & (1llu << (bits - 1))) != 0) ?
+             ret | ~mask : ret);
     }
 
   return *(FAR int64_t *)val;


### PR DESCRIPTION
## Summary

Restore the explicit signed conversion and parenthesize the sign-bit test so it is evaluated before the bitwise AND.  Without this, operator precedence makes the decoder test bit zero instead of the sign bit and negative inline operands are reported as large positive values.

Build the width mask without shifting by the full width of uint64_t. This avoids recursively invoking UBSan while decoding a 64-bit inline operand.

## Impact

RELEASE

## Testing

CI