### PR TITLE
{bp-19813} boards/risc-v/hpm6360evk: build fix

### DIFF
--- a/boards/risc-v/hpm6000/hpm6360evk/scripts/Make.defs
+++ b/boards/risc-v/hpm6000/hpm6360evk/scripts/Make.defs
@@ -24,7 +24,7 @@ include $(TOPDIR)/.config
 include $(TOPDIR)/tools/Config.mk
 include $(TOPDIR)/arch/risc-v/src/common/Toolchain.defs
 
-LDSCRIPT = ld.script
+LDSCRIPT = flash.script
 
 ARCHSCRIPT += $(BOARD_DIR)$(DELIM)scripts$(DELIM)$(LDSCRIPT)
 


### PR DESCRIPTION
## Summary

switch to flash.script to avoid running out of storage

before:
Register: hello
Register: nsh
Register: sh
LD: nuttx
riscv32-unknown-elf-ld: /nuttx/nuttx section .text will not fit in region ilm riscv32-unknown-elf-ld: region ilm overflowed by 904 bytes
Memory region         Used Size  Region Size  %age Used
             ilm:      131976 B       128 KB    100.69%
             dlm:       11360 B       128 KB      8.67%
        axi_sram:          0 GB       256 KB      0.00%
axi_sram_noncacheable:          0 GB       256 KB      0.00%
        ahb_sram:          0 GB        32 KB      0.00%
make[1]: *** [Makefile:195: nuttx] Error 1
make: *** [tools/Unix.mk:569: nuttx] Error 2

after:
Register: hello
Register: sh
Register: nsh
LD: nuttx
Memory region         Used Size  Region Size  %age Used
           flash:      145132 B        16 MB      0.87%
             ilm:          0 GB       128 KB      0.00%
             dlm:       11360 B       128 KB      8.67%
        axi_sram:          0 GB       256 KB      0.00%
axi_sram_noncacheable:          0 GB       256 KB      0.00%
        ahb_sram:          0 GB        32 KB      0.00%
CP: nuttx.hex

## Impact

RELEASE

## Testing

LOCAL AND CI