### PR TITLE
arch/nrf52/nrf53/nrf91: allow zero-length I2C transfers

### DIFF
--- a/arch/arm/src/nrf52/nrf52_i2c.c
+++ b/arch/arm/src/nrf52/nrf52_i2c.c
@@ -358,10 +358,12 @@ static int nrf52_i2c_transfer(struct i2c_master_s *dev,
             }
 #endif
 
-          /* Write TXD data pointer */
+          /* Write TXD data pointer. Zero-length transfers (used for bus
+           * scanning) never access the buffer, so any pointer is valid.
+           */
 
           regval = (uint32_t)priv->ptr;
-          DEBUGASSERT(nrf52_easydma_valid(regval));
+          DEBUGASSERT(priv->dcnt == 0 || nrf52_easydma_valid(regval));
           nrf52_i2c_putreg(priv, NRF52_TWIM_TXDPTR_OFFSET, regval);
 
           /* Write number of bytes in TXD buffer */
@@ -380,10 +382,12 @@ static int nrf52_i2c_transfer(struct i2c_master_s *dev,
         }
       else
         {
-          /* Write RXD data pointer */
+          /* Write RXD data pointer. Zero-length transfers (used for bus
+           * scanning) never access the buffer, so any pointer is valid.
+           */
 
           regval = (uint32_t)priv->ptr;
-          DEBUGASSERT(nrf52_easydma_valid(regval));
+          DEBUGASSERT(priv->dcnt == 0 || nrf52_easydma_valid(regval));
           nrf52_i2c_putreg(priv, NRF52_TWIM_RXDPTR_OFFSET, regval);
 
           /* Write number of bytes in RXD buffer */

--- a/arch/arm/src/nrf53/nrf53_i2c.c
+++ b/arch/arm/src/nrf53/nrf53_i2c.c
@@ -408,10 +408,12 @@ static int nrf53_i2c_transfer(struct i2c_master_s *dev,
             }
 #endif
 
-          /* Write TXD data pointer */
+          /* Write TXD data pointer. Zero-length transfers (used for bus
+           * scanning) never access the buffer, so any pointer is valid.
+           */
 
           regval = (uint32_t)priv->ptr;
-          DEBUGASSERT(nrf53_easydma_valid(regval));
+          DEBUGASSERT(priv->dcnt == 0 || nrf53_easydma_valid(regval));
           nrf53_i2c_putreg(priv, NRF53_TWIM_TXDPTR_OFFSET, regval);
 
           /* Write number of bytes in TXD buffer */
@@ -430,10 +432,12 @@ static int nrf53_i2c_transfer(struct i2c_master_s *dev,
         }
       else
         {
-          /* Write RXD data pointer */
+          /* Write RXD data pointer. Zero-length transfers (used for bus
+           * scanning) never access the buffer, so any pointer is valid.
+           */
 
           regval = (uint32_t)priv->ptr;
-          DEBUGASSERT(nrf53_easydma_valid(regval));
+          DEBUGASSERT(priv->dcnt == 0 || nrf53_easydma_valid(regval));
           nrf53_i2c_putreg(priv, NRF53_TWIM_RXDPTR_OFFSET, regval);
 
           /* Write number of bytes in RXD buffer */

--- a/arch/arm/src/nrf91/nrf91_i2c.c
+++ b/arch/arm/src/nrf91/nrf91_i2c.c
@@ -408,10 +408,12 @@ static int nrf91_i2c_transfer(struct i2c_master_s *dev,
             }
 #endif
 
-          /* Write TXD data pointer */
+          /* Write TXD data pointer. Zero-length transfers (used for bus
+           * scanning) never access the buffer, so any pointer is valid.
+           */
 
           regval = (uint32_t)priv->ptr;
-          DEBUGASSERT(nrf91_easydma_valid(regval));
+          DEBUGASSERT(priv->dcnt == 0 || nrf91_easydma_valid(regval));
           nrf91_i2c_putreg(priv, NRF91_TWIM_TXDPTR_OFFSET, regval);
 
           /* Write number of bytes in TXD buffer */
@@ -430,10 +432,12 @@ static int nrf91_i2c_transfer(struct i2c_master_s *dev,
         }
       else
         {
-          /* Write RXD data pointer */
+          /* Write RXD data pointer. Zero-length transfers (used for bus
+           * scanning) never access the buffer, so any pointer is valid.
+           */
 
           regval = (uint32_t)priv->ptr;
-          DEBUGASSERT(nrf91_easydma_valid(regval));
+          DEBUGASSERT(priv->dcnt == 0 || nrf91_easydma_valid(regval));
           nrf91_i2c_putreg(priv, NRF91_TWIM_RXDPTR_OFFSET, regval);
 
           /* Write number of bytes in RXD buffer */


### PR DESCRIPTION
## Summary
Allow zero-length I2C transfers when DEBUGASSERT is enabled.

Zero-length transfers (used for I2C bus scanning) never access the transfer buffer, so any EasyDMA pointer is valid.

`i2c dev -z` command is still broken for nordic chips, but at least it doesn't crash.

## Impact
bugfix

## Testing
I2C bus scan on Nordic Power Kit 2
