### PR TITLE
docs/boards/ci20: Remove redundant mkimage command

### DIFF
--- a/Documentation/platforms/mips/jz4780/boards/mips-creator-ci20/index.rst
+++ b/Documentation/platforms/mips/jz4780/boards/mips-creator-ci20/index.rst
@@ -37,8 +37,7 @@ You can use the following command to configure the NuttX build:
   ./tools/configure.sh -l ci20/nsh
 
    make CROSSDEV=mips-mti-elf-
-   mkimage -A mips -O linux -T kernel -C none -a 0x80000180 -e 0x800004ac \
-    -n "nx" -d nuttx.bin <tftp_dir>/nuttx.umg
+   cp uImage <tftp_dir>/nuttx.umg
 
 Run this from U-Boot prompt:
 


### PR DESCRIPTION
## Summary

Remove the manual mkimage step because CONFIG_UBOOT_UIMAGE=y already generates a valid uImage. This brings the documentation up to date with the uImage usage that was already standard in practice.

## Testing

Use make autobuild to verify the documentation change.

Confirmed that nsh and jumbo configs produce working
images

NuttShell (NSH) NuttX-13.0.0
nsh> uname -a
NuttX 13.0.0 be7b5c084c Aug  6 2026 14:47:10 mips ci20
nsh> 
