### PR TITLE
cmake: normalize .config on reconfigure

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -368,6 +368,9 @@ if(NOT EXISTS ${NUTTX_BINARY_DIR}/.config OR NOT "${NUTTX_DEFCONFIG}" STREQUAL
   # Do olddefconfig step to expand the abbreviated defconfig into normal config
   nuttx_olddefconfig()
 
+  # save the orig compressed formatted defconfig at the very beginning
+  nuttx_save_defconfig_orig()
+
   file(RENAME ${NUTTX_BINARY_DIR}/.config.compressed
        ${NUTTX_BINARY_DIR}/.config)
   set(ENV{KCONFIG_CONFIG} ${NUTTX_BINARY_DIR}/.config)
@@ -385,9 +388,11 @@ if(NOT EXISTS ${NUTTX_BINARY_DIR}/.config OR NOT "${NUTTX_DEFCONFIG}" STREQUAL
   endif()
   file(WRITE ${NUTTX_BINARY_DIR}/.config "${_config_init_content}")
 
-  # store original expanded .config
-  configure_file(${NUTTX_BINARY_DIR}/.config ${NUTTX_BINARY_DIR}/.config.orig
-                 COPYONLY)
+  # store original expanded .config; plain copy so .config does not become a
+  # configure dependency: the compiler cannot change after the first configure,
+  # so a modified .config must not reconfigure mid-build
+  execute_process(COMMAND ${CMAKE_COMMAND} -E copy ${NUTTX_BINARY_DIR}/.config
+                          ${NUTTX_BINARY_DIR}/.config.orig)
 
   set(NUTTX_DEFCONFIG_SAVED
       ${NUTTX_DEFCONFIG}
@@ -411,6 +416,11 @@ if(NOT EXISTS ${NUTTX_BINARY_DIR}/.config OR NOT "${NUTTX_DEFCONFIG}" STREQUAL
   message(STATUS "  Board:  ${NUTTX_BOARD}")
   message(STATUS "  Config: ${NUTTX_CONFIG}")
   message(STATUS "  Appdir: ${NUTTX_APPS_DIR}")
+else()
+  # Normalize user modifications to .config (e.g. kconfig-tweak) so dependent
+  # defaults materialize, as the Make flow does on each build
+  set(ENV{KCONFIG_CONFIG} ${NUTTX_BINARY_DIR}/.config)
+  nuttx_olddefconfig()
 endif()
 
 # declare global custom targets at very beginning `nuttx_global` is used to hold

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -367,6 +367,9 @@ if(NOT EXISTS ${CMAKE_BINARY_DIR}/.config OR NOT "${NUTTX_DEFCONFIG}" STREQUAL
   # Do olddefconfig step to expand the abbreviated defconfig into normal config
   nuttx_olddefconfig()
 
+  # save the orig compressed formatted defconfig at the very beginning
+  nuttx_save_defconfig_orig()
+
   file(RENAME ${CMAKE_BINARY_DIR}/.config.compressed
        ${CMAKE_BINARY_DIR}/.config)
   set(ENV{KCONFIG_CONFIG} ${CMAKE_BINARY_DIR}/.config)
@@ -384,9 +387,11 @@ if(NOT EXISTS ${CMAKE_BINARY_DIR}/.config OR NOT "${NUTTX_DEFCONFIG}" STREQUAL
   endif()
   file(WRITE ${CMAKE_BINARY_DIR}/.config "${_config_init_content}")
 
-  # store original expanded .config
-  configure_file(${CMAKE_BINARY_DIR}/.config ${CMAKE_BINARY_DIR}/.config.orig
-                 COPYONLY)
+  # store original expanded .config; plain copy so .config does not become a
+  # configure dependency: the compiler cannot change after the first configure,
+  # so a modified .config must not reconfigure mid-build
+  execute_process(COMMAND ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/.config
+                          ${CMAKE_BINARY_DIR}/.config.orig)
 
   set(NUTTX_DEFCONFIG_SAVED
       ${NUTTX_DEFCONFIG}
@@ -410,6 +415,11 @@ if(NOT EXISTS ${CMAKE_BINARY_DIR}/.config OR NOT "${NUTTX_DEFCONFIG}" STREQUAL
   message(STATUS "  Board:  ${NUTTX_BOARD}")
   message(STATUS "  Config: ${NUTTX_CONFIG}")
   message(STATUS "  Appdir: ${NUTTX_APPS_DIR}")
+else()
+  # Normalize user modifications to .config (e.g. kconfig-tweak) so dependent
+  # defaults materialize, as the Make flow does on each build
+  set(ENV{KCONFIG_CONFIG} ${CMAKE_BINARY_DIR}/.config)
+  nuttx_olddefconfig()
 endif()
 
 # declare global custom targets at very beginning `nuttx_global` is used to hold

--- a/cmake/nuttx_kconfig.cmake
+++ b/cmake/nuttx_kconfig.cmake
@@ -216,8 +216,12 @@ function(nuttx_olddefconfig)
         "nuttx_olddefconfig: Failed to initialize Kconfig configuration: ${KCONFIG_OUTPUT}"
     )
   endif()
+endfunction()
 
-  # save the orig compressed formatted defconfig at the very beginning
+# save the orig compressed formatted defconfig at the very beginning; only valid
+# during the initial configure while .config.compressed exists
+
+function(nuttx_save_defconfig_orig)
   execute_process(COMMAND savedefconfig --out ${NUTTX_BINARY_DIR}/defconfig.tmp
                   WORKING_DIRECTORY ${NUTTX_DIR})
 
@@ -227,7 +231,6 @@ function(nuttx_olddefconfig)
       ${NUTTX_BINARY_DIR}/.config.compressed ${NUTTX_BINARY_DIR}/defconfig.tmp
       ${NUTTX_BINARY_DIR}/defconfig.orig
     WORKING_DIRECTORY ${NUTTX_DIR})
-
 endfunction()
 
 function(nuttx_setconfig)

--- a/cmake/nuttx_kconfig.cmake
+++ b/cmake/nuttx_kconfig.cmake
@@ -216,8 +216,12 @@ function(nuttx_olddefconfig)
         "nuttx_olddefconfig: Failed to initialize Kconfig configuration: ${KCONFIG_OUTPUT}"
     )
   endif()
+endfunction()
 
-  # save the orig compressed formatted defconfig at the very beginning
+# save the orig compressed formatted defconfig at the very beginning; only valid
+# during the initial configure while .config.compressed exists
+
+function(nuttx_save_defconfig_orig)
   execute_process(COMMAND savedefconfig --out ${CMAKE_BINARY_DIR}/defconfig.tmp
                   WORKING_DIRECTORY ${NUTTX_DIR})
 
@@ -227,7 +231,6 @@ function(nuttx_olddefconfig)
       ${CMAKE_BINARY_DIR}/.config.compressed ${CMAKE_BINARY_DIR}/defconfig.tmp
       ${CMAKE_BINARY_DIR}/defconfig.orig
     WORKING_DIRECTORY ${NUTTX_DIR})
-
 endfunction()
 
 function(nuttx_setconfig)


### PR DESCRIPTION
## Summary

olddefconfig only ran when .config was generated from the defconfig, so changes applied to an existing .config (e.g. with kconfig-tweak) never got their dependent defaults. Run olddefconfig on reconfigure as well, as the Make flow does on every build.

## Impact

align cmake with make

## Testing

update cmake generated config with kconfig-tweak


