### PR TITLE
sched/semaphore: Clear mutex blocking bit after timeout

### DIFF
--- a/sched/semaphore/sem_waitirq.c
+++ b/sched/semaphore/sem_waitirq.c
@@ -96,14 +96,19 @@ void nxsem_wait_irq(FAR struct tcb_s *wtcb, int errcode)
 
       dq_rem((FAR dq_entry_t *)wtcb, SEM_WAITLIST(sem));
 
-      /* This restores the value to what it was before the previous sem_wait.
-       * This caused the thread to be blocked in the first place.
-       *
-       * For mutexes, the holder is updated by the thread itself
-       * when it exits nxsem_wait
+      /* Restore the semaphore state changed by the previous sem_wait().
+       * For mutexes, the holder TID remains unchanged, but the blocking bit
+       * must be cleared when the timed-out task was the last waiter.
        */
 
-      if (!mutex)
+      if (mutex)
+        {
+          if (dq_empty(SEM_WAITLIST(sem)))
+            {
+              atomic_fetch_and(NXSEM_MHOLDER(sem), ~NXSEM_MBLOCKING_BIT);
+            }
+        }
+      else
         {
           atomic_fetch_add(NXSEM_COUNT(sem), 1);
         }


### PR DESCRIPTION
Clear NXSEM_MBLOCKING_BIT in nxsem_wait_irq() when a mutex waiter is removed and the wait queue becomes empty.

## Summary

Fix a timed mutex regression introduced by
[apache/nuttx@f3231a1934](https://github.com/apache/nuttx/commit/f3231a1934ff0c9473695d3b1af023b11b49f0e0).

That commit removed clearing of `NXSEM_MBLOCKING_BIT` after a mutex
waiter is removed. Its assumption that the resumed thread clears the bit
does not hold for a timeout, because the thread returns `ETIMEDOUT`
without acquiring the mutex.

Consequently, after the last waiter times out, the mutex can remain
marked as blocking even though its wait queue is empty. A later unlock
then cannot transfer ownership or release the mutex correctly.

Clear `NXSEM_MBLOCKING_BIT` when a timed-out task was the last mutex
waiter. Keep the bit set when other waiters remain.

Regression tests are provided by
[martin-krasula/nuttx-apps@d584eeda4](https://github.com/martin-krasula/nuttx-apps/commit/d584eeda4).

## Impact

Only mutex waits terminated by a timeout are affected. There are no API,
ABI, configuration, or hardware changes.

- pthread_mutex_timedlock()

## Testing

Host:
- Linux 7.0.0-27-generic, x86_64
- GCC 15.2.0

Target:
- NuttX SIM
- Configuration: `sim:ostest`
- `CONFIG_PRIORITY_INHERITANCE=y`
- `CONFIG_DEBUG_ASSERTIONS=y`

Built and executed with:

```console
$ ./tools/configure.sh -E -a ../nuttx_fork_apps sim:ostest
$ make -j16
$ ./nuttx
```
The regression test verifies:

- timeout of the only mutex waiter
- reuse of the mutex after the last waiter times out
- timeout of one waiter while another remains queued
- ownership transfer to the remaining waiter

Result:
```
user_main: timed mutex test
mutex_test: PASSED
timedmutex regression test: PASSED
user_main: timed mutex test
mutex_test: PASSED
timedmutex regression test: PASSED
user_main: timed mutex test
mutex_test: PASSED
timedmutex regression test: PASSED
user_main: timed mutex test
mutex_test: PASSED
timedmutex regression test: PASSED
```
Full report is here: 
[ostest.log](https://github.com/user-attachments/files/30691108/ostest.log)
