### PR TITLE
{bp-19701} arch/arm/stm32h5/serial: fix UART8 buffer guard typo

### DIFF
--- a/arch/arm/src/stm32h5/stm32_serial.c
+++ b/arch/arm/src/stm32h5/stm32_serial.c
@@ -395,7 +395,7 @@ static char g_uart7rxfifo[RXDMA_BUFFER_SIZE];
 #  endif
 #endif
 
-#ifdef CONFIG_STM32H8_UART8_SERIALDRIVER
+#ifdef CONFIG_STM32_UART8_SERIALDRIVER
 static char g_uart8rxbuffer[CONFIG_UART8_RXBUFSIZE];
 static char g_uart8txbuffer[CONFIG_UART8_TXBUFSIZE];
 #  ifdef CONFIG_UART8_RXDMA


### PR DESCRIPTION
## Summary

Use CONFIG_STM32_UART8_SERIALDRIVER so g_uart8rxbuffer and g_uart8txbuffer are compiled when UART8 is enabled.

## Impact

RELEASE

## Testing

CI