### PR TITLE
arch/x86_64: align the user stack pointer when entering user space

### DIFF
--- a/arch/x86_64/src/common/x86_64_syscall.c
+++ b/arch/x86_64/src/common/x86_64_syscall.c
@@ -151,6 +151,14 @@ uint64_t *x86_64_syscall(uint64_t *regs)
           regs[REG_RSI] = arg3;
           regs[REG_RCX] = arg1;
 
+          /* Align the user stack pointer: the entry point is entered as
+           * if it was called, so the stack must be 16 byte aligned with
+           * the return address slot accounted for. Otherwise the SSE
+           * accesses generated for variadic functions fault.
+           */
+
+          regs[REG_RSP] = (regs[REG_RSP] & ~0x0f) - 8;
+
           break;
         }
 
@@ -180,6 +188,10 @@ uint64_t *x86_64_syscall(uint64_t *regs)
           regs[REG_RDI] = arg2;
           regs[REG_RSI] = arg3;
           regs[REG_RCX] = arg1;
+
+          /* Align the user stack pointer, see SYS_task_start */
+
+          regs[REG_RSP] = (regs[REG_RSP] & ~0x0f) - 8;
 
           break;
         }


### PR DESCRIPTION
## Summary

The task and pthread entry points were entered with the stack pointer left by the kernel side of the startup path, not aligned to the 16 bytes the ABI requires: applications calling a variadic function with floating point arguments crashed with a general protection exception on the first SSE store of the argument save area. Align the stack pointer when returning to user space, where the value is known.

## Impact

fix for LTP in kernel mode for intel64

## Testing

LTP in kernel mode pass for intel64