### PR TITLE
arch/arm/stm32h5: Fix handling of GPIO port I

### DIFF
--- a/arch/arm/include/stm32h5/chip.h
+++ b/arch/arm/include/stm32h5/chip.h
@@ -87,7 +87,7 @@
 #endif
 
 #define STM32_NDMA                     (2)   /* DMA1-2 */
-#define STM32_NPORTS                   (8)   /* 8 GPIO ports, GPIOA-GPIOI */
+#define STM32_NPORTS                   (9)   /* 9 GPIO ports, GPIOA-GPIOI */
 #define STM32_NADC                     (2)   /* 12-bit ADC1, up to 20 channels */
 #define STM32_NDAC                     (1)   /* 12-bit DAC1 */
 #define STM32_NCRC                     (1)   /* CRC */

--- a/arch/arm/src/stm32h5/stm32_gpio.c
+++ b/arch/arm/src/stm32h5/stm32_gpio.c
@@ -78,6 +78,9 @@ const uint32_t g_gpiobase[STM32_NPORTS] =
 #if STM32_NPORTS > 7
   STM32_GPIOH_BASE,
 #endif
+#if STM32_NPORTS > 8
+  STM32_GPIOI_BASE,
+#endif
 };
 
 /****************************************************************************

--- a/arch/arm/src/stm32h5/stm32h5xx_rcc.c
+++ b/arch/arm/src/stm32h5/stm32h5xx_rcc.c
@@ -226,7 +226,7 @@ static inline void rcc_enableahb2(void)
 #if STM32_NPORTS > 7
              | RCC_AHB2ENR_GPIOHEN
 #endif
-#if STM32_NPORTS > 7
+#if STM32_NPORTS > 8
              | RCC_AHB2ENR_GPIOIEN
 #endif
 


### PR DESCRIPTION
## Summary

STM32H5 GPIO port I is not currently usable. The STM32H5 has GPIO ports A through I (a total of 9), but port I is not handled correctly in three places:

* `arch/arm/include/stm32h5/chip.h`: `STM32_NPORTS` is 8 instead of 9
* `arch/arm/src/stm32h5/stm32_gpio.c`: Port I's register base is not defined
* `arch/arm/src/stm32h5/stm32h5xx_rcc.c`: Port I clock gating is not using the correct value for the comparison with `STM32_NPORTS`

## Impact

Without this change, attempting to access port I on an STM32H5 will fail silently, because `stm32_gpiowrite` and `stm32_gpioread` compare the port to `STM32_NPORTS`. Writes do nothing, and reads always return 0.

## Testing

The NUCLEO-H563ZI's MCU is in a package where GPIOI is not bonded, but the registers are still present and functional. With the following code, the functionality of `stm32_gpiowrite` can be checked. It sets GPIO port I pin 0 to high and then low, logging the contents of the GPIOI output data register (ODR).

[nucleo-h563zi-gpio-i-test.patch](https://github.com/user-attachments/files/30909217/nucleo-h563zi-gpio-i-test.patch)

### Before

```
GPIOI ODR 00000000
GPIOI ODR 00000000
```

### After

```
GPIOI ODR 00000001
GPIOI ODR 00000000
```

This has also been tested on a custom PCB with an LED connected to a port I GPIO pin. Previously the LED did not turn on. With this change the LED can be controlled.