### PR TITLE
arch/risc-v: add missing CMake support for standalone ELF applications

### DIFF
--- a/arch/risc-v/src/cmake/elf.cmake
+++ b/arch/risc-v/src/cmake/elf.cmake
@@ -1,0 +1,40 @@
+# ##############################################################################
+# arch/risc-v/src/cmake/elf.cmake
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more contributor
+# license agreements.  See the NOTICE file distributed with this work for
+# additional information regarding copyright ownership.  The ASF licenses this
+# file to you under the Apache License, Version 2.0 (the "License"); you may not
+# use this file except in compliance with the License.  You may obtain a copy of
+# the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+# License for the specific language governing permissions and limitations under
+# the License.
+#
+# ##############################################################################
+
+# Link options for standalone ELF applications, matching the Make flow
+# LDELFFLAGS from arch/risc-v/src/common/Toolchain.defs
+
+nuttx_elf_compile_options(-fvisibility=hidden)
+
+nuttx_mod_compile_options(-fvisibility=hidden)
+
+nuttx_mod_link_options(-r)
+
+nuttx_elf_link_options_ifdef(CONFIG_BINFMT_ELF_RELOCATABLE -r)
+
+if(CONFIG_ARCH_RV32)
+  nuttx_elf_link_options(--oformat elf32-littleriscv)
+else()
+  nuttx_elf_link_options(--oformat elf64-littleriscv)
+endif()
+
+nuttx_elf_link_options(-e _start)

--- a/arch/risc-v/src/common/CMakeLists.txt
+++ b/arch/risc-v/src/common/CMakeLists.txt
@@ -140,3 +140,10 @@ if(CONFIG_ARCH_USE_S_MODE)
 endif()
 
 target_sources(arch PRIVATE ${SRCS})
+
+nuttx_add_aux_library(STARTUP_OBJS crt0.c)
+
+target_compile_options(
+  STARTUP_OBJS
+  PRIVATE
+    $<GENEX_EVAL:$<TARGET_PROPERTY:nuttx_global,NUTTX_ELF_APP_COMPILE_OPTIONS>>)


### PR DESCRIPTION
## Summary

The CMake build had no STARTUP_OBJS (crt0) target and no elf.cmake, so applications were linked without crt0 and without '-e _start': the ELF entry defaulted to main and applications crashed on exit returning to a NULL address.

Add STARTUP_OBJS and elf.cmake with the LDELFFLAGS equivalents from Toolchain.defs, following the other architectures.

## Impact

fix broken ELF apps with cmake

## Testing

automate tests with ntfc for kernel build

