### PR TITLE
arch/risc-v: fix uninitialized HW cmds and bus clock

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_i2c.c
+++ b/arch/risc-v/src/common/espressif/esp_i2c.c
@@ -563,19 +563,24 @@ static void esp_i2c_sendstart(struct esp_i2c_priv_s *priv)
 {
   struct i2c_msg_s *msg = &priv->msgv[priv->msgid];
   uint32_t fifo_val = 0;
-  i2c_ll_hw_cmd_t restart_cmd;
-  i2c_ll_hw_cmd_t write_cmd;
-  i2c_ll_hw_cmd_t end_cmd;
+  i2c_ll_hw_cmd_t restart_cmd =
+    {
+      .op_code = I2C_LL_CMD_RESTART
+    };
+
+  i2c_ll_hw_cmd_t write_cmd =
+    {
+      .byte_num = 1,
+      .ack_en = 1,
+      .op_code = I2C_LL_CMD_WRITE
+    };
+
+  i2c_ll_hw_cmd_t end_cmd =
+    {
+      .op_code = I2C_LL_CMD_END
+    };
 
   /* Write I2C command registers */
-
-  restart_cmd.op_code = I2C_LL_CMD_RESTART;
-
-  write_cmd.byte_num = 1;
-  write_cmd.ack_en = 1;
-  write_cmd.op_code = I2C_LL_CMD_WRITE;
-
-  end_cmd.op_code = I2C_LL_CMD_END;
 
   i2c_ll_master_write_cmd_reg(priv->ctx->dev, restart_cmd, 0);
   i2c_ll_master_write_cmd_reg(priv->ctx->dev, write_cmd, 1);
@@ -688,8 +693,15 @@ static void esp_i2c_startrecv(struct esp_i2c_priv_s *priv)
   int ack_value = 0;
   struct i2c_msg_s *msg = &priv->msgv[priv->msgid];
   int n = msg->length - priv->bytes;
-  i2c_ll_hw_cmd_t read_cmd;
-  i2c_ll_hw_cmd_t end_cmd;
+  i2c_ll_hw_cmd_t read_cmd =
+    {
+      0
+    };
+
+  i2c_ll_hw_cmd_t end_cmd =
+    {
+      0
+    };
 
   if (n > 1)
     {
@@ -780,7 +792,7 @@ static void esp_i2c_init_clock(struct esp_i2c_priv_s *priv,
 
   I2C_CLOCK_SRC_ATOMIC()
     {
-      i2c_hal_set_bus_timing(priv->ctx, priv->config->clk_freq,
+      i2c_hal_set_bus_timing(priv->ctx, bus_freq,
                              priv->clk_src, src_clk_frequency);
     }
 


### PR DESCRIPTION
## Summary

<!-- This field should contain a summary of the changes. It will be pre-filled with the commit's message and descriptions. Adjust it accordingly -->

* espressif/i2c: fix uninitialized HW cmds and per-transfer bus clock

Initialize i2c_ll_hw_cmd_t in sendstart/startrecv so ack_exp/done are not left with stack garbage that can NACK
or skip the address byte. Program i2c_hal_set_bus_timing() with the requested bus_freq instead of
the board default so msg frequency is applied.

Co-authored-by: Cursor <cursoragent@cursor.com>
Signed-off-by: Filipe Cavalcanti <filipe.cavalcanti@espressif.com>

## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: Yes, fix possible corruption in I2C communication.
<!-- Does it impact user's applications? How? -->

Impact on build: No.
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: Only RISC-V Espressif devices.
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: No.
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: No.
<!-- Does it impact NuttX's security? -->

Impact on compatibility: No.
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

### AI Disclaimer
AI was used to find source of bug. Verified and tested on hardware by myself.

## Testing
Tested on heavily populated I2C bus on `esp32p4-tab5` board.
Fixed some random issues during I2C devices initialization.

- **Before the fix:** I2C would initialize some devices but not others, occasionally sending wrong start/stop on the bus.
```
Failed to register ST7123: -5
i2c: 0x4ff06208 10
Failed to init touch screen controller: -5
```
<img width="887" height="237" alt="image" src="https://github.com/user-attachments/assets/88bc6d56-b234-4fdd-a0eb-e7d85c1d143b" />


- **After the fix:** I2C bus properly talks to device.
<img width="1088" height="233" alt="image" src="https://github.com/user-attachments/assets/dfc2bd87-1f9d-432a-aa1d-feb6e155c1be" />
