### PR TITLE
drivers/usbhost: Define the xHCI endpoint-allocation trace.

### DIFF
--- a/drivers/usbhost/usbhost_xhci_trace.c
+++ b/drivers/usbhost/usbhost_xhci_trace.c
@@ -87,11 +87,11 @@ static const struct xhci_usbhost_trace_s g_trace2[TRACE2_NSTRINGS] =
   TRENTRY(XHCI_VTRACE2_PORTSC_CONNECTED,
           "XHCI RHPort%d connected, pscwait: %d\n"),
   TRENTRY(XHCI_VTRACE2_PORTSC_DISCONND,
-          "XHCI RHport%d disconnected, pscwait: %d\n"),
+          "XHCI RHPort%d disconnected, pscwait: %d\n"),
   TRENTRY(XHCI_VTRACE2_MONWAKEUP,
           "XHCI Hub port%d connected: %d\n"),
   TRENTRY(XHCI_VTRACE2_CTRLINOUT,
-          "HXCI CTRLIN/OUT: RHPort%d req: %02x\n"),
+          "XHCI CTRLIN/OUT: RHPort%d req: %02x\n"),
   TRENTRY(XHCI_VTRACE2_EPALLOC,
           "XHCI EP%d allocated, type: %d\n"),
 };

--- a/drivers/usbhost/usbhost_xhci_trace.c
+++ b/drivers/usbhost/usbhost_xhci_trace.c
@@ -92,6 +92,8 @@ static const struct xhci_usbhost_trace_s g_trace2[TRACE2_NSTRINGS] =
           "XHCI Hub port%d connected: %d\n"),
   TRENTRY(XHCI_VTRACE2_CTRLINOUT,
           "HXCI CTRLIN/OUT: RHPort%d req: %02x\n"),
+  TRENTRY(XHCI_VTRACE2_EPALLOC,
+          "XHCI EP%d allocated, type: %d\n"),
 };
 
 /****************************************************************************

--- a/drivers/usbhost/usbhost_xhci_trace.h
+++ b/drivers/usbhost/usbhost_xhci_trace.h
@@ -64,6 +64,7 @@ enum usbhost_trace1codes_e
   XHCI_VTRACE2_PORTSC_DISCONND,     /* XHCI RHport disconnected */
   XHCI_VTRACE2_MONWAKEUP,           /* XHCI RHPort connected wakeup */
   XHCI_VTRACE2_CTRLINOUT,           /* XHCI CTRLIN/OUT */
+  XHCI_VTRACE2_EPALLOC,             /* XHCI Endpoint allocated */
   __TRACE2_NSTRINGS                 /* Total number of enumeration values */
 };
 


### PR DESCRIPTION
## Summary

`usbhost_xhci_pci.c` traces endpoint allocation with `XHCI_VTRACE2_EPALLOC`, but that id is defined in neither the enumeration nor the string table. The driver does not compile once verbose tracing is enabled:

```
usbhost/usbhost_xhci_pci.c:3285:19: error: 'XHCI_VTRACE2_EPALLOC' undeclared
  (first use in this function); did you mean 'XHCI_VTRACE2_PORTSC'?
```

It builds today only because `usbhost_vtrace2()` collapses to a macro that discards its arguments unless `HAVE_USBHOST_TRACE_VERBOSE` is defined — so nobody finds this until they go looking for a trace, which is exactly when they need it.

The first commit adds the id and its string, keeping the two tables in step. The second is text only: the control transfer entry names the controller `HXCI`, so a log of an enumeration reads as though a different controller were involved, and one neighbouring entry spells the port `RHport` where the rest of the table spells it `RHPort`.

## Impact

- **Build:** `CONFIG_USBHOST_XHCI_PCI=y` with `CONFIG_USBHOST_TRACE_VERBOSE=y` does not compile before this change and does compile after. No other configuration is affected, since the code in question is discarded by the macro otherwise.
- **User visible:** endpoint allocation now appears in a verbose trace instead of being unbuildable, and the controller is named correctly in the log.
- **Compatibility:** the new id is appended before `__TRACE2_NSTRINGS`, so existing ids keep their values.
- **Hardware, documentation, security:** unaffected.

## Testing

**Host:** macOS 15.5 (Apple Silicon).

Reproduced and verified entirely in tree, with no hardware needed:

```
tools/configure.sh -E qemu-intel64:jumbo
kconfig-tweak --enable CONFIG_USBHOST_TRACE
kconfig-tweak --enable CONFIG_USBHOST_TRACE_VERBOSE
make olddefconfig && make
```

**Before (master):**

```
usbhost/usbhost_xhci_pci.c:3285:19: error: 'XHCI_VTRACE2_EPALLOC' undeclared
```

**After (this branch):** the same configuration builds clean.

The trace output was also exercised on an ESWIN EIC7700X board (RISC-V, 4 cores SMP), whose xHCI support will be upstreamed later, where the corrected entries appear as expected during enumeration:

```
XHCI EP1 allocated, type: 3
XHCI CTRLIN/OUT: RHPort1 req: 06
```
