### PR TITLE
arch/risc-v/espressif: fix SPI IOMUX false positive without SPI2

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_spi.c
+++ b/arch/risc-v/src/common/espressif/esp_spi.c
@@ -127,18 +127,26 @@
 #endif
 
 /* Verify whether SPI has been assigned IOMUX pins.
- * Otherwise, SPI signals will be routed via GPIO Matrix.
+ * Otherwise, SPI signals will be routed via GPIO Matrix.  Chips without
+ * SPI2_IOMUX_* definitions (e.g. ESP32-P4) have no IOMUX pins for SPI and
+ * are always routed via GPIO Matrix.
  */
 
-#define SPI_IS_CS_IOMUX   (CONFIG_ESPRESSIF_SPI2_CSPIN == SPI2_IOMUX_CSPIN)
-#define SPI_IS_CLK_IOMUX  (CONFIG_ESPRESSIF_SPI2_CLKPIN == SPI2_IOMUX_CLKPIN)
-#define SPI_IS_MOSI_IOMUX (CONFIG_ESPRESSIF_SPI2_MOSIPIN == SPI2_IOMUX_MOSIPIN)
-#define SPI_IS_MISO_IOMUX (CONFIG_ESPRESSIF_SPI2_MISOPIN == SPI2_IOMUX_MISOPIN)
+#if defined(CONFIG_ESPRESSIF_SPI2) && defined(SPI2_IOMUX_CSPIN)
+#  define SPI_IS_CS_IOMUX   (CONFIG_ESPRESSIF_SPI2_CSPIN == SPI2_IOMUX_CSPIN)
+#  define SPI_IS_CLK_IOMUX  (CONFIG_ESPRESSIF_SPI2_CLKPIN == SPI2_IOMUX_CLKPIN)
+#  define SPI_IS_MOSI_IOMUX (CONFIG_ESPRESSIF_SPI2_MOSIPIN == \
+                             SPI2_IOMUX_MOSIPIN)
+#  define SPI_IS_MISO_IOMUX (CONFIG_ESPRESSIF_SPI2_MISOPIN == \
+                             SPI2_IOMUX_MISOPIN)
 
-#define SPI_VIA_IOMUX     ((SPI_IS_CS_IOMUX || SPI_HAVE_SWCS) && \
-                           (SPI_IS_CLK_IOMUX) &&                 \
-                           (SPI_IS_MOSI_IOMUX) &&                \
-                           (SPI_IS_MISO_IOMUX)) ? 1 : 0
+#  define SPI_VIA_IOMUX     ((SPI_IS_CS_IOMUX || SPI_HAVE_SWCS) && \
+                             (SPI_IS_CLK_IOMUX) &&                 \
+                             (SPI_IS_MOSI_IOMUX) &&                \
+                             (SPI_IS_MISO_IOMUX)) ? 1 : 0
+#else
+#  define SPI_VIA_IOMUX     0
+#endif
 
 /* SPI default frequency (limited by clock divider) */
 


### PR DESCRIPTION
## Summary

<!-- This field should contain a summary of the changes. It will be pre-filled with the commit's message and descriptions. Adjust it accordingly -->

* arch/risc-v/espressif: fix SPI IOMUX false positive without SPI2

SPI_VIA_IOMUX used SPI2 IOMUX pin macros that are undefined when SPI2
is disabled or on chips without IOMUX SPI pins (e.g. ESP32-P4), so the
driver took the IOMUX path and never routed SPI3 via the GPIO matrix.

Assisted-by: Cursor Grok 4.5

## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: No.
<!-- Does it impact user's applications? How? -->

Impact on build: No.
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: Fixes issue when using SPI3 but not SPI2, which routed CS pin on the wrong path.
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: No.
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: No.
<!-- Does it impact NuttX's security? -->

Impact on compatibility: No.
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

## Testing
Tested on `esp32p4-tab5` SD Card support using SPI3.

### Building
Build NSH defconfig with SPI3, SDMMC and FAT_FS support.

### Results
Before changes:
```
esp_spi_poll_send: send=0x95 and recv=0x0
esp_spi_poll_send: send=0xff and recv=0x0
mmcsd_mediainitialize: ERROR: Send CMD0 failed: R1=00
```
The SD Card would fail to mount since improper data was present on SPI bus.

After changes:
```
nsh> mount -t vfat /dev/mmcsd0 /mnt
nsh> ls /mnt
/mnt:
hello.txt
nsh> cat /mnt/hello.txt
Hello World
nsh> echo 'NuttX RTOS' >> /mnt/hello.txt
nsh> cat /mnt/hello.txt
Hello World!
NuttX RTOS
```