### PR TITLE
{bp-19714} net/igmp: fix length check that always dropped valid IGMP packets

### DIFF
--- a/net/igmp/igmp_input.c
+++ b/net/igmp/igmp_input.c
@@ -131,7 +131,7 @@ void igmp_input(struct net_driver_s *dev)
 
   /* Verify the message length */
 
-  if (dev->d_len < NET_LL_HDRLEN(dev) + (iphdrlen + IGMP_HDRLEN))
+  if (dev->d_len < iphdrlen + IGMP_HDRLEN)
     {
       IGMP_STATINCR(g_netstats.igmp.length_errors);
       nwarn("WARNING: Length error\n");


### PR DESCRIPTION
## Summary

igmp_input() verified the packet length with:

  if (dev->d_len < NET_LL_HDRLEN(dev) + (iphdrlen + IGMP_HDRLEN))

but dev->d_len at this point holds the IPv4 total length (IP header plus payload) without the link-layer header, consistent with the convention established in ipv4_in()/ipv6_in() (which do `dev->d_len -= NET_LL_HDRLEN(dev)`) and used by all other transport input handlers (icmp, tcp, udp), none of which reference NET_LL_HDRLEN.

Adding NET_LL_HDRLEN(dev) to the right-hand side made the check always true for valid IGMP packets:

  iphdrlen + IGMP_HDRLEN < NET_LL_HDRLEN + iphdrlen + IGMP_HDRLEN
                         (= 0 < NET_LL_HDRLEN)

so every well-formed IGMP message hit the "Length error" path and was silently dropped, breaking IGMP membership query/report processing.

Drop the extra NET_LL_HDRLEN(dev) so the check matches the other protocol handlers.

## Impact

RELEASE

## Testing

CI