### PR TITLE
{bp-19676} arch/arm64/src/imx9/imx9_usdhc.c: Fix imx9 usdhc DMA initialization

### DIFF
--- a/arch/arm64/src/imx9/imx9_usdhc.c
+++ b/arch/arm64/src/imx9/imx9_usdhc.c
@@ -1477,6 +1477,11 @@ static void imx9_reset(struct sdio_dev_s *dev)
 
   mcinfo("Reset complete\n");
 
+  /* Set PROCTL to select SDMA or no DMA. */
+
+  modifyreg32(priv->addr + IMX9_USDHC_PROCTL_OFFSET,
+              USDHC_PROCTL_DMAS_MASK, USDHC_PROCTL_DMAS_NODMA);
+
   /* Make sure that all clocking is disabled */
 
   imx9_clock(dev, CLOCK_SDIO_DISABLED);


### PR DESCRIPTION
## Summary

USDHC_PROCTL selects whether the usdhc uses SDMA or ADMA. This driver only uses the SDMA or no DMA at all, so select that option. There might be a wrong register value left by ROM code or an earlier bootloader which uses ADMA.

## Impact

RELEASE

## Testing

CI