### PR TITLE
{bp-19742} drivers/usbhost: Refuse to register the same class driver twice.

### DIFF
--- a/drivers/usbhost/usbhost_registerclass.c
+++ b/drivers/usbhost/usbhost_registerclass.c
@@ -81,6 +81,7 @@
 
 int usbhost_registerclass(struct usbhost_registry_s *usbclass)
 {
+  FAR struct usbhost_registry_s *curr;
   irqstate_t flags;
 
   uinfo("Registering class:%p nids:%d\n", usbclass, usbclass->nids);
@@ -92,6 +93,22 @@ int usbhost_registerclass(struct usbhost_registry_s *usbclass)
    */
 
   flags = spin_lock_irqsave(&g_classregistry_lock);
+
+  /* Refuse an entry that is already registered.
+   *
+   * These are static structures, so registering one twice points the
+   * entry's own link at itself and the list loses its end.  A later search
+   * for a class that is not there never returns, holding this lock.
+   */
+
+  for (curr = g_classregistry; curr != NULL; curr = curr->flink)
+    {
+      if (curr == usbclass)
+        {
+          spin_unlock_irqrestore(&g_classregistry_lock, flags);
+          return OK;
+        }
+    }
 
   /* Add the new class ID info to the head of the list */
 


### PR DESCRIPTION
## Summary

The registry is a singly linked list of static structures, so registering one of them a second time does not add a second entry: it points that entry's own link at itself, and the list stops having an end.

Nothing notices while every device that turns up matches something near the head, because the search returns before it reaches the loop.  The first device that matches nothing at all, meaning anything without a class driver built in, walks the list to look for it and never comes back, holding the registry lock.  On a multiprocessor the rest of the system follows it down: every other processor that touches the registry spins, and on the one measured here that included the console, so a board with a USB keyboard and no keyboard driver came up and then answered nothing.

Registering twice is easy to do by accident.  drivers_initialize() calls usbhost_drivers_initialize(), which registers every class the configuration selected, and board code that also registers one, which many boards do, gets a second call for free.

So look before linking, and treat a repeat registration as the no-op the caller expected it to be.

Assisted-by: Claude:claude-opus-5

## Impact

RELEASE

## Testing

CI