### PR TITLE
tools/cxd56/mkspk: proper resources free on error.

### DIFF
--- a/tools/cxd56/mkspk.c
+++ b/tools/cxd56/mkspk.c
@@ -123,31 +123,35 @@ static struct args *parse_args(int argc, char **argv)
     {
       fprintf(stderr,
         "mkspk [-c <number>] <filename> <save name> [<output file>]\n");
-      exit(EXIT_FAILURE);
+      goto parse_args_error;
     }
 
   if (args->core < 0)
     {
       fprintf(stderr, "Core number is not set. Please use -c option.\n");
-      exit(EXIT_FAILURE);
+      goto parse_args_error;
     }
 
   if (strlen(args->savename) > 63)
     {
       fprintf(stderr, "savename too long.\n");
-      exit(EXIT_FAILURE);
+      goto parse_args_error;
     }
 
   return args;
+
+parse_args_error:
+  free(args->outputfile);
+  exit(EXIT_FAILURE);
 }
 
 static struct elf_file *load_elf(const char *filename)
 {
   size_t fsize;
   int pos;
-  char *buf;
-  FILE *fp;
-  struct elf_file *ef;
+  char *buf = NULL;
+  FILE *fp = NULL;
+  struct elf_file *ef = NULL;
   Elf32_Shdr *sh;
   uint16_t i;
   int ret;
@@ -155,13 +159,13 @@ static struct elf_file *load_elf(const char *filename)
   fp = fopen(filename, "rb");
   if (!fp)
     {
-      return NULL;
+      goto load_elf_error;
     }
 
   ef = malloc(sizeof(*ef));
   if (!ef)
     {
-      return NULL;
+      goto load_elf_error;
     }
 
   pos = fseek(fp, 0, SEEK_END);
@@ -171,14 +175,14 @@ static struct elf_file *load_elf(const char *filename)
   buf = malloc(fsize);
   if (!buf)
     {
-      return NULL;
+      goto load_elf_error;
     }
 
   ret = fread(buf, fsize, 1, fp);
   fclose(fp);
   if (ret != 1)
     {
-      return NULL;
+      goto load_elf_error;
     }
 
   ef->data = buf;
@@ -191,9 +195,7 @@ static struct elf_file *load_elf(const char *filename)
         h->e_ident[EI_MAG1] == 'E' &&
         h->e_ident[EI_MAG2] == 'L' && h->e_ident[EI_MAG3] == 'F'))
     {
-      free(ef);
-      free(buf);
-      return NULL;
+      goto load_elf_error;
     }
 
   ef->phdr = (Elf32_Phdr *) (buf + ef->ehdr->e_phoff);
@@ -219,6 +221,12 @@ static struct elf_file *load_elf(const char *filename)
     }
 
   return ef;
+
+load_elf_error:
+  if (fp) fclose(fp);
+  free(ef);
+  free(buf);
+  return NULL;
 }
 
 static void *create_image(struct elf_file *elf, int core, char *savename,
@@ -325,10 +333,11 @@ int main(int argc, char **argv)
   struct args *args;
   struct elf_file *elf;
   struct cipher *c;
-  uint8_t *spkimage;
+  uint8_t *spkimage = NULL;
   int size = 0;
-  FILE *fp;
+  FILE *fp = NULL;
   char footer[16];
+  int ret = EXIT_SUCCESS;
 
   args = parse_args(argc, argv);
 
@@ -336,7 +345,8 @@ int main(int argc, char **argv)
   if (!elf)
     {
       fprintf(stderr, "Loading ELF %s failure.\n", args->elffile);
-      exit(EXIT_FAILURE);
+      ret = EXIT_FAILURE;
+      goto main_exit;
     }
 
   spkimage = create_image(elf, args->core, args->savename, &size);
@@ -355,20 +365,21 @@ int main(int argc, char **argv)
   if (!fp)
     {
       fprintf(stderr, "Output file open error.\n");
-      free(spkimage);
-      exit(EXIT_FAILURE);
+      ret = EXIT_FAILURE;
+      goto main_exit;
     }
 
   fwrite(spkimage, size, 1, fp);
   fwrite(footer, 16, 1, fp);
+  memset(spkimage, 0, size);
 
-  fclose(fp);
+  goto main_exit;
 
   printf("File %s is successfully created.\n", args->outputfile);
+
+main_exit:
+  if (fp) fclose(fp);
   free(args->outputfile);
-
-  memset(spkimage, 0, size);
   free(spkimage);
-
-  exit(EXIT_SUCCESS);
+  exit(ret);
 }


### PR DESCRIPTION
## Summary

Poroperly free up resources (allocated memory, file descriptors) on error.

Reported-by: xjDeng.

## Impact

`nuttx/tools/cxd56/mkspk.c` is a host tool that builds Spresense firmware images, and now have fixed resources free on error which should satisfy memory leak code scanners.

## Testing

Build host:
```
% uname -a
FreeBSD hexagon 14.4-RELEASE-p8 FreeBSD 14.4-RELEASE-p8 cederom-releng-14.4.8-igc_test_20260810-n273771-e99dffa6c4c8 GENERIC amd64
```

Checkpatch:
```
% ./tools/checkpatch.sh -c -u -m -g HEAD~...HEAD
Used config files:
    1: .codespellrc
  All checks pass.
```

Before:

```
% git branch
* master

% git log --oneline -5
e64b28974bf (HEAD -> master, origin/master, origin/HEAD) boards/nrf5340-dk: configure HFXO capacitance
45657b976b2 arch/nrf53: fix HFXO trim field extraction
3ac88f0f976 drivers/lcd: honour the LCD_APA102_* settings in the apa102 LCD driver

% ./tools/configure.sh -B spresense:nsh
  Copy files
  Select CONFIG_HOST_BSD=y
  Refreshing...
(..)
#
# configuration written to .config
#

% gmake -j
(..)
Memory region         Used Size  Region Size  %age Used
             ram:      116548 B      1536 KB      7.41%
         gnssram:           0 B       640 KB      0.00%
Generating: nuttx.spk
tools/cxd56/mkspk -c2 nuttx nuttx nuttx.spk;
File nuttx.spk is successfully created.
Done.

% ./tools/flash_writer.py -s -a -c /dev/cuaU0 -b 115200 nuttx.spk
/XXX/nuttx.git/./tools/flash_writer.py:27: DeprecationWarning: 'telnetlib' is deprecated and slated for removal in Python 3.13
  import telnetlib
/bin/sh: ./reset_board.sh: not found
Please press RESET button on target board
>>> Install files ...
install -b 115200
Install nuttx.spk
|0%-----------------------------50%------------------------------100%|
######################################################################

116672 bytes loaded.
Package validation is OK.
Saving package to "nuttx"
updater# >>> Save Configuration to FlashROM ...
set bootable M0P
M0P is not valid bootable. config not changed.
updater# sync
updater# Restarting the board ...
reboot


% cu -l /dev/cuaU0 -s 115200
Connected
cxd56_farapiinitialize: Mismatched version: loader(20591) != Self(20596)
cxd56_farapiinitialize: Please update loader and gnssfw firmwares!!

NuttShell (NSH) NuttX-10.4.0
nsh>
nsh> uname -a
NuttX 10.4.0 e64b28974bf Aug 14 2026 01:48:41 arm spresense
nsh> ?
help usage:  help [-v] [<cmd>]

    .           cp          exit        mkdir       rmdir       true
    [           cmp         expr        mkrd        set         truncate
    ?           dirname     false       mount       kill        uname
    alias       date        fdinfo      mv          pkill       umount
    unalias     df          free        pidof       sleep       unset
    basename    dmesg       help        printf      usleep      uptime
    break       echo        hexdump     ps          source      watch
    cat         env         ls          pwd         test        xd
    cd          exec        du          rm          time        wait

Builtin Apps:
    dd     nsh    sh
nsh> ~
```

After:

```
% git branch
* cederom-20260813-tools_cxd56_mkspk_free_resources_fix

% git log --oneline -3
b37b800a94 (HEAD -> cederom-20260813-tools_cxd56_mkspk_free_resources_fix, cederom/cederom-20260813-tools_cxd56_mkspk_free_resources_fix) tools/cxd56/mkspk: proper resources free on error.
e64b28974b (origin/master, origin/HEAD, master) boards/nrf5340-dk: configure HFXO capacitance
45657b976b arch/nrf53: fix HFXO trim field extraction

% ./tools/configure.sh -B spresense:nsh
  Copy files
  Select CONFIG_HOST_BSD=y
  Refreshing...
(..)
#
# configuration written to .config
#

% gmake -j
(..)
Memory region         Used Size  Region Size  %age Used
             ram:      116552 B      1536 KB      7.41%
         gnssram:           0 B       640 KB      0.00%
Generating: nuttx.spk
tools/cxd56/mkspk -c2 nuttx nuttx nuttx.spk;
File nuttx.spk is successfully created.
Done.

% ./tools/flash_writer.py -s -a -c /dev/cuaU0 -b 115200 nuttx.spk
/XXX/nuttx.git/./tools/flash_writer.py:27: DeprecationWarning: 'telnetlib' is deprecated and slated for removal in Python 3.13
  import telnetlib
/bin/sh: ./reset_board.sh: not found
Please press RESET button on target board
>>> Install files ...
install -b 115200
Install nuttx.spk
|0%-----------------------------50%------------------------------100%|
######################################################################

116672 bytes loaded.
Package validation is OK.
Saving package to "nuttx"
updater# >>> Save Configuration to FlashROM ...
set bootable M0P
M0P is not valid bootable. config not changed.
updater# sync
updater# Restarting the board ...
reboot


% cu -l /dev/cuaU0 -s 115200
Connected
cxd56_farapiinitialize: Mismatched version: loader(20591) != Self(20596)
cxd56_farapiinitialize: Please update loader and gnssfw firmwares!!

NuttShell (NSH) NuttX-13.0.0
nsh>
nsh> uname -a
NuttX 13.0.0 3e14158cee-dirty Aug 14 2026 01:57:34 arm spresense
nsh> ?
help usage:  help [-v] [<cmd>]

    .           cp          exit        mkdir       rmdir       true
    [           cmp         expr        mkrd        set         truncate
    ?           dirname     false       mount       kill        uname
    alias       date        fdinfo      mv          pkill       umount
    unalias     df          free        pidof       sleep       unset
    basename    dmesg       help        printf      usleep      uptime
    break       echo        hexdump     ps          source      watch
    cat         env         ls          pwd         test        xd
    cd          exec        du          rm          time        wait

Builtin Apps:
    dd     nsh    sh
nsh> ~
[EOT]
hexagon% ls -al nuttx.spk
-rw-r--r--  1 cederom wheel 116672 14 sie 01:57 nuttx.spk
```