### PR TITLE
{bp-19770} fs/romfs: fix node cache overflow in directories with >256 entries

### DIFF
--- a/fs/romfs/fs_romfsutil.c
+++ b/fs/romfs/fs_romfsutil.c
@@ -417,7 +417,7 @@ static int romfs_cachenode(FAR struct romfs_mountpt_s *rm,
   char childname[NAME_MAX + 1];
   uint32_t linkoffset;
   uint32_t info;
-  uint8_t num = 0;
+  size_t num = 0;
   size_t nsize;
   int ret;
 


### PR DESCRIPTION
## Summary

romfs_cachenode() tracked the allocated size of rn_child in a uint8_t while rn_count is a uint16_t. Past 256 entries the size wraps to zero, the grow condition rn_count == num - 1 can never be true again and the array is not reallocated: entries are written beyond the allocation, corrupting the heap.

Track the allocated size in a size_t.

## Impact

RELEASE

## Testing

CI