### PR TITLE
arch/risc-v: add LDO source for Espressif devices

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_ldo.c
+++ b/arch/risc-v/src/common/espressif/esp_ldo.c
@@ -1,0 +1,125 @@
+/****************************************************************************
+ * arch/risc-v/src/common/espressif/esp_ldo.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <string.h>
+#include <nuttx/debug.h>
+
+#include "soc/soc_caps.h"
+#include "esp_ldo.h"
+#include "hal/ldo_ll.h"
+#include "esp_ldo_regulator.h"
+
+#ifndef CONFIG_ARCH_CHIP_ESP32P4
+# error "ESP LDO Control usable for ESP32-P4 only"
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp_ldo_channel_acquire
+ *
+ * Description:
+ *   Acquire an on-chip LDO regulator channel and enable its output at the
+ *   requested voltage.
+ *
+ * Input Parameters:
+ *   config - Channel description. chan_id and voltage_mv are inputs;
+ *            handler receives the channel handle on success.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; -EIO is returned if the channel
+ *   could not be acquired.
+ *
+ ****************************************************************************/
+
+int esp_ldo_channel_acquire(struct esp_ldo_config_t *config)
+{
+  esp_ldo_channel_handle_t ldo_chan = NULL;
+  esp_ldo_channel_config_t chan_cfg;
+  esp_err_t err;
+
+  DEBUGASSERT(config != NULL);
+
+  memset(&chan_cfg, 0, sizeof(chan_cfg));
+  chan_cfg.chan_id          = config->chan_id;
+  chan_cfg.voltage_mv       = config->voltage_mv;
+  chan_cfg.flags.adjustable = false;
+
+  err = esp_ldo_acquire_channel(&chan_cfg, &ldo_chan);
+  if (err != ESP_OK)
+    {
+      _err("acquire channel failed: %d\n", (int)err);
+      return -EIO;
+    }
+
+  config->handler = (void *)ldo_chan;
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: esp_ldo_channel_release
+ *
+ * Description:
+ *   Release a channel previously acquired with
+ *   esp_ldo_channel_acquire().
+ *
+ * Input Parameters:
+ *   config - The same structure passed to esp_ldo_channel_acquire(). Its
+ *            handler field is cleared on success.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; -EINVAL if the channel was not
+ *   acquired, or -EIO if the release failed.
+ *
+ ****************************************************************************/
+
+int esp_ldo_channel_release(struct esp_ldo_config_t *config)
+{
+  esp_err_t err;
+
+  DEBUGASSERT(config != NULL);
+
+  if (config->handler == NULL)
+    {
+      return -EINVAL;
+    }
+
+  err = esp_ldo_release_channel((esp_ldo_channel_handle_t)config->handler);
+  if (err != ESP_OK)
+    {
+      _err("release channel failed: %d\n", (int)err);
+      return -EIO;
+    }
+
+  config->handler = NULL;
+
+  return OK;
+}

--- a/arch/risc-v/src/common/espressif/esp_ldo.h
+++ b/arch/risc-v/src/common/espressif/esp_ldo.h
@@ -1,0 +1,116 @@
+/****************************************************************************
+ * arch/risc-v/src/common/espressif/esp_ldo.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_RISCV_SRC_COMMON_ESPRESSIF_ESP_LDO_H
+#define __ARCH_RISCV_SRC_COMMON_ESPRESSIF_ESP_LDO_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* Description of an on-chip LDO regulator channel. The channel ID and the
+ * output voltage are board/schematic dependent and must be provided by the
+ * caller. Only ESP32-P4 provides these regulators.
+ */
+
+struct esp_ldo_config_t
+{
+  uint8_t  chan_id;     /* LDO channel ID, e.g. 3 for LDO_VO3 */
+  uint16_t voltage_mv;  /* Output voltage, in millivolts */
+  void    *handler;     /* Opaque channel handle, set by acquire */
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Name: esp_ldo_channel_acquire
+ *
+ * Description:
+ *   Acquire an on-chip LDO regulator channel and enable its output at the
+ *   requested voltage. The channel is configured as non-adjustable, so the
+ *   same channel may be acquired more than once by different consumers.
+ *
+ * Input Parameters:
+ *   config - Channel description. chan_id and voltage_mv are inputs;
+ *            handler receives the channel handle on success and must be
+ *            preserved for the matching esp_ldo_channel_release() call.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; -EIO is returned if the channel
+ *   could not be acquired.
+ *
+ ****************************************************************************/
+
+int esp_ldo_channel_acquire(struct esp_ldo_config_t *config);
+
+/****************************************************************************
+ * Name: esp_ldo_channel_release
+ *
+ * Description:
+ *   Release a channel previously acquired with
+ *   esp_ldo_channel_acquire(). The regulator output is turned off once the
+ *   last consumer of the channel releases it.
+ *
+ * Input Parameters:
+ *   config - The same structure passed to esp_ldo_channel_acquire(). Its
+ *            handler field is cleared on success.
+ *
+ * Returned Value:
+ *   Zero (OK) is returned on success; -EINVAL if the channel was not
+ *   acquired, or -EIO if the release failed.
+ *
+ ****************************************************************************/
+
+int esp_ldo_channel_release(struct esp_ldo_config_t *config);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* __ASSEMBLY__ */
+#endif /* __ARCH_RISCV_SRC_COMMON_ESPRESSIF_ESP_LDO_H */


### PR DESCRIPTION
## Summary

<!-- This field should contain a summary of the changes. It will be pre-filled with the commit's message and descriptions. Adjust it accordingly -->

* arch/risc-v: LDO driver for Espressif devices

Adds LDO support for RISC-V Espressif devices. In general, should only affect ESP32-P4 on a few boards.
ESP32-P4 has 4 channels of low-dropout voltage regulators, which are programmable. Can be used to power external devices.

## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: No.
<!-- Does it impact user's applications? How? -->

Impact on build: No.
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: Allows using one of the four programmable LDOs on ESP32-P4 devices.
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: No.
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: No.
<!-- Does it impact NuttX's security? -->

Impact on compatibility: No.
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

## Testing
Tested on `esp32p4-tab5`. The LDO support was used to power the MIPI DSI physical layer.

Results can be seen on this PR [#3671](https://github.com/apache/nuttx-apps/pull/3671) where the display is working as expected.