### PR TITLE
Define atomic macros for C++ project to fix nuttx/spinlock.h compilat…

### DIFF
--- a/include/nuttx/atomic.h
+++ b/include/nuttx/atomic.h
@@ -207,6 +207,125 @@ typedef volatile int64_t atomic64_t;
 #define atomic64_try_cmpxchg_relaxed(obj, expected, desired) \
   ATOMIC_FUNC(compare_exchange_weak, 8)(obj, (FAR int64_t *)expected, desired, __ATOMIC_RELAXED, __ATOMIC_RELAXED)
 
+#elif defined(__cplusplus)
+/* Store Operations */
+#define atomic_set(obj, val)                  __atomic_store_n(obj, val, __ATOMIC_RELAXED)
+#define atomic_set_release(obj, val)          __atomic_store_n(obj, val, __ATOMIC_RELEASE)
+#define atomic64_set(obj, val)                __atomic_store_n(obj, val, __ATOMIC_RELAXED)
+#define atomic64_set_release(obj, val)        __atomic_store_n(obj, val, __ATOMIC_RELEASE)
+
+/* Load Operations */
+#define atomic_read(obj)                      __atomic_load_n(obj, __ATOMIC_RELAXED)
+#define atomic_read_acquire(obj)              __atomic_load_n(obj, __ATOMIC_ACQUIRE)
+#define atomic64_read(obj)                    __atomic_load_n(obj, __ATOMIC_RELAXED)
+#define atomic64_read_acquire(obj)            __atomic_load_n(obj, __ATOMIC_ACQUIRE)
+
+/* Fetch Add Operations */
+#define atomic_fetch_add(obj, val)            __atomic_fetch_add(obj, val, __ATOMIC_ACQ_REL)
+#define atomic_fetch_add_acquire(obj, val)    __atomic_fetch_add(obj, val, __ATOMIC_ACQUIRE)
+#define atomic_fetch_add_release(obj, val)    __atomic_fetch_add(obj, val, __ATOMIC_RELEASE)
+#define atomic_fetch_add_relaxed(obj, val)    __atomic_fetch_add(obj, val, __ATOMIC_RELAXED)
+#define atomic64_fetch_add(obj, val)          __atomic_fetch_add(obj, val, __ATOMIC_ACQ_REL)
+#define atomic64_fetch_add_acquire(obj, val)  __atomic_fetch_add(obj, val, __ATOMIC_ACQUIRE)
+#define atomic64_fetch_add_release(obj, val)  __atomic_fetch_add(obj, val, __ATOMIC_RELEASE)
+#define atomic64_fetch_add_relaxed(obj, val)  __atomic_fetch_add(obj, val, __ATOMIC_RELAXED)
+
+/* Fetch Sub Operations */
+#define atomic_fetch_sub(obj, val)            __atomic_fetch_sub(obj, val, __ATOMIC_ACQ_REL)
+#define atomic_fetch_sub_acquire(obj, val)    __atomic_fetch_sub(obj, val, __ATOMIC_ACQUIRE)
+#define atomic_fetch_sub_release(obj, val)    __atomic_fetch_sub(obj, val, __ATOMIC_RELEASE)
+#define atomic_fetch_sub_relaxed(obj, val)    __atomic_fetch_sub(obj, val, __ATOMIC_RELAXED)
+#define atomic64_fetch_sub(obj, val)          __atomic_fetch_sub(obj, val, __ATOMIC_ACQ_REL)
+#define atomic64_fetch_sub_acquire(obj, val)  __atomic_fetch_sub(obj, val, __ATOMIC_ACQUIRE)
+#define atomic64_fetch_sub_release(obj, val)  __atomic_fetch_sub(obj, val, __ATOMIC_RELEASE)
+#define atomic64_fetch_sub_relaxed(obj, val)  __atomic_fetch_sub(obj, val, __ATOMIC_RELAXED)
+
+/* Fetch AND Operations */
+#define atomic_fetch_and(obj, val)            __atomic_fetch_and(obj, val, __ATOMIC_ACQ_REL)
+#define atomic_fetch_and_acquire(obj, val)    __atomic_fetch_and(obj, val, __ATOMIC_ACQUIRE)
+#define atomic_fetch_and_release(obj, val)    __atomic_fetch_and(obj, val, __ATOMIC_RELEASE)
+#define atomic_fetch_and_relaxed(obj, val)    __atomic_fetch_and(obj, val, __ATOMIC_RELAXED)
+#define atomic64_fetch_and(obj, val)          __atomic_fetch_and(obj, val, __ATOMIC_ACQ_REL)
+#define atomic64_fetch_and_acquire(obj, val)  __atomic_fetch_and(obj, val, __ATOMIC_ACQUIRE)
+#define atomic64_fetch_and_release(obj, val)  __atomic_fetch_and(obj, val, __ATOMIC_RELEASE)
+#define atomic64_fetch_and_relaxed(obj, val)  __atomic_fetch_and(obj, val, __ATOMIC_RELAXED)
+
+/* Fetch OR Operations */
+#define atomic_fetch_or(obj, val)             __atomic_fetch_or(obj, val, __ATOMIC_ACQ_REL)
+#define atomic_fetch_or_acquire(obj, val)     __atomic_fetch_or(obj, val, __ATOMIC_ACQUIRE)
+#define atomic_fetch_or_release(obj, val)     __atomic_fetch_or(obj, val, __ATOMIC_RELEASE)
+#define atomic_fetch_or_relaxed(obj, val)     __atomic_fetch_or(obj, val, __ATOMIC_RELAXED)
+#define atomic64_fetch_or(obj, val)           __atomic_fetch_or(obj, val, __ATOMIC_ACQ_REL)
+#define atomic64_fetch_or_acquire(obj, val)   __atomic_fetch_or(obj, val, __ATOMIC_ACQUIRE)
+#define atomic64_fetch_or_release(obj, val)   __atomic_fetch_or(obj, val, __ATOMIC_RELEASE)
+#define atomic64_fetch_or_relaxed(obj, val)   __atomic_fetch_or(obj, val, __ATOMIC_RELAXED)
+
+/* Fetch XOR Operations */
+#define atomic_fetch_xor(obj, val)            __atomic_fetch_xor(obj, val, __ATOMIC_ACQ_REL)
+#define atomic_fetch_xor_acquire(obj, val)    __atomic_fetch_xor(obj, val, __ATOMIC_ACQUIRE)
+#define atomic_fetch_xor_release(obj, val)    __atomic_fetch_xor(obj, val, __ATOMIC_RELEASE)
+#define atomic_fetch_xor_relaxed(obj, val)    __atomic_fetch_xor(obj, val, __ATOMIC_RELAXED)
+#define atomic64_fetch_xor(obj, val)          __atomic_fetch_xor(obj, val, __ATOMIC_ACQ_REL)
+#define atomic64_fetch_xor_acquire(obj, val)  __atomic_fetch_xor(obj, val, __ATOMIC_ACQUIRE)
+#define atomic64_fetch_xor_release(obj, val)  __atomic_fetch_xor(obj, val, __ATOMIC_RELEASE)
+#define atomic64_fetch_xor_relaxed(obj, val)  __atomic_fetch_xor(obj, val, __ATOMIC_RELAXED)
+
+/* Exchange Operations */
+#define atomic_xchg(obj, val)                 __atomic_exchange_n(obj, val, __ATOMIC_ACQ_REL)
+#define atomic_xchg_acquire(obj, val)         __atomic_exchange_n(obj, val, __ATOMIC_ACQUIRE)
+#define atomic_xchg_release(obj, val)         __atomic_exchange_n(obj, val, __ATOMIC_RELEASE)
+#define atomic_xchg_relaxed(obj, val)         __atomic_exchange_n(obj, val, __ATOMIC_RELAXED)
+#define atomic64_xchg(obj, val)               __atomic_exchange_n(obj, val, __ATOMIC_ACQ_REL)
+#define atomic64_xchg_acquire(obj, val)       __atomic_exchange_n(obj, val, __ATOMIC_ACQUIRE)
+#define atomic64_xchg_release(obj, val)       __atomic_exchange_n(obj, val, __ATOMIC_RELEASE)
+#define atomic64_xchg_relaxed(obj, val)       __atomic_exchange_n(obj, val, __ATOMIC_RELAXED)
+
+/* Compare and Exchange (Strong) - 32-bit */
+#define atomic_cmpxchg(obj, expected, desired) \
+  __atomic_compare_exchange_n((uint32_t *)(obj), (uint32_t *)(expected), (uint32_t)(desired), false, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED)
+
+#define atomic_cmpxchg_acquire(obj, expected, desired) \
+  __atomic_compare_exchange_n((uint32_t *)(obj), (uint32_t *)(expected), (uint32_t)(desired), false, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED)
+
+#define atomic_cmpxchg_release(obj, expected, desired) \
+  __atomic_compare_exchange_n((uint32_t *)(obj), (uint32_t *)(expected), (uint32_t)(desired), false, __ATOMIC_RELEASE, __ATOMIC_RELAXED)
+
+#define atomic_cmpxchg_relaxed(obj, expected, desired) \
+  __atomic_compare_exchange_n((uint32_t *)(obj), (uint32_t *)(expected), (uint32_t)(desired), false, __ATOMIC_RELAXED, __ATOMIC_RELAXED)
+
+/* Try Compare and Exchange (Weak) - 32-bit */
+#define atomic_try_cmpxchg(obj, expected, desired) \
+  __atomic_compare_exchange_n((uint32_t *)(obj), (uint32_t *)(expected), (uint32_t)(desired), true, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED)
+
+#define atomic_try_cmpxchg_acquire(obj, expected, desired) \
+  __atomic_compare_exchange_n((uint32_t *)(obj), (uint32_t *)(expected), (uint32_t)(desired), true, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED)
+
+#define atomic_try_cmpxchg_release(obj, expected, desired) \
+  __atomic_compare_exchange_n((uint32_t *)(obj), (uint32_t *)(expected), (uint32_t)(desired), true, __ATOMIC_RELEASE, __ATOMIC_RELAXED)
+
+#define atomic_try_cmpxchg_relaxed(obj, expected, desired) \
+  __atomic_compare_exchange_n((uint32_t *)(obj), (uint32_t *)(expected), (uint32_t)(desired), true, __ATOMIC_RELAXED, __ATOMIC_RELAXED)
+  
+/* Compare and Exchange (Strong) - 64-bit */
+#define atomic64_cmpxchg(obj, expected, desired) \
+  __atomic_compare_exchange_n(obj, expected, desired, false, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED)
+#define atomic64_cmpxchg_acquire(obj, expected, desired) \
+  __atomic_compare_exchange_n(obj, expected, desired, false, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED)
+#define atomic64_cmpxchg_release(obj, expected, desired) \
+  __atomic_compare_exchange_n(obj, expected, desired, false, __ATOMIC_RELEASE, __ATOMIC_RELAXED)
+#define atomic64_cmpxchg_relaxed(obj, expected, desired) \
+  __atomic_compare_exchange_n(obj, expected, desired, false, __ATOMIC_RELAXED, __ATOMIC_RELAXED)
+
+/* Try Compare and Exchange (Weak) - 64-bit */
+#define atomic64_try_cmpxchg(obj, expected, desired) \
+  __atomic_compare_exchange_n(obj, expected, desired, true, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED)
+#define atomic64_try_cmpxchg_acquire(obj, expected, desired) \
+  __atomic_compare_exchange_n(obj, expected, desired, true, __ATOMIC_ACQUIRE, __ATOMIC_RELAXED)
+#define atomic64_try_cmpxchg_release(obj, expected, desired) \
+  __atomic_compare_exchange_n(obj, expected, desired, true, __ATOMIC_RELEASE, __ATOMIC_RELAXED)
+#define atomic64_try_cmpxchg_relaxed(obj, expected, desired) \
+  __atomic_compare_exchange_n(obj, expected, desired, true, __ATOMIC_RELAXED, __ATOMIC_RELAXED)
+
 #endif
 
 /****************************************************************************

--- a/include/nuttx/atomic.h
+++ b/include/nuttx/atomic.h
@@ -305,7 +305,7 @@ typedef volatile int64_t atomic64_t;
 
 #define atomic_try_cmpxchg_relaxed(obj, expected, desired) \
   __atomic_compare_exchange_n((uint32_t *)(obj), (uint32_t *)(expected), (uint32_t)(desired), true, __ATOMIC_RELAXED, __ATOMIC_RELAXED)
-  
+
 /* Compare and Exchange (Strong) - 64-bit */
 #define atomic64_cmpxchg(obj, expected, desired) \
   __atomic_compare_exchange_n(obj, expected, desired, false, __ATOMIC_ACQ_REL, __ATOMIC_RELAXED)


### PR DESCRIPTION
## Issue
Fail to build Pi Pico NuttX C++ project with SMP feature as <nuttx/spinlock.h> is a C header that uses raw macro calls (atomic_cmpxchg_acquire(...)).

## Summary
Failed to build a Pi Pico C++ project with SMP enabled due to the missing atomic marcos for nuttx/spinlock.h 
Define atomic macros for C++ project to fix nuttx/spinlock.h compilation issue

## Impact
Failed to build a Pi Pico (RP2040) C++ project with the SMP feature enabled. Notably, robust SMP support on the RP2040 is a key feature that encourages developers to choose NuttX over other RTOS options.

## Testing
Follow the steps on https://github.com/teamprof/arduprof-template/tree/main/pico-nuttx-app to create a C++ project: 
  git clone --recurse-submodules https://github.com/teamprof/arduprof-template.gif
  cd arduprof-template/pico-nuttx-app
  ln -s ../src apps/arduprof
  cd nuttx
  ./tools/configure.sh -l ../src/boards/arm/rp2040/raspberrypi-pico/configs/smp
  make

Launch a Serial Terminal and connect to Pico's GPIO0/1 at 115200bps
Run "arduprof" under nsh in the terminal

Before

LN: platform/board to /home/teamprof/prj/arduino/arduprof-template/pico-nuttx-app/apps/platform/dummy
Register: arduprof
Register: hello
Register: dd
Register: nsh
Register: sh
Register: taskset
Register: ostest
Register: getprime
Register: smp
CXX:  AppContext.cxx In file included from ././../lib/arduprof/src/./os/nuttx/thread/.././MessageQueue.h:29,
                 from ././../lib/arduprof/src/./os/nuttx/thread/../MessageBus.h:28,
                 from ././../lib/arduprof/src/./os/nuttx/thread/ThreadBase.h:28,
                 from ././../lib/arduprof/src/ArduProf.h:77,
                 from ././ArduProfApp.h:59,
                 from ./AppContext.h:22,
                 from AppContext.cxx:21:
/home/teamprof/prj/arduino/arduprof-template/pico-nuttx-app/nuttx/include/nuttx/spinlock.h: In function 'void rspin_lock(rspinlock_t*)':
/home/teamprof/prj/arduino/arduprof-template/pico-nuttx-app/nuttx/include/nuttx/spinlock.h:614:11: error: 'atomic_cmpxchg_acquire' was not declared in this scope
  614 |   while (!atomic_cmpxchg_acquire((FAR atomic_t *)&lock->val,
      |           ^~~~~~~~~~~~~~~~~~~~~~
/home/teamprof/prj/arduino/arduprof-template/pico-nuttx-app/nuttx/include/nuttx/spinlock.h: In function 'bool rspin_trylock(rspinlock_t*)':
/home/teamprof/prj/arduino/arduprof-template/pico-nuttx-app/nuttx/include/nuttx/spinlock.h:687:10: error: 'atomic_cmpxchg_acquire' was not declared in this scope
  687 |   return atomic_cmpxchg_acquire((FAR atomic_t *)&lock->val,
      |          ^~~~~~~~~~~~~~~~~~~~~~
/home/teamprof/prj/arduino/arduprof-template/pico-nuttx-app/nuttx/include/nuttx/spinlock.h: In function 'bool rspin_unlock(rspinlock_t*)':
/home/teamprof/prj/arduino/arduprof-template/pico-nuttx-app/nuttx/include/nuttx/spinlock.h:914:7: error: 'atomic_set_release' was not declared in this scope
  914 |       atomic_set_release((FAR atomic_t *)&lock->val, 0);
      |       ^~~~~~~~~~~~~~~~~~
././../lib/arduprof/src/./os/nuttx/thread/.././MessageQueue.h: In member function 'void nuttxos::MessageQueue::postEvent(void*, const Message&, int)':
././../lib/arduprof/src/./os/nuttx/thread/.././MessageQueue.h:146:51: error: '_lock_pool' was not declared in this scope
  146 |             irqstate_t flags = spin_lock_irqsave(&_lock_pool);
      |                                                   ^~~~~~~~~~
././../lib/arduprof/src/./os/nuttx/thread/../MessageBus.h: In member function 'virtual void nuttxos::MessageBus::messageLoop(uint32_t)':
././../lib/arduprof/src/./os/nuttx/thread/../MessageBus.h:78:51: error: '_lock_pool' was not declared in this scope
   78 |             irqstate_t flags = spin_lock_irqsave(&_lock_pool);
      |                                                   ^~~~~~~~~~
make[2]: *** [/home/teamprof/prj/arduino/arduprof-template/pico-nuttx-app/apps/Application.mk:268: AppContext.cxx.home.teamprof.prj.arduino.arduprof-template.pico-nuttx-app.src.app.o] Error 1
make[1]: *** [Makefile:54: /home/teamprof/prj/arduino/arduprof-template/pico-nuttx-app/apps/../src/app_all] Error 2
make: *** [tools/LibTargets.mk:248: /home/teamprof/prj/arduino/arduprof-template/pico-nuttx-app/apps/libapps.a] Error 2


After
~/prj/arduino/arduprof-template/pico-nuttx-app/nuttx$ make
CPP:  /home/teamprof/prj/arduino/arduprof-template/pico-nuttx-app/nuttx/boards/arm/rp2040/raspberrypi-pico/scripts/raspberrypi-pico-flash.ld-> /home/teamprof/prj/arduino/arduprof-template/pico-nuttx-app/nuttx/boards/arm/rp20LD: nuttx
Memory region         Used Size  Region Size  %age Used
           flash:        196 KB         2 MB      9.57%
            sram:       14320 B       264 KB      5.30%
Generating: nuttx.uf2
Done.


minicom screenshot of running on Pi Pico
<img width="1326" height="893" alt="run-pico-smp" src="https://github.com/user-attachments/assets/5dd1b09e-195d-4c30-88a9-bd4e889aae88" />

