### PR TITLE
arch/arm: Fix FlexCAN config initializers clobbering rx_pin instead of enable_high

### DIFF
--- a/arch/arm/src/kinetis/kinetis_flexcan.c
+++ b/arch/arm/src/kinetis/kinetis_flexcan.c
@@ -268,11 +268,11 @@ static const struct flexcan_config_s kinetis_flexcan2_config =
   .tx_pin    = PIN_CAN2_TX,
   .rx_pin    = PIN_CAN2_RX,
 #ifdef PIN_CAN2_ENABLE
-  .enable_pin = PIN_CAN2_ENABLE,
-  .rx_pin     = CAN2_ENABLE_HIGH,
+  .enable_pin  = PIN_CAN2_ENABLE,
+  .rx_pin      = CAN2_ENABLE_OUT,
 #else
-  .enable_pin = 0,
-  .rx_pin     = 0,
+  .enable_pin  = 0,
+  .enable_high = 0,
 #endif
   .bus_irq   = KINETIS_IRQ_CAN2_BUS,
   .error_irq = KINETIS_IRQ_CAN2_ERROR,

--- a/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
+++ b/arch/arm/src/s32k1xx/s32k1xx_flexcan.c
@@ -273,11 +273,11 @@ static const struct flexcan_config_s s32k1xx_flexcan2_config =
   .tx_pin    = PIN_CAN2_TX,
   .rx_pin    = PIN_CAN2_RX,
 #ifdef PIN_CAN2_ENABLE
-  .enable_pin = PIN_CAN2_ENABLE,
-  .rx_pin     = CAN2_ENABLE_HIGH,
+  .enable_pin  = PIN_CAN2_ENABLE,
+  .rx_pin      = CAN2_ENABLE_OUT,
 #else
-  .enable_pin = 0,
-  .rx_pin     = 0,
+  .enable_pin  = 0,
+  .enable_high = 0,
 #endif
   .bus_irq   = S32K1XX_IRQ_CAN2_BUS,
   .error_irq = S32K1XX_IRQ_CAN2_ERROR,

--- a/arch/arm/src/s32k3xx/s32k3xx_flexcan.c
+++ b/arch/arm/src/s32k3xx/s32k3xx_flexcan.c
@@ -305,11 +305,11 @@ static const struct flexcan_config_s s32k3xx_flexcan2_config =
   .rx_pin    = PIN_CAN2_RX,
   .no_buffers  = 64,
 #ifdef PIN_CAN2_ENABLE
-  .enable_pin = PIN_CAN2_ENABLE,
+  .enable_pin  = PIN_CAN2_ENABLE,
   .enable_high = CAN2_ENABLE_OUT,
 #else
-  .enable_pin = 0,
-  .rx_pin     = 0,
+  .enable_pin  = 0,
+  .enable_high = 0,
 #endif
 #ifdef PIN_CAN2_STB
   .stb_pin  = PIN_CAN2_STB,


### PR DESCRIPTION
## Summary

The FlexCAN per-controller config initializers in three ARM drivers contain a
copy-paste defect: inside the CAN2 (and, on S32K3XX, CAN3) blocks a second
`.rx_pin` designator appears where `.enable_high` was intended. C designated
initializers let a later designator for the same member silently override an
earlier one, so `.rx_pin = PIN_CANx_RX` is discarded and `.enable_high` is
never assigned at all, falling back to 0 from static zero-initialization.

## Testing

Tested locally on a S32K1 device with a CAN interface connected to it. The changes done to the other boards were not physically validated (but the error would be the same as they share the pins definition)
