### PR TITLE
arch/Kconfig: add image option

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -1607,3 +1607,19 @@ config BOOT_SDRAM_DATA
 		.data and .bss sections can be initialized.
 
 endmenu # Boot Memory Configuration
+
+menu "Image Options"
+
+config FLASH_HEADER_SIZE
+	hex "Image header size"
+	default 0x0
+	---help---
+		Bootloaders might require a image header that describes the image
+		or is used e.g. for image validation. This sets the size of this
+		header. Some devices might require strict alignment of the location
+		after the header (e.g. when the image starts with the vector table),
+		this alignment should be performed in the linker script. To avoid
+		a possible alignment issue it is best to extend the header size
+		to match the alignment.
+
+endmenu # Image Options

--- a/boards/arm/stm32f4/nucleo-f411re/scripts/flash.ld
+++ b/boards/arm/stm32f4/nucleo-f411re/scripts/flash.ld
@@ -27,10 +27,23 @@
  * range.
  */
 
+#include <nuttx/config.h>
+#if (CONFIG_FLASH_SIZE != 0)
+#define FLASH_START CONFIG_FLASH_START + CONFIG_FLASH_HEADER_SIZE
+#define FLASH_SIZE  CONFIG_FLASH_SIZE - CONFIG_FLASH_HEADER_SIZE
+#define RAM_START   CONFIG_RAM_START
+#define RAM_SIZE    CONFIG_RAM_SIZE
+#else
+#define FLASH_START 0x08000000
+#define FLASH_SIZE  512K
+#define RAM_START   0x20000000
+#define RAM_SIZE    128K
+#endif
+
 MEMORY
 {
-  flash (rx) : ORIGIN = 0x08000000, LENGTH = 512K
-  sram (rwx) : ORIGIN = 0x20000000, LENGTH = 128K
+  flash (rx) : ORIGIN = FLASH_START, LENGTH = FLASH_SIZE
+  sram (rwx) : ORIGIN = RAM_START, LENGTH = RAM_SIZE
 }
 
 OUTPUT_ARCH(arm)
@@ -38,6 +51,10 @@ EXTERN(_vectors)
 ENTRY(_stext)
 SECTIONS
 {
+    /* Ensure that the vector table is correctly aligned */
+
+    . = ALIGN(0x200);
+
     .text : {
         _stext = ABSOLUTE(.);
         *(.vectors)


### PR DESCRIPTION
## Summary

~Add extra boot memory options to enforce the use of boot memory configuration options. This allows linker files to detect if they should prefer the specified boot memory options. This supports using boot memory config without breaking the existing defconfigs.~

Add image option to describe the size of an image header when a bootloader would need one.

When using the image header by a bootloader that is in nuttx-apps I would use the PREBUILD mechanism or a equivalent cmake mechanism to set the boot memory configuration and the image header size (using kconfig-tweak).
 
## Impact

None, enabler for improving bootloader support.

## Testing

tested on qemu-armv7a:nsh
```console
...
user_main: Exiting
ostest_main: Exiting with status 0
nsh>
```