### PR TITLE
arch/arm/stm32: allow UART7/8 serial driver on H5

### DIFF
--- a/arch/arm/src/common/stm32/Kconfig.uart
+++ b/arch/arm/src/common/stm32/Kconfig.uart
@@ -538,7 +538,7 @@ endchoice # USART8 Driver Configuration
 
 choice
 	prompt "UART7 Driver Configuration"
-	depends on STM32_HAVE_IP_USART && STM32_UART7
+	depends on (STM32_HAVE_IP_USART || STM32_HAVE_USART_H5) && STM32_UART7
 	default STM32_UART7_SERIALDRIVER
 
 config STM32_UART7_SERIALDRIVER
@@ -560,7 +560,7 @@ endchoice # UART7 Driver Configuration
 
 choice
 	prompt "UART8 Driver Configuration"
-	depends on STM32_HAVE_IP_USART && STM32_UART8
+	depends on (STM32_HAVE_IP_USART || STM32_HAVE_USART_H5) && STM32_UART8
 	default STM32_UART8_SERIALDRIVER
 
 config STM32_UART8_SERIALDRIVER


### PR DESCRIPTION
## Summary

On STM32H5, enabling UART7 or UART8 did not make `CONFIG_STM32_UART*_SERIALDRIVER` selectable. The driver choices in `Kconfig.uart` depended only on `STM32_HAVE_IP_USART`, which H5 never sets (`STM32_HAVE_USART_H5` is selected instead).

This change widens the UART7/UART8 choice dependencies, so the standard serial driver can be selected the same way as on common IP-USART chips.

## Impact

- STM32H5 boards can enable UART7/UART8 as serial ports (`CONFIG_STM32_UART7/8_SERIALDRIVER`).
- Without this fix, UART7/8 configuration silently fails: the build succeeds but the H5 serial driver instances are not compiled in.
- No functional change for non-H5 chips that already use `STM32_HAVE_IP_USART`.

> NOTE: UART8 buffer definitions in `stm32h5/stm32_serial.c` are still guarded by the typo `CONFIG_STM32H8_UART8_SERIALDRIVER`, so enabling UART8 after this Kconfig fix fails to compile until that guard is corrected. That is fixed by [#19701](https://github.com/apache/nuttx/pull/19701)

## Testing

Tested on STM32 Nucleo-H563ZI with UART7 configured.

Board code patch used for this test [nucleo-h563zi-nsh-uart7-test.patch](https://github.com/user-attachments/files/30749452/nucleo-h563zi-nsh-uart7-test.patch)


Build configuration:

```sh
cmake -B build -DBOARD_CONFIG=nucleo-h563zi:nsh -GNinja
cmake --build build
```

### Without this change (Expected 1 ttyS device)

```bash
ABCG

NuttShell (NSH)
nsh> ls /dev
/dev:
 console
 null
 ttyS0
 zero
nsh>
```

### With this change (Expected 2 ttyS device)

```bash
ABCG

NuttShell (NSH)
nsh> ls /dev
/dev:
 console
 null
 ttyS0
 ttyS1
 zero
nsh>
```