### PR TITLE
boards/esp32s3-ws-lcd128: use esp_hr_timer_init(), fix Wi-Fi build

### DIFF
--- a/boards/xtensa/esp32s3/esp32s3-ws-lcd128/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/esp32s3-ws-lcd128/src/esp32s3_bringup.c
@@ -57,8 +57,8 @@
 #  include "esp32s3_wifi_adapter.h"
 #endif
 
-#ifdef CONFIG_ESP32S3_RT_TIMER
-#  include "esp32s3_rt_timer.h"
+#ifdef CONFIG_ESPRESSIF_HR_TIMER
+#  include "espressif/esp_hr_timer.h"
 #endif
 
 #ifdef CONFIG_ESP32S3_I2C
@@ -314,11 +314,11 @@ int esp32s3_bringup(void)
     }
 #endif
 
-#ifdef CONFIG_ESP32S3_RT_TIMER
-  ret = esp32s3_rt_timer_init();
+#ifdef CONFIG_ESPRESSIF_HR_TIMER
+  ret = esp_hr_timer_init();
   if (ret < 0)
     {
-      syslog(LOG_ERR, "Failed to initialize RT timer: %d\n", ret);
+      syslog(LOG_ERR, "ERROR: esp_hr_timer_init() failed: %d\n", ret);
     }
 #endif
 


### PR DESCRIPTION
## Summary

`boards/xtensa/esp32s3/esp32s3-ws-lcd128/src/esp32s3_bringup.c` was missed when
the chip-specific RT timer was replaced by the common-source HR Timer. It still
guards on `CONFIG_ESP32S3_RT_TIMER`, includes `"esp32s3_rt_timer.h"` and calls
`esp32s3_rt_timer_init()` — none of which exist in the tree any more:

```
$ git ls-files | grep -c esp32s3_rt_timer
0
```

`c17e16eaed` ("xtensa/espressif: Update common-source integration for Xtensa
devices") deleted `arch/xtensa/src/esp32s3/esp32s3_rt_timer.{c,h}` and converted
every other esp32s3 board's bringup to `CONFIG_ESPRESSIF_HR_TIMER` /
`"espressif/esp_hr_timer.h"` / `esp_hr_timer_init()`. This board kept the old
form.

## Why it is a build breakage, not dead code

`ESP32S3_RT_TIMER` still exists as a deprecated alias whose only job is
`select ESPRESSIF_HR_TIMER`, and `ESPRESSIF_WIRELESS` selects it
(`arch/xtensa/src/common/espressif/Kconfig`):

```
config ESPRESSIF_WIRELESS
	...
	select ESP32S3_RT_TIMER if ARCH_CHIP_ESP32S3
```

So enabling Wi-Fi on this board switches the stale block on and the build dies:

```
board/esp32s3_bringup.c:61:12: fatal error: esp32s3_rt_timer.h: No such file or directory
```

No `esp32s3-ws-lcd128` defconfig enables Wi-Fi, so CI never compiles that
combination — which is why this has gone unnoticed.

## The change

Switch to the guard, include and initializer every other esp32s3 board uses
(`esp32s3-devkit`, `esp32s3-eye`, `esp32s3-box`, `esp32s3-korvo-2`, …), including
their `"ERROR: esp_hr_timer_init() failed: %d\n"` message form. No new variant is
introduced.

No functional change for the board's existing defconfigs (`nsh`, `coremark`,
`ostest`, `watchdog`, `imu-qmi8658`, `notouch-lvgl`, `touch-lvgl`): none of them
set `ESP32S3_RT_TIMER` or `ESPRESSIF_HR_TIMER`, so the block stays compiled out
exactly as before.

## Testing

Reproduced and verified by compiling, with the *same* configuration before and
after the patch:

```
./tools/configure.sh -a ../apps esp32s3-ws-lcd128:nsh
kconfig-tweak --enable  CONFIG_ESPRESSIF_WIFI
kconfig-tweak --enable  CONFIG_SCHED_LPWORK
kconfig-tweak --enable  CONFIG_DRIVERS_WIRELESS
kconfig-tweak --enable  CONFIG_DRIVERS_IEEE80211
kconfig-tweak --enable  CONFIG_NETDEV_WIRELESS_IOCTL
kconfig-tweak --enable  CONFIG_WIRELESS_WAPI
kconfig-tweak --enable  CONFIG_NET_TCP
kconfig-tweak --enable  CONFIG_NET_UDP
kconfig-tweak --enable  CONFIG_TIMER
kconfig-tweak --set-val CONFIG_IOB_NCHAINS    32
kconfig-tweak --set-val CONFIG_IOB_NBUFFERS   100
kconfig-tweak --set-val CONFIG_IOB_BUFSIZE    400
kconfig-tweak --set-val CONFIG_IOB_THROTTLE   40
kconfig-tweak --set-val CONFIG_TLS_TASK_NELEM 4
make olddefconfig && make -j4
```

The extra options beyond `CONFIG_ESPRESSIF_WIFI` are the ordinary Wi-Fi
prerequisites that the in-tree Wi-Fi defconfigs (e.g.
`esp32s3-devkit:wifi`) already set; they are unrelated to this patch and were
needed only to get a Wi-Fi-enabled ws-lcd128 configuration to build at all.

* **Before:** `board/esp32s3_bringup.c:61:12: fatal error: esp32s3_rt_timer.h:
  No such file or directory`
* **After:** builds and images cleanly (`nuttx`, `nuttx.bin` generated), no new
  warnings from the board file.
* `tools/checkpatch.sh -g HEAD`: all checks pass.

Not tested on hardware — no ESP32-S3-LCD-1.28 board here. The change is a
mechanical rename to the current API, and the affected block is compiled out in
all of the board's existing defconfigs.

## Disclosure

This root-cause analysis, patch, and build verification were performed by an AI
agent (Claude Code, operated and directed by the submitter), and the result was
reviewed by the submitter before posting.
