### PR TITLE
libs/libc/netdb: Size an answer header by its header, not by its union.

### DIFF
--- a/include/nuttx/net/dns.h
+++ b/include/nuttx/net/dns.h
@@ -158,6 +158,19 @@ begin_packed_struct struct dns_question_s
 
 /* The DNS answer message structure */
 
+/* The fixed part of an answer: type, class, ttl and length, before the
+ * address itself.
+ *
+ * Use this rather than sizeof(struct dns_answer_s) to test whether a
+ * response holds a whole answer header.  That structure also carries the
+ * union below, sixteen bytes once IPv6 is built, so its sizeof demands far
+ * more of the response than the header needs and wrongly rejects a
+ * trailing answer as truncated.  The address that follows is bounds
+ * checked separately, against its len field.
+ */
+
+#define DNS_ANSWER_HEADER_SIZE 10
+
 begin_packed_struct struct dns_answer_s
 {
   uint16_t type;

--- a/libs/libc/netdb/lib_dnsquery.c
+++ b/libs/libc/netdb/lib_dnsquery.c
@@ -694,13 +694,13 @@ static int dns_recv_response(int sd, FAR union dns_addr_u *addr, int naddr,
           break;
         }
 
-      /* Verify that a complete answer header (10 bytes: type, class,
-       * ttl[2], len) is available before casting to dns_answer_s.
-       * Without this check, accessing ans->ttl and ans->type/class/len
-       * would be an OOB read if fewer than 10 bytes remain.
+      /* Verify that a complete answer header is available before casting
+       * to dns_answer_s.  Without this check, accessing ans->ttl and
+       * ans->type/class/len would be an OOB read if fewer than
+       * DNS_ANSWER_HEADER_SIZE bytes remain.
        */
 
-      if (nameptr + sizeof(struct dns_answer_s) > endofbuffer)
+      if (nameptr + DNS_ANSWER_HEADER_SIZE > endofbuffer)
         {
           ret = -EILSEQ;
           nwarn("DNS answer header truncated\n");
@@ -726,11 +726,11 @@ static int dns_recv_response(int sd, FAR union dns_addr_u *addr, int naddr,
       if (ans->type  == HTONS(DNS_RECTYPE_A) &&
           ans->class == HTONS(DNS_CLASS_IN) &&
           ans->len   == HTONS(4) &&
-          nameptr + 10 + 4 <= endofbuffer)
+          nameptr + DNS_ANSWER_HEADER_SIZE + 4 <= endofbuffer)
         {
           FAR struct sockaddr_in *inaddr;
 
-          nameptr += 10 + 4;
+          nameptr += DNS_ANSWER_HEADER_SIZE + 4;
 
           ninfo("IPv4 address: %u.%u.%u.%u\n",
                 ip4_addr1(ans->u.ipv4.s_addr),
@@ -755,11 +755,11 @@ static int dns_recv_response(int sd, FAR union dns_addr_u *addr, int naddr,
       if (ans->type  == HTONS(DNS_RECTYPE_AAAA) &&
           ans->class == HTONS(DNS_CLASS_IN) &&
           ans->len   == HTONS(16) &&
-          nameptr + 10 + 16 <= endofbuffer)
+          nameptr + DNS_ANSWER_HEADER_SIZE + 16 <= endofbuffer)
         {
           FAR struct sockaddr_in6 *inaddr;
 
-          nameptr += 10 + 16;
+          nameptr += DNS_ANSWER_HEADER_SIZE + 16;
 
           ninfo("IPv6 address: %04x:%04x:%04x:%04x:%04x:%04x:%04x:%04x\n",
                 NTOHS(ans->u.ipv6.s6_addr16[0]),
@@ -785,7 +785,7 @@ static int dns_recv_response(int sd, FAR union dns_addr_u *addr, int naddr,
       else
 #endif
         {
-          nameptr = nameptr + 10 + NTOHS(ans->len);
+          nameptr = nameptr + DNS_ANSWER_HEADER_SIZE + NTOHS(ans->len);
         }
     }
 


### PR DESCRIPTION
## Summary

  * A DNS answer that sits at the end of a response is rejected as truncated,
    so an A record lookup succeeds or fails depending on how much padding the
    server happened to send after it.
  * `dns_recv_response()` in `libs/libc/netdb/lib_dnsquery.c` checks that
    enough of the response remains to hold an answer header. It sized that
    check with `sizeof(struct dns_answer_s)`, but that structure is the
    10-byte header plus a union holding the largest address it can carry.
    With IPv6 built the union is 16 bytes, so the check demanded 26 bytes
    where 10 were needed.
  * The header size is now a named constant, `DNS_ANSWER_HEADER_SIZE`, beside
    the structure in `include/nuttx/net/dns.h`. The rest of this function
    already used the literal 10 for the same quantity.
  * Only IPv4-only builds escaped it: there `sizeof` happens to equal 14, and
    an A record supplies exactly 14 bytes.
  * No related issue filed.

## Impact

  * Is new feature added? Is existing feature changed? **NO.** Bug fix only.
  * Impact on user? **YES, positive.** Lookups that previously returned only
    the AAAA record, or nothing, now return the A record too. No API change,
    no configuration change.
  * Impact on build? **NO.**
  * Impact on hardware? **NO.** Architecture-independent libc code.
  * Impact on documentation? **NO.**
  * Impact on security? **Worth a note.** The check is a bounds check and this
    lowers the threshold from 26 bytes to 10. That is the correct bound: 10 is
    `sizeof` the header fields actually dereferenced at that point
    (`type`, `class`, `ttl`, `len`), and the variable-length address that
    follows is bounds checked separately, further down, against its own `len`
    field. No read is widened.
  * Impact on compatibility? **NO.** IPv4-only builds see no behavioural
    change.
  * Anything else? The old bound was not merely conservative, it was
    inconsistent: the surrounding code already advances by the literal 10.

## Testing

  I confirm that changes are verified on local setup and works as intended:

  * Build Host: macOS 26.5.1, arm64 (Apple Silicon), xPack riscv-none-elf-gcc
    15.2.0
  * Target: RISC-V, ESWIN EIC7700X EVB (downstream board port, not yet
    upstream), kernel build, IPv4+IPv6 enabled

  Reproduce by querying a server that returns a bare answer with no authority
  or additional records, so the answer is last in the packet:

  ```
  $ dig +noedns @10.1.1.2 github.com A      # ANSWER 1, AUTHORITY 0, ADDITIONAL 0
      -> answer is last in the packet, 14 bytes remain, rejected

  $ dig +noedns @10.11.5.254 github.com A   # ANSWER 1, AUTHORITY 13, ADDITIONAL 7
      -> 26+ bytes remain, accepted
  ```

  Testing logs before change:

  ```
  nsh> nslookup apache.org
  [CPU1] dns_recv_response: DNS answer header truncated
  Host: apache.org Addr: 2a04:4e42::644
  ```

  The AAAA record arrives; the A record is discarded.

  Testing logs after change:

  ```
  nsh> nslookup apache.org
  Host: apache.org Addr: 2a04:4e42::644
  Host: apache.org Addr: 151.101.2.132
  ```

## PR verification Self-Check

  * [x] This PR introduces only one functional change.
  * [x] I have updated all required description fields above.
  * [x] My PR adheres to Contributing Guidelines and Documentation.
  * [ ] My PR is still work in progress (not ready for review).
  * [x] My PR is ready for review and can be safely merged into a codebase.

---

*Claude (claude-opus-5) assisted with diagnosing this bug and with authoring the
code comment and this PR description. The commit carries an `Assisted-by:` tag
per [CONTRIBUTING.md](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md) §1.5.*
