### PR TITLE
xtensa/esp32: Let a protected build boot from simple boot

### DIFF
--- a/boards/xtensa/esp32/common/scripts/kernel-space.ld
+++ b/boards/xtensa/esp32/common/scripts/kernel-space.ld
@@ -20,6 +20,8 @@
  *
  ****************************************************************************/
 
+#include <nuttx/config.h>
+
 /* Provide these so there is no need for using config files for this */
 
 __uirom_start = ORIGIN(UIROM);
@@ -159,6 +161,85 @@ SECTIONS
     *libkarch.a:interrupt.*(.literal.intr_get_item .text.intr_get_item)
     *libkarch.a:interrupt.*(.literal.intr_handler_get_arg .text.intr_handler_get_arg)
 
+#ifdef CONFIG_ESPRESSIF_SIMPLE_BOOT
+    /* Simple boot has no second-stage bootloader.  __start() runs
+     * bootloader_init() and map_rom_segments() before any flash mapping
+     * exists, so everything they reach must be resident in RAM.
+     */
+
+    /* __start() itself runs before the mapping it creates, so it cannot
+     * live in the flash it is about to map.
+     */
+
+    esp32_start.*(.literal .text .literal.* .text.*)
+
+    *libkarch.a:*esp_loader.*(.literal .text .literal.* .text.*)
+    *libkarch.a:*bootloader_init.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*bootloader_common.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*bootloader_common_loader.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*bootloader_console.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*bootloader_console_loader.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*bootloader_banner_wrap.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*bootloader_clock_init.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*bootloader_clock_loader.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*bootloader_efuse.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*bootloader_esp32.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*bootloader_flash.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*bootloader_flash_config_esp32.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*bootloader_mem.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*bootloader_panic.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*bootloader_random.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*bootloader_random_esp32.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*bootloader_sha.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*bootloader_soc.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*esp_image_format.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*flash_encrypt.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*flash_qio_mode.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*brownout_hal.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*cpu.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*cpu_region_protect.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*gpio_hal.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*periph_ctrl.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*clk.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*clk_tree_hal.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*esp_clk_tree.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*esp_clk_tree_common.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*rtc_init.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*rtc_clk.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*rtc_clk_init.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*rtc_sleep.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*rtc_time.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*regi2c_ctrl.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*efuse_hal.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*efuse_utility.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*mmu_hal.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*mpu_hal.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*cache_esp32.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*cache_hal_esp32.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*uart_hal.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*uart_hal_iram.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*uart_periph.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*wdt_hal_iram.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*esp_rom_uart.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*esp_rom_sys.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*esp_rom_spiflash.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*esp_rom_wdt.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*log.*(.text .text.* .literal .literal.*)
+    *libkarch.a:*log_lock.*(.literal .literal.* .text .text.*)
+    *libkarch.a:*log_print.*(.literal .literal.* .text .text.*)
+    *libkarch.a:*log_timestamp.*(.literal .literal.* .text .text.*)
+    *libkarch.a:*log_timestamp_common.*(.literal .literal.* .text .text.*)
+    *libkarch.a:*log_write.*(.literal .literal.* .text .text.*)
+    *libkarch.a:esp_app_desc.*(.literal .literal.* .text .text.*)
+    *libkarch.a:esp_flash_api.*(.text .text.* .literal .literal.*)
+    *libkarch.a:esp_flash_spi_init.*(.text .text.* .literal .literal.*)
+    *libkarch.a:spi_flash_hal_gpspi.*(.literal .literal.* .text .text.*)
+    *libkarch.a:spi_flash_encrypt_hal_iram.*(.text .text.* .literal .literal.*)
+    *libkarch.a:spi_flash_os_func_noos.*(.literal .literal.* .text .text.*)
+    *libkarch.a:spi_flash_os_func_app.*(.literal .literal.* .text .text.*)
+    *libkarch.a:spi_flash_wrap.*(.literal .literal.* .text .text.*)
+#endif
+
     *(.wifirxiram .wifirxiram.*)
     *(.wifi0iram  .wifi0iram.*)
     *(.wifislpiram .wifislpiram.*)
@@ -270,6 +351,67 @@ SECTIONS
     *libkarch.a:os.*(.rodata.g_int_flags_count .rodata.g_int_flags)
     *libkc.a:arch_atomic.*(.rodata .rodata.*)
 
+#ifdef CONFIG_ESPRESSIF_SIMPLE_BOOT
+    /* The read-only data of everything pinned into IRAM above. */
+
+    esp32_start.*(.rodata .rodata.*)
+
+    *libkarch.a:*esp_loader.*(.rodata .rodata.*)
+    *libkarch.a:*bootloader_init.*(.rodata .rodata.*)
+    *libkarch.a:*bootloader_common.*(.rodata .rodata.*)
+    *libkarch.a:*bootloader_common_loader.*(.rodata .rodata.*)
+    *libkarch.a:*bootloader_console.*(.rodata .rodata.*)
+    *libkarch.a:*bootloader_console_loader.*(.rodata .rodata.*)
+    *libkarch.a:*bootloader_banner_wrap.*(.rodata .rodata.*)
+    *libkarch.a:*bootloader_clock_init.*(.rodata .rodata.*)
+    *libkarch.a:*bootloader_clock_loader.*(.rodata .rodata.*)
+    *libkarch.a:*bootloader_efuse.*(.rodata .rodata.*)
+    *libkarch.a:*bootloader_esp32.*(.rodata .rodata.*)
+    *libkarch.a:*bootloader_flash.*(.rodata .rodata.*)
+    *libkarch.a:*bootloader_flash_config_esp32.*(.rodata .rodata.*)
+    *libkarch.a:*bootloader_mem.*(.rodata .rodata.*)
+    *libkarch.a:*bootloader_panic.*(.rodata .rodata.*)
+    *libkarch.a:*bootloader_random.*(.rodata .rodata.*)
+    *libkarch.a:*bootloader_random_esp32.*(.rodata .rodata.*)
+    *libkarch.a:*bootloader_sha.*(.rodata .rodata.*)
+    *libkarch.a:*bootloader_soc.*(.rodata .rodata.*)
+    *libkarch.a:*esp_image_format.*(.rodata .rodata.*)
+    *libkarch.a:*flash_encrypt.*(.rodata .rodata.*)
+    *libkarch.a:*flash_qio_mode.*(.rodata .rodata.*)
+    *libkarch.a:*brownout_hal.*(.rodata .rodata.*)
+    *libkarch.a:*cpu.*(.rodata .rodata.*)
+    *libkarch.a:*cpu_region_protect.*(.rodata .rodata.*)
+    *libkarch.a:*gpio_hal.*(.rodata .rodata.*)
+    *libkarch.a:*periph_ctrl.*(.rodata .rodata.*)
+    *libkarch.a:*clk.*(.rodata .rodata.*)
+    *libkarch.a:*clk_tree_hal.*(.rodata .rodata.*)
+    *libkarch.a:*esp_clk_tree.*(.rodata .rodata.*)
+    *libkarch.a:*esp_clk_tree_common.*(.rodata .rodata.*)
+    *libkarch.a:*rtc_init.*(.rodata .rodata.*)
+    *libkarch.a:*rtc_clk.*(.rodata .rodata.*)
+    *libkarch.a:*rtc_clk_init.*(.rodata .rodata.*)
+    *libkarch.a:*rtc_time.*(.rodata .rodata.*)
+    *libkarch.a:*regi2c_ctrl.*(.rodata .rodata.*)
+    *libkarch.a:*efuse_hal.*(.rodata .rodata.*)
+    *libkarch.a:*efuse_utility.*(.rodata .rodata.*)
+    *libkarch.a:*mmu_hal.*(.rodata .rodata.*)
+    *libkarch.a:*mpu_hal.*(.rodata .rodata.*)
+    *libkarch.a:*cache_esp32.*(.rodata .rodata.*)
+    *libkarch.a:*cache_hal_esp32.*(.rodata .rodata.*)
+    *libkarch.a:*uart_hal.*(.rodata .rodata.*)
+    *libkarch.a:*uart_hal_iram.*(.rodata .rodata.*)
+    *libkarch.a:*uart_periph.*(.rodata .rodata.*)
+    *libkarch.a:*wdt_hal_iram.*(.rodata .rodata.*)
+    *libkarch.a:*esp_rom_uart.*(.rodata .rodata.*)
+    *libkarch.a:*esp_rom_sys.*(.rodata .rodata.*)
+    *libkarch.a:*esp_rom_spiflash.*(.rodata .rodata.*)
+    *libkarch.a:*esp_rom_wdt.*(.rodata .rodata.*)
+    *libkarch.a:*log.*(.rodata .rodata.*)
+    *libkarch.a:esp_app_desc.*(.rodata .rodata.*)
+    *libkarch.a:esp_flash_api.*(.rodata .rodata.*)
+    *libkarch.a:esp_flash_spi_init.*(.rodata .rodata.*)
+#endif
+
     *libsched.a:sched_suspendscheduler.*(.rodata  .rodata.*)
     *libsched.a:sched_thistask.*(.rodata  .rodata.*)
     *libsched.a:sched_note.*(.rodata  .rodata.*)
@@ -366,6 +508,23 @@ SECTIONS
     _text_end = ABSOLUTE(.);
     _etext = .;
   } >KIROM
+
+#ifdef CONFIG_ESPRESSIF_SIMPLE_BOOT
+  /* Simple boot has no second-stage bootloader to map the flash, so __start()
+   * does it.  map_rom_segments() reads the segment table out of the image in
+   * flash, but the entry point still needs these to be defined.
+   */
+
+  _image_irom_vma = ADDR(.flash.text);
+  _image_irom_lma = LOADADDR(.flash.text);
+  _image_irom_size = LOADADDR(.flash.text) + SIZEOF(.flash.text) -
+                     _image_irom_lma;
+
+  _image_drom_vma = ADDR(.flash.rodata);
+  _image_drom_lma = LOADADDR(.flash.rodata);
+  _image_drom_size = LOADADDR(.flash.rodata) + SIZEOF(.flash.rodata) -
+                     _image_drom_lma;
+#endif
 
   .rtc.text :
   {


### PR DESCRIPTION
## Summary

A protected build on the ESP32 could only use the legacy IDF image format. This pull request lets it boot from simple boot instead.

Kconfig already allowed the choice. `ESP32_APP_FORMAT_LEGACY` is only a `default y if BUILD_PROTECTED`, not a `select`, so a user could clear it and get `CONFIG_ESPRESSIF_SIMPLE_BOOT=y`. The result did not link, and after it linked it did not boot.

Simple boot has no second-stage bootloader. `__start()` maps the flash itself, so everything it reaches has to be in RAM already. `kernel-space.ld` pinned none of it, and it did not place `esp32_start` at all, so the entry point landed in the flash that the code was about to map:

```
entry 0x400d0ba4
Fatal exception (0): IllegalInstruction
epc1=0x400d0ba6
```

## What changed

One file, `boards/xtensa/esp32/common/scripts/kernel-space.ld`, and every block is behind `CONFIG_ESPRESSIF_SIMPLE_BOOT`. A legacy build gets exactly the IRAM it had before.

It pins `esp32_start` and the bootloader, flash, ROM, clock and log objects that `bootloader_init()` and `map_rom_segments()` reach, with the matching read-only data.

It defines the six `_image_irom_*` and `_image_drom_*` symbols that `__start()` needs to link. Under simple boot `map_rom_segments()` reads the segment table out of the image in flash, so these only have to exist.

It adds `#include <nuttx/config.h>`. The file held no conditionals until now, so nothing revealed the omission. Without it the new blocks compiled away in silence and the link failed exactly as if the file had never been edited. This cost me a build cycle and is worth knowing about for anyone adding a conditional to this script.

The default does not change. A protected build still uses the legacy format unless the user clears `CONFIG_ESP32_APP_FORMAT_LEGACY`.

This is the ESP32 counterpart of #19764, which did the same for the ESP32-S3.

## Testing

Board: ESP32-DevKitC V4, with an ESP32-D0WD-V3 revision 3.1.

Host: macOS 15 on Apple Silicon, `xtensa-esp32-elf-gcc` 12.2.0.

| configuration | image format | result |
|---|---|---|
| `esp32-devkitc:knsh` | simple boot | boots to NSH, maps 7 segments |
| `esp32-devkitc:knsh` | legacy | unchanged, boots to NSH |

With simple boot the kernel flashes at `0x1000` and the user image at `0x90000`. There is no bootloader and no partition table to flash:

```
rst:0x1 (POWERON_RESET),boot:0x13 (SPI_FAST_FLASH_BOOT)
entry 0x40091c90
*** Booting NuttX ***
imap: lma 0x00010020 vma 0x400d0020 len 0x15f4c  (89932)
dmap: lma 0x00030020 vma 0x3f400020 len 0x2c64   (11364)
total segments stored 7
ABCESP32 chip revision is v3.1

NuttShell (NSH) NuttX-12.2.1
```

`ostest` reaches the same point in both image formats, so userspace behaves the same either way.

Note for reviewers: `ostest` does not finish on `esp32-devkitc:knsh` in **either** format. It stops in the barrier test with `barrier_test: ERROR thread 6 create, status=12`. That is heap size, not this change — the protected user heap arena is 95,908 B against 320,236 B in the flat build, and eight barrier threads want 8192 B of stack each. I confirmed it is pre-existing by building `esp32-devkitc:knsh` from `master` and getting the identical failure on the same board.

`tools/checkpatch.sh -c -u -m -g` reports no errors.
