### PR TITLE
{bp-19541} sim/alsa: Use bundled codec headers.

### DIFF
--- a/arch/sim/src/sim/CMakeLists.txt
+++ b/arch/sim/src/sim/CMakeLists.txt
@@ -137,6 +137,9 @@ if(CONFIG_SIM_SOUND_ALSA)
   list(APPEND SRCS posix/sim_alsa.c)
   list(APPEND SRCS sim_offload.c)
   list(APPEND STDLIBS asound)
+  target_include_directories(
+    arch PRIVATE ${NUTTX_APPS_DIR}/audioutils/lame/lame/include
+                 ${NUTTX_APPS_DIR}/audioutils/libmad/libmad)
 endif()
 
 # host sources ###############################################################

--- a/arch/sim/src/sim/sim_offload.c
+++ b/arch/sim/src/sim/sim_offload.c
@@ -27,7 +27,7 @@
 #include <nuttx/kmalloc.h>
 #include <nuttx/debug.h>
 
-#include <lame/lame.h>
+#include <lame.h>
 #include <mad.h>
 
 #include "sim_offload.h"


### PR DESCRIPTION
## Summary

Expose the bundled LAME and libmad headers to the sim:alsa arch target and include LAME through its installed public header name. This lets the CMake build compile sim_offload.c without relying on host codec development packages.

## Impact

RELEASE

## Testing

CI