### PR TITLE
arch/arm/stm32h5/serial: fix UART8 buffer guard typo

### DIFF
--- a/arch/arm/src/stm32h5/stm32_serial.c
+++ b/arch/arm/src/stm32h5/stm32_serial.c
@@ -395,7 +395,7 @@ static char g_uart7rxfifo[RXDMA_BUFFER_SIZE];
 #  endif
 #endif
 
-#ifdef CONFIG_STM32H8_UART8_SERIALDRIVER
+#ifdef CONFIG_STM32_UART8_SERIALDRIVER
 static char g_uart8rxbuffer[CONFIG_UART8_RXBUFSIZE];
 static char g_uart8txbuffer[CONFIG_UART8_TXBUFSIZE];
 #  ifdef CONFIG_UART8_RXDMA


### PR DESCRIPTION
## Summary

In `stm32h5/stm32_serial.c`, the UART8 RX/TX buffer definitions were guarded by `CONFIG_STM32H8_UART8_SERIALDRIVER` (typo). The rest of the UART8 serial instance correctly uses `CONFIG_STM32_UART8_SERIALDRIVER`.

This change corrects the guard to `CONFIG_STM32_UART8_SERIALDRIVER` so the buffers are compiled with the UART8 driver.

> NOTE: The compile failure only shows up when UART8 serial is actually selectable on H5. That requires the UART7/8 Kconfig gate-keeping fix from [#19700](https://github.com/apache/nuttx/pull/19700); without it, `CONFIG_STM32_UART8_SERIALDRIVER` is dropped and this typo stays latent.

## Impact

- Fixes STM32H5 UART8 serial builds once `CONFIG_STM32_UART8_SERIALDRIVER` is enabled.

## Testing

Tested compiling `nucleo-h563zi:nsh` with UART8 configured (together with the Kconfig fix from  [#19700](https://github.com/apache/nuttx/pull/19700)).

Board code patch used for this test: [nucleo-h563zi-nsh-uart8-typo-test.patch](https://github.com/user-attachments/files/30749602/nucleo-h563zi-nsh-uart8-typo-test.patch)


Build configuration:

```sh
cmake -B build -DBOARD_CONFIG=nucleo-h563zi:nsh -GNinja
cmake --build build
```

### Without this change (Compilation fails)

```bash
cmake --build build
[39/1164] Building C object arch/CMakeFiles/arch.dir/arm/src/stm32h5/stm32_serial.c.o
FAILED: [code=1] arch/CMakeFiles/arch.dir/arm/src/stm32h5/stm32_serial.c.o

...

nuttx/arch/arm/src/stm32h5/stm32_serial.c:1058:19: error: 'g_uart8rxbuffer' undeclared here (not in a function); did you mean 'g_usart3rxbuffer'?
 1058 |         .buffer = g_uart8rxbuffer,
      |                   ^~~~~~~~~~~~~~~
      |                   g_usart3rxbuffer
nuttx/arch/arm/src/stm32h5/stm32_serial.c:1063:19: error: 'g_uart8txbuffer' undeclared here (not in a function); did you mean 'g_usart3txbuffer'?
 1063 |         .buffer = g_uart8txbuffer,
      |                   ^~~~~~~~~~~~~~~
      |                   g_usart3txbuffer
[56/1164] Building C object arch/CMakeFiles/arch.dir/arm/src/common/arm_usestack.c.o
ninja: build stopped: subcommand failed.
```

### With this change (Compilation succeeds)

```bash
cmake --build build
[1162/1164] Linking CXX executable nuttx
Memory region         Used Size  Region Size  %age Used
           flash:      227392 B         2 MB     10.84%
            sram:       10512 B       256 KB      4.01%
[1164/1164] Generating System.map
```
