### PR TITLE
tools/rust: Fix softfloat abi target spec name

### DIFF
--- a/tools/i486-unknown-nuttx.json
+++ b/tools/i486-unknown-nuttx.json
@@ -21,7 +21,7 @@
   "os": "nuttx",
   "position-independent-executables": false,
   "relro-level": "full",
-  "rustc-abi": "x86-softfloat",
+  "rustc-abi": "softfloat",
   "stack-probes": {
     "kind": "inline"
   },

--- a/tools/x86_64-unknown-nuttx.json
+++ b/tools/x86_64-unknown-nuttx.json
@@ -19,7 +19,7 @@
   "plt-by-default": false,
   "position-independent-executables": true,
   "relro-level": "full",
-  "rustc-abi": "x86-softfloat",
+  "rustc-abi": "softfloat",
   "stack-probes": {
     "kind": "inline"
   },


### PR DESCRIPTION
Rename abi "x86-softfloat" to just "softfloat" to enable compatibility with newer rust nightly versions.

## Summary

Rust recently changed the name of the softfloat abi to one more unified across targets, and more recently, removed the compat alias. 

See [this PR](https://github.com/rust-lang/rust/pull/157151) for the removal of the alias and [this PR](https://github.com/rust-lang/rust/pull/151154) for the introduction of the new abi name.

## Impact

This should allow rust programs compiling with nuttx's build scaffolding to be able to use newer nightly compilers.

## Testing

This was tested with the latest rust version as of writing this (nightly-2026-08-09) with the "hello" example app for rust for the linux sim target.

Unfortunately due to a [change to libc](https://github.com/rust-lang/libc/pull/5245), compiling said example on x86/x86_64 with cargo remains broken. The cargo-less version builds and runs through.