### PR TITLE
{bp-19373} drivers/i2s/i2schar: Fix return types

### DIFF
--- a/drivers/i2s/i2schar.c
+++ b/drivers/i2s/i2schar.c
@@ -500,73 +500,122 @@ static int i2schar_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
     {
       case I2SIOC_GRXDATAWIDTH:
         {
-          *(FAR uint32_t *)arg = I2S_RXDATAWIDTH(priv->i2s, 0);
+          *(FAR int32_t *)arg = I2S_RXDATAWIDTH(priv->i2s, 0);
+          if (*(FAR int32_t *)arg < 0)
+            {
+              ret = *(FAR int32_t *)arg;
+            }
+
           break;
         }
 
       case I2SIOC_GTXDATAWIDTH:
         {
-          *(FAR uint32_t *)arg = I2S_TXDATAWIDTH(priv->i2s, 0);
+          *(FAR int32_t *)arg = I2S_TXDATAWIDTH(priv->i2s, 0);
+          if (*(FAR int32_t *)arg < 0)
+            {
+              ret = *(FAR int32_t *)arg;
+            }
         }
         break;
 
       case I2SIOC_GRXCHANNELS:
         {
           *(FAR int *)arg = I2S_RXCHANNELS(priv->i2s, 0);
+          if (*(FAR int *)arg < 0)
+            {
+              ret = *(FAR int *)arg;
+            }
         }
         break;
 
       case I2SIOC_GTXCHANNELS:
         {
           *(FAR int *)arg = I2S_TXCHANNELS(priv->i2s, 0);
+          if (*(FAR int *)arg < 0)
+            {
+              ret = *(FAR int *)arg;
+            }
         }
         break;
 
       case I2SIOC_GRXSAMPLERATE:
         {
-          *(FAR uint32_t *)arg = I2S_RXSAMPLERATE(priv->i2s, 0);
+          *(FAR int32_t *)arg = I2S_RXSAMPLERATE(priv->i2s, 0);
+          if (*(FAR int32_t *)arg < 0)
+            {
+              ret = *(FAR int32_t *)arg;
+            }
         }
         break;
 
       case I2SIOC_GTXSAMPLERATE:
         {
-          *(FAR uint32_t *)arg = I2S_TXSAMPLERATE(priv->i2s, 0);
+          *(FAR int32_t *)arg = I2S_TXSAMPLERATE(priv->i2s, 0);
+          if (*(FAR int32_t *)arg < 0)
+            {
+              ret = *(FAR int32_t *)arg;
+            }
         }
         break;
 
       case I2SIOC_SRXDATAWIDTH:
         {
-          *(FAR uint32_t *)arg = I2S_RXDATAWIDTH(priv->i2s, arg);
+          *(FAR int32_t *)arg = I2S_RXDATAWIDTH(priv->i2s, arg);
+          if (*(FAR int32_t *)arg < 0)
+            {
+              ret = *(FAR int32_t *)arg;
+            }
           break;
         }
 
       case I2SIOC_STXDATAWIDTH:
         {
-          *(FAR uint32_t *)arg = I2S_TXDATAWIDTH(priv->i2s, arg);
+          *(FAR int32_t *)arg = I2S_TXDATAWIDTH(priv->i2s, arg);
+          if (*(FAR int32_t *)arg < 0)
+            {
+              ret = *(FAR int32_t *)arg;
+            }
         }
         break;
 
       case I2SIOC_SRXCHANNELS:
         {
           *(FAR int *)arg = I2S_RXCHANNELS(priv->i2s, arg);
+          if (*(FAR int *)arg < 0)
+            {
+              ret = *(FAR int *)arg;
+            }
         }
         break;
 
       case I2SIOC_STXCHANNELS:
         {
           *(FAR int *)arg = I2S_TXCHANNELS(priv->i2s, arg);
+          if (*(FAR int *)arg < 0)
+            {
+              ret = *(FAR int *)arg;
+            }
         }
         break;
 
       case I2SIOC_SRXSAMPLERATE:
         {
-          *(FAR uint32_t *)arg = I2S_RXSAMPLERATE(priv->i2s, arg);
+          *(FAR int32_t *)arg = I2S_RXSAMPLERATE(priv->i2s, arg);
+          if (*(FAR int32_t *)arg < 0)
+            {
+              ret = *(FAR int32_t *)arg;
+            }
         }
         break;
 
       case I2SIOC_STXSAMPLERATE:
         {
-          *(FAR uint32_t *)arg = I2S_TXSAMPLERATE(priv->i2s, arg);
+          *(FAR int32_t *)arg = I2S_TXSAMPLERATE(priv->i2s, arg);
+          if (*(FAR int32_t *)arg < 0)
+            {
+              ret = *(FAR int32_t *)arg;
+            }
         }
         break;
 


### PR DESCRIPTION
## Summary

This commit fixes the incorrect casting of signed types to unsigned types in the I2S character driver.

NOTE: the I2S character driver IOCTLs retain their original argument types. This is fine, because errors are reported through errno by the ioctl call. The returned value in the 'arg' parameter is to be ignored when the call results in an error. Outside of error codes, all i2s interfaces return unsigned values.

## Impact

RELEASE

## Testing

CI