### PR TITLE
ci: Build the documentation from its lock file.

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -19,10 +19,12 @@ on:
       - master
     paths:
       - 'Documentation/**'
+      - '.github/workflows/doc.yml'
 
   pull_request:
     paths:
       - 'Documentation/**'
+      - '.github/workflows/doc.yml'
 
 concurrency:
   group: docs-${{ github.event.pull_request.number || github.ref }}
@@ -45,7 +47,7 @@ jobs:
           sudo apt update
           sudo apt install plantuml
           pip3 install pipenv
-          pipenv install
+          pipenv sync
           pipenv run make html
       - uses: actions/upload-artifact@v7.0.1
         with:


### PR DESCRIPTION
## Summary

The documentation job installs its Python environment with `pipenv install`, which does not honour the committed `Pipfile.lock`. Every run in the logs — failing and passing alike — prints `Locking dependencies...` and `Updated Pipfile.lock`, then installs from the set it has just re-resolved. Each documentation build therefore takes whatever PyPI resolves that day rather than what the lock file names.

On the evening of 2026-08-03 one of those resolutions produced a virtualenv without `packaging`, and four unrelated pull requests failed identically, before Sphinx had read a single file:

```
File ".../sphinx/extension.py", line 7, in <module>
    from packaging.version import InvalidVersion, Version
ModuleNotFoundError: No module named 'packaging'
make: *** [Makefile:52: clean] Error 1
```

```
failure  08-03T23:37  feature/st7123-touch
failure  08-03T22:03  feature/mpu6050-drdy-interrupt
failure  08-03T21:30  fdpic-libelf
failure  08-03T21:30  arm-pic-r9
success  08-03T18:54  arm-pic-r9      <- same branch, three hours earlier
```

`pipenv sync` installs exactly what `Pipfile.lock` names and never re-resolves, which is what the lock file is for. Nothing else about the job changes.

The lock is complete enough to install from as it stands: it covers all fourteen packages the `Pipfile` asks for, and it does contain `packaging`.

`pipenv install --deploy` was the other candidate. It refuses to run when the lock does not match the `Pipfile` instead of silently re-resolving, which is stricter and arguably more correct — but the two hashes do not currently agree, so it would fail the job outright until someone regenerates the lock. `sync` fixes the flakiness now without that. Happy to switch if maintainers would rather have the strict form and a regenerated lock in the same PR.

## Why the trigger changes

The workflow ran only for changes under `Documentation/`, so a change to the documentation build was never exercised by the build it changed. It now triggers on `.github/workflows/doc.yml` as well.

That is what tests this PR: without it, a workflow-only change would report no documentation build at all.

## Impact

CI only. No effect on any build, board or API.

Nothing is pinned that was not pinned before — determinism comes from the lock file, not from freezing the `pipenv` version, and no other workflow in the tree pins its pip installs.

## Testing

The documentation job on this PR is the test, and it exercises exactly the changed file.
