### PR TITLE
arch/tricore: idle donot depend on illd

### DIFF
--- a/arch/tricore/src/common/tricore_idle.c
+++ b/arch/tricore/src/common/tricore_idle.c
@@ -33,6 +33,16 @@
 #include "tricore_internal.h"
 
 /****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#if defined(__TASKING__)
+#  define tricore_idle_loop() __asm__ volatile ("1: loopu 1p")
+#else
+#  define tricore_idle_loop() __asm__ volatile ("1: loopu 1b")
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -67,10 +77,7 @@ void up_idle(void)
   board_autoled_off(LED_CPU);
 #endif
 
-  /* This would be an appropriate place to put some MCU-specific logic to
-   * sleep in a reduced power mode until an interrupt occurs to save power
-   */
+  tricore_idle_loop();
 
-  Ifx_Ssw_infiniteLoop();
 #endif
 }


### PR DESCRIPTION
## Summary

The arch/tricore idle loop used the Infineon iLLD helper
`Ifx_Ssw_infiniteLoop()`, which coupled the core idle path to the
iLLD/Ssw layer. This replaces it with a self-contained `loopu`
(loop unconditional) instruction wrapper, `tricore_idle_loop()`.
`loopu` branches to itself until an interrupt is taken, which is the
standard TriCore low-power idle sequence. The GNU and Tasking
assemblers spell the backward label differently, so the macro
dispatches on the toolchain (GNU `1b` / Tasking `1p`).

This removes the arch/tricore idle path's dependency on the Infineon
iLLD/Ssw layer. There is no behavior change: the loop is still left
by any IRQ that causes a context switch away from the idle task.

## Impact

- Area: arch/tricore idle path only.
- Behavior: unchanged.
- User / build / documentation / security / compatibility: no impact.

## Testing

- Build Host: Linux x86_64, GCC 11.3.1 (tricore-elf-gcc)
- Target: tricore, triboard_tc4x9_com:nsh

Build (0 errors, ELF produced):

```
LD: nuttx
```

Runtime (flashed to TC4x board, boots to NSH):

```
NuttShell (NSH) NuttX-13.0.0
nsh>
```
