### PR TITLE
arch/x86_64: kernel build with Cmake

### DIFF
--- a/Documentation/platforms/x86_64/intel64/boards/qemu-intel64/index.rst
+++ b/Documentation/platforms/x86_64/intel64/boards/qemu-intel64/index.rst
@@ -201,7 +201,7 @@ are built separately. It uses ROMFS to load the user-space applications.
 This is intended to run on QEMU with COM serial port support.
 
 Steps to build kernel image with user-space apps in ROMFS::
-    
+
     ./tools/configure.sh qemu-intel64/knsh_romfs
     make -j
     make export -j
@@ -212,6 +212,24 @@ Steps to build kernel image with user-space apps in ROMFS::
     mv boot_romfsimg.h ../nuttx/arch/x86_64/src/board/romfs_boot.c
     popd
     make -j
+
+With CMake the user-space applications and the ROMFS image are built as
+part of the normal build (``genromfs`` and ``xxd`` must be available on
+the host)::
+
+    cmake -B build -GNinja -DBOARD_CONFIG=qemu-intel64/knsh_romfs .
+    cmake --build build
+
+Then run the image with::
+
+    qemu-system-x86_64 -cpu host -enable-kvm -m 2G -kernel build/nuttx \
+        -nographic -serial mon:stdio
+
+The applications are installed to ``build/bin`` and mounted from ROMFS
+at ``/system/bin``. The configuration does not set ``CONFIG_PATH_INITIAL``,
+so start applications with an absolute path (``/system/bin/hello``) or
+enable ``CONFIG_LIBC_ENVPATH`` and ``CONFIG_PATH_INITIAL="/system/bin"``
+to resolve bare command names.
 
 knsh_romfs_pci
 --------------

--- a/arch/arm64/src/CMakeLists.txt
+++ b/arch/arm64/src/CMakeLists.txt
@@ -24,7 +24,7 @@ add_subdirectory(${NUTTX_CHIP_ABS_DIR} EXCLUDE_FROM_ALL exclude_chip)
 # Include directories (before system ones) as PUBLIC so that it can be exposed
 # to libboard
 target_include_directories(arch BEFORE PUBLIC ${NUTTX_CHIP_ABS_DIR} common)
-if(NOT CONFIG_BUILD_FLAT)
+if(CONFIG_BUILD_PROTECTED)
   target_include_directories(arch_interface BEFORE PUBLIC ${NUTTX_CHIP_ABS_DIR}
                                                           common)
 endif()

--- a/arch/x86_64/src/CMakeLists.txt
+++ b/arch/x86_64/src/CMakeLists.txt
@@ -29,7 +29,7 @@ add_subdirectory(common)
 target_include_directories(arch BEFORE PUBLIC ${NUTTX_CHIP_ABS_DIR} common
                                               ${ARCH_SUBDIR})
 
-if(NOT CONFIG_BUILD_FLAT)
+if(CONFIG_BUILD_PROTECTED)
   target_include_directories(arch_interface BEFORE PUBLIC ${NUTTX_CHIP_ABS_DIR}
                                                           common ${ARCH_SUBDIR})
 endif()

--- a/arch/x86_64/src/cmake/Toolchain.cmake
+++ b/arch/x86_64/src/cmake/Toolchain.cmake
@@ -27,6 +27,12 @@ set(CMAKE_SYSTEM_VERSION 1)
 
 set(ARCH_SUBDIR intel64)
 
+# host toolchain linker and strip, used for standalone ELF applications;
+# --strip-unneeded keeps the symbols required for relocation processing
+# (CONFIG_BINFMT_ELF_RELOCATABLE binaries are loaded from ET_REL objects)
+set(CMAKE_LD ld)
+set(CMAKE_STRIP strip --strip-unneeded)
+
 # override the ARCHIVE command
 set(CMAKE_ARCHIVE_COMMAND "<CMAKE_AR> rcs <TARGET> <LINK_FLAGS> <OBJECTS>")
 set(CMAKE_RANLIB_COMMAND "<CMAKE_RANLIB> <TARGET>")

--- a/boards/x86_64/qemu/qemu-intel64/src/CMakeLists.txt
+++ b/boards/x86_64/qemu/qemu-intel64/src/CMakeLists.txt
@@ -26,6 +26,30 @@ if(CONFIG_BOARDCTL_RESET)
   list(APPEND SRCS qemu_reset.c)
 endif()
 
+if(CONFIG_BUILD_KERNEL)
+  # Pack the standalone application binaries into the ROMFS image registered by
+  # qemu_boardinit.c. The application targets are not known yet when this
+  # directory is configured, so the dependency is resolved at generation time
+  # from the nuttx target property. The nuttx_add_romfs helper cannot be used
+  # here: its library is added to apps_post, which the application targets
+  # depend on (cycle).
+  add_custom_command(
+    OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/romfs_boot.c
+    COMMAND genromfs -f romfs.img -d ${CMAKE_BINARY_DIR}/bin -V NuttXBootVol
+    COMMAND xxd -i romfs.img romfs_boot.c
+    DEPENDS $<TARGET_PROPERTY:nuttx,NUTTX_LOADABLE_APPS>
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+  # the board target is defined in a parent directory: anchor the generated
+  # source with a local target so the build rule is emitted
+  add_custom_target(board_romfs
+                    DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/romfs_boot.c)
+  add_dependencies(board board_romfs)
+  list(APPEND SRCS ${CMAKE_CURRENT_BINARY_DIR}/romfs_boot.c)
+elseif(CONFIG_BOARD_LATE_INITIALIZE)
+  # empty ROMFS placeholder, see Makefile
+  list(APPEND SRCS romfs_stub.c)
+endif()
+
 target_sources(board PRIVATE ${SRCS})
 
 set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/qemu.ld")

--- a/cmake/nuttx_add_application.cmake
+++ b/cmake/nuttx_add_application.cmake
@@ -199,7 +199,15 @@ function(nuttx_add_application)
           COMMAND
             ${CMAKE_COMMAND} -E copy ${CMAKE_BINARY_DIR}/bin_debug/${ELF_NAME}
             ${CMAKE_BINARY_DIR}/bin/${ELF_NAME}
-          COMMAND ${CMAKE_STRIP} ${CMAKE_BINARY_DIR}/bin/${ELF_NAME}
+            # keep the application attribute symbols through strip so the binary
+            # loader can still read them, see NX_KEEP in Application.mk
+          COMMAND
+            ${CMAKE_STRIP} -K nx_stacksize -K nx_priority -K nx_uid -K nx_gid -K
+            nx_mode ${CMAKE_BINARY_DIR}/bin/${ELF_NAME}
+            # match the Application.mk install rule: ld -r output is not marked
+            # executable, but filesystem images built from bin/ must carry the
+            # execute permission
+          COMMAND chmod +x ${CMAKE_BINARY_DIR}/bin/${ELF_NAME}
           COMMENT "Building ELF:${ELF_NAME}"
           COMMAND_EXPAND_LISTS)
       else()


### PR DESCRIPTION

## Summary

1. arch: fix arch_interface guard for kernel builds
2. arch/x86_64: define CMAKE_LD and CMAKE_STRIP for ELF applications
3. cmake: fix installed application binaries to match Application.mk 
4. boards/x86_64/qemu-intel64: generate ROMFS image in CMake kernel builds
5. Documentation: describe CMake build for qemu-intel64 knsh_romfs

## Impact

kernel build works now with cmake

## Testing

kernel build automate tests with ntfc
