### PR TITLE
{bp-19691} kinetis/rtc: Enable global lock for all

### DIFF
--- a/arch/arm/src/kinetis/kinetis_rtc.c
+++ b/arch/arm/src/kinetis/kinetis_rtc.c
@@ -63,9 +63,7 @@
  * Private Data
  ****************************************************************************/
 
-#ifdef CONFIG_RTC_HIRES
 static spinlock_t g_rtc_lock = SP_UNLOCKED;
-#endif
 
 #ifdef CONFIG_RTC_ALARM
 static alarmcb_t g_alarmcb;


### PR DESCRIPTION
## Summary

g_rtc_lock is used by the up_rtc_settime, a base RTC function. Therefore, it should be available even for this procedure, not just when CONFIG_RTC_HIRES.

## Impact

RELEASE

## Testing

CI