### PR TITLE
net/igmp: fix checksum validation that always dropped valid IGMP packets

### DIFF
--- a/net/igmp/igmp_input.c
+++ b/net/igmp/igmp_input.c
@@ -141,7 +141,7 @@ void igmp_input(struct net_driver_s *dev)
 #ifdef CONFIG_NET_IGMP_CHECKSUMS
   /* Calculate and check the IGMP checksum */
 
-  if (net_chksum((FAR uint16_t *)igmp, IGMP_HDRLEN) != 0)
+  if (net_chksum((FAR uint16_t *)igmp, IGMP_HDRLEN) != 0xffff)
     {
       IGMP_STATINCR(g_netstats.igmp.chksum_errors);
       nwarn("WARNING: Checksum error\n");


### PR DESCRIPTION
## Summary

`igmp_input()` rejected every well-formed IGMP packet as a checksum error because the validation compared `net_chksum()` against `0` instead of `0xffff`. This breaks IGMP membership query/report processing entirely whenever `CONFIG_NET_IGMP_CHECKSUMS` is enabled.

## Problem

In `net/igmp/igmp_input.c`, the IGMP checksum was validated as:

```c
#ifdef CONFIG_NET_IGMP_CHECKSUMS
  if (net_chksum((FAR uint16_t *)igmp, IGMP_HDRLEN) != 0)
    {
      IGMP_STATINCR(g_netstats.igmp.chksum_errors);
      nwarn("WARNING: Checksum error\n");
      goto drop;
    }
#endif
```

With `CONFIG_NET_IGMP_CHECKSUMS` enabled, every valid IGMP message hits the `goto drop` path and is silently discarded, so the host never answers Membership Queries and never processes Membership Reports from neighbors.

## Root Cause

`net_chksum()` (in `net/utils/net_chksum.c`) returns the **raw one's complement sum** of all 16-bit words over the buffer — it does **not** take the one's complement of that sum:

```c
uint16_t net_chksum(FAR uint16_t *data, uint16_t len)
{
  return HTONS(chksum(0, (uint8_t *)data, len));
}
```

For a valid IGMP packet, the sender (`net/igmp/igmp_send.c`) stores `igmp->chksum = ~igmp_chksum(...)`. Let `S` be the one's complement sum of the header with the checksum field zeroed. The received packet therefore contains `~S` in the checksum field, and summing all 16-bit words yields:

````
S + ~S = 0xffff   (one's complement arithmetic)
````

So the correct validation is `!= 0xffff`, not `!= 0`. The old check `!= 0` is true for every legal IGMP packet (it can only be 0 in the degenerate case where the sum is exactly 0), so all valid packets were dropped.

This is the same Internet checksum principle used by IPv4 (RFC 1071) and TCP/UDP.

## Fix

Compare against `0xffff`:

```c
  if (net_chksum((FAR uint16_t *)igmp, IGMP_HDRLEN) != 0xffff)
```

## Consistency

This matches the convention already used by the other transport input handlers in the tree:

- `net/devif/ipv4_input.c` — `(ipv4_chksum(IPv4BUF) != 0xffff)`
- `net/tcp/tcp_input.c`   — `(tcp_chksum(dev) != 0xffff)`

and is symmetric with the sender side in `net/igmp/igmp_send.c`, which writes `igmp->chksum = ~igmp_chksum(...)`.

## Impact

- **Bug fix only**, no behavioral change for malformed packets (they still go to `goto drop`).
- Restores IGMP receive path when `CONFIG_NET_IGMP_CHECKSUMS=y`: Membership Queries now correctly trigger the delaying-member state machine, and Membership Reports correctly cancel the report timer.
- No impact when `CONFIG_NET_IGMP_CHECKSUMS` is disabled (the block is compiled out).
- Related to the earlier fix `f11df565` ("net/igmp: fix length check that always dropped valid IGMP packets") — together they restore a fully broken IGMP input path.

## Testing

Verified by inspection against `net_chksum()` semantics and cross-checked with `ipv4_input.c` / `tcp_input.c`. Code path is gated behind `CONFIG_NET_IGMP_CHECKSUMS` so the default build is unchanged.