### PR TITLE
net/igmp: fix length check that always dropped valid IGMP packets

### DIFF
--- a/net/igmp/igmp_input.c
+++ b/net/igmp/igmp_input.c
@@ -131,7 +131,7 @@ void igmp_input(struct net_driver_s *dev)
 
   /* Verify the message length */
 
-  if (dev->d_len < NET_LL_HDRLEN(dev) + (iphdrlen + IGMP_HDRLEN))
+  if (dev->d_len < iphdrlen + IGMP_HDRLEN)
     {
       IGMP_STATINCR(g_netstats.igmp.length_errors);
       nwarn("WARNING: Length error\n");


### PR DESCRIPTION
## Summary

`igmp_input()` dropped every well-formed IGMP packet due to a wrong
length check. Fix by aligning the check with the `dev->d_len` semantic
used by the rest of the IPv4 stack.

## Root Cause

The check was:

    if (dev->d_len < NET_LL_HDRLEN(dev) + (iphdrlen + IGMP_HDRLEN))

However, by the time transport handlers are called from `ipv4_in()`,
`dev->d_len` already holds the IPv4 total length (IP header + payload)
**without** the link-layer header:

- `ipv4_in()` runs `dev->d_len -= NET_LL_HDRLEN(dev);` first
- `ipv4_in()` then trims to `totlen` from the IPv4 header (`dev->d_len = totlen`)
- `ipv6_in()` follows the same convention
- `icmp_input()`, `tcp_ipv4_input()`, `udp_ipv4_input()` never reference
  `NET_LL_HDRLEN` — they all treat `dev->d_len` as the IP-layer length

Adding `NET_LL_HDRLEN(dev)` to the right-hand side made the check always
true for valid IGMP packets:

    iphdrlen + IGMP_HDRLEN < NET_LL_HDRLEN + iphdrlen + IGMP_HDRLEN
                           (i.e. 0 < NET_LL_HDRLEN)

So every valid IGMP message hit the "Length error" path and was silently
dropped, breaking IGMP membership query/report processing.

## Fix

Drop the extra `NET_LL_HDRLEN(dev)`:

    if (dev->d_len < iphdrlen + IGMP_HDRLEN)

This matches the convention used by `icmp_input()`, `tcp_ipv4_input()`,
and `udp_ipv4_input()`.

## Impact

- Fixes a regression that silently dropped all valid incoming IGMP
  packets (membership queries and reports).
- No impact on ICMP/TCP/UDP input paths: they never reference
  `NET_LL_HDRLEN` and are unaffected by this change.
- No impact on `ipv4_input.c` / `ipv6_input.c`: `dev->d_len` semantic is
  unchanged.

## Testing

- Code review confirms the `dev->d_len` convention across the stack
  (`ipv4_in`, `ipv6_in`, `icmp_input`, `tcp_ipv4_input`,
  `udp_ipv4_input`, `igmp_send`).
- Verify with `CONFIG_NET_IGMP=y`: IGMP membership query/report packets
  are now accepted instead of being dropped with "Length error".