### PR TITLE
arch/nrf53: add DCDC regulator support

### DIFF
--- a/arch/arm/src/nrf53/Kconfig
+++ b/arch/arm/src/nrf53/Kconfig
@@ -424,6 +424,13 @@ config NRF53_SYSTIMER_RTC
 
 endchoice # System Timer Source
 
+config NRF53_DCDC
+	bool "Enable DC/DC regulator"
+	default n
+	---help---
+		This option enables the DC/DC regulator, which reduces
+		current consumption. This requires extra circuitry (inductors).
+
 if NRF53_SYSTIMER_RTC
 
 config NRF53_SYSTIMER_RTC_INSTANCE

--- a/arch/arm/src/nrf53/hardware/nrf53_regulators.h
+++ b/arch/arm/src/nrf53/hardware/nrf53_regulators.h
@@ -1,0 +1,59 @@
+/****************************************************************************
+ * arch/arm/src/nrf53/hardware/nrf53_regulators.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_NRF53_HARDWARE_NRF53_REGULATORS_H
+#define __ARCH_ARM_SRC_NRF53_HARDWARE_NRF53_REGULATORS_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include "nrf53_memorymap.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Register offsets *********************************************************/
+
+#define NRF53_REGULATORS_MAINREGSTATUS_OFFSET 0x428  /* Main supply status */
+#define NRF53_REGULATORS_SYSTEMOFF_OFFSET     0x500  /* System OFF register */
+#define NRF53_REGULATORS_POFCON_OFFSET        0x510  /* Power-fail comparator configuration */
+#define NRF53_REGULATORS_MAINDCDCEN_OFFSET    0x704  /* DC/DC enable register for VREGMAIN */
+#define NRF53_REGULATORS_RADIODCDCEN_OFFSET   0x904  /* DC/DC enable register for VREGRADIO */
+#define NRF53_REGULATORS_HDCDCEN_OFFSET       0xb00  /* DC/DC enable register for VREGH */
+
+/* Register definitions *****************************************************/
+
+#define NRF53_REGULATORS_MAINREGSTATUS        (NRF53_REGULATORS_BASE + NRF53_REGULATORS_MAINREGSTATUS_OFFSET)
+#define NRF53_REGULATORS_SYSTEMOFF            (NRF53_REGULATORS_BASE + NRF53_REGULATORS_SYSTEMOFF_OFFSET)
+#define NRF53_REGULATORS_POFCON               (NRF53_REGULATORS_BASE + NRF53_REGULATORS_POFCON_OFFSET)
+#define NRF53_REGULATORS_MAINDCDCEN           (NRF53_REGULATORS_BASE + NRF53_REGULATORS_MAINDCDCEN_OFFSET)
+#define NRF53_REGULATORS_RADIODCDCEN          (NRF53_REGULATORS_BASE + NRF53_REGULATORS_RADIODCDCEN_OFFSET)
+#define NRF53_REGULATORS_HDCDCEN              (NRF53_REGULATORS_BASE + NRF53_REGULATORS_HDCDCEN_OFFSET)
+
+/* Register bit definitions *************************************************/
+
+#define REGULATORS_DCDCEN_ENABLE              (1 << 0)
+
+#endif /* __ARCH_ARM_SRC_NRF53_HARDWARE_NRF53_REGULATORS_H */

--- a/arch/arm/src/nrf53/nrf53_clockconfig.c
+++ b/arch/arm/src/nrf53/nrf53_clockconfig.c
@@ -36,6 +36,7 @@
 #include "nrf53_clockconfig.h"
 #include "hardware/nrf53_clock.h"
 #include "hardware/nrf53_power.h"
+#include "hardware/nrf53_regulators.h"
 #include "hardware/nrf53_gpio.h"
 
 #ifdef CONFIG_NRF53_APPCORE
@@ -129,5 +130,11 @@ void nrf53_clockconfig(void)
     {
       /* Wait for HFCLK192M to be running */
     }
+#endif
+
+#ifdef CONFIG_NRF53_DCDC
+  /* Enable DC/DC regulator */
+
+  putreg32(1, NRF53_REGULATORS_MAINDCDCEN);
 #endif
 }


### PR DESCRIPTION

## Summary

arch/nrf53: add DCDC regulator support

## Impact

new feature

## Testing

thingy53
