### PR TITLE
libs/libc/machine/risc-v: Correct RISC-V optimized functions.

### DIFF
--- a/libs/libc/machine/risc-v/arch_memcmp.S
+++ b/libs/libc/machine/risc-v/arch_memcmp.S
@@ -45,12 +45,33 @@ ARCH_LIBCFUN(memcmp):
 
 	beqz	a2, .Lequal
 
-	/* Check if both pointers share alignment */
+	/* The loops below load from both pointers at a boundary, which asks
+	 * that the two agree about where a boundary falls, not that either
+	 * is already on one.  Test the difference of the pointers, not their
+	 * union.
+	 */
 
-	or	t0, a0, a1
+	xor	t0, a0, a1
 	andi	t0, t0, SZREG-1
 	bnez	t0, .Lbyte_cmp
 
+	/* Same offset: walk both up to the boundary a byte at a time,
+	 * stopping early on a difference.
+	 */
+
+.Lalign_head:
+	andi	t0, a0, SZREG-1
+	beqz	t0, .Laligned
+	lbu	t1, 0(a0)
+	lbu	t2, 0(a1)
+	bne	t1, t2, .Ldiff
+	addi	a0, a0, 1
+	addi	a1, a1, 1
+	addi	a2, a2, -1
+	beqz	a2, .Lequal
+	j	.Lalign_head
+
+.Laligned:
 	li	t0, SZREG
 	bltu	a2, t0, .Lbyte_cmp
 

--- a/libs/libc/machine/risc-v/arch_strcmp.S
+++ b/libs/libc/machine/risc-v/arch_strcmp.S
@@ -26,10 +26,45 @@
 ARCH_LIBCFUN(strcmp):
 	.cfi_sections .debug_frame
 	.cfi_startproc
-	or    a4, a0, a1
 	li    t2, -1
+
+	/* Two pointers the same distance past a boundary can be compared
+	 * a register at a time once both are walked up to it.  Only
+	 * pointers that disagree about where the boundary falls need the
+	 * byte loop, since no single aligned load serves both.  Test the
+	 * difference of the pointers, not their union.
+	 */
+
+	xor   a4, a0, a1
 	and   a4, a4, SZREG-1
 	bnez  a4, .Lmisaligned
+
+	/* Same offset: walk both up to the boundary a byte at a time,
+	 * stopping early on a difference or a terminator.
+	 */
+
+	and   a4, a0, SZREG-1
+	beqz  a4, .Laligned
+.Lhead:
+	lbu   a2, 0(a0)
+	lbu   a3, 0(a1)
+	bne   a2, a3, .Lheaddiff
+	addi  a0, a0, 1
+	addi  a1, a1, 1
+	beqz  a2, .Lheadeq
+	and   a4, a0, SZREG-1
+	bnez  a4, .Lhead
+	j     .Laligned
+
+.Lheaddiff:
+	sub   a0, a2, a3
+	ret
+
+.Lheadeq:
+	li    a0, 0
+	ret
+
+.Laligned:
 
 #if SZREG == 4
 	li a5, 0x7f7f7f7f

--- a/libs/libc/machine/risc-v/arch_strlcpy.S
+++ b/libs/libc/machine/risc-v/arch_strlcpy.S
@@ -72,7 +72,17 @@ ARCH_LIBCFUN(strlcpy):
 
 	addi	a2, a2, -1		/* reserve space for null terminator */
 
-	/* Bytewise copy head: align src to SZREG boundary */
+	/* The word loop below aligns src and then stores a register at a
+	 * time to dst, so it is safe only where the two pointers agree about
+	 * where a boundary falls.  Where they do not, no single boundary
+	 * serves both and the copy goes a byte at a time.
+	 */
+
+	xor	t0, a0, a1
+	andi	t0, t0, SZREG-1
+	bnez	t0, .Lcopy_tail
+
+	/* Bytewise copy head: align src, and with it dst */
 
 .Lcopy_head:
 	beqz	a2, .Ltruncated

--- a/libs/libc/machine/risc-v/arch_strncmp.S
+++ b/libs/libc/machine/risc-v/arch_strncmp.S
@@ -44,13 +44,36 @@ ARCH_LIBCFUN(strncmp):
 
 	beqz	a2, .Lequal
 
-	/* Check alignment consistency */
+	/* The word loop below loads from both pointers at a boundary, which
+	 * asks that the two agree about where a boundary falls, not that
+	 * either is already on one.  Test the difference of the pointers,
+	 * not their union.
+	 */
 
-	or	t0, a0, a1
+	xor	t0, a0, a1
 	andi	t0, t0, SZREG-1
 	bnez	t0, .Lbyte_loop
 
-	/* Both aligned - load masks */
+	/* Same offset: walk both up to the boundary a byte at a time,
+	 * stopping early on a difference or a terminator.
+	 */
+
+.Lsnc_align_head:
+	andi	t0, a0, SZREG-1
+	beqz	t0, .Lsnc_aligned
+	lbu	t0, 0(a0)
+	lbu	t1, 0(a1)
+	bne	t0, t1, .Ldiff
+	beqz	t0, .Lequal
+	addi	a0, a0, 1
+	addi	a1, a1, 1
+	addi	a2, a2, -1
+	beqz	a2, .Lequal
+	j	.Lsnc_align_head
+
+.Lsnc_aligned:
+
+	/* Load masks */
 
 #if SZREG == 8
 	lla	t2, .Lsnc_mask01


### PR DESCRIPTION
## Summary

Four functions in the RISC-V machine directory decide whether to work a
register at a time by asking whether both pointers are already on a boundary.
That is the wrong question, and in one case it produces a store that the ISA
does not guarantee will work at all.

`strlcpy` aligns only its source and then stores a whole register at a time to
a destination that is aligned by luck. `memcmp`, `strncmp` and `strcmp` test
`or` of the two pointers, so a pair that is equally misaligned falls back to
the byte loop the word loop exists to replace.

Two commits: the `strlcpy` store, then the three compares.

## Where this comes from

I opened #19735 with C implementations of these routines, built around
testing whether two pointers *agree* about where a boundary falls rather than
whether either is already on one. While that was in review, #19781 and #19782
landed assembly implementations covering a wider set of functions, so I have
dropped my versions; the assembly is the better base and is faster than my C
in most cases.

This PR carries over the one idea from #19735 that did not make it across, and
applies it to the code that is now in tree. It is not a re-run of that review.
I will close #19735 once this lands; the part of it that belongs in the shared
BSD implementation rather than an arch directory, which is what
@xiaoxiang781216 asked for there, follows as its own PR.

## Why it matters more than a missed optimisation

Misaligned access is not guaranteed on RISC-V. The base ISA permits it to be
unsupported, and implementations differ:

- where firmware emulates it, every access traps into machine mode
- where nothing emulates it, the access faults

So a routine in a machine directory cannot assume a misaligned store will
work, whatever it might cost. `arch_strcpy.S` and `arch_memcpy.S` already take
this view. `arch_strlcpy.S` does not.

**This is also why QEMU is a poor place to measure or test it.** QEMU executes
misaligned accesses natively at full speed, so the `strlcpy` defect is
invisible there: correct results, no penalty, nothing to see. Every number
below is from silicon.

## Measured

EIC7700X, rv64 at 1.4 GHz, `CONFIG_RISCV_STRING_FUNCTION=y`, 32 KB operands,
taken with the benchmark in apache/nuttx-apps#3706. `generic` is the same
board with the machine directory disabled, included so the byte-loop rate is
visible.

Source and destination misaligned by different amounts, which is the case
`strlcpy` gets wrong:

```
                generic     before      after
  strlcpy         410.4        7.5      490.0 MB/s
```

7.5 MB/s is about 178 cycles per byte, flat from 512 bytes to 32 KB, which is
what a trapped and emulated store costs on this part. It is 55x slower than
the generic C it replaced.

Source and destination equally misaligned, which is the case the compares
reject:

```
                generic     before      after
  memcmp           30.7       34.4      456.0 MB/s
  strncmp          32.2       32.2      254.0 MB/s
  strcmp           41.2       40.9      280.0 MB/s
```

Each `before` figure is the generic rate, so the word loops were not being
entered at all.

Both aligned, to show the guard costs nothing where it does not fire:

```
                 before      after
  strlcpy        2474.0     2452.0 MB/s
  memcmp          452.0      458.0 MB/s
  strncmp         266.0      256.0 MB/s
  strcmp          282.0      280.9 MB/s
```

Pointers that genuinely disagree still take the byte loop. No unaligned access
is introduced anywhere.

## Testing

- Correctness: `testing/libc/arch_libc` under qemu rv64, all functions pass
  before and after. The `strlcpy` defect is a performance defect on the parts
  that emulate, so no correctness test can catch it, and none did.
- Throughput: the benchmark in apache/nuttx-apps#3706, which sweeps sizes
  against every source and destination alignment pair. An aligned measurement
  at a single size cannot see any of this.
