### PR TITLE
arch/arm64/bcm2711: DMA driver implementation

### DIFF
--- a/arch/arm64/src/bcm2711/CMakeLists.txt
+++ b/arch/arm64/src/bcm2711/CMakeLists.txt
@@ -21,7 +21,7 @@
 # BCM2711 specific C source files
 
 set(SRCS bcm2711_boot.c bcm2711_mailbox.c bcm2711_serial.c bcm2711_gpio.c
-         bcm2711_oneshot.c)
+         bcm2711_oneshot.c bcm2711_dma.c)
 
 if(CONFIG_SMP)
   list(APPEND SRCS bcm2711_cpustart.c)

--- a/arch/arm64/src/bcm2711/Make.defs
+++ b/arch/arm64/src/bcm2711/Make.defs
@@ -27,6 +27,7 @@ CHIP_CSRCS += bcm2711_mailbox.c
 CHIP_CSRCS += bcm2711_serial.c
 CHIP_CSRCS += bcm2711_gpio.c
 CHIP_CSRCS += bcm2711_oneshot.c
+CHIP_CSRCS += bcm2711_dma.c
 
 ifeq ($(CONFIG_SMP),y)
 CHIP_CSRCS += bcm2711_cpustart.c

--- a/arch/arm64/src/bcm2711/bcm2711_dma.c
+++ b/arch/arm64/src/bcm2711/bcm2711_dma.c
@@ -1,0 +1,908 @@
+/****************************************************************************
+ * arch/arm64/src/bcm2711/bcm2711_dma.c
+ *
+ * Author: Matteo Golin <linguini@apache.org>
+ *
+ * SPDX-License-Identifer: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership. The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/debug.h>
+#include <nuttx/irq.h>
+#include <nuttx/mutex.h>
+
+#include "bcm2711_dma.h"
+
+#include "arm64_arch.h"
+#include "arm64_gic.h"
+#include "hardware/bcm2711_dma.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Helpers for static initialization of DMA channels */
+
+#define DMA_CHAN_SINIT_BASE(chno, chtype, chbase, chirq)                     \
+  {                                                                          \
+      .chan =                                                                \
+          {                                                                  \
+              .ops = &g_chanops,                                             \
+          },                                                                 \
+      .no = (chno),                                                          \
+      .base = (chbase),                                                      \
+      .irq = (chirq),                                                        \
+      .type = (chtype),                                                      \
+      .lock = NXMUTEX_INITIALIZER,                                           \
+  }
+
+#define DMA_CHAN_SINIT(chno, chtype, chirq)                                  \
+  DMA_CHAN_SINIT_BASE(chno, chtype, BCM_DMA(chno), chirq)
+
+/****************************************************************************
+ * Private Types
+ ****************************************************************************/
+
+/* DMA channel type */
+
+enum dma_type_e
+{
+  DMA_REG,  /* Regular */
+  DMA_DMA4, /* DMA 4 */
+  DMA_LITE, /* DMA Lite */
+};
+
+/* BCM2711 DMA channel
+ *
+ * NOTE: by storing the control block memory in this struct (static
+ * allocation), we are currently ignoring the linked-list feature of the DMA
+ * interfaces where control blocks can point to one another in sequence.
+ */
+
+struct bcm2711_dma_chan_s
+{
+  struct dma_chan_s chan; /* DMA channel struct expected by upper-half */
+  mutex_t lock;           /* Mutually exclusive access to channel */
+  int no;                 /* Channel number */
+  int irq;                /* IRQ number for this channel */
+  enum dma_type_e type;   /* Channel type */
+  uint32_t base;          /* Channel registers base address */
+  union
+  {
+    struct bcm2711_dma_cb_s reg;
+    struct bcm2711_dma4_cb_s dma4;
+    struct bcm2711_dmalite_cb_s lite;
+  } ctrlblk;         /* Control block for channel */
+  dma_callback_t cb; /* Callback for end of transfer */
+  void *cb_arg;      /* Callback argument */
+};
+
+/* BCM2711 DMA device incorporating global operations */
+
+struct bcm2711_dma_dev_s
+{
+  struct dma_dev_s dev; /* DMA device struct expected by upper-half */
+  bool inited;          /* True if DMA interfaces initialized */
+};
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+/* Channel operations */
+
+static int bcm2711_config(struct dma_chan_s *chan,
+                          const struct dma_config_s *cfg);
+static int bcm2711_start(struct dma_chan_s *chan, dma_callback_t callback,
+                         void *arg, uintptr_t dst, uintptr_t src, size_t len);
+static int bcm2711_start_cyclic(struct dma_chan_s *chan,
+                                dma_callback_t callback, void *arg,
+                                uintptr_t dst, uintptr_t src, size_t len,
+                                size_t period_len);
+
+#ifdef CONFIG_DMA_LINK
+static int bcm2711_start_link(struct dma_chan_s *chan,
+                              dma_callback_t callback, void *arg,
+                              unsigned int work_mode,
+                              struct dma_link_config_s *cfg);
+#endif
+
+static int bcm2711_stop(struct dma_chan_s *chan);
+static int bcm2711_pause(struct dma_chan_s *chan);
+static int bcm2711_resume(struct dma_chan_s *chan);
+static size_t bcm2711_residual(struct dma_chan_s *chan);
+
+/* Device operations */
+
+static struct dma_chan_s *bcm2711_get_chan(struct dma_dev_s *dev,
+                                           unsigned int ident);
+static void bcm2711_put_chan(struct dma_dev_s *dev, struct dma_chan_s *chan);
+
+/****************************************************************************
+ * Private Data
+ ****************************************************************************/
+
+/* Global device handling arbitration of channels */
+
+static struct bcm2711_dma_dev_s g_dev = {
+    .dev =
+        {
+            .get_chan = bcm2711_get_chan,
+            .put_chan = bcm2711_put_chan,
+        },
+    .inited = false,
+};
+
+/* Operations for each channel to use */
+
+static const struct dma_ops_s g_chanops = {
+    .config = bcm2711_config,
+    .start = bcm2711_start,
+    .start_cyclic = bcm2711_start_cyclic,
+#ifdef CONFIG_DMA_LINK
+    .start_link = bcm2711_start_link,
+#endif
+    .stop = bcm2711_stop,
+    .pause = bcm2711_pause,
+    .resume = bcm2711_resume,
+    .residual = bcm2711_residual,
+};
+
+/* List of all channels.
+ *
+ * Channels are initialized such that their channel number corresponds to
+ * their index in this list.
+ */
+
+static struct bcm2711_dma_chan_s g_channels[BCM_DMA_CHANNUM] = {
+    DMA_CHAN_SINIT(0, DMA_REG, BCM_IRQ_VC_DMA0),
+    DMA_CHAN_SINIT(1, DMA_REG, BCM_IRQ_VC_DMA1),
+    DMA_CHAN_SINIT(2, DMA_REG, BCM_IRQ_VC_DMA2),
+    DMA_CHAN_SINIT(3, DMA_REG, BCM_IRQ_VC_DMA3),
+    DMA_CHAN_SINIT(4, DMA_REG, BCM_IRQ_VC_DMA4),
+    DMA_CHAN_SINIT(5, DMA_REG, BCM_IRQ_VC_DMA5),
+    DMA_CHAN_SINIT(6, DMA_REG, BCM_IRQ_VC_DMA6),
+    DMA_CHAN_SINIT(7, DMA_LITE, BCM_IRQ_VC_DMA7N8),
+    DMA_CHAN_SINIT(8, DMA_LITE, BCM_IRQ_VC_DMA7N8),
+    DMA_CHAN_SINIT(9, DMA_LITE, BCM_IRQ_VC_DMA9N10),
+    DMA_CHAN_SINIT(10, DMA_LITE, BCM_IRQ_VC_DMA9N10),
+    DMA_CHAN_SINIT(11, DMA_DMA4, BCM_IRQ_VC_DMA11),
+    DMA_CHAN_SINIT(12, DMA_DMA4, BCM_IRQ_VC_DMA12),
+    DMA_CHAN_SINIT(13, DMA_DMA4, BCM_IRQ_VC_DMA13),
+    DMA_CHAN_SINIT(14, DMA_DMA4, BCM_IRQ_VC_DMA14),
+    DMA_CHAN_SINIT_BASE(15, DMA_REG, BCM_DMA15, BCM_IRQ_VC_DMA15),
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: bcm2711_channel_handler
+ *
+ * Description:
+ *   Handle interrupt servicing for a specific DMA channel.
+ *
+ * Input Parameters:
+ *   priv - The channel to service the interrupt for
+ *
+ * Returned Value:
+ *   0 on success, negated errno on failure.
+ *
+ ****************************************************************************/
+
+static int bcm2711_channel_handler(struct bcm2711_dma_chan_s *priv)
+{
+  /* Check that this channel actually needs handling */
+
+  if (!(getreg32(BCM_DMA_INT_STATUS) & BCM_DMA_INT_STATUS_INT(priv->no)))
+    {
+      return 0;
+    }
+
+  /* Handle the interrupt TODO */
+
+  /* Clear the interrupt TODO */
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: bcm2711_interrupt_handler
+ *
+ * Description:
+ *   The primary DMA interrupt handler. This handler is used for _every_ DMA
+ *   channel IRQ.
+ *
+ * Input Parameters:
+ *   irq - The IRQ number
+ *   context - The interrupt context
+ *   arg - The argument passed to the interrupt handler
+ *
+ * Returned Value:
+ *   0 on success, negated errno on failure.
+ *
+ ****************************************************************************/
+
+static int bcm2711_interrupt_handler(int irq, void *context, void *arg)
+{
+  /* First, check if this is a shared DMA Lite IRQ. If it is, we might need to
+   * service both channels.
+   *
+   * `bcm2711_channel_handler` checks the interrupt status bit of the channel,
+   * so it will not perform unneeded servicing.
+   */
+
+  if (irq == BCM_IRQ_VC_DMA7N8)
+    {
+      bcm2711_channel_handler(&g_channels[7]);
+      bcm2711_channel_handler(&g_channels[8]);
+      return 0;
+    }
+  else if (irq == BCM_IRQ_VC_DMA9N10)
+    {
+      bcm2711_channel_handler(&g_channels[9]);
+      bcm2711_channel_handler(&g_channels[10]);
+      return 0;
+    }
+
+  /* If we are here, this was a not a DMA Lite channel shared IRQ. In this
+   * case, we can just focus on servicing the interrupt which corresponds to
+   * this channel. When registering the interrupt, the argument we passed was
+   * the reference to the channel device struct.
+   */
+
+  bcm2711_channel_handler(arg);
+  return 0;
+}
+
+/****************************************************************************
+ * Name: bcm2711_config
+ *
+ * Description:
+ *   Configure DMA before using
+ *
+ * Input Parameters:
+ *   chan - The channel to configure
+ *   cfg - The configuration settings to use
+ *
+ * Returned Value:
+ *   0 on success, negated error code on failure.
+ *
+ ****************************************************************************/
+
+static int bcm2711_config(struct dma_chan_s *chan,
+                          const struct dma_config_s *cfg)
+{
+  struct bcm2711_dma_chan_s *priv = (struct bcm2711_dma_chan_s *)chan;
+
+  /* For all types:
+   *
+   * timeout: might need an external watchdog?
+   * option: ignored, no special options right now.
+   */
+
+  switch (priv->type)
+    {
+    case DMA_LITE:
+
+      /* direction: ?
+       * priority: maybe can map to CS_PANIC_PRIORITY/CS_PRIORITY?
+       *
+       * dst_width: TI_DEST_WIDTH
+       * src_width: TI_SRC_WIDTH
+       *
+       * dst_drq: TI_DEST_DREQ? TI_PERMAP?
+       * src_drq: TI_SRC_DREQ? TI_PERMAP?
+       *
+       * dst_step: TI_DEST_INC, only some values are allowed
+       * src_step: TI_SRC_INC, only some values are allowed
+       */
+
+      /* TODO */
+
+      break;
+
+    case DMA_REG:
+
+      /* direction: ?
+       * priority:
+       *
+       * dst_width:
+       * src_width:
+       *
+       * dst_drq:
+       * src_drq:
+       *
+       * dst_step:
+       * src_step:
+       */
+
+      /* TODO */
+
+      break;
+
+    case DMA_DMA4:
+
+      /* direction: ?
+       * priority: maybe can map to CS_PANIC_QOS/CS_QOS
+       *
+       * dst_width: DESTI_SIZE
+       * src_width: SRCI_SIZE
+       *
+       * dst_drq: TI_D_DREQ? TI_PERMAP?
+       * src_drq: TI_S_DREQ? TI_PERMAP?
+       *
+       * dst_step can go in DESTI_STRIDE as signed 2's compliment
+       * src_step can go in SRCI_STRIDE as a signed 2's compliment
+       * If there is a stride set, then set TI_TDMODE bit.
+       */
+
+      /* TODO */
+
+      break;
+    }
+
+  /* TODO */
+
+  return 0;
+}
+
+/****************************************************************************
+ * Name: bcm2711_start
+ *
+ * Description:
+ *   Start the DMA transfer. NOTE: The DMA module does *NOT* perform any
+ *   cache operations. It is the responsibility of the DMA client to clean
+ *   DMA buffers after staring of the DMA TX operations.
+ *
+ * Assumptions:
+ *   DMA_CONFIG was called before this to configure the DMA transfer.
+ *
+ * Input Parameters:
+ *   chan - The channel to start
+ *   callback - The callback to be called when the transfer is finished
+ *   arg - The argument for the callback
+ *   dst - The destination address
+ *   src - The source address
+ *   len - The length to transfer
+ *
+ * Returned Value:
+ *   0 on success, error code on failure.
+ *
+ ****************************************************************************/
+
+static int bcm2711_start(struct dma_chan_s *chan, dma_callback_t callback,
+                         void *arg, uintptr_t dst, uintptr_t src, size_t len)
+{
+  struct bcm2711_dma_chan_s *priv = (struct bcm2711_dma_chan_s *)chan;
+
+  priv->cb = callback;
+  priv->cb_arg = arg;
+
+  /* NOTE: We've assumed that `bcm2711_config` has already been called to
+   * configure settings for the transfer. Therefore, reserved fields of the
+   * control block are already zeroed, and other fields have populated
+   * configuration settings. We only need to populate the destination address,
+   * source address and transfer length now.
+   *
+   * We also enable interrupts for control block completion here.
+   */
+
+  switch (priv->type)
+    {
+    case DMA_REG:
+
+      /* Only 32-bit values allowed here, check for no upper bits */
+
+      if ((src & UINT32_MAX) != src || (dst & UINT32_MAX) != dst ||
+          (len & UINT32_MAX) != len)
+        {
+          return -EINVAL;
+        }
+
+      priv->ctrlblk.reg.source_ad = src;
+      priv->ctrlblk.reg.dest_ad = dst;
+
+      /* TODO: txfr length setting based on 2D mode or not */
+
+      /* Enable control block complete interrupt */
+
+      priv->ctrlblk.dma4.ti |= BCM_DMA4_TI_INTEN;
+      break;
+
+    case DMA_LITE:
+
+      /* Only 32-bit src, destination addresses allowed.
+       * 16-bit transfer length max imposed.
+       */
+
+      if ((src & UINT32_MAX) != src || (dst & UINT32_MAX) != dst ||
+          (len & UINT16_MAX) != len)
+        {
+          return -EINVAL;
+        }
+
+      priv->ctrlblk.lite.source_ad = src;
+      priv->ctrlblk.lite.dest_ad = dst;
+      priv->ctrlblk.lite.txfr_len = len;
+
+      /* Enable control block complete interrupt */
+
+      priv->ctrlblk.lite.ti |= BCM_DMA_TI_INTEN;
+      break;
+
+    case DMA_DMA4:
+
+      /* Only up to 32-bit lengths supported. Destination and source addresses
+       * can be up to 40 bits long.
+       */
+
+      if ((src & 0xffffffffff) != src || (dst & 0xffffffffff) != dst ||
+          (len & UINT32_MAX) != len)
+        {
+          return -EINVAL;
+        }
+
+      /* Put lower address bits in control block src/dst */
+
+      priv->ctrlblk.dma4.src = src & UINT32_MAX;
+      priv->ctrlblk.dma4.dest = dst & UINT32_MAX;
+
+      /* Put upper address bits in control block srci/desti */
+
+      priv->ctrlblk.dma4.srci =
+          (src >> BCM_DMA4_SRCI_ADDR_SHIFT) & BCM_DMA4_SRCI_ADDR;
+      priv->ctrlblk.dma4.desti =
+          (dst >> BCM_DMA4_DESTI_ADDR_SHIFT) & BCM_DMA4_DESTI_ADDR;
+
+      /* TODO: txfr length setting based on 2D mode or not */
+
+      /* Enable control block complete interrupt */
+
+      priv->ctrlblk.reg.ti |= BCM_DMA_TI_INTEN;
+      break;
+    }
+
+  /* A DMA transfer is started by writing the address of a control block
+   * structure into CONBLK_AD (or CB for DMA4) and then setting the active
+   * bit.
+   */
+
+  switch (priv->type)
+    {
+    case DMA_REG:
+      /* Intentional fall-through */
+    case DMA_LITE:
+      putreg32((uintptr_t)&priv->ctrlblk, BCM_DMA_CONBLK_AD(priv->base));
+      break;
+    case DMA_DMA4:
+      putreg32((uintptr_t)&priv->ctrlblk, BCM_DMA4_CB(priv->base));
+      break;
+    }
+
+  /* Control block is fully configured, interrupts are enabled, control block
+   * address is populated; activate the channel to start the DMA operation.
+   */
+
+  modreg32(BCM_DMA_CS_ACTIVE, BCM_DMA_CS_ACTIVE, BCM_DMA_CS(priv->base));
+  return 0;
+}
+
+/****************************************************************************
+ * Name: bcm2711_start_cyclic
+ *
+ * Description:
+ *   Start the cyclic DMA transfer.
+ *   Note: the callback gets called for each period length data DMA transfer.
+ *
+ * Input Parameters:
+ *   chan - The channel to do the transfer on
+ *   callback - The callback to call at each period
+ *   arg - The argument to the callback
+ *   dst - The destination address
+ *   src - The source address
+ *   len - The length of the transfer
+ *   period_len - The period length in bytes
+ *
+ * Returned Value:
+ *   0 on success, negated error code on failure.
+ *
+ ****************************************************************************/
+
+static int bcm2711_start_cyclic(struct dma_chan_s *chan,
+                                dma_callback_t callback, void *arg,
+                                uintptr_t dst, uintptr_t src, size_t len,
+                                size_t period_len)
+{
+  struct bcm2711_dma_chan_s *priv = (struct bcm2711_dma_chan_s *)chan;
+
+  priv->cb = callback;
+  priv->cb_arg = arg;
+
+  /* TODO */
+
+  return -ENOSYS;
+}
+
+#ifdef CONFIG_DMA_LINK
+
+/****************************************************************************
+ * Name: bcm2711_start_link
+ *
+ * Description:
+ *   Start the DMA link transfer.
+ *   Note: the callback gets called when the DMA link transfer finishes.
+ *
+ * Input Parameters:
+ *   chan - The channel to perform the transfer on
+ *   callback - The callback to call when the transfer finishes
+ *   arg - The argument to the callback function
+ *   work_mode - Not sure? I think work queue TODO
+ *   cfg - A linked list of source/destination addresses and sizes
+ *
+ * Returned Value:
+ *   0 on success, negated error code on failure.
+ *
+ ****************************************************************************/
+
+static int bcm2711_start_link(struct dma_chan_s *chan,
+                              dma_callback_t callback, void *arg,
+                              unsigned int work_mode,
+                              struct dma_link_config_s *cfg)
+{
+  /* TODO */
+
+  return -ENOSYS;
+}
+#endif
+
+/****************************************************************************
+ * Name: bcm2711_stop
+ *
+ * Description:
+ *   Stop the DMA transfer.
+ *
+ * Input Parameters:
+ *   chan - The channel whose transfer to stop
+ *
+ * Returned Value:
+ *   0 on success, negated error code otherwise.
+ *
+ ****************************************************************************/
+
+static int bcm2711_stop(struct dma_chan_s *chan)
+{
+  struct bcm2711_dma_chan_s *priv = (struct bcm2711_dma_chan_s *)chan;
+
+  /* Clear the next control block register, then abort the current transfer.
+   * This will cause the transfer to stop.
+   */
+
+  switch (priv->type)
+    {
+    case DMA_REG:
+      /* Intentional fall-through */
+    case DMA_LITE:
+      putreg32(0, BCM_DMA_NEXTCONBK(priv->base));
+      break;
+    case DMA_DMA4:
+      putreg32(0, BCM_DMA4_NEXT_CB(priv->base));
+      break;
+    }
+
+  modreg32(BCM_DMA_CS_ABORT, BCM_DMA_CS_ABORT, BCM_DMA_CS(priv->base));
+  return 0;
+}
+
+/****************************************************************************
+ * Name: bcm2711_pause
+ *
+ * Description:
+ *   Pause the DMA transfer. After DMA_PAUSE() is called, DMA_RESUME() must
+ *   be called to restart the transfer again.
+ *
+ * Input Parameters:
+ *   chan - The channel whose transfer to pause
+ *
+ * Returned Value:
+ *   0 on success and negative error code on failure
+ *
+ ****************************************************************************/
+
+static int bcm2711_pause(struct dma_chan_s *chan)
+{
+  struct bcm2711_dma_chan_s *priv = (struct bcm2711_dma_chan_s *)chan;
+
+  modreg32(0, BCM_DMA_CS_ACTIVE, BCM_DMA_CS(priv->base));
+  return 0;
+}
+
+/****************************************************************************
+ * Name: bcm2711_resume
+ *
+ * Description:
+ *   Resume the DMA transfer.
+ *
+ * Input Parameters:
+ *   chan - descr
+ *
+ * Returned Value:
+ *   description
+ *
+ ****************************************************************************/
+
+static int bcm2711_resume(struct dma_chan_s *chan)
+{
+  struct bcm2711_dma_chan_s *priv = (struct bcm2711_dma_chan_s *)chan;
+
+  modreg32(BCM_DMA_CS_ACTIVE, BCM_DMA_CS_ACTIVE, BCM_DMA_CS(priv->base));
+  return 0;
+}
+
+/****************************************************************************
+ * Name: bcm2711_residual
+ *
+ * Description:
+ *   Returns the number of bytes remaining to be transferred.
+ *
+ * Input Parameters:
+ *   chan - The channel to get the residual bytes of
+ *
+ * Returned Value:
+ *   The number of bytes remaining to be transferred.
+ *
+ ****************************************************************************/
+
+static size_t bcm2711_residual(struct dma_chan_s *chan)
+{
+  struct bcm2711_dma_chan_s *priv = (struct bcm2711_dma_chan_s *)chan;
+  uint32_t regval;
+  size_t len = 0;
+
+  switch (priv->type)
+    {
+    case DMA_LITE:
+      regval = getreg32(BCM_DMA_TXFR_LEN(priv->base));
+      len = regval & BCM_DMA_TXFR_LEN_XLENGTH;
+      break;
+    case DMA_REG:
+      regval = getreg32(BCM_DMA_TXFR_LEN(priv->base));
+      len = regval; /* TODO: handle 2D case */
+      break;
+    case DMA_DMA4:
+      regval = getreg32(BCM_DMA4_LEN(priv->base));
+      len = regval; /* TODO: handle 2D case */
+      break;
+    }
+
+  return len;
+}
+
+/****************************************************************************
+ * Name: bcm2711_get_chan
+ *
+ * Description:
+ *   Get a DMA channel. This function gives the caller mutually exclusive
+ *   access to the DMA channel specified by the 'ident' argument.
+ *
+ *   If the DMA channel is not available, then DMA_GET_CHAN will wait
+ *   until the holder of the channel relinquishes the channel by calling
+ *   DMA_PUT_CHAN().  WARNING: If you have two devices sharing a DMA
+ *   channel and the code never releases the channel, the DMA_GET_CHAN
+ *   call for the other will hang forever in this function!
+ *
+ * Input Parameters:
+ *   dev - DMA device struct reference
+ *   ident - The number of the channel to get
+ *
+ * Returned Value:
+ *   A reference to the DMA channel device. Returns NULL if the channel number
+ *   is invalid.
+ *
+ ****************************************************************************/
+
+static struct dma_chan_s *bcm2711_get_chan(struct dma_dev_s *dev,
+                                           unsigned int ident)
+{
+  struct bcm2711_dma_chan_s *priv;
+
+  if (ident > 15)
+    {
+      return NULL;
+    }
+
+  /* Lock the DMA channel for use */
+
+  priv = &g_channels[ident];
+  nxmutex_lock(&g_channels[ident].lock);
+
+  /* Enable power for the DMA channel (no enable toggle for channel 15) */
+
+  if (ident != 15)
+    {
+      modreg32(BCM_DMA_ENABLE_EN(priv->no), BCM_DMA_ENABLE_EN(priv->no),
+               BCM_DMA_ENABLE);
+    }
+
+  /* Reset the DMA channel TODO */
+
+  /* Enable the interrupt handler for this channel, which is already
+   * registered. Can be unconditional, it doesn't matter if we enable the
+   * shared IRQ twice.
+   */
+
+  up_enable_irq(priv->irq);
+
+  return &priv->chan;
+}
+
+/****************************************************************************
+ * Name: bcm2711_put_chan
+ *
+ * Description:
+ *   Release a DMA channel. If another thread is waiting for this DMA channel
+ *   in a call to DMA_GET_CHAN, then this function will re-assign the DMA
+ *   channel to that thread and wake it up. NOTE: The 'chan' used in this
+ *   argument must NEVER be used again until DMA_GET_CHAN() is called again
+ *   to re-gain access to the channel.
+ *
+ *   WARNING: assumes that the channel is not performing a DMA operation
+ *   during release time.
+ *
+ * Input Parameters:
+ *   dev - The DMA device struct reference
+ *   chan - The DMA channel struct reference being released
+ *
+ ****************************************************************************/
+
+static void bcm2711_put_chan(struct dma_dev_s *dev, struct dma_chan_s *chan)
+{
+  uint32_t regval;
+  struct bcm2711_dma_chan_s *priv = (struct bcm2711_dma_chan_s *)chan;
+
+  DEBUGASSERT(chan != NULL);
+
+  /* The channel is no longer being used, we can safely power it down (not an
+   * option for DMA15).
+   *
+   * WARNING: disabling a channel during DMA operation is fatal.
+   * TODO: check DMA_BUSY bit.
+   */
+
+  if (priv->no != 15)
+    {
+      modreg32(0, BCM_DMA_ENABLE_EN(priv->no), BCM_DMA_ENABLE);
+    }
+
+  /* Disable the interrupt handler for this channel.
+   *
+   * For DMA Lite channels, we check to see if both of the two
+   * channels associated with the IRQ are disabled before un-registering the
+   * handler. Otherwise, we might un-register the handler while the other
+   * channel sharing it still needs it.
+   */
+
+  switch (priv->type)
+    {
+    case DMA_LITE:
+      regval = getreg32(BCM_DMA_ENABLE);
+
+      if (priv->irq == BCM_IRQ_VC_DMA7N8 &&
+          !(regval & (BCM_DMA_ENABLE_EN(7) | BCM_DMA_ENABLE_EN(7))))
+        {
+          up_disable_irq(priv->irq); /* 7 & 8 are both disabled */
+        }
+      else if (priv->irq == BCM_IRQ_VC_DMA9N10 &&
+               !(regval & (BCM_DMA_ENABLE_EN(9) | BCM_DMA_ENABLE_EN(10))))
+        {
+          up_disable_irq(priv->irq); /* 9 & 10 are both disabled */
+        }
+
+      break;
+    default: /* All other DMA channel kinds have their own IRQ */
+      up_disable_irq(priv->irq);
+      break;
+    }
+
+  /* Release the lock on the channel */
+
+  nxmutex_unlock(&priv->lock);
+}
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+struct dma_dev_s *bcm2711_dma_initialize(void)
+{
+  unsigned i;
+  int err;
+  struct bcm2711_dma_chan_s *chan;
+
+  if (g_dev.inited)
+    {
+      return &g_dev.dev;
+    }
+
+  /* Disable all DMA channels by default when not used */
+
+  putreg32(0, BCM_DMA_ENABLE);
+
+  /* Register interrupt handler functions but do not enable them yet.
+   *
+   * NOTE: interrupt handlers are enabled when DMA channels are claimed
+   * using `get_chan`. This is because each channel has its own interrupt
+   * (except DMA Lite channels which share). We conserve power and interrupts
+   * by only enabling DMA channels that are requested for use, and by
+   * disabling those channels' interrupts & power when they are returned from
+   * use with `put_chan`.
+   */
+
+  for (i = 0; i < BCM_DMA_CHANNUM; i++)
+    {
+      chan = &g_channels[i];
+
+      /* TODO: should I return NULL if interrupt handlers fail to attach? */
+
+      switch (chan->type)
+        {
+        case DMA_LITE:
+
+          /* Check if interrupt handler is already registered; don't register
+           * twice. TODO: is this possible to check?
+           * NOTE: does it matter to register twice here?
+           */
+
+          err = irq_attach(chan->irq, bcm2711_interrupt_handler, NULL);
+          if (err < 0)
+            {
+              dmaerr("Could not attach interrupt handler for DMA Lite %d",
+                     chan->no);
+              return NULL;
+            }
+
+          up_prioritize_irq(chan->irq, 0);
+          up_set_irq_type(chan->irq, IRQ_RISING_EDGE);
+          break;
+
+        default: /* All other kinds of DMA channels */
+          err = irq_attach(chan->irq, bcm2711_interrupt_handler, chan);
+          if (err < 0)
+            {
+              dmaerr("Could not attach interrupt handler for DMA channel %d",
+                     chan->no);
+              return NULL;
+            }
+
+          up_prioritize_irq(chan->irq, 0);
+          up_set_irq_type(chan->irq, IRQ_RISING_EDGE);
+          break;
+        }
+    }
+
+  g_dev.inited = true;
+  return &g_dev.dev;
+}

--- a/arch/arm64/src/bcm2711/bcm2711_dma.h
+++ b/arch/arm64/src/bcm2711/bcm2711_dma.h
@@ -1,0 +1,60 @@
+/****************************************************************************
+ * arch/arm64/src/bcm2711/bcm2711_dma.h
+ *
+ * Author: Matteo Golin <linguini@apache.org>
+ *
+ * SPDX-License-Identifer: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership. The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License. You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM64_SRC_BCM2711_BCM2711_DMA_H
+#define __ARCH_ARM64_SRC_BCM2711_BCM2711_DMA_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <nuttx/dma/dma.h>
+
+#ifndef __ASSEMBLY__
+
+#undef EXTERN
+#if defined(__cplusplus)
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/* TODO: some functions */
+
+#undef EXTERN
+#if defined(__cplusplus)
+}
+#endif
+
+#endif /* __ASSEMBLY__ */
+
+#endif /* __ARCH_ARM64_SRC_BCM2711_BCM2711_DMA_H */

--- a/arch/arm64/src/bcm2711/hardware/bcm2711_dma.h
+++ b/arch/arm64/src/bcm2711/hardware/bcm2711_dma.h
@@ -27,109 +27,150 @@
  * Included Files
  ****************************************************************************/
 
-#include "bcm2711_memmap.h"
 #include <arch/types.h>
+
+#include <nuttx/compiler.h>
+
+#include "bcm2711_memmap.h"
 
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* DMA channel offsets */
+#define BCM_DMA_CHANNUM (16) /* Number of DMA channels */
 
-#define BCM_DMA_CH0_OFFSET 0x000
-#define BCM_DMA_CH1_OFFSET 0x100
-#define BCM_DMA_CH2_OFFSET 0x200
-#define BCM_DMA_CH3_OFFSET 0x300
-#define BCM_DMA_CH4_OFFSET 0x400
-#define BCM_DMA_CH5_OFFSET 0x500
-#define BCM_DMA_CH6_OFFSET 0x600
-#define BCM_DMA_CH7_OFFSET 0x700
-#define BCM_DMA_CH8_OFFSET 0x800
-#define BCM_DMA_CH9_OFFSET 0x900
-#define BCM_DMA_CH10_OFFSET 0xa00
-#define BCM_DMA_CH11_OFFSET 0xb00
-#define BCM_DMA_CH12_OFFSET 0xc00
-#define BCM_DMA_CH13_OFFSET 0xd00
-#define BCM_DMA_CH14_OFFSET 0xe00
-#define BCM_DMA_CH15_OFFSET 0x000
+/* DMA channel addresses
+ *
+ * NOTE:
+ *
+ * DMA 7-10 are DMA Lite channels.
+ * DMA 11-14 are DMA4 channels.
+ *
+ * DMA15 has its own unique base address and cannot be looked up with the
+ * BCM_DMA(n) macro. It is exclusively used by the VPU.
+ *
+ * DMA11 can access the PCIe interface.
+ *
+ * DMA0 and DMA15 have an external 128-bit 8-word read FIFO.
+ */
 
-/* DMA channel addresses */
-
-#define BCM_DMA0 (BCM_DMA0_BASE + BCM_DMA_CH0_OFFSET)
-#define BCM_DMA1 (BCM_DMA0_BASE + BCM_DMA_CH1_OFFSET)
-#define BCM_DMA2 (BCM_DMA0_BASE + BCM_DMA_CH2_OFFSET)
-#define BCM_DMA3 (BCM_DMA0_BASE + BCM_DMA_CH3_OFFSET)
-#define BCM_DMA4 (BCM_DMA0_BASE + BCM_DMA_CH4_OFFSET)
-#define BCM_DMA5 (BCM_DMA0_BASE + BCM_DMA_CH5_OFFSET)
-#define BCM_DMA6 (BCM_DMA0_BASE + BCM_DMA_CH6_OFFSET)
-#define BCM_DMA7 (BCM_DMA0_BASE + BCM_DMA_CH7_OFFSET)   /* Lite */
-#define BCM_DMA8 (BCM_DMA0_BASE + BCM_DMA_CH8_OFFSET)   /* Lite */
-#define BCM_DMA9 (BCM_DMA0_BASE + BCM_DMA_CH9_OFFSET)   /* Lite */
-#define BCM_DMA10 (BCM_DMA0_BASE + BCM_DMA_CH10_OFFSET) /* Lite */
-#define BCM_DMA11 (BCM_DMA0_BASE + BCM_DMA_CH11_OFFSET) /* DMA4 */
-#define BCM_DMA12 (BCM_DMA0_BASE + BCM_DMA_CH12_OFFSET) /* DMA4 */
-#define BCM_DMA13 (BCM_DMA0_BASE + BCM_DMA_CH13_OFFSET) /* DMA4 */
-#define BCM_DMA14 (BCM_DMA0_BASE + BCM_DMA_CH14_OFFSET) /* DMA4 */
-#define BCM_DMA15 (BCM_DMA15_BASE + BCM_DMA_CH15_OFFSET)
+#define BCM_DMA(n) (BCM_DMA0_BASE + 0x100 * (n))
+#define BCM_DMA15 (BCM_DMA15_BASE)
 
 /* DMA control block data structures */
 
-/* DMA control block definition */
-
-struct bcm2711_dma_cb_s
-{
-  _uint32_t ti;        /* Transfer information */
-  _uint32_t source_ad; /* Source address */
-  _uint32_t dest_ad;   /* Destination address */
-  _uint32_t txfr_len;  /* Transfer length */
-  _uint32_t stride;    /* 2D mode stride */
-  _uint32_t nextconbk; /* Next control block address */
-  _uint32_t _reserved1;
-  _uint32_t _reserved2;
-};
-
-/* DMA Lite control block definition */
-
-struct bcm2711_dmalite_cb_s
-{
-  _uint32_t ti;        /* Transfer information */
-  _uint32_t source_ad; /* Source address */
-  _uint32_t dest_ad;   /* Destination address */
-  _uint32_t txfr_len;  /* Transfer length */
-  _uint32_t _reserved1;
-  _uint32_t nextconbk; /* Next control block address */
-  _uint32_t _reserved2;
-  _uint32_t _reserved3;
-};
-
-/* DMA 4 control block definition */
-
-struct bcm2711_dma4_cb_s
-{
-  _uint32_t ti;        /* Transfer information */
-  _uint32_t src;       /* Source address */
-  _uint32_t srci;      /* Source information */
-  _uint32_t dest;      /* Destination address */
-  _uint32_t desti;     /* Destination information */
-  _uint32_t len;       /* Transfer length */
-  _uint32_t nextconbk; /* Next control block address */
-  _uint32_t _reserved;
-};
-
-/* DMA registers offsets */
-
-#define BCM_DMA_CS_OFFSET 0x00        /* Control and status */
-#define BCM_DMA_CONBLK_AD_OFFSET 0x04 /* Control block address */
-#define BCM_DMA_DEBUG 0x020           /* Debug */
-
-/* TODO: Do I need to do base + offset for the above three for all 14
- * channels?
+/* DMA control block definition.
+ *
+ * Must start at a 256-bit aligned address.
+ * Fields marked reserved must be zeroed.
  */
 
-/* DMA registers */
+begin_packed_struct struct bcm2711_dma_cb_s
+{
+  volatile _uint32_t ti;        /* Transfer information */
+  volatile _uint32_t source_ad; /* Source address */
+  volatile _uint32_t dest_ad;   /* Destination address */
+  volatile _uint32_t txfr_len;  /* Transfer length */
+  volatile _uint32_t stride;    /* 2D mode stride */
+  volatile _uint32_t nextconbk; /* Next control block address */
+  volatile _uint32_t _reserved1;
+  volatile _uint32_t _reserved2;
+} aligned_data(32) end_packed_struct;
+
+/* DMA Lite control block definition
+ *
+ * DMA Lite has a 128 bit internal data structure, so a 128-bit wide read
+ * burst will stall the bus if more than 1 beat.
+ *
+ * 2D transfers are not supported with stride registers.
+ *
+ * Length register is 16 bits, so max transfer is 65536 bytes.
+ */
+
+begin_packed_struct struct bcm2711_dmalite_cb_s
+{
+  volatile _uint32_t ti;        /* Transfer information */
+  volatile _uint32_t source_ad; /* Source address */
+  volatile _uint32_t dest_ad;   /* Destination address */
+  volatile _uint32_t txfr_len;  /* Transfer length */
+  volatile _uint32_t _reserved1;
+  volatile _uint32_t nextconbk; /* Next control block address */
+  volatile _uint32_t _reserved2;
+  volatile _uint32_t _reserved3;
+} aligned_data(32) end_packed_struct;
+
+/* DMA 4 control block definition
+ *
+ * Higher performance; decoupled read/write. Can access 40 address bits. Can
+ * perform write bursts.
+ */
+
+begin_packed_struct struct bcm2711_dma4_cb_s
+{
+  volatile _uint32_t ti;        /* Transfer information */
+  volatile _uint32_t src;       /* Source address */
+  volatile _uint32_t srci;      /* Source information */
+  volatile _uint32_t dest;      /* Destination address */
+  volatile _uint32_t desti;     /* Destination information */
+  volatile _uint32_t len;       /* Transfer length */
+  volatile _uint32_t nextconbk; /* Next control block address */
+  volatile _uint32_t _reserved;
+} aligned_data(32) end_packed_struct;
+
+/* Regular & DMA Lite register offsets */
+
+#define BCM_DMA_CS_OFFSET 0x00        /* Control and status */
+#define BCM_DMA_CONBLK_AD_OFFSET 0x04 /* Cntrl blk address */
+#define BCM_DMA_TI_OFFSET 0x08        /* Cntrl blk transfer info */
+#define BCM_DMA_SOURCE_AD_OFFSET 0x0c /* Cntrl blk source address */
+#define BCM_DMA_DEST_AD_OFFSET 0x10   /* Cntrl blk destination address */
+#define BCM_DMA_TXFR_LEN_OFFSET 0x14  /* Cntrl blk txfr length remaining */
+#define BCM_DMA_STRIDE_OFFSET 0x18    /* Cntrl blk 2D stride */
+#define BCM_DMA_NEXTCONBK_OFFSET 0x1c /* Next cntrl blk address */
+#define BCM_DMA_DEBUG_OFFSET 0x20     /* Debug */
+
+/* DMA4 register offsets */
+
+#define BCM_DMA4_CS_OFFSET BCM_DMA_CS_OFFSET
+#define BCM_DMA4_CB_OFFSET BCM_DMA_CONBLK_AD_OFFSET /* Cntrl blk address */
+#define BCM_DMA4_DEBUG_OFFSET 0x0c                  /* Debug */
+#define BCM_DMA4_TI_OFFSET 0x10                     /* Cntrl blk txfr info */
+#define BCM_DMA4_SRC_OFFSET 0x14     /* Cntrl blk source addr */
+#define BCM_DMA4_SRCI_OFFSET 0x18    /* Cntrl blk source addr & info */
+#define BCM_DMA4_DEST_OFFSET 0x1c    /* Cntrl blk dest addr */
+#define BCM_DMA4_DESTI_OFFSET 0x20   /* Cntrl blk dest addr & info */
+#define BCM_DMA4_LEN_OFFSET 0x24     /* Cntrl blk txfr length remaining */
+#define BCM_DMA4_NEXT_CB_OFFSET 0x28 /* Next cntrl blk addr */
+
+/* Regular & DMA Lite registers */
+
+#define BCM_DMA_CS(base) ((base) + BCM_DMA_CS_OFFSET)
+#define BCM_DMA_CONBLK_AD(base) ((base) + BCM_DMA_CONBLK_AD_OFFSET)
+#define BCM_DMA_TI(base) ((base) + BCM_DMA_TI_OFFSET)
+#define BCM_DMA_SOURCE_AD(base) ((base) + BCM_DMA_SOURCE_AD_OFFSET)
+#define BCM_DMA_DEST_AD(base) ((base) + BCM_DMA_DEST_AD_OFFSET)
+#define BCM_DMA_TXFR_LEN(base) ((base) + BCM_DMA_TXFR_LEN_OFFSET)
+#define BCM_DMA_STRIDE(base) ((base) + BCM_DMA_STRIDE_OFFSET)
+#define BCM_DMA_NEXTCONBK(base) ((base) + BCM_DMA_NEXTCONBK_OFFSET)
+#define BCM_DMA_DEBUG(base) ((base) + BCM_DMA_DEBUG_OFFSET)
+
+/* DMA4 registers */
+
+#define BCM_DMA4_CS(base) ((base) + BCM_DMA4_CS_OFFSET)
+#define BCM_DMA4_CB(base) ((base) + BCM_DMA4_CB_OFFSET)
+#define BCM_DMA4_DEBUG(base) ((base) + BCM_DMA4_DEBUG_OFFSET)
+#define BCM_DMA4_TI(base) ((base) + BCM_DMA4_TI_OFFSET)
+#define BCM_DMA4_SRC(base) ((base) + BCM_DMA4_SRC_OFFSET)
+#define BCM_DMA4_SRCI(base) ((base) + BCM_DMA4_SRCI_OFFSET)
+#define BCM_DMA4_DEST(base) ((base) + BCM_DMA4_DEST_OFFSET)
+#define BCM_DMA4_DESTI(base) ((base) + BCM_DMA4_DESTI_OFFSET)
+#define BCM_DMA4_LEN(base) ((base) + BCM_DMA4_LEN_OFFSET)
+#define BCM_DMA4_NEXT_CB(base) ((base) + BCM_DMA4_NEXT_CB_OFFSET)
+
+/* Global DMA registers used for interrupt status and enabling */
 
 #define BCM_DMA_INT_STATUS (BCM_DMA0_BASE + 0xfe0) /* Interrupt status */
-#define BCM_DMA_INT_ENABLE (BCM_DMA0_BASE + 0xff0) /* Enable bits */
+#define BCM_DMA_ENABLE (BCM_DMA0_BASE + 0xff0)     /* Enable bits */
 
 /* DMA register bit definitions */
 
@@ -223,6 +264,7 @@ struct bcm2711_dma4_cb_s
 #define BCM_DMA4_SRCI_INC (1 << 12)         /* Increment source address */
 #define BCM_DMA4_SRCI_BURSTLEN (0xf << 8)   /* Burst transfer length */
 #define BCM_DMA4_SRCI_ADDR (0xff)           /* High bits of source address */
+#define BCM_DMA4_SRCI_ADDR_SHIFT (32)       /* Bit shift high bits down */
 
 #define BCM_DMA4_DESTI_STRIDE (0xffff << 16) /* Destination stride */
 #define BCM_DMA4_DESTI_IGNORE (1 << 15)      /* Ignore writes */
@@ -230,6 +272,7 @@ struct bcm2711_dma4_cb_s
 #define BCM_DMA4_DESTI_INC (1 << 12)         /* Increment dest address */
 #define BCM_DMA4_DESTI_BURSTLEN (0xf << 8)   /* Burst transfer length */
 #define BCM_DMA4_DESTI_ADDR (0xff)           /* High bits of dest address */
+#define BCM_DMA4_DESTI_ADDR_SHIFT (32)       /* Bit shift high bits down */
 
 #define BCM_DMA4_LEN_YLENGTH (0x3fff << 16) /* Y transfer len in 2D mode */
 #define BCM_DMA4_LEN_XLENGTH (0xffff)       /* X transfer len in bytes */
@@ -239,41 +282,14 @@ struct bcm2711_dma4_cb_s
 
 /* Interrupt status register bit definitions */
 
-#define BCM_DMA_INT15 (1 << 15) /* Interrupt status of DMA15 */
-#define BCM_DMA_INT14 (1 << 14) /* Interrupt status of DMA14 */
-#define BCM_DMA_INT13 (1 << 13) /* Interrupt status of DMA13 */
-#define BCM_DMA_INT12 (1 << 12) /* Interrupt status of DMA12 */
-#define BCM_DMA_INT11 (1 << 11) /* Interrupt status of DMA11 */
-#define BCM_DMA_INT10 (1 << 10) /* Interrupt status of DMA10 */
-#define BCM_DMA_INT9 (1 << 9)   /* Interrupt status of DMA9 */
-#define BCM_DMA_INT8 (1 << 8)   /* Interrupt status of DMA8 */
-#define BCM_DMA_INT7 (1 << 7)   /* Interrupt status of DMA7 */
-#define BCM_DMA_INT6 (1 << 6)   /* Interrupt status of DMA6 */
-#define BCM_DMA_INT5 (1 << 5)   /* Interrupt status of DMA5 */
-#define BCM_DMA_INT4 (1 << 4)   /* Interrupt status of DMA4 */
-#define BCM_DMA_INT2 (1 << 2)   /* Interrupt status of DMA2 */
-#define BCM_DMA_INT1 (1 << 1)   /* Interrupt status of DMA1 */
-#define BCM_DMA_INT0 (1 << 0)   /* Interrupt status of DMA0 */
+#define BCM_DMA_INT_STATUS_INT(n)                                            \
+  (1 << (n)) /* Interrupt status of DMA channel 'n' */
 
 /* Enable register bit definitions */
 
 #define BCM_DMA_ENABLE_PAGELITE (0xf << 28) /* Set 1G SDRAM page */
 #define BCM_DMA_ENABLE_PAGE (0xf << 24)     /* Set 1G SDRAM page */
-#define BCM_DMA_ENABLE_EN14 (1 << 14)       /* Enable DMA14 */
-#define BCM_DMA_ENABLE_EN13 (1 << 13)       /* Enable DMA13 */
-#define BCM_DMA_ENABLE_EN12 (1 << 12)       /* Enable DMA12 */
-#define BCM_DMA_ENABLE_EN11 (1 << 11)       /* Enable DMA11 */
-#define BCM_DMA_ENABLE_EN10 (1 << 10)       /* Enable DMA10 */
-#define BCM_DMA_ENABLE_EN9 (1 << 9)         /* Enable DMA9 */
-#define BCM_DMA_ENABLE_EN8 (1 << 8)         /* Enable DMA8 */
-#define BCM_DMA_ENABLE_EN7 (1 << 7)         /* Enable DMA7 */
-#define BCM_DMA_ENABLE_EN6 (1 << 6)         /* Enable DMA6 */
-#define BCM_DMA_ENABLE_EN5 (1 << 5)         /* Enable DMA5 */
-#define BCM_DMA_ENABLE_EN4 (1 << 4)         /* Enable DMA4 */
-#define BCM_DMA_ENABLE_EN3 (1 << 3)         /* Enable DMA3 */
-#define BCM_DMA_ENABLE_EN2 (1 << 2)         /* Enable DMA2 */
-#define BCM_DMA_ENABLE_EN1 (1 << 1)         /* Enable DMA1 */
-#define BCM_DMA_ENABLE_EN0 (1 << 0)         /* Enable DMA0 */
+#define BCM_DMA_ENABLE_EN(n) (1 << (n))     /* Enable DMA channel 'n' */
 
 /* TODO: Section 4.2.1.3 Peripheral DREQ Signals of Datasheet */
 


### PR DESCRIPTION
# NOTE

This PR is a WIP. I am opening it as a draft because:
* It documents some progress for the last GSoC milestone now that the deadline is approaching
* I can get feedback on my use of the DMA upper-half driver, which is [entirely undocumented](https://nuttx.apache.org/docs/latest/components/drivers/special/dma.html) and used very few times in the kernel (UART16550, DMA audio).

It looks like I had discovered this a while ago on #8773 but never heard back from the author. If anyone has used this DMA driver, or anyone at Xiaomi might be willing to document it/provide a test application to verify correctness of my driver that would be awesome!

## Summary

This commit introduces support for the BCM2711's 16 DMA channels, including the 4 DMA Lite and 4 DMA4 channels. It uses the NuttX DMA standard upper-half for compatibility with other drivers. The intention is for the majority of these channels to be used internally by other BCM2711 peripheral drivers. As such, each peripheral should be allocated an appropriate channel for its exclusive use (i.e. DMA4 channels for intensive peripherals like EMMC, frame buffer and networking, DMA Lite for low-data peripherals like a UART console).

## Impact

Pre-cursor to a network driver (#16953) for the RPi4B Ethernet, which is the last milestone for my GSoC contract #18507.

Full support for DMA interfaces which should provide a large speedup for all
peripherals who later integrate this approach.

## Testing

N/A, this is still a draft.