### PR TITLE
drivers/eeprom: add 24CW160 support

### DIFF
--- a/drivers/eeprom/i2c_xx24xx.c
+++ b/drivers/eeprom/i2c_xx24xx.c
@@ -41,6 +41,11 @@
  *              24xx1025  131072    128   2     1010PAA Special case: address
  *                                                      bit is shifted.
  *              24xx1026  131072    128   2     1010AAP
+ *              24CM02    262144    256   2     1010APP
+ *              24CW160     2048     32   2     1010AAA Not a 24xx16
+ *                                                      variant: 24CW uses
+ *                                                      2-byte addressing
+ *                                                      and 32-byte pages.
  *
  * Atmel
  *              AT24C01      128     8    1     1010AAA
@@ -214,6 +219,9 @@ static const struct ee24xx_geom_s g_ee24xx_devices[] =
   {
     11, 5, 2, 2, 0
   }, /* AT24CM02  262144  256     2 */
+  {
+    4, 2, 2, 0, 0
+  }, /* 24CW160     2048   32     2 */
 
   /* STM devices */
 

--- a/include/nuttx/eeprom/eeprom.h
+++ b/include/nuttx/eeprom/eeprom.h
@@ -132,6 +132,7 @@ enum eeprom_24xx_e
   EEPROM_24XX1025,
   EEPROM_24XX1026,
   EEPROM_24CM02,
+  EEPROM_24CW160,
 
   /* Atmel geometries - none... */
 


### PR DESCRIPTION

## Summary

Add support for the Microchip 24CW160 (2048B, 32-byte pages, 2-byte data address)

## Impact

new feature

## Testing

tested with Nordic Power Kit 2 (based on nrf52840 with on-board eeprom)
