### PR TITLE
boards/nrf5340-dk: configure HFXO capacitance

### DIFF
--- a/boards/arm/nrf53/nrf5340-dk/include/board.h
+++ b/boards/arm/nrf53/nrf5340-dk/include/board.h
@@ -42,6 +42,7 @@
 
 #define BOARD_SYSTICK_CLOCK         (64000000)
 #define BOARD_OSC_XOSC32KI_INTCAP   (OSC_XOSC32KI_INTCAP_C7PF)
+#define BOARD_OSC_XOSC32MCAPS_CAP   (7)
 
 /* LED definitions **********************************************************/
 


### PR DESCRIPTION
## Summary

The nRF5340 DK uses the HFXO internal load capacitors at 7 pF. Provide the board value so nrf53_oscconfig() programs XOSC32MCAPS instead of leaving the radio crystal untrimmed.

## Impact

fixes a strange bug where nrf5340-dk with BLE was detected by the smartphone but not by my PC

## Testing

nrf5340-dk with BLE