### PR TITLE
drivers/usbhost: Fix xHCI faults on a conforming controller.

### DIFF
--- a/drivers/usbhost/usbhost_xhci.h
+++ b/drivers/usbhost/usbhost_xhci.h
@@ -268,6 +268,15 @@
 #define XHCI_PORTSC_DR               (1 << 30)             /* Bit 30: Device Removable */
 #define XHCI_PORTSC_WPR              (1 << 31)             /* Bit 31: Warm Port Reset */
 
+/* The write-one-to-clear bits of PORTSC.  Mask these out of any
+ * read-modify-write of the register, unless clearing them is intended.
+ */
+
+#define XHCI_PORTSC_RW1C             (XHCI_PORTSC_PED | XHCI_PORTSC_CSC | \
+                                      XHCI_PORTSC_PEC | XHCI_PORTSC_WRC | \
+                                      XHCI_PORTSC_OCC | XHCI_PORTSC_PRC | \
+                                      XHCI_PORTSC_PLC | XHCI_PORTSC_CEC)
+
 /* Port Power Management Status and Control (USB3) */
 
 #define XHCI_PORTPMSC_U1TO_SHIFT     (0)                   /* Bits 0-7: U1 Timeout */

--- a/drivers/usbhost/usbhost_xhci_pci.c
+++ b/drivers/usbhost/usbhost_xhci_pci.c
@@ -4365,17 +4365,22 @@ static int xhci_mem_alloc(FAR struct usbhost_xhci_s *priv)
   size_t tmp;
   int    i;
 
-  /* Allocate Scratchpad Buffer Array */
+  /* Allocate the Scratchpad Buffer Array, if one is wanted.  no_scratch
+   * may be zero, and a zero byte allocation returns NULL.
+   */
 
-  tmp = priv->no_scratch * sizeof(uint64_t);
-  priv->pg_sb = kmm_memalign(XHCI_BUF_ALIGN, tmp);
-  if (!priv->pg_sb)
+  if (priv->no_scratch > 0)
     {
-      pcierr("pg_sb malloc failed\n");
-      return -ENOMEM;
-    }
+      tmp = priv->no_scratch * sizeof(uint64_t);
+      priv->pg_sb = kmm_memalign(XHCI_BUF_ALIGN, tmp);
+      if (!priv->pg_sb)
+        {
+          pcierr("pg_sb malloc failed\n");
+          return -ENOMEM;
+        }
 
-  memset(priv->pg_sb, 0, tmp);
+      memset(priv->pg_sb, 0, tmp);
+    }
 
   for (i = 0; i < priv->no_scratch; i++)
     {

--- a/drivers/usbhost/usbhost_xhci_pci.c
+++ b/drivers/usbhost/usbhost_xhci_pci.c
@@ -519,6 +519,12 @@ static struct pci_driver_s g_pci_xhci_drv =
  * Private Functions
  ****************************************************************************/
 
+/* xHCI requires aligned accesses of each register's own size, and
+ * narrower ones may be ignored.  volatile does not pin the access width,
+ * so every accessor below launders the value through a register with an
+ * empty asm, on loads and stores both, to force the full-width access.
+ */
+
 /****************************************************************************
  * Name: xhci_capa_getreg
  *
@@ -530,8 +536,11 @@ static struct pci_driver_s g_pci_xhci_drv =
 static uint32_t xhci_capa_getreg(FAR struct usbhost_xhci_s *priv,
                                  unsigned int offset)
 {
-  uintptr_t addr = priv->capa_base + offset;
-  return *((FAR volatile uint32_t *)addr);
+  uintptr_t addr   = priv->capa_base + offset;
+  uint32_t  regval = *((FAR volatile uint32_t *)addr);
+
+  __asm__ __volatile__("" : "+r"(regval));
+  return regval;
 }
 
 /****************************************************************************
@@ -545,8 +554,11 @@ static uint32_t xhci_capa_getreg(FAR struct usbhost_xhci_s *priv,
 static uint8_t xhci_capa_getreg_1b(FAR struct usbhost_xhci_s *priv,
                                    unsigned int offset)
 {
-  uintptr_t addr = priv->capa_base + offset;
-  return *((FAR volatile uint8_t *)addr);
+  uintptr_t addr   = priv->capa_base + offset;
+  uint8_t   regval = *((FAR volatile uint8_t *)addr);
+
+  __asm__ __volatile__("" : "+r"(regval));
+  return regval;
 }
 
 /****************************************************************************
@@ -562,6 +574,8 @@ static void xhci_capa_putreg_1b(FAR struct usbhost_xhci_s *priv,
                                 uint8_t value)
 {
   uintptr_t addr = priv->capa_base + offset;
+
+  __asm__ __volatile__("" : "+r"(value));
   *((FAR volatile uint8_t *)addr) = value;
 }
 
@@ -576,8 +590,11 @@ static void xhci_capa_putreg_1b(FAR struct usbhost_xhci_s *priv,
 static uint32_t xhci_oper_getreg(FAR struct usbhost_xhci_s *priv,
                                  unsigned int offset)
 {
-  uintptr_t addr = priv->oper_base + offset;
-  return *((FAR volatile uint32_t *)addr);
+  uintptr_t addr   = priv->oper_base + offset;
+  uint32_t  regval = *((FAR volatile uint32_t *)addr);
+
+  __asm__ __volatile__("" : "+r"(regval));
+  return regval;
 }
 
 /****************************************************************************
@@ -593,6 +610,8 @@ static void xhci_oper_putreg(FAR struct usbhost_xhci_s *priv,
                              uint32_t value)
 {
   uintptr_t addr = priv->oper_base + offset;
+
+  __asm__ __volatile__("" : "+r"(value));
   *((FAR volatile uint32_t *)addr) = value;
 }
 
@@ -609,6 +628,8 @@ static void xhci_oper_putreg_8b(FAR struct usbhost_xhci_s *priv,
                                 uint64_t value)
 {
   uintptr_t addr = priv->oper_base + offset;
+
+  __asm__ __volatile__("" : "+r"(value));
   *((FAR volatile uint64_t *)addr) = value;
 }
 
@@ -623,8 +644,11 @@ static void xhci_oper_putreg_8b(FAR struct usbhost_xhci_s *priv,
 static uint32_t xhci_runt_getreg(FAR struct usbhost_xhci_s *priv,
                                  unsigned int offset)
 {
-  uintptr_t addr = priv->runt_base + offset;
-  return *((FAR volatile uint32_t *)addr);
+  uintptr_t addr   = priv->runt_base + offset;
+  uint32_t  regval = *((FAR volatile uint32_t *)addr);
+
+  __asm__ __volatile__("" : "+r"(regval));
+  return regval;
 }
 
 /****************************************************************************
@@ -640,6 +664,8 @@ static void xhci_runt_putreg(FAR struct usbhost_xhci_s *priv,
                              uint32_t value)
 {
   uintptr_t addr = priv->runt_base + offset;
+
+  __asm__ __volatile__("" : "+r"(value));
   *((FAR volatile uint32_t *)addr) = value;
 }
 
@@ -656,6 +682,8 @@ static void xhci_runt_putreg_8b(FAR struct usbhost_xhci_s *priv,
                                 uint64_t value)
 {
   uintptr_t addr = priv->runt_base + offset;
+
+  __asm__ __volatile__("" : "+r"(value));
   *((FAR volatile uint64_t *)addr) = value;
 }
 
@@ -672,6 +700,8 @@ static void xhci_door_putreg(FAR struct usbhost_xhci_s *priv,
                              uint32_t value)
 {
   uintptr_t addr = priv->door_base + offset;
+
+  __asm__ __volatile__("" : "+r"(value));
   *((FAR volatile uint32_t *)addr) = value;
 }
 

--- a/drivers/usbhost/usbhost_xhci_pci.c
+++ b/drivers/usbhost/usbhost_xhci_pci.c
@@ -74,6 +74,10 @@
  */
 
 #define XHCI_HALT_TIMEOUT_MS     (100)
+
+/* Milliseconds allowed for a port to enable after reset. */
+
+#define XHCI_PORT_RESET_MS       (500)
 #define XHCI_BUFSIZE             (512)
 
 /* Port numbers macros */
@@ -1360,9 +1364,12 @@ static int xhci_port_enable(FAR struct usbhost_xhci_s *priv,
 
   if (!(regval & XHCI_PORTSC_PED))
     {
-      /* Reset the port */
+      /* Reset the port, masking the write-one-to-clear bits out of the
+       * value first.  See XHCI_PORTSC_RW1C.
+       */
 
-      regval = xhci_oper_getreg(priv, XHCI_PORTSC(rhpndx));
+      regval  = xhci_oper_getreg(priv, XHCI_PORTSC(rhpndx));
+      regval &= ~XHCI_PORTSC_RW1C;
       regval |= XHCI_PORTSC_PR;
       xhci_oper_putreg(priv, XHCI_PORTSC(rhpndx), regval);
 
@@ -1370,16 +1377,25 @@ static int xhci_port_enable(FAR struct usbhost_xhci_s *priv,
 
       /* Wait for Enabled state for port */
 
-      retries = 10;
-      while (!(xhci_oper_getreg(priv, XHCI_PORTSC(rhpndx))
-               & XHCI_PORTSC_PED) && retries > 0)
+      for (retries = XHCI_PORT_RESET_MS; retries > 0; retries--)
         {
-          retries--;
-          up_mdelay(100);
+          regval = xhci_oper_getreg(priv, XHCI_PORTSC(rhpndx));
+          if ((regval & XHCI_PORTSC_PED) != 0)
+            {
+              break;
+            }
+
+          up_mdelay(1);
         }
 
-      if (retries == 0)
+      /* Test the port, not the counter: a port that comes up on the last
+       * attempt leaves the loop with the count exhausted too.
+       */
+
+      if ((regval & XHCI_PORTSC_PED) == 0)
         {
+          pcierr("port %d will not enable, PORTSC %08" PRIx32 "\n", rhpndx,
+                 regval);
           return -ETIMEDOUT;
         }
     }

--- a/drivers/usbhost/usbhost_xhci_pci.c
+++ b/drivers/usbhost/usbhost_xhci_pci.c
@@ -1938,7 +1938,15 @@ static int xhci_command(FAR struct usbhost_xhci_s *priv,
   trb->d1 = priv->cmdres.d1;
   trb->d2 = priv->cmdres.d2;
 
-  if (XHCI_TRB_D1_CC_GET(trb->d1) != XHCI_TRB_CC_SUCCESS)
+  if (XHCI_TRB_D1_CC_GET(trb->d1) == XHCI_TRB_CC_SUCCESS)
+    {
+      /* The completion event decides the result, whether it arrived by
+       * interrupt or was found by the poll above.
+       */
+
+      ret = OK;
+    }
+  else
     {
       pcierr("event CC = %d\n", XHCI_TRB_D1_CC_GET(trb->d1));
       ret = -EIO;

--- a/drivers/usbhost/usbhost_xhci_pci.c
+++ b/drivers/usbhost/usbhost_xhci_pci.c
@@ -68,6 +68,12 @@
 #define XHCI_CMD_MAX             (16)
 #define XHCI_EVENT_MAX           (232)
 #define XHCI_TD_MAX              (8)
+
+/* Milliseconds allowed for the controller to halt.  The specification
+ * asks for 16.
+ */
+
+#define XHCI_HALT_TIMEOUT_MS     (100)
 #define XHCI_BUFSIZE             (512)
 
 /* Port numbers macros */
@@ -1104,9 +1110,12 @@ static int xhci_ctrl_start(FAR struct usbhost_xhci_s *priv)
 
   xhci_oper_putreg(priv, XHCI_CONFIG, priv->no_slots);
 
-  /* Slot 0 in Device Context is reserved for Scratchpad Buffer Array */
+  /* Slot 0 of the Device Context array points at the Scratchpad Buffer
+   * Array, or is zero when the controller asked for none.
+   */
 
-  priv->pg_ctx[0] = htole64(up_addrenv_va_to_pa(priv->pg_sb));
+  priv->pg_ctx[0] = priv->pg_sb ?
+                    htole64(up_addrenv_va_to_pa(priv->pg_sb)) : 0;
 
   /* Device Context Base Address Array Pointer */
 
@@ -1227,27 +1236,41 @@ static int xhci_ctrl_start(FAR struct usbhost_xhci_s *priv)
 
 static int xhci_ctrl_halt(FAR struct usbhost_xhci_s *priv)
 {
-  int ret = -EAGAIN;
-  int i;
+  uint32_t regval;
+  int      i;
 
-  /* Halt controller */
+  /* A controller that was never started is already halted and says so.
+   * There is no transition to wait for, so check before waiting.
+   */
 
-  xhci_oper_putreg(priv, XHCI_USBCMD, 0);
-
-  /* Wait for controller halted */
-
-  for (i = 0; i < 10; i++)
+  regval = xhci_oper_getreg(priv, XHCI_USBSTS);
+  if ((regval & XHCI_USBSTS_HCH) != 0)
     {
-      up_mdelay(100);
-
-      if (xhci_oper_getreg(priv, XHCI_USBSTS) & XHCI_USBSTS_HCH)
-        {
-          ret = OK;
-          break;
-        }
+      return OK;
     }
 
-  return ret;
+  /* Clear Run/Stop and leave the rest of the register alone.  Writing the
+   * whole of it zero would clear the interrupt and host system error
+   * enables along with it.
+   */
+
+  regval  = xhci_oper_getreg(priv, XHCI_USBCMD);
+  regval &= ~XHCI_USBCMD_RS;
+  xhci_oper_putreg(priv, XHCI_USBCMD, regval);
+
+  for (i = 0; i < XHCI_HALT_TIMEOUT_MS; i++)
+    {
+      regval = xhci_oper_getreg(priv, XHCI_USBSTS);
+      if ((regval & XHCI_USBSTS_HCH) != 0)
+        {
+          return OK;
+        }
+
+      up_udelay(1000);
+    }
+
+  pcierr("controller will not halt, USBSTS %08" PRIx32 "\n", regval);
+  return -EAGAIN;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

This replaces the previous contents of this PR. The single large commit
reviewers objected to has been split, and the rest of the work moved to
follow-up PRs so each can be reviewed on its own. This PR is now the first of
four and carries only the fixes needed to reach a device at all.

Five independent faults, one commit each:

- **Register access width.** xHCI requires aligned accesses of each register's
  own size and a controller may ignore narrower ones. `volatile` does not pin
  the width: GCC 16.1.0 at `-Os` narrows a 32-bit load feeding a single-bit
  test into a byte load, so polling USBSTS for HCH never observes the halted
  state. Every accessor now launders the value through a register with an empty
  asm, on loads and stores. This is the only compiler-related fix in the set;
  the driver works with earlier compilers.
- **Zero scratchpad buffers.** HCSPARAMS2 may report none, as QEMU's controller
  does. The driver sized the array from that count unconditionally and read the
  NULL from a zero-byte `kmm_memalign()` as `-ENOMEM`, so such a controller
  never started.
- **Halting.** `xhci_ctrl_halt()` wrote USBCMD zero unconditionally and waited
  for HCH on a controller that was already halted, and cleared INTE and HSEE
  along with R/S.
- **Port reset.** Eight PORTSC bits are write-one-to-clear, so writing back the
  value just read cleared PED and every change bit, disabling the port being
  reset.
- **Command completion.** `xhci_command()` returned `-ETIMEDOUT` when a
  completion arrived without an interrupt, even though the fallback poll had
  already retrieved the event, so callers unwound work the controller had done.

Follow-ups, in order: separating the driver from the PCI bus, the data path
fixes for real devices, and hub support.

## Impact

`USBHOST_XHCI_PCI` users only. No API or configuration change, and no
behavioural change on a controller that already worked.

## Testing

Built for `qemu-intel64:nsh` with `USBHOST_XHCI_PCI`, `USBHOST_MSC` and
`USBHOST_HIDKBD`, driver object confirmed in the link.

Run at this commit under QEMU with `-device qemu-xhci` and a `usb-storage`
device:

```
nsh> ls /dev
 sda
nsh> mount -t vfat /dev/sda /mnt
nsh> cat /mnt/HELLO.TXT
qemu-xhci-regression-ok
```

Not tested standalone on hardware, and it cannot be: the EIC7700 EVB attaches
through `include/nuttx/usb/xhci.h`, which the next PR introduces. The full
four-PR series was exercised on that board, where a USB flash disk behind a
6-port hub mounts and reads.
