### PR TITLE
{bp-19811} fs/cromfs: Fix stale cache read in read() fast path.

### DIFF
--- a/fs/cromfs/fs_cromfs.c
+++ b/fs/cromfs/fs_cromfs.c
@@ -997,26 +997,30 @@ static ssize_t cromfs_read(FAR struct file *filep, FAR char *buffer,
 
               /* Get the address and offset in the CROMFS image to obtain
                * the data.  Check if we already have this offset in the
-               * cache.
+               * cache.  This path decompresses into the caller's buffer,
+               * not into ff_buffer, so it may only read the cache, never
+               * populate it.
                */
 
-              src     = (FAR const uint8_t *)currhdr + LZF_TYPE1_HDR_SIZE;
+              src = (FAR const uint8_t *)currhdr + LZF_TYPE1_HDR_SIZE;
               voloffs = cromfs_addr2offset(fs, src);
-              if (voloffs != ff->ff_offset)
+              if (voloffs == ff->ff_offset)
+                {
+                  DEBUGASSERT(ff->ff_ulen >= copysize);
+                  memcpy(dest, ff->ff_buffer, copysize);
+                }
+              else
                 {
                   unsigned int decomplen;
 
                   decomplen = lzf_decompress(src, complen, dest,
                                              fs->cv_bsize);
-
-                  ff->ff_offset = voloffs;
-                  ff->ff_ulen   = decomplen;
+                  DEBUGASSERT(decomplen >= copysize);
                 }
 
               finfo("voloffs=%" PRIu32 " blkoffs=%" PRIu32
-                    " ulen=%" PRIu16 " ff_offset=%" PRIu32 " copysize=%u\n",
-                    voloffs, blkoffs, ulen, ff->ff_offset, copysize);
-              DEBUGASSERT(ff->ff_ulen >= copysize);
+                    " ulen=%" PRIu16 " copysize=%u\n",
+                    voloffs, blkoffs, ulen, copysize);
             }
           else
             {


### PR DESCRIPTION
## Summary

cromfs_read()'s fast path decompresses a block directly into the caller's buffer whenever a read reaches a block at its start and the caller has room for the whole decompressed block, bypassing the per-file decompression cache (ff_buffer). It nonetheless marked that block as cached by setting ff_offset, without ever writing ff_buffer itself.

A later read of the same block that fell onto the slow path trusted that false cache tag, skipped decompression, and copied from ff_buffer without it ever having been populated for that block. A repeated identical fast-path read of the same block hit the same false tag and skipped decompression entirely, leaving the caller's buffer untouched and returning whatever was already there.

Fixed by having the fast path only read the cache, never populate it: reuse ff_buffer when a prior slow-path read already cached the same block, otherwise decompress straight into the caller's buffer without touching ff_offset/ff_buffer.

## Impact

RELEASE

## Testing

CI