### PR TITLE
arch/nrf53: add HFCLK XTAL oscillator support

### DIFF
--- a/arch/arm/src/nrf53/hardware/nrf53_ficr_cpuapp.h
+++ b/arch/arm/src/nrf53/hardware/nrf53_ficr_cpuapp.h
@@ -47,6 +47,7 @@
 #define NRF53_FICR_INFO_CODEPAGESIZE_OFFSET 0x220  /* Code memory page size in bytes */
 #define NRF53_FICR_INFO_CODESIZE_OFFSET     0x224  /* Code memory size  */
 #define NRF53_FICR_INFO_DEVICETYPE_OFFSET   0x228  /* Device type */
+#define NRF53_FICR_XOSC32MTRIM_OFFSET       0xc20  /* XOSC32M capacitor selection trim values */
                                                    /* TODO */
 
 /* FICR Register Addresses *************************************************/
@@ -62,7 +63,14 @@
 #define NRF53_FICR_INFO_CODEPAGESIZE        (NRF53_FICR_BASE + NRF53_FICR_INFO_CODEPAGESIZE_OFFSET)
 #define NRF53_FICR_INFO_CODESIZE            (NRF53_FICR_BASE + NRF53_FICR_INFO_CODESIZE_OFFSET)
 #define NRF53_FICR_INFO_DEVICETYPE          (NRF53_FICR_BASE + NRF53_FICR_INFO_DEVICETYPE_OFFSET)
+#define NRF53_FICR_XOSC32MTRIM              (NRF53_FICR_BASE + NRF53_FICR_XOSC32MTRIM_OFFSET)
 
 /* TODO */
+
+/* XOSC32M capacitor selection trim values */
+
+#define FICR_XOSC32MTRIM_OFFSET_MASK        (0x1f)
+#define FICR_XOSC32MTRIM_SLOPE_SHIFT        (5)
+#define FICR_XOSC32MTRIM_SLOPE_MASK         (0x1f << FICR_XOSC32MTRIM_SLOPE_SHIFT)
 
 #endif /* __ARCH_ARM_SRC_NRF53_HARDWARE_NRF53_FICR_CPUAPP_H */

--- a/arch/arm/src/nrf53/hardware/nrf53_osc.h
+++ b/arch/arm/src/nrf53/hardware/nrf53_osc.h
@@ -48,6 +48,9 @@
 
 /* Register bit definitions *************************************************/
 
+#define OSC_XOSC32MCAPS_CAPVALUE_MASK  (0x1f)
+#define OSC_XOSC32MCAPS_ENABLE         (1 << 8)
+
 #define OSC_XOSC32KI_INTCAP_SHIFT      (0)
 #define OSC_XOSC32KI_INTCAP_MASK       (0x3 << OSC_XOSC32KI_INTCAP_SHIFT)
 #  define OSC_XOSC32KI_INTCAP_EXT      (0x0 << OSC_XOSC32KI_INTCAP_SHIFT)

--- a/arch/arm/src/nrf53/nrf53_oscconfig.c
+++ b/arch/arm/src/nrf53/nrf53_oscconfig.c
@@ -36,6 +36,7 @@
 #include "nrf53_oscconfig.h"
 #include "nrf53_gpio.h"
 #include "hardware/nrf53_osc.h"
+#include "hardware/nrf53_ficr.h"
 
 /****************************************************************************
  * Pre-processor Definitions
@@ -49,6 +50,42 @@
 
 #define LFXO_XL1_GPIO_PIN  (GPIO_MCUSEL_PERIP | GPIO_PORT0 | GPIO_PIN(0))
 #define LFXO_XL2_GPIO_PIN  (GPIO_MCUSEL_PERIP | GPIO_PORT0 | GPIO_PIN(1))
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#if defined(CONFIG_NRF53_HFCLK_XTAL) && defined(BOARD_OSC_XOSC32MCAPS_CAP)
+static void nrf53_hfxo_intcap(void)
+{
+  uint32_t slope_field;
+  uint32_t slope_mask;
+  uint32_t slope_sign;
+  int32_t  slope;
+  uint32_t offset;
+  uint32_t capvalue;
+  uint32_t trim;
+
+  trim = getreg32(NRF53_FICR_XOSC32MTRIM);
+
+  slope_field = (trim & FICR_XOSC32MTRIM_OFFSET_MASK);
+  slope_mask = FICR_XOSC32MTRIM_OFFSET_MASK;
+  slope_sign = (slope_mask - (slope_mask >> 1));
+  slope = (int32_t)(slope_field ^ slope_sign) - (int32_t)slope_sign;
+
+  offset = ((trim & FICR_XOSC32MTRIM_SLOPE_MASK) >>
+            FICR_XOSC32MTRIM_SLOPE_SHIFT);
+
+  /* CAPVALUE = (((FICR->XOSC32MTRIM.SLOPE+56)*(CAPACITANCE*2-14))
+   *            +((FICR->XOSC32MTRIM.OFFSET-8)<<4)+32)>>6;
+   */
+
+  capvalue = ((slope + 56) * ((BOARD_OSC_XOSC32MCAPS_CAP * 2) - 14)
+              + ((offset - 8) << 4) + 32) >> 6;
+
+  putreg32(OSC_XOSC32MCAPS_ENABLE | capvalue, NRF53_OSC_XOSC32MCAPS);
+}
+#endif
 
 /****************************************************************************
  * Public Functions
@@ -71,7 +108,9 @@ void nrf53_oscconfig(void)
   putreg32(BOARD_OSC_XOSC32KI_INTCAP, NRF53_OSC_XOSC32KI_INTCAP);
 #endif
 
-#ifdef CONFIG_NRF53_HFCLK_XTAL
-#  warning TODO: missing HFCLK XTAL oscillator config
+#if defined(CONFIG_NRF53_HFCLK_XTAL) && defined(BOARD_OSC_XOSC32MCAPS_CAP)
+  /* Configure internal capacitors for HFXO */
+
+  nrf53_hfxo_intcap();
 #endif
 }

--- a/boards/arm/nrf53/thingy53/include/board.h
+++ b/boards/arm/nrf53/thingy53/include/board.h
@@ -43,6 +43,8 @@
 #define BOARD_SYSTICK_CLOCK         (64000000)
 #define BOARD_OSC_XOSC32KI_INTCAP   (OSC_XOSC32KI_INTCAP_C7PF)
 
+#define BOARD_OSC_XOSC32MCAPS_CAP   (8)
+
 /* Button definitions *******************************************************/
 
 /* Board supports four buttons. */


### PR DESCRIPTION
## Summary

arch/nrf53: add HFCLK XTAL oscillator support

## Impact

new feature

## Testing

thingy53