### PR TITLE
{bp-19847} sim: Makefile Lame build fix - #19847

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -43,6 +43,7 @@ endif
 
 ifeq ($(CONFIG_AUDIOUTILS_LAME),y)
 INCLUDES += ${INCDIR_PREFIX}$(APPSDIR)/audioutils/lame/lame/include
+INCLUDES += ${INCDIR_PREFIX}$(APPSDIR)/audioutils/lame/lame/libmp3lame/vector
 endif
 
 CPPFLAGS += $(INCLUDES)

--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -42,7 +42,7 @@ INCLUDES += ${INCDIR_PREFIX}$(APPSDIR)/audioutils/libmad/libmad
 endif
 
 ifeq ($(CONFIG_AUDIOUTILS_LAME),y)
-INCLUDES += ${INCDIR_PREFIX}$(APPSDIR)/audioutils/lame/lame
+INCLUDES += ${INCDIR_PREFIX}$(APPSDIR)/audioutils/lame/lame/include
 endif
 
 CPPFLAGS += $(INCLUDES)

--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -37,11 +37,11 @@ ifeq ($(CONFIG_VIDEOUTILS_LIBX264),y)
 INCLUDES += ${INCDIR_PREFIX}$(APPSDIR)/videoutils/x264/x264
 endif
 
-ifeq ($(CONFIG_VIDEOUTILS_LIBMAD),y)
+ifeq ($(CONFIG_AUDIOUTILS_LIBMAD),y)
 INCLUDES += ${INCDIR_PREFIX}$(APPSDIR)/audioutils/libmad/libmad
 endif
 
-ifeq ($(CONFIG_VIDEOUTILS_LAME),y)
+ifeq ($(CONFIG_AUDIOUTILS_LAME),y)
 INCLUDES += ${INCDIR_PREFIX}$(APPSDIR)/audioutils/lame/lame
 endif
 

--- a/arch/sim/src/sim/CMakeLists.txt
+++ b/arch/sim/src/sim/CMakeLists.txt
@@ -138,8 +138,10 @@ if(CONFIG_SIM_SOUND_ALSA)
   list(APPEND SRCS sim_offload.c)
   list(APPEND STDLIBS asound)
   target_include_directories(
-    arch PRIVATE ${NUTTX_APPS_DIR}/audioutils/lame/lame/include
-                 ${NUTTX_APPS_DIR}/audioutils/libmad/libmad)
+    arch
+    PRIVATE ${NUTTX_APPS_DIR}/audioutils/lame/lame/include
+            ${NUTTX_APPS_DIR}/audioutils/lame/lame/libmp3lame/vector
+            ${NUTTX_APPS_DIR}/audioutils/libmad/libmad)
 endif()
 
 # host sources ###############################################################


### PR DESCRIPTION
## Summary

sim: update Makefile to match Cmake config
follow the https://github.com/apache/nuttx/commit/3b1aea4bb0f7af36ca931ca969f360b001830fa8 commit and update the include

sim: fix LAME inclusion typo
the LAME and LIBMAD AUDIOUTILS are not correctly selected

## Impact

RELEASE

## Testing
CI