### PR TITLE
fs/vfs/fs_read.c: Allow NULL iov_base when CONFIG_ARCH_TEXT_VBASE == 0

### DIFF
--- a/fs/vfs/fs_read.c
+++ b/fs/vfs/fs_read.c
@@ -176,6 +176,14 @@ ssize_t file_readv(FAR struct file *filep,
       return -EFAULT;
     }
 
+  /* -------------------- DO NOT REMOVE --------------------
+   * Only for kernel builds with CONFIG_ARCH_TEXT_VBASE == 0.
+   * In this case we have to allow the NULL buffer otherwise
+   * kernel builds will fail to load elf binaries found at 0.
+   */
+
+#if !defined(CONFIG_BUILD_KERNEL) || CONFIG_ARCH_TEXT_VBASE != 0
+
   /* Are all iov_base accessible? */
 
   for (ret = 0; ret < iovcnt; ret++)
@@ -185,6 +193,7 @@ ssize_t file_readv(FAR struct file *filep,
           return -EFAULT;
         }
     }
+#endif
 
   ret = -EBADF;
 


### PR DESCRIPTION
## Summary

For kernel builds where CONFIG_ARCH_TEXT_VBASE is set to 0, allow a NULL buffer in file_readv() to prevent ELF binary loading failures for binaries located at address 0.

This fix was originally introduced in #18830, but was inadvertently reverted by someone unaware that platforms with CONFIG_ARCH_TEXT_VBASE equal to 0 cannot function at all without it. This commit restores the necessary check to prevent regressions in zero-based text kernel configurations. 

## Impact

Most platforms remain completely unaffected since only about 5 boards utilize a text virtual base of zero.
The change is intended to be a noop for most platforms. 

## Testing

Before this change the following errors are seen before a crash dump:
```
[    0.000000] libelf_read: ERROR: Read from offset 56 failed: 14
[    0.010000] libelf_loadfile: ERROR: Failed to read section 1: -14
[    0.010000] libelf_load_with_addrenv: ERROR: libelf_loadfile failed: -14
[    0.020000] elf_loadbinary: Failed to load ELF program binary: -14
[    0.030000] exec_internal: ERROR: Failed to load program '/bin/init': -14
[    0.030000] dump_assert_info: Current Version: NuttX  13.0.0 35354473c6-dirty Aug 14 2026 16:41:52 a
rm
[    0.030000] dump_assert_info: Assertion failed : at file: init/nx_bringup.c:389 task: AppBringUp pro
cess: Kernel 0x80301b71
```

The following objdump shows that the _/bin/init_ text is loaded at 0

```
$ arm-none-eabi-objdump -h init 

init:     file format elf32-littlearm

Sections:
Idx Name          Size      VMA       LMA       File off  Algn
  0 .text         0000abc4  00000000  00000000  00000038  2**3
                  CONTENTS, ALLOC, LOAD, RELOC, READONLY, CODE
  1 .rodata       0000336c  0000abc8  0000abc8  0000ac00  2**3
                  CONTENTS, ALLOC, LOAD, RELOC, READONLY, DATA
  2 .ARM.extab    00000000  00000000  00000000  0000df6c  2**0
                  CONTENTS, ALLOC, LOAD, READONLY, DATA
  3 .ARM.exidx    00000008  00000000  00000000  0000df6c  2**2
                  CONTENTS, ALLOC, LOAD, RELOC, READONLY, DATA
  4 .data         0000026c  00000008  00000008  0000df74  2**2
                  CONTENTS, ALLOC, LOAD, RELOC, DATA
  5 .init_array   00000000  00000274  00000274  0000e1e0  2**0
                  CONTENTS, ALLOC, LOAD, DATA
  6 .fini_array   00000000  00000274  00000274  0000e1e0  2**0
                  CONTENTS, ALLOC, LOAD, DATA
  7 .bss          00000540  00000274  00000274  0000e1e0  2**2
                  ALLOC
  8 .comment      00001e2a  00000000  00000000  0000e1e0  2**0
                  CONTENTS, READONLY
  9 .ARM.attributes 00000037  00000000  00000000  0001000a  2**0
                  CONTENTS, READONLY

```

After this change the nuttx image runs successfully.

NuttShell (NSH) NuttX-13.0.0
knsh> uname -a
NuttX 13.0.0 06530d6d17-dirty Aug 14 2026 22:39:25 arm beaglebone-black
knsh> ls /bin
/bin:
 dd
 getprime
 hello
 init
 sh
knsh> /bin/hello
Hello, World!!
knsh> 

