### PR TITLE
{bp-19769} arch/arm/stm32h5: Fix handling of GPIO port I

### DIFF
--- a/arch/arm/include/stm32h5/chip.h
+++ b/arch/arm/include/stm32h5/chip.h
@@ -87,7 +87,7 @@
 #endif
 
 #define STM32_NDMA                     (2)   /* DMA1-2 */
-#define STM32_NPORTS                   (8)   /* 8 GPIO ports, GPIOA-GPIOI */
+#define STM32_NPORTS                   (9)   /* 9 GPIO ports, GPIOA-GPIOI */
 #define STM32_NADC                     (2)   /* 12-bit ADC1, up to 20 channels */
 #define STM32_NDAC                     (1)   /* 12-bit DAC1 */
 #define STM32_NCRC                     (1)   /* CRC */

--- a/arch/arm/src/stm32h5/stm32_gpio.c
+++ b/arch/arm/src/stm32h5/stm32_gpio.c
@@ -78,6 +78,9 @@ const uint32_t g_gpiobase[STM32_NPORTS] =
 #if STM32_NPORTS > 7
   STM32_GPIOH_BASE,
 #endif
+#if STM32_NPORTS > 8
+  STM32_GPIOI_BASE,
+#endif
 };
 
 /****************************************************************************

--- a/arch/arm/src/stm32h5/stm32h5xx_rcc.c
+++ b/arch/arm/src/stm32h5/stm32h5xx_rcc.c
@@ -226,7 +226,7 @@ static inline void rcc_enableahb2(void)
 #if STM32_NPORTS > 7
              | RCC_AHB2ENR_GPIOHEN
 #endif
-#if STM32_NPORTS > 7
+#if STM32_NPORTS > 8
              | RCC_AHB2ENR_GPIOIEN
 #endif
 


### PR DESCRIPTION
## Summary

Correct the number of GPIO ports (STM32_NPORTS) from 8 to 9 and include GPIOI in the g_gpiobase array. Also fix the comparison that would prevent the GPIOI clock from being enabled (this is really a no-op, though).

## Impact

RELEASE

## Testing

CI