### PR TITLE
{bp-19589} net/tcp/tcp_send: Remove work_available check when updating retransmit timer

### DIFF
--- a/net/tcp/tcp_send.c
+++ b/net/tcp/tcp_send.c
@@ -149,7 +149,7 @@ static void tcp_sendcommon(FAR struct net_driver_s *dev,
     }
   else
     {
-      if (work_available(&conn->work) && conn->tx_unacked != 0)
+      if (conn->tx_unacked != 0)
         {
           conn->timeout = false;
           tcp_update_retrantimer(conn, conn->rto);


### PR DESCRIPTION
## Summary

The condition work_available(&conn->work) && tx_unacked != 0 prevented tcp_update_retrantimer from being called when the work queue was still busy, leaving conn->timer stale or zero on subsequent sends. This caused the RTT estimation to compute a false RTT (m = rto - 0 = rto), creating a positive feedback loop that inflated the RTO to extreme values (e.g., 232 half-seconds = ~116 seconds).

Fix: remove the work_available check so that tcp_update_retrantimer is always called when there is unacknowledged data. The decision to re-queue the work is handled internally by tcp_update_timer.

## Impact

RELEASE

## Testing

CI