### PR TITLE
arch/nrf53: fix HFXO trim field extraction

### DIFF
--- a/arch/arm/src/nrf53/nrf53_oscconfig.c
+++ b/arch/arm/src/nrf53/nrf53_oscconfig.c
@@ -68,13 +68,14 @@ static void nrf53_hfxo_intcap(void)
 
   trim = getreg32(NRF53_FICR_XOSC32MTRIM);
 
-  slope_field = (trim & FICR_XOSC32MTRIM_OFFSET_MASK);
-  slope_mask = FICR_XOSC32MTRIM_OFFSET_MASK;
+  slope_field = ((trim & FICR_XOSC32MTRIM_SLOPE_MASK) >>
+                 FICR_XOSC32MTRIM_SLOPE_SHIFT);
+  slope_mask = (FICR_XOSC32MTRIM_SLOPE_MASK >>
+                FICR_XOSC32MTRIM_SLOPE_SHIFT);
   slope_sign = (slope_mask - (slope_mask >> 1));
   slope = (int32_t)(slope_field ^ slope_sign) - (int32_t)slope_sign;
 
-  offset = ((trim & FICR_XOSC32MTRIM_SLOPE_MASK) >>
-            FICR_XOSC32MTRIM_SLOPE_SHIFT);
+  offset = trim & FICR_XOSC32MTRIM_OFFSET_MASK;
 
   /* CAPVALUE = (((FICR->XOSC32MTRIM.SLOPE+56)*(CAPACITANCE*2-14))
    *            +((FICR->XOSC32MTRIM.OFFSET-8)<<4)+32)>>6;


### PR DESCRIPTION
## Summary

arch/nrf53: fix HFXO trim field extraction

## Impact

the previous code somehow worked on thingy53 but didn't work well on nrf5340-dk

## Testing

nrf5340-dk and thinyg53 with BLE