### PR TITLE
drivers/devfreq: add missing governor_data field and ondemand declaration

### DIFF
--- a/include/nuttx/devfreq.h
+++ b/include/nuttx/devfreq.h
@@ -63,6 +63,7 @@ struct devfreq_s
   FAR const struct devfreq_driver_s *driver;
 
   FAR const uint32_t *freq_table;
+  FAR void *governor_data;
 
   struct qos_constraints_s constraints;
 
@@ -353,6 +354,7 @@ void devfreq_procfs_initialize(void);
 
 FAR struct devfreq_governor_s *devfreq_performance(void);
 FAR struct devfreq_governor_s *devfreq_powersave(void);
+FAR struct devfreq_governor_s *devfreq_ondemand(void);
 
 #undef EXTERN
 #if defined(__cplusplus)


### PR DESCRIPTION
## Summary

The ondemand governor (`drivers/devfreq/devfreq_ondemand.c`) stores its
private state in `dev->governor_data` and defines `devfreq_ondemand()`,
but neither the `governor_data` field in `struct devfreq_s` nor the
`devfreq_ondemand()` declaration were present in
`include/nuttx/devfreq.h`. As a result, building with
`CONFIG_DEVFREQ_GOV_ONDEMAND=y` failed to compile.

This gap was introduced during upstreaming of the devfreq framework: the
two definitions originally lived in a downstream commit whose main topic
was a cpufreq refactor, and that commit was not part of the devfreq
upstreaming series. The performance and powersave governors do not use
`governor_data`, so the problem only surfaces when the ondemand governor
is enabled (which additionally requires `!CONFIG_SCHED_CPULOAD_NONE` and
is off by default), which is why it was not caught earlier.

This PR:
- adds the `governor_data` field to `struct devfreq_s`
- declares `devfreq_ondemand()` alongside `devfreq_performance()` and
  `devfreq_powersave()`

Reported-by: @raiden00pl

## Impact

- Fixes a build failure for `CONFIG_DEVFREQ_GOV_ONDEMAND=y`.
- No impact on existing configurations: `governor_data` is a new field in
  `struct devfreq_s` and the declaration is additive; the default build
  (ondemand off) is unchanged.
- No API breakage; no behavioral change to the performance/powersave
  governors.

## Testing

**Host**
- OS: Linux x86_64 (Ubuntu)
- Toolchain: host `gcc` (sim)
- Base: apache/master

**Before this PR** — building sim with the ondemand governor enabled
fails to compile `devfreq_ondemand.c` because `struct devfreq_s` has no
`governor_data` member and `devfreq_ondemand()` is undeclared.

**After this PR** — clean build:

```
./tools/configure.sh -l sim:nsh
kconfig-tweak --file .config -e CONFIG_DEVFREQ
kconfig-tweak --file .config -e CONFIG_DEVFREQ_PROCFS
kconfig-tweak --file .config -e CONFIG_DEVFREQ_PROCFS_QOS
kconfig-tweak --file .config -d CONFIG_SCHED_CPULOAD_NONE
kconfig-tweak --file .config -e CONFIG_SCHED_CPULOAD_SYSCLK
kconfig-tweak --file .config -e CONFIG_DEVFREQ_GOV_ONDEMAND
make olddefconfig
make -j
```

Result:
```
CC:  devfreq/devfreq_ondemand.c
...
LD:  nuttx
```

`devfreq_ondemand.o` is produced and linking succeeds with no errors or warnings.

`tools/checkpatch.sh -g apache/master..HEAD` passes.