### PR TITLE
boards/nrf53: fix BLE HCI initialization for app core

### DIFF
--- a/boards/arm/nrf53/nrf5340-dk/src/nrf53_bringup.c
+++ b/boards/arm/nrf53/nrf5340-dk/src/nrf53_bringup.c
@@ -104,6 +104,10 @@ static int nrf53_appcore_bleinit(void)
     }
 
 #  ifdef CONFIG_DRIVERS_BLUETOOTH
+  /* Wait a moment to make sure the netcore initializes BLE */
+
+  nxsched_usleep(1000);
+
   ret = bt_driver_register(bt_dev);
   if (ret < 0)
     {

--- a/boards/arm/nrf53/thingy53/src/nrf53_bringup.c
+++ b/boards/arm/nrf53/thingy53/src/nrf53_bringup.c
@@ -91,6 +91,10 @@ static int nrf53_appcore_bleinit(void)
     }
 
 #  ifdef CONFIG_DRIVERS_BLUETOOTH
+  /* Wait a moment to make sure the netcore initializes BLE */
+
+  nxsched_usleep(1000);
+
   ret = bt_driver_register(bt_dev);
   if (ret < 0)
     {


### PR DESCRIPTION
## Summary

After simplifications in NuttX init process, app core boots too fast so that net core doesn't have time to initialize HCI service.

This PR add a short sleep before BLE initialization in app core as a temporary fix, in the future it should be done better.

## Impact

fix BLE

## Testing

thingy53