### PR TITLE
{bp-19590} gpio: Fix GPIO expanders warnings

### DIFF
--- a/drivers/ioexpander/iso1h812g.c
+++ b/drivers/ioexpander/iso1h812g.c
@@ -181,8 +181,8 @@ static void iso1h812g_deselect(FAR struct spi_dev_s *spi,
  * Name: iso1h812g_direction
  *
  * Description:
- *   ISO1H812G is only input pin. However interface is provided in order
- *   to avoid system falls if called.
+ *   ISO1H812G is only output expander. However interface is provided in
+ *   order to avoid system falls if called.
  *
  * Input Parameters:
  *   dev - Device-specific state data
@@ -201,7 +201,12 @@ static int iso1h812g_direction(FAR struct ioexpander_dev_s *dev,
 
   DEBUGASSERT(priv != NULL && priv->config != NULL);
 
-  gpiowarn("WARNING: ISO1H812G is only input expander!\n");
+  if (IOEXPANDER_DIRECTION_IN == direction
+      || IOEXPANDER_DIRECTION_IN_PULLUP == direction
+      || IOEXPANDER_DIRECTION_IN_PULLDOWN == direction)
+    {
+      gpiowarn("WARNING: ISO1H812G is only output expander!\n");
+    }
 
   return OK;
 }

--- a/drivers/ioexpander/iso1i813t.c
+++ b/drivers/ioexpander/iso1i813t.c
@@ -180,7 +180,7 @@ static void iso1i813t_deselect(FAR struct spi_dev_s *spi,
  * Name: iso1i813t_direction
  *
  * Description:
- *   ISO1I813T is only input pin. However interface is provided in order
+ *   ISO1I813T is only input expander. However interface is provided in order
  *   to avoid system falls if called.
  *
  * Input Parameters:
@@ -200,7 +200,11 @@ static int iso1i813t_direction(FAR struct ioexpander_dev_s *dev,
 
   DEBUGASSERT(priv != NULL && priv->config != NULL);
 
-  gpiowarn("WARNING: ISO1I813T is only input expander!\n");
+  if (IOEXPANDER_DIRECTION_OUT == direction
+      || IOEXPANDER_DIRECTION_OUT_OPENDRAIN == direction)
+    {
+      gpiowarn("WARNING: ISO1I813T is only input expander!\n");
+    }
 
   return OK;
 }


### PR DESCRIPTION
## Summary

- ISO1H812G is *output* only expander, not input.
- Warning make sense when we try to set the expander the wrong way.

## Impact

RELEASE

## Testing

CI