### PR TITLE
{bp-19779} tools/rust: Fix softfloat abi target spec name

### DIFF
--- a/tools/i486-unknown-nuttx.json
+++ b/tools/i486-unknown-nuttx.json
@@ -21,7 +21,7 @@
   "os": "nuttx",
   "position-independent-executables": false,
   "relro-level": "full",
-  "rustc-abi": "x86-softfloat",
+  "rustc-abi": "softfloat",
   "stack-probes": {
     "kind": "inline"
   },

--- a/tools/x86_64-unknown-nuttx.json
+++ b/tools/x86_64-unknown-nuttx.json
@@ -19,7 +19,7 @@
   "plt-by-default": false,
   "position-independent-executables": true,
   "relro-level": "full",
-  "rustc-abi": "x86-softfloat",
+  "rustc-abi": "softfloat",
   "stack-probes": {
     "kind": "inline"
   },


### PR DESCRIPTION
## Summary

Rename abi "x86-softfloat" to just "softfloat" to enable compatibility with newer rust nightly versions.

Rust recently changed the name of the softfloat abi to one more unified across targets, and more recently, removed the compat alias.

## Impact

RELEASE

## Testing

CI