### PR TITLE
mips/Makefile: Add nuttx build with CONFIG_ALLSYMS enabled.

### DIFF
--- a/arch/mips/src/Makefile
+++ b/arch/mips/src/Makefile
@@ -89,11 +89,29 @@ libarch$(LIBEXT): $(OBJS)
 board/libboard$(LIBEXT):
 	$(Q) $(MAKE) -C board libboard$(LIBEXT) EXTRAFLAGS="$(EXTRAFLAGS)"
 
+define LINK_ALLSYMS
+	$(Q) $(TOPDIR)/tools/mkallsyms.py $(NUTTX) allsyms.tmp --orderbyname $(CONFIG_SYMTAB_ORDEREDBYNAME)
+	$(Q) $(call COMPILE, allsyms.tmp, allsyms$(OBJEXT), -x c)
+	$(Q) $(LD) --entry=__start $(LDFLAGS) $(LIBPATHS) $(EXTRA_LIBPATHS) \
+		-o $(NUTTX) $(HEAD_OBJ) allsyms$(OBJEXT) $(EXTRA_OBJS) \
+		$(LDSTARTGROUP) $(LDLIBS) $(EXTRA_LIBS) $(LDENDGROUP)
+	$(Q) $(call DELFILE, allsyms.tmp allsyms$(OBJEXT))
+endef
+
 nuttx$(EXEEXT): $(HEAD_OBJ) board/libboard$(LIBEXT) $(ARCHSCRIPT)
 	@echo "LD: nuttx"
+ifneq ($(CONFIG_ALLSYMS),y)
 	$(Q) $(LD) --entry=__start $(LDFLAGS) $(LIBPATHS) $(EXTRA_LIBPATHS) \
 		-o $(NUTTX) $(HEAD_OBJ) $(EXTRA_OBJS) \
 		$(LDSTARTGROUP) $(LDLIBS) $(EXTRA_LIBS) $(LDENDGROUP)
+else
+	$(Q) # Link and generate default table
+	$(Q) $(if $(wildcard $(shell echo $(NUTTX))),,$(call LINK_ALLSYMS,$^))
+	$(Q) # Extract all symbols
+	$(Q) $(call LINK_ALLSYMS, $^)
+	$(Q) # Extract again since the table offset may changed
+	$(Q) $(call LINK_ALLSYMS, $^)
+endif
 ifneq ($(CONFIG_WINDOWS_NATIVE),y)
 	$(Q) $(NM) $(NUTTX) | \
 	grep -v '\(compiled\)\|\(\$(OBJEXT)$$\)\|\( [aUw] \)\|\(\.\.ng$$\)\|\(LASH[RL]DI\)' | \


### PR DESCRIPTION
Change the arch/mips/src/Makefile to build nuttx with CONFIG_ALLSYMS enabled in MIPS architecture. This enables symbol name showing in system, such as 'dumpstack 3' shows both functions name and addresses.

This change is referred to arch/tricore/src/Makefile and updated to work well with MIPS. And it works with and without CONFIG_ALLSYMS enabled.

Fixes apache#19728

*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

Change the arch/mips/src/Makefile to build nuttx with CONFIG_ALLSYMS enabled in MIPS architecture. This enables symbol name showing in system, such as 'dumpstack 3' shows both functions name and addresses.

This change is referred to arch/tricore/src/Makefile and updated to work well with MIPS. And it works with and without CONFIG_ALLSYMS enabled.

## Impact

It is used for building nuttx in MIPS architecture with or without CONFIG_ALLSYMS enabled.

## Testing

1. tools/configure.sh -l ci20:nsh
2. make -j10
3. nuttx is built, nuttx.bin, nuttx.map are generated.
4. open nuttx.map, search `symtab_allsyms`, not find instance.

Then
1. make menuconfig, select `load all symbols for debugging` in `Library Routines`, save and exit.
2. check .config, confirm `CONFIG_ALLSYMS` is defined.
3. make clean && make -j10
4. nuttx is built, nuttx.bin, nuttx.map are generated,
5. open nuttx.map, search `symtab_allsyms`, there are several instances. And there are `.data.g_allsyms` and `.data.g_nallsyms` defined.

The testing host is WSL2 with Linux-6.6.114.1-microsoft-standand-WSL2 kernel.
I have NO pic32 or jz4780 board, I did NOT test the real nuttx in hardware.

No special document update needed.

