### PR TITLE
arch/arm64/src/imx9/imx9_usdhc.c: Fix imx9 usdhc DMA initialization

### DIFF
--- a/arch/arm64/src/imx9/imx9_usdhc.c
+++ b/arch/arm64/src/imx9/imx9_usdhc.c
@@ -1477,6 +1477,11 @@ static void imx9_reset(struct sdio_dev_s *dev)
 
   mcinfo("Reset complete\n");
 
+  /* Set PROCTL to select SDMA or no DMA. */
+
+  modifyreg32(priv->addr + IMX9_USDHC_PROCTL_OFFSET,
+              USDHC_PROCTL_DMAS_MASK, USDHC_PROCTL_DMAS_NODMA);
+
   /* Make sure that all clocking is disabled */
 
   imx9_clock(dev, CLOCK_SDIO_DISABLED);


### PR DESCRIPTION

## Summary

This fixes a bug manifesting on imx9 platform uSD card driver, if someone has initialized the uSD controller to
use ADMA1/2 before entering NuttX and the NuttX tries to use DMA (this is the Kconfig default) for the uSD. The error happens for example in a  case when a bootloader (or NuttX itself) has been booted directly from the uSD card.

USDHC_PROCTL register selects whether the usdhc uses SDMA (or no DMA at all) or ADMA. This driver only uses the SDMA or no DMA, so select that option. That is the reset value, but there might be a wrong register value left by ROM code or an earlier bootloader which uses ADMA.

## Impact

Bugfix ony for imx9 using uSD with DMA in the case where an earlier bootloader has already initialized uSD IP differently. No functional effect in other conditions, no impact for other platforms.

## Testing

Tested on imx93-evk:bootloader by setting the EVK bootstrap switches to boot directly from the SD card, enabling the SD card for the EVK and the FS debug in the NuttX configuration, building and copying the NuttX image to the card with dd.

Here are the added config flags for the EVK:

```
# CONFIG_MMCSD_HAVE_CARDDETECT is not set
# CONFIG_MMCSD_HAVE_WRITEPROTECT is not set
# CONFIG_MMCSD_IOCSUPPORT is not set
# CONFIG_MMCSD_MMCSUPPORT is not set
CONFIG_IMX9_USDHC2=y
CONFIG_IMX9_USDHC2_INVERT_CD=y
CONFIG_DEBUG_FS=y
CONFIG_DEBUG_FS_ERROR=y
CONFIG_GRAN=y
CONFIG_GRAN_INTR=y
CONFIG_IMX9_DMA_ALLOC=y
CONFIG_IMX9_DMA_ALLOC_POOL_SIZE=81920
```

When the card is in place, without the fix already reading SCR register reading fails with the following trace:
```
ERROR: Timeout: remaining: 8
ERROR: Awakened with 08
ERROR: mmcsd_eventwait for READ DATA failed: -110
ERROR: Could not get SD SCR register(-110)
Slot not empty, but initialization failed: -110
```

With the fix, the SD card initializes and work correctly also in the case it has been previously initialized by the ROM code.
