### PR TITLE
arch/arm/src/common/stm32: read UID with 32-bit accesses

### DIFF
--- a/arch/arm/src/common/stm32/stm32_uid.c
+++ b/arch/arm/src/common/stm32/stm32_uid.c
@@ -40,6 +40,9 @@
 
 #include <nuttx/config.h>
 
+#include <string.h>
+
+#include "arm_internal.h"
 #include "chip.h"
 #include "stm32_uid.h"
 
@@ -51,12 +54,19 @@
 
 void stm32_get_uniqueid(uint8_t uniqueid[12])
 {
+  uint32_t uid[3];
   int i;
 
-  for (i = 0; i < 12; i++)
+  /* Read the UID with 32-bit accesses. Some parts (STM32H5) store the UID
+   * in flash memory that does not support 8-bit reads.
+   */
+
+  for (i = 0; i < 3; i++)
     {
-      uniqueid[i] = *((uint8_t *)(STM32_SYSMEM_UID) + i);
+      uid[i] = getreg32(STM32_SYSMEM_UID + 4 * i);
     }
+
+  memcpy(uniqueid, uid, 12);
 }
 
 #endif /* STM32_SYSMEM_UID */


### PR DESCRIPTION
## Summary

STM32H5 stores the UID in flash memory that supports only 16-bit or 32-bit read accesses. The 8-bit reads introduced with the stm32_uid unification generate an AHB bus error and hard fault the chip when the Ethernet driver reads the MAC address.

Read the UID as three 32-bit words into an aligned buffer and copy it to the caller's buffer. On little-endian ARM the resulting byte order is identical to byte reads, so behavior is unchanged for the other STM32 families.

Fixes: https://github.com/apache/nuttx/issues/19771

## Impact

fix STM32H5 UID access, read with getreg32 should work with all families

## Testing

tested on nucleo-h503rb, nucleo-u5a5zji-q and stm32u083c-dk
