### PR TITLE
arch/arm/kinetis/rtc: Enable global lock for all

### DIFF
--- a/arch/arm/src/kinetis/kinetis_rtc.c
+++ b/arch/arm/src/kinetis/kinetis_rtc.c
@@ -63,9 +63,7 @@
  * Private Data
  ****************************************************************************/
 
-#ifdef CONFIG_RTC_HIRES
 static spinlock_t g_rtc_lock = SP_UNLOCKED;
-#endif
 
 #ifdef CONFIG_RTC_ALARM
 static alarmcb_t g_alarmcb;


### PR DESCRIPTION
g_rtc_lock is used by the up_rtc_settime, a base RTC function. Therefore, it should be available even for this procedure, not just when CONFIG_RTC_HIRES.

## Summary

This change is needed for successful compilation for Kinetis K60 with the following combination of config defines:
```
CONFIG_NSH_DISABLE_DATE=n
CONFIG_KINETIS_RTC=y
CONFIG_RTC=y
CONFIG_RTC_DRIVER=y
CONFIG_RTC_EXTERNAL=n
CONFIG_RTC_HIRES=n
CONFIG_RTC_ALARM=n
```

## Impact

After applying this change, we can compile NuttX with the given combination of defines.

## Testing

I have successfully compiled NuttX for our K60-based board, set the date/time using `date` command and confirmed that the time persist after reboot.