### PR TITLE
arch/x86_64: fix page table levels in pgalloc

### DIFF
--- a/arch/x86_64/src/common/x86_64_pgalloc.c
+++ b/arch/x86_64/src/common/x86_64_pgalloc.c
@@ -50,7 +50,7 @@
 
 /* Last PGT level */
 
-#define PGT_LAST    (X86_MMU_PT_LEVELS)
+#define PGT_LAST    (X86_MMU_PT_LEVELS - 1)
 
 /****************************************************************************
  * Private Functions
@@ -82,7 +82,7 @@ uintptr_t x86_64_get_pgtable(arch_addrenv_t *addrenv, uintptr_t vaddr)
 
   /* Get the current level MAX_LEVELS-1 entry corresponding to this vaddr */
 
-  ptlevel = ARCH_SPGTS;
+  ptlevel = ARCH_SPGTS - 1;
   ptprev  = x86_64_pgvaddr(addrenv->spgtables[ARCH_SPGTS - 1]);
   if (!ptprev)
     {


### PR DESCRIPTION
## Summary

Two level errors corrupted kernel memory when a user process extended its heap with sbrk:

- PGT_LAST was X86_MMU_PT_LEVELS (4), but valid levels are 0-3, so the final level entry was written with an out-of-range index.

- x86_64_get_pgtable indexed the PD (level 2) with level 3, installing newly allocated page tables into the wrong PD slot.

## Impact

fix for kernel build

## Testing

qemu-intel64 kernel build with ostest
