### PR TITLE
sched/setpriority: handle CPU affinity change for running task

### DIFF
--- a/sched/sched/sched_setpriority.c
+++ b/sched/sched/sched_setpriority.c
@@ -92,7 +92,26 @@ static inline void nxsched_running_setpriority(FAR struct tcb_s *tcb,
     {
 #ifdef CONFIG_SMP
       tcb->sched_priority = (uint8_t)sched_priority;
-      if (nxsched_deliver_task(this_cpu(), tcb->cpu, SWITCH_EQUAL))
+
+      /* If the task no longer is eligible to run on this CPU, then
+       * we need to perform the context switch unconditionally.
+       */
+
+      if ((tcb == this_task()) && (tcb->affinity & (1 << tcb->cpu)) == 0)
+        {
+          bool switch_needed;
+
+          switch_needed = nxsched_remove_readytorun(tcb);
+          DEBUGASSERT(switch_needed == true);
+
+          switch_needed = nxsched_add_readytorun(tcb);
+          DEBUGASSERT(switch_needed == false);
+
+          DEBUGASSERT(tcb != this_task());
+          up_switch_context(this_task(), tcb);
+          UNUSED(switch_needed);
+        }
+      else if (nxsched_deliver_task(this_cpu(), tcb->cpu, SWITCH_EQUAL))
         {
           up_switch_context(this_task(), tcb);
         }


### PR DESCRIPTION
## Summary

When a running task changes its CPU affinity on SMP and the new mask no longer includes its current CPU, `nxsched_set_priority()` requests an equal-priority reschedule on the current CPU. The task can be moved to `g_readytorun` without waking the idle target CPU, leaving it unable to run again.

Remove the task from its current CPU, add it back through `nxsched_add_readytorun()` so a suitable CPU is selected, and switch context unconditionally when the running task is no longer eligible for its current CPU.

Fixes #19680.

## Impact

- Existing SMP task-affinity behavior is corrected; no new feature or API is added.
- No user adaptation is required.
- No impact on the build process, hardware interfaces, documentation, security, or compatibility.
- Non-SMP scheduling behavior is unchanged.

## Testing

Build host: Ubuntu Linux, x86-64, GCC.

Target: QEMU ARM64, `qemu-armv8a:nsh_smp`, two Cortex-A53 CPUs.

Build command:

    make distclean -j20
    ./tools/configure.sh -l qemu-armv8a:nsh_smp
    make -j20

QEMU command:

    qemu-system-aarch64 -cpu cortex-a53 -smp 2 -nographic \
      -machine virt,virtualization=on,gic-version=3 -net none \
      -chardev stdio,id=con,mux=on -serial chardev:con \
      -mon chardev=con,mode=readline -kernel ./nuttx

A local reproducer starts two equal-priority `SCHED_RR` threads on CPU1. T0 changes its affinity to CPU0 while CPU0 is idle and T1 remains runnable on CPU1.

Before this change, T0 never resumes and the test stops after:

    orphan: T0 started on CPU1
    orphan: T1 started on CPU1
    orphan: both tasks are ready; releasing T0
    orphan: T0 changes affinity CPU1 -> CPU0

After this change, T0 resumes on CPU0:

    orphan: T0 started on CPU1
    orphan: T1 started on CPU1
    orphan: both tasks are ready; releasing T0
    orphan: T0 changes affinity CPU1 -> CPU0
    orphan: sched_setaffinity ret=0, T0 resumed on CPU0
    orphan: T0 resumed on CPU0 (affinity ret=0)

Code and commit checks:

    ./tools/checkpatch.sh -g HEAD~1..HEAD
    ✔️ All checks pass.

## PR verification Self-Check

- [x] This PR introduces only one functional change.
- [x] I have updated all required description fields above.
- [x] My PR adheres to the Contributing Guidelines and coding standard.
- [ ] My PR is still work in progress (not ready for review).
- [x] My PR is ready for review and can be safely merged into the codebase.
