### PR TITLE
drivers/analog: add MCP445X potentiometer support

### DIFF
--- a/Documentation/components/drivers/character/analog/index.rst
+++ b/Documentation/components/drivers/character/analog/index.rst
@@ -26,4 +26,5 @@ The NuttX analog drivers are split into two parts:
 
   adc/index.rst
   dac/index.rst
+  pot/index.rst
 

--- a/Documentation/components/drivers/character/analog/pot/index.rst
+++ b/Documentation/components/drivers/character/analog/pot/index.rst
@@ -1,0 +1,63 @@
+======================
+Digital Potentiometers
+======================
+
+The digital potentiometer driver is split into an "upper half" character
+driver (``drivers/analog/pot.c``) and chip-specific "lower half" drivers.
+The application interface is defined in ``include/nuttx/analog/pot.h``.
+
+Device model
+============
+
+A potentiometer is modeled as a set of wipers, each with a position in
+``[0, max]``. Optional capabilities are advertised in ``pot_info_s.caps``
+so applications can discover what a given chip supports instead of
+probing commands:
+
+- ``POT_CAP_READBACK`` - wiper position can be read back
+- ``POT_CAP_MOVE`` - relative wiper move (the only interface available on
+  up/down-pin devices without readback, e.g. Renesas X9C10x)
+- ``POT_CAP_ENABLE`` - wiper enable/shutdown
+- ``POT_CAP_NV`` - non-volatile wiper store/recall
+
+If ``pot_info_s.rab`` (terminal A-B resistance in ohms) is non-zero, the
+wiper resistance is ``ohms = val * rab / max``. The value is supplied by
+board logic to the lower half initializer, since the resistance variant
+of a chip is not runtime-discoverable.
+
+Application interface
+=====================
+
+All commands take a pointer argument. Optional commands return
+``-ENOTSUP`` when the lower half does not implement them.
+
+======================== ========================== =====================
+IOCTL                    Argument                   Description
+======================== ========================== =====================
+``POTIOC_GET_INFO``      ``struct pot_info_s *``    Device properties
+``POTIOC_SET_WIPER``     ``struct pot_wiper_s *``   Set wiper position
+``POTIOC_GET_WIPER``     ``struct pot_wiper_s *``   Get wiper position
+``POTIOC_MOVE_WIPER``    ``struct pot_move_s *``    Move wiper by signed
+                                                    number of steps
+``POTIOC_SET_ENABLE``    ``struct pot_enable_s *``  Enable or shut down
+                                                    a wiper
+``POTIOC_STORE_WIPER``   ``struct pot_nv_s *``      Store wiper to a
+                                                    non-volatile slot
+``POTIOC_RECALL_WIPER``  ``struct pot_nv_s *``      Recall wiper from a
+                                                    non-volatile slot
+======================== ========================== =====================
+
+Vendor-specific features (e.g. per-terminal switches, register access,
+wiper lock) are not part of the common interface: lower halves expose
+them through chip-specific ioctl commands forwarded via ``po_ioctl``.
+
+Supported chips
+===============
+
+========== ===== ====================================================
+Chip       Bus   Notes
+========== ===== ====================================================
+MCP445X    I2C   Quad wiper, 257 taps. Terminal control via the
+                 ``ANIOC_MCP445X_*`` ioctls, see
+                 ``include/nuttx/analog/mcp445x.h``.
+========== ===== ====================================================

--- a/drivers/analog/CMakeLists.txt
+++ b/drivers/analog/CMakeLists.txt
@@ -69,6 +69,13 @@ endif()
 if(CONFIG_POT)
   # Include the common POT character driver
   list(APPEND SRCS pot.c)
+
+  # Include POT device drivers
+
+  if(CONFIG_POT_MCP445X)
+    list(APPEND SRCS mcp445x.c)
+  endif()
+
 endif()
 
 # Check for ADC devices

--- a/drivers/analog/CMakeLists.txt
+++ b/drivers/analog/CMakeLists.txt
@@ -64,6 +64,13 @@ if(CONFIG_OPAMP)
   list(APPEND SRCS opamp.c)
 endif()
 
+# Check for POT devices
+
+if(CONFIG_POT)
+  # Include the common POT character driver
+  list(APPEND SRCS pot.c)
+endif()
+
 # Check for ADC devices
 
 if(CONFIG_ADC)

--- a/drivers/analog/Kconfig
+++ b/drivers/analog/Kconfig
@@ -486,6 +486,16 @@ config MCP48XX_SPI_FREQUENCY
 
 endif # DAC
 
+config POT
+	bool "Digital Potentiometer"
+	default n
+	---help---
+		Select to enable support for digital potentiometers.
+
+if POT
+
+endif # POT
+
 config OPAMP
 	bool "Operational Amplifier"
 	default n

--- a/drivers/analog/Kconfig
+++ b/drivers/analog/Kconfig
@@ -494,6 +494,19 @@ config POT
 
 if POT
 
+config POT_MCP445X
+	bool "MCP445X support"
+	default n
+	select I2C
+	---help---
+		Enable driver support for the Microchip MCP4451 quad digital
+		potentiometer.
+
+config POT_MCP445X_I2C_FREQUENCY
+	int "MCP445X I2C frequency"
+	default 400000
+	depends on POT_MCP445X
+
 endif # POT
 
 config OPAMP

--- a/drivers/analog/Make.defs
+++ b/drivers/analog/Make.defs
@@ -82,6 +82,12 @@ ifeq ($(CONFIG_POT),y)
 
 CSRCS += pot.c
 
+# Include POT device drivers
+
+ifeq ($(CONFIG_POT_MCP445X),y)
+  CSRCS += mcp445x.c
+endif
+
 endif
 
 # Check for ADC devices

--- a/drivers/analog/Make.defs
+++ b/drivers/analog/Make.defs
@@ -74,6 +74,16 @@ CSRCS += opamp.c
 
 endif
 
+# Check for POT devices
+
+ifeq ($(CONFIG_POT),y)
+
+# Include the common POT character driver
+
+CSRCS += pot.c
+
+endif
+
 # Check for ADC devices
 
 ifeq ($(CONFIG_ADC),y)
@@ -152,6 +162,12 @@ ifeq ($(CONFIG_OPAMP),y)
   DEPPATH += --dep-path analog
   VPATH += :analog
   CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)drivers$(DELIM)analog
+else
+ifeq ($(CONFIG_POT),y)
+  DEPPATH += --dep-path analog
+  VPATH += :analog
+  CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)drivers$(DELIM)analog
+endif
 endif
 endif
 endif

--- a/drivers/analog/mcp445x.c
+++ b/drivers/analog/mcp445x.c
@@ -1,0 +1,542 @@
+/****************************************************************************
+ * drivers/analog/mcp445x.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <stdbool.h>
+#include <assert.h>
+#include <errno.h>
+#include <nuttx/debug.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/kmalloc.h>
+#include <nuttx/analog/pot.h>
+#include <nuttx/analog/mcp445x.h>
+#include <nuttx/i2c/i2c_master.h>
+
+/****************************************************************************
+ * Preprocessor definitions
+ ****************************************************************************/
+
+/* MCP445X commands */
+
+#define MCP445X_CMD_SHIFT    (2)
+#define MCP445X_CMD_MASK     (3u << MCP445X_CMD_SHIFT)
+#define MCP445X_CMD_WRITE    (0u << MCP445X_CMD_SHIFT)
+#define MCP445X_CMD_INCR     (1u << MCP445X_CMD_SHIFT)
+#define MCP445X_CMD_DECR     (2u << MCP445X_CMD_SHIFT)
+#define MCP445X_CMD_READ     (3u << MCP445X_CMD_SHIFT)
+
+#define MCP445X_REG_SHIFT    (4)
+#define MCP445X_DATA_MASK    (0x1ffu)
+
+/* Register map */
+
+#define MCP445X_REG_WIPER0   (0x00)  /* Volatile Wiper 0 */
+#define MCP445X_REG_WIPER1   (0x01)  /* Volatile Wiper 1 */
+#define MCP445X_REG_TCON0    (0x04)  /* Volatile TCON0 (Wipers 0-1) */
+#define MCP445X_REG_STATUS   (0x05)  /* Status */
+#define MCP445X_REG_WIPER2   (0x06)  /* Volatile Wiper 2 */
+#define MCP445X_REG_WIPER3   (0x07)  /* Volatile Wiper 3 */
+#define MCP445X_REG_TCON1    (0x0a)  /* Volatile TCON1 (Wipers 2-3) */
+
+#define MCP445X_NWIPERS      (4)
+
+/* Wiper full scale (8-bit devices, 257 taps) */
+
+#define MCP445X_WIPER_MAX    (0x100)
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+struct mcp445x_dev_s
+{
+  FAR struct i2c_master_s *i2c;  /* I2C interface */
+  uint8_t addr;                  /* I2C address */
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/* I2C Helpers */
+
+static int  mcp445x_reg_write(FAR struct mcp445x_dev_s *priv, uint8_t reg,
+                              uint16_t val);
+static int  mcp445x_reg_read(FAR struct mcp445x_dev_s *priv, uint8_t reg,
+                             FAR uint16_t *val);
+
+/* Potentiometer methods */
+
+static int  mcp445x_setup(FAR struct pot_dev_s *dev);
+static void mcp445x_shutdown(FAR struct pot_dev_s *dev);
+static int  mcp445x_setwiper(FAR struct pot_dev_s *dev, uint8_t wiper,
+                             uint32_t val);
+static int  mcp445x_getwiper(FAR struct pot_dev_s *dev, uint8_t wiper,
+                             FAR uint32_t *val);
+static int  mcp445x_move(FAR struct pot_dev_s *dev, uint8_t wiper,
+                         int32_t steps);
+static int  mcp445x_enable(FAR struct pot_dev_s *dev, uint8_t wiper,
+                           bool enable);
+static int  mcp445x_settcon(FAR struct pot_dev_s *dev, uint8_t wiper,
+                            uint8_t flags);
+static int  mcp445x_gettcon(FAR struct pot_dev_s *dev, uint8_t wiper,
+                            FAR uint8_t *flags);
+static int  mcp445x_ioctl(FAR struct pot_dev_s *dev, int cmd,
+                          unsigned long arg);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/* Volatile wiper register for a given wiper index */
+
+static const uint8_t g_mcp445x_wiper_reg[MCP445X_NWIPERS] =
+{
+  MCP445X_REG_WIPER0,
+  MCP445X_REG_WIPER1,
+  MCP445X_REG_WIPER2,
+  MCP445X_REG_WIPER3
+};
+
+static const struct pot_ops_s g_potops =
+{
+  mcp445x_setup,        /* po_setup */
+  mcp445x_shutdown,     /* po_shutdown */
+  mcp445x_setwiper,     /* po_setwiper */
+  mcp445x_getwiper,     /* po_getwiper */
+  mcp445x_move,         /* po_move */
+  mcp445x_enable,       /* po_enable */
+  NULL,                 /* po_store */
+  NULL,                 /* po_recall */
+  mcp445x_ioctl         /* po_ioctl */
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: mcp445x_reg_write
+ *
+ * Description:
+ *   Write a 9-bit value to a MCP445X register.
+ *
+ ****************************************************************************/
+
+static int mcp445x_reg_write(FAR struct mcp445x_dev_s *priv, uint8_t reg,
+                             uint16_t val)
+{
+  struct i2c_config_s config;
+  uint8_t             buffer[2];
+
+  buffer[0] = (reg << MCP445X_REG_SHIFT) | MCP445X_CMD_WRITE |
+              ((val >> 8) & 0x01);
+  buffer[1] = val;
+
+  /* Set up the I2C configuration */
+
+  config.frequency = CONFIG_POT_MCP445X_I2C_FREQUENCY;
+  config.address   = priv->addr;
+  config.addrlen   = 7;
+
+  return i2c_write(priv->i2c, &config, buffer, 2);
+}
+
+/****************************************************************************
+ * Name: mcp445x_reg_read
+ *
+ * Description:
+ *   Read a 9-bit value from a MCP445X register.
+ *
+ ****************************************************************************/
+
+static int mcp445x_reg_read(FAR struct mcp445x_dev_s *priv, uint8_t reg,
+                            FAR uint16_t *val)
+{
+  struct i2c_config_s config;
+  uint8_t             cmd;
+  uint8_t             buffer[2];
+  int                 ret;
+
+  cmd = (reg << MCP445X_REG_SHIFT) | MCP445X_CMD_READ;
+
+  /* Set up the I2C configuration */
+
+  config.frequency = CONFIG_POT_MCP445X_I2C_FREQUENCY;
+  config.address   = priv->addr;
+  config.addrlen   = 7;
+
+  ret = i2c_writeread(priv->i2c, &config, &cmd, 1, buffer, 2);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  *val = ((uint16_t)buffer[0] << 8 | buffer[1]) & MCP445X_DATA_MASK;
+  return OK;
+}
+
+/****************************************************************************
+ * Name: mcp445x_setup
+ *
+ * Description:
+ *   Configure the potentiometer. This method is called the first time
+ *   that the potentiometer device is opened.
+ *
+ ****************************************************************************/
+
+static int mcp445x_setup(FAR struct pot_dev_s *dev)
+{
+  return OK;
+}
+
+/****************************************************************************
+ * Name: mcp445x_shutdown
+ *
+ * Description:
+ *   Disable the potentiometer. This method is called when the
+ *   potentiometer device is closed.
+ *
+ ****************************************************************************/
+
+static void mcp445x_shutdown(FAR struct pot_dev_s *dev)
+{
+}
+
+/****************************************************************************
+ * Name: mcp445x_setwiper
+ *
+ * Description:
+ *   Set a wiper value.
+ *
+ ****************************************************************************/
+
+static int mcp445x_setwiper(FAR struct pot_dev_s *dev, uint8_t wiper,
+                            uint32_t val)
+{
+  FAR struct mcp445x_dev_s *priv = dev->pd_priv;
+
+  return mcp445x_reg_write(priv, g_mcp445x_wiper_reg[wiper], val);
+}
+
+/****************************************************************************
+ * Name: mcp445x_getwiper
+ *
+ * Description:
+ *   Get a wiper value.
+ *
+ ****************************************************************************/
+
+static int mcp445x_getwiper(FAR struct pot_dev_s *dev, uint8_t wiper,
+                            FAR uint32_t *val)
+{
+  FAR struct mcp445x_dev_s *priv = dev->pd_priv;
+  uint16_t                  regval;
+  int                       ret;
+
+  ret = mcp445x_reg_read(priv, g_mcp445x_wiper_reg[wiper], &regval);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  *val = regval;
+  return OK;
+}
+
+/****************************************************************************
+ * Name: mcp445x_cmd
+ *
+ * Description:
+ *   Send a single-byte command (INCR/DECR) for a register.
+ *
+ ****************************************************************************/
+
+static int mcp445x_cmd(FAR struct mcp445x_dev_s *priv, uint8_t reg,
+                       uint8_t cmd)
+{
+  struct i2c_config_s config;
+  uint8_t             buffer;
+
+  buffer = (reg << MCP445X_REG_SHIFT) | cmd;
+
+  config.frequency = CONFIG_POT_MCP445X_I2C_FREQUENCY;
+  config.address   = priv->addr;
+  config.addrlen   = 7;
+
+  return i2c_write(priv->i2c, &config, &buffer, 1);
+}
+
+/****************************************************************************
+ * Name: mcp445x_move
+ *
+ * Description:
+ *   Move a wiper using the native INCR/DECR commands. The device stops
+ *   at full scale and at zero.
+ *
+ ****************************************************************************/
+
+static int mcp445x_move(FAR struct pot_dev_s *dev, uint8_t wiper,
+                        int32_t steps)
+{
+  FAR struct mcp445x_dev_s *priv = dev->pd_priv;
+  uint8_t                   cmd;
+  uint32_t                  n;
+  int                       ret = OK;
+
+  cmd = steps < 0 ? MCP445X_CMD_DECR : MCP445X_CMD_INCR;
+  n   = steps < 0 ? -(uint32_t)steps : (uint32_t)steps;
+
+  if (n > dev->pd_max)
+    {
+      n = dev->pd_max;
+    }
+
+  while (n-- > 0 && ret == OK)
+    {
+      ret = mcp445x_cmd(priv, g_mcp445x_wiper_reg[wiper], cmd);
+    }
+
+  return ret;
+}
+
+/****************************************************************************
+ * Name: mcp445x_enable
+ *
+ * Description:
+ *   Enable or force a wiper into shutdown via the TCON HW bit.
+ *
+ ****************************************************************************/
+
+static int mcp445x_enable(FAR struct pot_dev_s *dev, uint8_t wiper,
+                          bool enable)
+{
+  uint8_t flags;
+  int     ret;
+
+  ret = mcp445x_gettcon(dev, wiper, &flags);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  if (enable)
+    {
+      flags |= MCP445X_TCON_HW;
+    }
+  else
+    {
+      flags &= ~MCP445X_TCON_HW;
+    }
+
+  return mcp445x_settcon(dev, wiper, flags);
+}
+
+/****************************************************************************
+ * Name: mcp445x_settcon
+ *
+ * Description:
+ *   Set wiper terminal control flags. The MCP445X_TCON_* flags map
+ *   directly to the MCP445X TCON nibble (D0=B, D1=W, D2=A, D3=HW).
+ *
+ ****************************************************************************/
+
+static int mcp445x_settcon(FAR struct pot_dev_s *dev, uint8_t wiper,
+                           uint8_t flags)
+{
+  FAR struct mcp445x_dev_s *priv = dev->pd_priv;
+  uint8_t                   reg;
+  uint8_t                   shift;
+  uint16_t                  regval;
+  int                       ret;
+
+  reg   = wiper < 2 ? MCP445X_REG_TCON0 : MCP445X_REG_TCON1;
+  shift = (wiper & 1) ? 4 : 0;
+
+  ret = mcp445x_reg_read(priv, reg, &regval);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  regval &= ~(0xf << shift);
+  regval |= (flags & 0xf) << shift;
+
+  return mcp445x_reg_write(priv, reg, regval);
+}
+
+/****************************************************************************
+ * Name: mcp445x_gettcon
+ *
+ * Description:
+ *   Get wiper terminal control flags.
+ *
+ ****************************************************************************/
+
+static int mcp445x_gettcon(FAR struct pot_dev_s *dev, uint8_t wiper,
+                           FAR uint8_t *flags)
+{
+  FAR struct mcp445x_dev_s *priv = dev->pd_priv;
+  uint8_t                   reg;
+  uint8_t                   shift;
+  uint16_t                  regval;
+  int                       ret;
+
+  reg   = wiper < 2 ? MCP445X_REG_TCON0 : MCP445X_REG_TCON1;
+  shift = (wiper & 1) ? 4 : 0;
+
+  ret = mcp445x_reg_read(priv, reg, &regval);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  *flags = (regval >> shift) & 0xf;
+  return OK;
+}
+
+/****************************************************************************
+ * Name: mcp445x_ioctl
+ *
+ * Description:
+ *   Chip-specific terminal control.
+ *
+ ****************************************************************************/
+
+static int mcp445x_ioctl(FAR struct pot_dev_s *dev, int cmd,
+                         unsigned long arg)
+{
+  int ret = OK;
+
+  switch (cmd)
+    {
+      case ANIOC_MCP445X_SET_TCON:
+        {
+          FAR struct mcp445x_tcon_s *tcon =
+            (FAR struct mcp445x_tcon_s *)((uintptr_t)arg);
+
+          DEBUGASSERT(tcon != NULL);
+          if (tcon->wiper >= MCP445X_NWIPERS)
+            {
+              ret = -EINVAL;
+            }
+          else
+            {
+              ret = mcp445x_settcon(dev, tcon->wiper, tcon->flags);
+            }
+
+          break;
+        }
+
+      case ANIOC_MCP445X_GET_TCON:
+        {
+          FAR struct mcp445x_tcon_s *tcon =
+            (FAR struct mcp445x_tcon_s *)((uintptr_t)arg);
+
+          DEBUGASSERT(tcon != NULL);
+          if (tcon->wiper >= MCP445X_NWIPERS)
+            {
+              ret = -EINVAL;
+            }
+          else
+            {
+              ret = mcp445x_gettcon(dev, tcon->wiper, &tcon->flags);
+            }
+
+          break;
+        }
+
+      default:
+        {
+          ret = -ENOTTY;
+          break;
+        }
+    }
+
+  return ret;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: mcp445x_initialize
+ *
+ * Description:
+ *   Initialize a MCP445X potentiometer.
+ *
+ * Input Parameters:
+ *   i2c  - An instance of the I2C interface to communicate with the device
+ *   addr - The I2C address of the MCP445X
+ *   rab  - Terminal A-B resistance in ohms, 0 if unknown
+ *
+ * Returned Value:
+ *   Valid MCP445X device structure reference on success; a NULL on failure
+ *
+ ****************************************************************************/
+
+FAR struct pot_dev_s *mcp445x_initialize(FAR struct i2c_master_s *i2c,
+                                         uint8_t addr, uint32_t rab)
+{
+  FAR struct mcp445x_dev_s *priv;
+  FAR struct pot_dev_s *potdev;
+
+  /* Sanity check */
+
+  DEBUGASSERT(i2c != NULL);
+
+  /* Initialize the MCP445X device structure */
+
+  priv = kmm_malloc(sizeof(struct mcp445x_dev_s));
+  if (priv == NULL)
+    {
+      aerr("ERROR: Failed to allocate mcp445x_dev_s instance\n");
+      return NULL;
+    }
+
+  potdev = kmm_zalloc(sizeof(struct pot_dev_s));
+  if (potdev == NULL)
+    {
+      aerr("ERROR: Failed to allocate pot_dev_s instance\n");
+      kmm_free(priv);
+      return NULL;
+    }
+
+  potdev->pd_nwipers = MCP445X_NWIPERS;
+  potdev->pd_max     = MCP445X_WIPER_MAX;
+  potdev->pd_rab     = rab;
+  potdev->pd_ops     = &g_potops;
+  potdev->pd_priv    = priv;
+
+  priv->i2c  = i2c;
+  priv->addr = addr;
+  return potdev;
+}

--- a/drivers/analog/pot.c
+++ b/drivers/analog/pot.c
@@ -1,0 +1,422 @@
+/****************************************************************************
+ * drivers/analog/pot.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <sys/types.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <assert.h>
+#include <errno.h>
+#include <nuttx/debug.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/fs/fs.h>
+#include <nuttx/analog/pot.h>
+
+#include <nuttx/irq.h>
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static int pot_open(FAR struct file *filep);
+static int pot_close(FAR struct file *filep);
+static int pot_ioctl(FAR struct file *filep, int cmd, unsigned long arg);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+static const struct file_operations g_pot_fops =
+{
+  pot_open,                      /* open */
+  pot_close,                     /* close */
+  NULL,                          /* read */
+  NULL,                          /* write */
+  NULL,                          /* seek */
+  pot_ioctl,                     /* ioctl */
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: pot_open
+ *
+ * Description:
+ *   This function is called whenever the potentiometer device is opened.
+ *
+ ****************************************************************************/
+
+static int pot_open(FAR struct file *filep)
+{
+  FAR struct inode     *inode = filep->f_inode;
+  FAR struct pot_dev_s *dev   = inode->i_private;
+  uint8_t               tmp;
+  int                   ret;
+
+  /* If the port is the middle of closing, wait until the close is
+   * finished.
+   */
+
+  ret = nxmutex_lock(&dev->pd_closelock);
+  if (ret >= 0)
+    {
+      /* Increment the count of references to the device.  If this is the
+       * first time that the driver has been opened for this device, then
+       * initialize the device.
+       */
+
+      tmp = dev->pd_ocount + 1;
+      if (tmp == 0)
+        {
+          /* More than 255 opens; uint8_t overflows to zero */
+
+          ret = -EMFILE;
+        }
+      else
+        {
+          /* Check if this is the first time that the driver has been
+           * opened.
+           */
+
+          if (tmp == 1)
+            {
+              /* Yes.. perform one time hardware initialization. */
+
+              ret = dev->pd_ops->po_setup(dev);
+              if (ret == OK)
+                {
+                  /* Save the new open count on success */
+
+                  dev->pd_ocount = tmp;
+                }
+            }
+        }
+
+      nxmutex_unlock(&dev->pd_closelock);
+    }
+
+  return ret;
+}
+
+/****************************************************************************
+ * Name: pot_close
+ *
+ * Description:
+ *   This routine is called when the potentiometer device is closed.
+ *
+ ****************************************************************************/
+
+static int pot_close(FAR struct file *filep)
+{
+  FAR struct inode     *inode = filep->f_inode;
+  FAR struct pot_dev_s *dev   = inode->i_private;
+  int                   ret;
+
+  ret = nxmutex_lock(&dev->pd_closelock);
+  if (ret >= 0)
+    {
+      /* Decrement the references to the driver.  If the reference count
+       * will decrement to 0, then uninitialize the driver.
+       */
+
+      if (dev->pd_ocount > 1)
+        {
+          dev->pd_ocount--;
+        }
+      else
+        {
+          /* There are no more references to the port */
+
+          dev->pd_ocount = 0;
+
+          /* Disable the potentiometer device */
+
+          dev->pd_ops->po_shutdown(dev);
+        }
+
+      nxmutex_unlock(&dev->pd_closelock);
+    }
+
+  return ret;
+}
+
+/****************************************************************************
+ * Name: pot_ioctl
+ ****************************************************************************/
+
+static int pot_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
+{
+  FAR struct inode     *inode = filep->f_inode;
+  FAR struct pot_dev_s *dev   = inode->i_private;
+  int                   ret   = OK;
+
+  ret = nxmutex_lock(&dev->pd_lock);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  switch (cmd)
+    {
+      /* Get the device properties */
+
+      case POTIOC_GET_INFO:
+        {
+          FAR struct pot_info_s *info =
+            (FAR struct pot_info_s *)((uintptr_t)arg);
+
+          DEBUGASSERT(info != NULL);
+          info->nwipers = dev->pd_nwipers;
+          info->max     = dev->pd_max;
+          info->rab     = dev->pd_rab;
+          info->caps    = 0;
+
+          if (dev->pd_ops->po_getwiper)
+            {
+              info->caps |= POT_CAP_READBACK;
+            }
+
+          if (dev->pd_ops->po_move)
+            {
+              info->caps |= POT_CAP_MOVE;
+            }
+
+          if (dev->pd_ops->po_enable)
+            {
+              info->caps |= POT_CAP_ENABLE;
+            }
+
+          if (dev->pd_ops->po_store || dev->pd_ops->po_recall)
+            {
+              info->caps |= POT_CAP_NV;
+            }
+
+          break;
+        }
+
+      /* Set a wiper value */
+
+      case POTIOC_SET_WIPER:
+        {
+          FAR struct pot_wiper_s *wiper =
+            (FAR struct pot_wiper_s *)((uintptr_t)arg);
+
+          DEBUGASSERT(wiper != NULL);
+          if (wiper->wiper >= dev->pd_nwipers || wiper->val > dev->pd_max)
+            {
+              ret = -EINVAL;
+            }
+          else if (dev->pd_ops->po_setwiper == NULL)
+            {
+              ret = -ENOTSUP;
+            }
+          else
+            {
+              ret = dev->pd_ops->po_setwiper(dev, wiper->wiper, wiper->val);
+            }
+
+          break;
+        }
+
+      /* Get a wiper value */
+
+      case POTIOC_GET_WIPER:
+        {
+          FAR struct pot_wiper_s *wiper =
+            (FAR struct pot_wiper_s *)((uintptr_t)arg);
+
+          DEBUGASSERT(wiper != NULL);
+          if (wiper->wiper >= dev->pd_nwipers)
+            {
+              ret = -EINVAL;
+            }
+          else if (dev->pd_ops->po_getwiper == NULL)
+            {
+              ret = -ENOTSUP;
+            }
+          else
+            {
+              ret = dev->pd_ops->po_getwiper(dev, wiper->wiper, &wiper->val);
+            }
+
+          break;
+        }
+
+      /* Move a wiper by a number of steps */
+
+      case POTIOC_MOVE_WIPER:
+        {
+          FAR struct pot_move_s *move =
+            (FAR struct pot_move_s *)((uintptr_t)arg);
+
+          DEBUGASSERT(move != NULL);
+          if (move->wiper >= dev->pd_nwipers)
+            {
+              ret = -EINVAL;
+            }
+          else if (dev->pd_ops->po_move == NULL)
+            {
+              ret = -ENOTSUP;
+            }
+          else
+            {
+              ret = dev->pd_ops->po_move(dev, move->wiper, move->steps);
+            }
+
+          break;
+        }
+
+      /* Enable or force a wiper into shutdown */
+
+      case POTIOC_SET_ENABLE:
+        {
+          FAR struct pot_enable_s *enable =
+            (FAR struct pot_enable_s *)((uintptr_t)arg);
+
+          DEBUGASSERT(enable != NULL);
+          if (enable->wiper >= dev->pd_nwipers)
+            {
+              ret = -EINVAL;
+            }
+          else if (dev->pd_ops->po_enable == NULL)
+            {
+              ret = -ENOTSUP;
+            }
+          else
+            {
+              ret = dev->pd_ops->po_enable(dev, enable->wiper,
+                                           enable->enable);
+            }
+
+          break;
+        }
+
+      /* Store a wiper value to a non-volatile slot */
+
+      case POTIOC_STORE_WIPER:
+        {
+          FAR struct pot_nv_s *nv = (FAR struct pot_nv_s *)((uintptr_t)arg);
+
+          DEBUGASSERT(nv != NULL);
+          if (nv->wiper >= dev->pd_nwipers)
+            {
+              ret = -EINVAL;
+            }
+          else if (dev->pd_ops->po_store == NULL)
+            {
+              ret = -ENOTSUP;
+            }
+          else
+            {
+              ret = dev->pd_ops->po_store(dev, nv->wiper, nv->slot);
+            }
+
+          break;
+        }
+
+      /* Recall a wiper value from a non-volatile slot */
+
+      case POTIOC_RECALL_WIPER:
+        {
+          FAR struct pot_nv_s *nv = (FAR struct pot_nv_s *)((uintptr_t)arg);
+
+          DEBUGASSERT(nv != NULL);
+          if (nv->wiper >= dev->pd_nwipers)
+            {
+              ret = -EINVAL;
+            }
+          else if (dev->pd_ops->po_recall == NULL)
+            {
+              ret = -ENOTSUP;
+            }
+          else
+            {
+              ret = dev->pd_ops->po_recall(dev, nv->wiper, nv->slot);
+            }
+
+          break;
+        }
+
+      /* Forward any unrecognized commands to the lower half */
+
+      default:
+        {
+          if (dev->pd_ops->po_ioctl)
+            {
+              ret = dev->pd_ops->po_ioctl(dev, cmd, arg);
+            }
+          else
+            {
+              ret = -ENOTTY;
+            }
+
+          break;
+        }
+    }
+
+  nxmutex_unlock(&dev->pd_lock);
+  return ret;
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: pot_register
+ ****************************************************************************/
+
+int pot_register(FAR const char *path, FAR struct pot_dev_s *dev)
+{
+  int ret;
+
+  DEBUGASSERT(dev != NULL && dev->pd_ops != NULL);
+
+  /* Initialize the potentiometer device structure */
+
+  dev->pd_ocount = 0;
+
+  /* Initialize mutexes */
+
+  nxmutex_init(&dev->pd_closelock);
+  nxmutex_init(&dev->pd_lock);
+
+  /* Register the potentiometer character driver */
+
+  ret = register_driver(path, &g_pot_fops, 0666, dev);
+  if (ret < 0)
+    {
+      nxmutex_destroy(&dev->pd_closelock);
+      nxmutex_destroy(&dev->pd_lock);
+    }
+
+  return ret;
+}

--- a/include/nuttx/analog/ioctl.h
+++ b/include/nuttx/analog/ioctl.h
@@ -156,6 +156,11 @@
 #define AN_POT_FIRST      (AN_ADS7046_FIRST + AN_ADS7046_NCMDS)
 #define AN_POT_NCMDS      16
 
+/* See include/nuttx/analog/mcp445x.h */
+
+#define AN_MCP445X_FIRST  (AN_POT_FIRST + AN_POT_NCMDS)
+#define AN_MCP445X_NCMDS  2
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/

--- a/include/nuttx/analog/ioctl.h
+++ b/include/nuttx/analog/ioctl.h
@@ -151,6 +151,11 @@
 #define AN_ADS7046_FIRST  (AN_MCP47X6_FIRST + AN_MCP47X6_NCMDS)
 #define AN_ADS7046_NCMDS  3
 
+/* See include/nuttx/analog/pot.h */
+
+#define AN_POT_FIRST      (AN_ADS7046_FIRST + AN_ADS7046_NCMDS)
+#define AN_POT_NCMDS      16
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/

--- a/include/nuttx/analog/mcp445x.h
+++ b/include/nuttx/analog/mcp445x.h
@@ -1,0 +1,70 @@
+/****************************************************************************
+ * include/nuttx/analog/mcp445x.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_ANALOG_MCP445X_H
+#define __INCLUDE_NUTTX_ANALOG_MCP445X_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/analog/ioctl.h>
+
+#include <stdint.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* IOCTL Commands ***********************************************************/
+
+/* Cmd: ANIOC_MCP445X_SET_TCON   Arg: struct mcp445x_tcon_s *tcon
+ * Cmd: ANIOC_MCP445X_GET_TCON   Arg: struct mcp445x_tcon_s *tcon
+ */
+
+#define ANIOC_MCP445X_SET_TCON    _ANIOC(AN_MCP445X_FIRST + 0)
+#define ANIOC_MCP445X_GET_TCON    _ANIOC(AN_MCP445X_FIRST + 1)
+
+/* Terminal control flags. A set bit means the given terminal is connected
+ * (B, W, A) or the wiper is not forced into shutdown (HW).
+ */
+
+#define MCP445X_TCON_B            (1 << 0)  /* Terminal B connected */
+#define MCP445X_TCON_W            (1 << 1)  /* Wiper terminal connected */
+#define MCP445X_TCON_A            (1 << 2)  /* Terminal A connected */
+#define MCP445X_TCON_HW           (1 << 3)  /* Wiper not in shutdown */
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* Terminal control for ANIOC_MCP445X_SET_TCON and ANIOC_MCP445X_GET_TCON */
+
+struct mcp445x_tcon_s
+{
+  uint8_t wiper;                 /* Wiper index */
+  uint8_t flags;                 /* Terminal control flags, see
+                                  * MCP445X_TCON_* */
+};
+
+#endif /* __INCLUDE_NUTTX_ANALOG_MCP445X_H */

--- a/include/nuttx/analog/pot.h
+++ b/include/nuttx/analog/pot.h
@@ -215,6 +215,28 @@ extern "C"
 
 int pot_register(FAR const char *path, FAR struct pot_dev_s *dev);
 
+/****************************************************************************
+ * Name: mcp445x_initialize
+ *
+ * Description:
+ *   Initialize a MCP445X potentiometer.
+ *
+ * Input Parameters:
+ *   i2c  - An instance of the I2C interface to communicate with the device
+ *   addr - The I2C address of the MCP445X
+ *   rab  - Terminal A-B resistance in ohms, 0 if unknown
+ *
+ * Returned Value:
+ *   Valid MCP445X device structure reference on success; a NULL on failure
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_POT_MCP445X
+struct i2c_master_s;
+FAR struct pot_dev_s *mcp445x_initialize(FAR struct i2c_master_s *i2c,
+                                         uint8_t addr, uint32_t rab);
+#endif
+
 #if defined(__cplusplus)
 }
 #endif

--- a/include/nuttx/analog/pot.h
+++ b/include/nuttx/analog/pot.h
@@ -1,0 +1,222 @@
+/****************************************************************************
+ * include/nuttx/analog/pot.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_ANALOG_POT_H
+#define __INCLUDE_NUTTX_ANALOG_POT_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/compiler.h>
+#include <nuttx/analog/ioctl.h>
+#include <nuttx/mutex.h>
+
+#include <stdbool.h>
+#include <stdint.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* IOCTL Commands ***********************************************************/
+
+/* Common IOCTL commands for all digital potentiometer drivers. Optional
+ * commands return -ENOTSUP if not implemented by the lower half; support
+ * is advertised in pot_info_s caps.
+ *
+ * Cmd: POTIOC_GET_INFO      Arg: struct pot_info_s *info
+ * Cmd: POTIOC_SET_WIPER     Arg: struct pot_wiper_s *wiper
+ * Cmd: POTIOC_GET_WIPER     Arg: struct pot_wiper_s *wiper
+ * Cmd: POTIOC_MOVE_WIPER    Arg: struct pot_move_s *move
+ * Cmd: POTIOC_SET_ENABLE    Arg: struct pot_enable_s *enable
+ * Cmd: POTIOC_STORE_WIPER   Arg: struct pot_nv_s *nv
+ * Cmd: POTIOC_RECALL_WIPER  Arg: struct pot_nv_s *nv
+ */
+
+#define POTIOC_GET_INFO     _ANIOC(AN_POT_FIRST + 0)
+#define POTIOC_SET_WIPER    _ANIOC(AN_POT_FIRST + 1)
+#define POTIOC_GET_WIPER    _ANIOC(AN_POT_FIRST + 2)
+#define POTIOC_MOVE_WIPER   _ANIOC(AN_POT_FIRST + 3)
+#define POTIOC_SET_ENABLE   _ANIOC(AN_POT_FIRST + 4)
+#define POTIOC_STORE_WIPER  _ANIOC(AN_POT_FIRST + 5)
+#define POTIOC_RECALL_WIPER _ANIOC(AN_POT_FIRST + 6)
+
+/* Device capabilities reported in pot_info_s */
+
+#define POT_CAP_READBACK    (1 << 0)  /* Wiper position can be read back */
+#define POT_CAP_MOVE        (1 << 1)  /* Relative wiper move supported */
+#define POT_CAP_ENABLE      (1 << 2)  /* Wiper enable/shutdown supported */
+#define POT_CAP_NV          (1 << 3)  /* Non-volatile store/recall supported */
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* Device properties for POTIOC_GET_INFO */
+
+struct pot_info_s
+{
+  uint8_t  nwipers;              /* Number of wipers */
+  uint32_t max;                  /* Wiper full scale position */
+  uint32_t rab;                  /* Terminal A-B resistance in ohms,
+                                  * 0 if unknown. ohms = val * rab / max */
+  uint32_t caps;                 /* Capabilities, see POT_CAP_* */
+};
+
+/* Wiper access for POTIOC_SET_WIPER and POTIOC_GET_WIPER */
+
+struct pot_wiper_s
+{
+  uint8_t  wiper;                /* Wiper index */
+  uint32_t val;                  /* Wiper value */
+};
+
+/* Relative wiper move for POTIOC_MOVE_WIPER */
+
+struct pot_move_s
+{
+  uint8_t wiper;                 /* Wiper index */
+  int32_t steps;                 /* Steps to move, negative moves down */
+};
+
+/* Wiper enable control for POTIOC_SET_ENABLE */
+
+struct pot_enable_s
+{
+  uint8_t wiper;                 /* Wiper index */
+  bool    enable;                /* false forces wiper into shutdown */
+};
+
+/* Non-volatile transfer for POTIOC_STORE_WIPER and POTIOC_RECALL_WIPER */
+
+struct pot_nv_s
+{
+  uint8_t wiper;                 /* Wiper index */
+  uint8_t slot;                  /* Non-volatile slot index */
+};
+
+struct pot_dev_s;
+struct pot_ops_s
+{
+  /* Configure the potentiometer. This method is called the first time
+   * that the potentiometer device is opened.
+   */
+
+  CODE int (*po_setup)(FAR struct pot_dev_s *dev);
+
+  /* Disable the potentiometer. This method is called when the
+   * potentiometer device is closed. This method reverses the operation
+   * of the setup method.
+   */
+
+  CODE void (*po_shutdown)(FAR struct pot_dev_s *dev);
+
+  /* Set a wiper value. Optional. */
+
+  CODE int (*po_setwiper)(FAR struct pot_dev_s *dev, uint8_t wiper,
+                          uint32_t val);
+
+  /* Get a wiper value. Optional. */
+
+  CODE int (*po_getwiper)(FAR struct pot_dev_s *dev, uint8_t wiper,
+                          FAR uint32_t *val);
+
+  /* Move a wiper by a number of steps, negative moves down. Optional. */
+
+  CODE int (*po_move)(FAR struct pot_dev_s *dev, uint8_t wiper,
+                      int32_t steps);
+
+  /* Enable or force a wiper into shutdown. Optional. */
+
+  CODE int (*po_enable)(FAR struct pot_dev_s *dev, uint8_t wiper,
+                        bool enable);
+
+  /* Store a wiper value to a non-volatile slot. Optional. */
+
+  CODE int (*po_store)(FAR struct pot_dev_s *dev, uint8_t wiper,
+                       uint8_t slot);
+
+  /* Recall a wiper value from a non-volatile slot. Optional. */
+
+  CODE int (*po_recall)(FAR struct pot_dev_s *dev, uint8_t wiper,
+                        uint8_t slot);
+
+  /* Lower-half logic may support chip-specific ioctl commands */
+
+  CODE int (*po_ioctl)(FAR struct pot_dev_s *dev, int cmd,
+                       unsigned long arg);
+};
+
+struct pot_dev_s
+{
+  /* Fields managed by common upper half potentiometer logic */
+
+  uint8_t                    pd_ocount;    /* The number of times the device
+                                            * has been opened */
+  mutex_t                    pd_closelock; /* Locks out new opens while close
+                                            * is in progress */
+  mutex_t                    pd_lock;      /* Serializes ioctl access */
+
+  /* Fields provided by lower half potentiometer logic */
+
+  uint8_t                    pd_nwipers;   /* Number of wipers */
+  uint32_t                   pd_max;       /* Wiper full scale value */
+  uint32_t                   pd_rab;       /* A-B resistance in ohms,
+                                            * 0 if unknown */
+  FAR const struct pot_ops_s *pd_ops;      /* Arch-specific operations */
+  FAR void                   *pd_priv;     /* Used by the arch-specific
+                                            * logic */
+};
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#if defined(__cplusplus)
+extern "C"
+{
+#endif
+
+/****************************************************************************
+ * Name: pot_register
+ *
+ * Description:
+ *   Register a digital potentiometer driver.
+ *
+ * Input Parameters:
+ *   path - The full path to the driver to register, e.g. "/dev/pot0"
+ *   dev  - An instance of the device-specific potentiometer interface
+ *
+ * Returned Value:
+ *   Zero on success; a negated errno value on failure.
+ *
+ ****************************************************************************/
+
+int pot_register(FAR const char *path, FAR struct pot_dev_s *dev);
+
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __INCLUDE_NUTTX_ANALOG_POT_H */


### PR DESCRIPTION
## Summary

- drivers/analog: add digital potentiometer driver support 
- drivers/analog: add MCP445X potentiometer support 

## Impact

new drivers

## Testing

tested with custom firmware for Nordic Power Profiler Kit 2 based on nuttx
