### PR TITLE
{bp-19740} drivers/usbdev/cdcacm: fix self-deadlock in cdcuart_txempty()

### DIFF
--- a/drivers/usbdev/cdcacm.c
+++ b/drivers/usbdev/cdcacm.c
@@ -2945,6 +2945,8 @@ static bool cdcuart_txempty(FAR struct uart_dev_s *dev)
       return true;
     }
 
+  spin_unlock_irqrestore(&priv->lock, flags);
+
   priv->ispolling = true;
   EP_POLL(ep);
   priv->ispolling = false;


### PR DESCRIPTION
## Summary

cdcuart_txempty() held priv->lock across EP_POLL(), which re-enters the class through cdcacm_wrcomplete() and takes that same non-recursive lock, and then took it a second time to read nwrq. Release it after the disconnected check, matching cdcuart_txready()/cdcuart_rxavailable().

Fixes: cc067ab199bb ("drivers/usbdev/cdcacm.c: Use small lock to protect cdcacm")

## Impact

RELEASE

## Testing

CI