### PR TITLE
arch/arm64: remove stale pgalloc sources from CMake build

### DIFF
--- a/arch/arm64/src/common/CMakeLists.txt
+++ b/arch/arm64/src/common/CMakeLists.txt
@@ -117,13 +117,6 @@ if(CONFIG_ARCH_ADDRENV)
   endif()
 endif()
 
-if(CONFIG_MM_PGALLOC)
-  list(APPEND SRCS arm64_physpgaddr.c)
-  if(CONFIG_ARCH_PGPOOL_MAPPING)
-    list(APPEND SRCS arm64_virtpgaddr.c)
-  endif()
-endif()
-
 if(CONFIG_ARCH_FPU)
   list(APPEND SRCS arm64_fpu.c)
   list(APPEND SRCS arm64_fpu_func.S)


### PR DESCRIPTION

## Summary

The CMake build referenced arm64_physpgaddr.c and arm64_virtpgaddr.c, which no longer exist (consolidated into arm64_pgalloc.c, already listed).

## Impact

fix kernel build with cmake for arm64

## Testing

kernel build with cmake for arm64 with NTFC
