### PR TITLE
drivers/usbhost: Make xHCI transfers work with real devices.

### DIFF
--- a/drivers/usbhost/Kconfig
+++ b/drivers/usbhost/Kconfig
@@ -832,6 +832,22 @@ config USBHOST_XHCI_MAX_DEVS
 	---help---
 		How many USB devices will be supported by xHCI driver.
 
+config USBHOST_XHCI_ENUM_RETRIES
+	int "xHCI enumeration attempts per port"
+	default 3
+	range 1 255
+	---help---
+		How many times to attempt enumeration of a newly connected device
+		before leaving the port alone until the device is unplugged.
+
+		A device whose descriptors cannot be read, or that no class driver
+		claims, fails enumeration every time.  Each failure marks the port
+		disconnected so the attempt repeats, so without a limit such a
+		device is retried for as long as it stays plugged in, logging and
+		taking a device slot on every pass.
+
+		The count is per root hub port and is cleared by a new connection.
+
 endif # USBHOST_XHCI
 
 menuconfig USBHOST_XHCI_PCI

--- a/drivers/usbhost/usbhost_xhci.c
+++ b/drivers/usbhost/usbhost_xhci.c
@@ -1141,6 +1141,10 @@ static int xhci_ctrl_start(FAR struct usbhost_xhci_s *priv)
   xhci_oper_putreg_8b(priv, XHCI_CRCR,
                       up_addrenv_va_to_pa(priv->cmd.ring) | XHCI_CRCR_RCS);
 
+  /* Do not sit on completions; see XHCI_IMOD_INTERVAL */
+
+  xhci_runt_putreg(priv, XHCI_IMOD(0), XHCI_IMOD_DEFAULT);
+
   /* Enable interrupts */
 
   regval = xhci_runt_getreg(priv, XHCI_IMAN(0));

--- a/drivers/usbhost/usbhost_xhci.c
+++ b/drivers/usbhost/usbhost_xhci.c
@@ -3949,9 +3949,23 @@ static int xhci_epalloc(FAR struct usbhost_driver_s *drvr,
 
   /* xhci_epno_get() returns Device Context Index (DCI) */
 
-  idx              = xhci_epno_get(epinfo);
-  mask             = XHCI_IN_CTX1_A(XHCI_EP_FLAG(idx));
-  dev              = rhport->dev;
+  idx  = xhci_epno_get(epinfo);
+  mask = XHCI_IN_CTX1_A(XHCI_EP_FLAG(idx));
+  dev  = rhport->dev;
+
+  /* There has to be a device to hang the endpoint off.  A port whose
+   * enumeration failed is retried after its slot has been given back, so
+   * this can run for a root hub port with nothing behind it.
+   */
+
+  if (dev == NULL)
+    {
+      uerr("no device on port %d\n", RHPNDX(rhport));
+      nxsem_destroy(&epinfo->iocsem);
+      kmm_free(epinfo);
+      return -ENODEV;
+    }
+
   dev->epinfo[idx - 1] = epinfo;
 
   /* TD rings already allocated but not connected yet. */

--- a/drivers/usbhost/usbhost_xhci.c
+++ b/drivers/usbhost/usbhost_xhci.c
@@ -3057,6 +3057,8 @@ static FAR uint8_t *xhci_dma_prepare(FAR struct usbhost_xhci_s *priv,
   if (!reachable ||
       ((uintptr_t)buffer & (line - 1)) != 0 || (buflen & (line - 1)) != 0)
     {
+      /* A stand-in is needed; see xhci_dmacapable() for the same test */
+
       /* The buffer shares a line with something else.  Work in a stand-in
        * that does not.
        */
@@ -3107,7 +3109,13 @@ static FAR uint8_t *xhci_dma_prepare(FAR struct usbhost_xhci_s *priv,
  *
  * Description:
  *   Read back what the controller wrote, and give up any stand-in buffer.
- *   Called on completion, before whoever is waiting is woken.
+ *
+ *   This must run in the context of whoever asked for the transfer, not in
+ *   the completion handler.  The buffer being copied back into may belong
+ *   to a user process, and its address means nothing in the work queue
+ *   thread that handles the completion event, where the write would fault
+ *   or corrupt another process.  The caller is blocked until the transfer
+ *   finishes anyway.
  *
  ****************************************************************************/
 
@@ -3163,10 +3171,6 @@ static void xhci_transfer_complete(FAR struct usbhost_xhci_s *priv,
 
   epinfo = priv->devs[slot - 1].epinfo[ep - 1];
   DEBUGASSERT(epinfo != NULL);
-
-  /* Read back what the controller wrote before anyone looks at it */
-
-  xhci_dma_finish(epinfo);
 
   flags = spin_lock_irqsave(&priv->spinlock);
 
@@ -4353,6 +4357,11 @@ static int xhci_ctrl_xfer(FAR struct usbhost_driver_s *drvr,
   /* And wait for the transfer to complete */
 
   nbytes = xhci_transfer_wait(priv, ep0info);
+
+  /* As for bulk: the copy back belongs in the caller's context */
+
+  xhci_dma_finish(ep0info);
+
   return nbytes >= 0 ? OK : (int)nbytes;
 
 errout_with_iocwait:
@@ -4512,6 +4521,13 @@ static ssize_t xhci_transfer(FAR struct usbhost_driver_s *drvr,
   /* Then wait for the transfer to complete */
 
   nbytes = xhci_transfer_wait(priv, epinfo);
+
+  /* And bring back what it produced, here rather than in the completion,
+   * because this is the context the caller's buffer belongs to.
+   */
+
+  xhci_dma_finish(epinfo);
+
   return nbytes;
 
 errout_with_iocwait:

--- a/drivers/usbhost/usbhost_xhci.c
+++ b/drivers/usbhost/usbhost_xhci.c
@@ -4611,6 +4611,7 @@ static void xhci_disconnect(FAR struct usbhost_driver_s *drvr,
 static int xhci_hw_getparams(FAR struct usbhost_xhci_s *priv)
 {
   uint32_t regval;
+  uint32_t erst;
 
   /* Get data form Host Controller Capability 1 Parameters */
 
@@ -4651,16 +4652,21 @@ static int xhci_hw_getparams(FAR struct usbhost_xhci_s *priv)
 
   uinfo("no scratch = %d\n", priv->no_scratch);
 
-  priv->no_erst = 1 << XHCI_HCSPARAMS2_ERST(regval);
+  /* How many event ring segments the controller will allow, which is a
+   * power of two and can reach 32768, so it is worked out at full width
+   * and only then narrowed to what this driver actually uses.  Computed
+   * into the field directly it would wrap to zero on any controller
+   * offering more than 128 segments, and a table declared to hold no
+   * entries gives a controller with nowhere to report anything.
+   */
 
-  uinfo("no_erst = %d\n", priv->no_erst);
+  erst = 1ul << XHCI_HCSPARAMS2_ERST(regval);
+
+  uinfo("erst max = %" PRIu32 "\n", erst);
 
   /* Limit event ring segment table to 1 */
 
-  if (priv->no_erst > XHCI_MAX_ERST)
-    {
-      priv->no_erst = XHCI_MAX_ERST;
-    }
+  priv->no_erst = (erst > XHCI_MAX_ERST) ? XHCI_MAX_ERST : erst;
 
   uinfo("no erst = %d\n", priv->no_erst);
 

--- a/drivers/usbhost/usbhost_xhci.c
+++ b/drivers/usbhost/usbhost_xhci.c
@@ -1291,8 +1291,13 @@ static void xhci_probe_ports(FAR struct usbhost_xhci_s *priv)
       portsc = xhci_oper_getreg(priv, XHCI_PORTSC(i));
       priv->rhport[i].connected = ((portsc & XHCI_PORTSC_CCS) != 0);
 
-      /* Clear status change */
+      /* Clear status change, but not PED.  Port Enabled/Disabled is
+       * write-one-to-clear, so writing back what was read disables any
+       * port that came up enabled, which is what a device attached at
+       * power up does.
+       */
 
+      portsc &= ~XHCI_PORTSC_PED;
       xhci_oper_putreg(priv, XHCI_PORTSC(i), portsc);
     }
 }

--- a/drivers/usbhost/usbhost_xhci.c
+++ b/drivers/usbhost/usbhost_xhci.c
@@ -27,6 +27,7 @@
 #include <assert.h>
 #include <nuttx/debug.h>
 #include <errno.h>
+#include <string.h>
 
 #include <sys/endian.h>
 
@@ -34,6 +35,7 @@
 #include <nuttx/kthread.h>
 #include <nuttx/wqueue.h>
 #include <nuttx/addrenv.h>
+#include <nuttx/cache.h>
 #include <nuttx/spinlock.h>
 
 #include <nuttx/usb/usb.h>
@@ -142,6 +144,9 @@ struct xhci_epinfo_s
   int                result;       /* The result of the transfer */
   size_t             xfrd;         /* On completion, will hold the number of bytes transferred */
   size_t             buflen;       /* Buffer length used for transfer */
+  FAR uint8_t       *buffer;       /* The caller's buffer, for cache maintenance */
+  FAR uint8_t       *bounce;       /* Aligned stand-in for it, or NULL */
+  bool               dmain;        /* Direction this buffer was prepared for */
   sem_t              iocsem;       /* Semaphore used to wait for transfer completion */
 #ifdef CONFIG_USBHOST_ASYNCH
   usbhost_asynch_t   callback;     /* Transfer complete callback */
@@ -411,6 +416,12 @@ static int xhci_isoc_setup(FAR struct xhci_rhport_s *rhport,
 #endif
 static ssize_t xhci_transfer_wait(FAR struct usbhost_xhci_s *priv,
                                   FAR struct xhci_epinfo_s *epinfo);
+static bool xhci_dmacapable(FAR struct usbhost_xhci_s *priv,
+                            FAR uint8_t *buffer, size_t buflen);
+static FAR uint8_t *xhci_dma_prepare(FAR struct xhci_epinfo_s *epinfo,
+                                     FAR uint8_t *buffer, size_t buflen,
+                                     bool dirin);
+static void xhci_dma_finish(FAR struct xhci_epinfo_s *epinfo);
 
 /* Interrupt handling *******************************************************/
 
@@ -2298,6 +2309,13 @@ static int xhci_control_setup(FAR struct xhci_rhport_s *rhport,
 
   if (buffer)
     {
+      buffer = xhci_dma_prepare(epinfo, buffer, buflen,
+                                (req->type & USB_REQ_DIR_IN) != 0);
+      if (buffer == NULL)
+        {
+          return -ENOMEM;
+        }
+
       trb[i].d0 = up_addrenv_va_to_pa(buffer);
       trb[i].d1 = XHCI_TRB_D1_TXLEN_SET(buflen);
       trb[i].d2 = XHCI_TRB_D2_TYPE_SET(XHCI_TRB_TYPE_DATA_STAGE);
@@ -2369,6 +2387,14 @@ static int xhci_normal_setup(FAR struct xhci_rhport_s *rhport,
   size_t                     chunk;
   uintptr_t                  pa;
   int                        n = 0;
+
+  /* Make the buffer safe for the controller to reach */
+
+  buffer = xhci_dma_prepare(epinfo, buffer, buflen, epinfo->dirin != 0);
+  if (buffer == NULL)
+    {
+      return -ENOMEM;
+    }
 
   /* One TRB describes one run of memory, and that run may not cross a 64K
    * boundary.  A longer transfer, or one starting near the wrong side of a
@@ -2445,6 +2471,14 @@ static int xhci_isoc_setup(FAR struct xhci_rhport_s *rhport,
 {
   FAR struct usbhost_xhci_s *priv = XHCI_PRIV_FROM_RHPORT(rhport);
   struct xhci_trb_s          trb;
+
+  /* Make the buffer safe for the controller to reach */
+
+  buffer = xhci_dma_prepare(epinfo, buffer, buflen, epinfo->dirin != 0);
+  if (buffer == NULL)
+    {
+      return -ENOMEM;
+    }
 
   /* Prepare TRB */
 
@@ -2740,6 +2774,152 @@ static void xhci_portsc_work(FAR void *arg)
 }
 
 /****************************************************************************
+ * Name: xhci_dmacapable
+ *
+ * Description:
+ *   Whether the controller may be pointed at this buffer.
+ *
+ *   The driver has no way to know this on its own.  Whether an address can
+ *   be turned into one the device will reach, and whether what lies behind
+ *   it is contiguous, is a property of the system the controller was fitted
+ *   into, so the answer comes from there.  A platform that says nothing is
+ *   taken to mean every address works, which is what a flat address space
+ *   gives.
+ *
+ ****************************************************************************/
+
+static bool xhci_dmacapable(FAR struct usbhost_xhci_s *priv,
+                            FAR uint8_t *buffer, size_t buflen)
+{
+  if (priv->ops->dmacapable == NULL)
+    {
+      return true;
+    }
+
+  return priv->ops->dmacapable(priv->arg, buffer, buflen);
+}
+
+/****************************************************************************
+ * Name: xhci_dma_prepare
+ *
+ * Description:
+ *   Make a caller's buffer safe for the controller to reach, and say which
+ *   address to hand it.
+ *
+ *   The controller writes memory behind the processor's back, so on a
+ *   machine whose caches are not coherent every buffer it touches must be
+ *   flushed before the controller reads and invalidated before the
+ *   processor does.
+ *
+ *   Both act a whole cache line at a time, which is unsafe for a buffer
+ *   that does not own its lines: invalidating drops whatever shares the
+ *   line, and a writeback lands on top of what the controller just put
+ *   there.  Class drivers pass their own structure members, a 31 byte
+ *   command block or a 13 byte status, which share lines.
+ *
+ *   Such a buffer gets an aligned stand-in and is copied at the ends.
+ *   Anything large enough to matter comes from a filesystem or from
+ *   xhci_ioalloc() and is already aligned.
+ *
+ * Returned Value:
+ *   The address to give the controller, or NULL if a stand-in was needed
+ *   and could not be allocated.
+ *
+ ****************************************************************************/
+
+static FAR uint8_t *xhci_dma_prepare(FAR struct xhci_epinfo_s *epinfo,
+                                     FAR uint8_t *buffer, size_t buflen,
+                                     bool dirin)
+{
+  size_t line = up_get_dcache_linesize();
+
+  epinfo->buffer = buffer;
+  epinfo->bounce = NULL;
+  epinfo->dmain  = dirin;
+
+  /* No cache to maintain, so nothing to arrange */
+
+  if (line == 0)
+    {
+      return buffer;
+    }
+
+  if (((uintptr_t)buffer & (line - 1)) != 0 || (buflen & (line - 1)) != 0)
+    {
+      /* The buffer shares a line with something else.  Work in a stand-in
+       * that does not.
+       */
+
+      epinfo->bounce = kmm_memalign(line, (buflen + line - 1) & ~(line - 1));
+      if (epinfo->bounce == NULL)
+        {
+          return NULL;
+        }
+
+      if (!dirin)
+        {
+          memcpy(epinfo->bounce, buffer, buflen);
+        }
+
+      buffer = epinfo->bounce;
+    }
+
+  /* Push what we are sending; drop what we are about to be sent, so that
+   * nothing the processor is still holding can be written back over it
+   * while the transfer is in flight.
+   */
+
+  if (dirin)
+    {
+      up_invalidate_dcache((uintptr_t)buffer, (uintptr_t)buffer + buflen);
+    }
+  else
+    {
+      up_clean_dcache((uintptr_t)buffer, (uintptr_t)buffer + buflen);
+    }
+
+  return buffer;
+}
+
+/****************************************************************************
+ * Name: xhci_dma_finish
+ *
+ * Description:
+ *   Read back what the controller wrote, and give up any stand-in buffer.
+ *   Called on completion, before whoever is waiting is woken.
+ *
+ ****************************************************************************/
+
+static void xhci_dma_finish(FAR struct xhci_epinfo_s *epinfo)
+{
+  FAR uint8_t *dma  = epinfo->bounce ? epinfo->bounce : epinfo->buffer;
+  bool         dirin = epinfo->dmain;
+
+  if (dma == NULL)
+    {
+      return;
+    }
+
+  if (dirin)
+    {
+      up_invalidate_dcache((uintptr_t)dma, (uintptr_t)dma + epinfo->buflen);
+
+      if (epinfo->bounce != NULL && epinfo->buffer != NULL)
+        {
+          memcpy(epinfo->buffer, epinfo->bounce, epinfo->buflen);
+        }
+    }
+
+  if (epinfo->bounce != NULL)
+    {
+      kmm_free(epinfo->bounce);
+      epinfo->bounce = NULL;
+    }
+
+  epinfo->buffer = NULL;
+}
+
+/****************************************************************************
  * Name: xhci_transfer_complete
  *
  * Description:
@@ -2761,6 +2941,10 @@ static void xhci_transfer_complete(FAR struct usbhost_xhci_s *priv,
 
   epinfo = priv->devs[slot - 1].epinfo[ep - 1];
   DEBUGASSERT(epinfo != NULL);
+
+  /* Read back what the controller wrote before anyone looks at it */
+
+  xhci_dma_finish(epinfo);
 
   flags = spin_lock_irqsave(&priv->spinlock);
 
@@ -3737,7 +3921,8 @@ static int xhci_free(FAR struct usbhost_driver_s *drvr, FAR uint8_t *buffer)
 static int xhci_ioalloc(FAR struct usbhost_driver_s *drvr,
                         FAR uint8_t **buffer, size_t buflen)
 {
-  int ret = -ENOMEM;
+  size_t line;
+  int    ret = -ENOMEM;
 
   DEBUGASSERT(drvr && buffer && buflen > 0);
 
@@ -3748,7 +3933,18 @@ static int xhci_ioalloc(FAR struct usbhost_driver_s *drvr,
       return -ENOMEM;
     }
 
-  /* Allocated buffer must not cross page boundaries */
+  /* Allocated buffer must not cross page boundaries.
+   *
+   * Round to whole cache lines as well as aligning the start, so that the
+   * buffer owns every line it touches and can be invalidated without
+   * disturbing whatever would otherwise share the last one.
+   */
+
+  line = up_get_dcache_linesize();
+  if (line > 1)
+    {
+      buflen = (buflen + line - 1) & ~(line - 1);
+    }
 
   *buffer = (FAR uint8_t *)kmm_memalign((XHCI_PAGE_SIZE / 2) , buflen);
   if (*buffer)
@@ -3847,6 +4043,13 @@ static int xhci_ctrl_xfer(FAR struct usbhost_driver_s *drvr,
 
   len = xhci_getle16(req->len);
 
+  /* Refuse a buffer the controller cannot reach, as for bulk transfers */
+
+  if (buffer != NULL && len > 0 && !xhci_dmacapable(priv, buffer, len))
+    {
+      return -EFAULT;
+    }
+
   /* Terse output only if we are tracing */
 
 #ifdef CONFIG_USBHOST_TRACE
@@ -3870,6 +4073,15 @@ static int xhci_ctrl_xfer(FAR struct usbhost_driver_s *drvr,
       ret = xhci_address_set(priv, rhport, true);
       if (ret == OK)
         {
+          /* The controller chose this address and wrote it into the
+           * output context.  Invalidate before reading, or the stale
+           * copy is used.
+           */
+
+          up_invalidate_dcache((uintptr_t)rhport->dev->ctx,
+                               (uintptr_t)rhport->dev->ctx +
+                               sizeof(struct xhci_dev_ctx_s));
+
           /* Store USB Device Address assigned by xHCI */
 
           ep0info->devaddr =
@@ -4009,6 +4221,16 @@ static ssize_t xhci_transfer(FAR struct usbhost_driver_s *drvr,
   int                        ret;
 
   DEBUGASSERT(priv && rhport && epinfo && buffer && buflen > 0);
+
+  /* Refuse a buffer the controller cannot reach rather than pointing it at
+   * the wrong memory.  A caller that has somewhere better to put the data
+   * will try again with it; the FAT filesystem does exactly that.
+   */
+
+  if (!xhci_dmacapable(priv, buffer, buflen))
+    {
+      return -EFAULT;
+    }
 
   /* We must have exclusive access to the xHCI hardware and data
    * structures.

--- a/drivers/usbhost/usbhost_xhci.c
+++ b/drivers/usbhost/usbhost_xhci.c
@@ -3802,6 +3802,68 @@ static int xhci_ep0configure(FAR struct usbhost_driver_s *drvr,
 }
 
 /****************************************************************************
+ * Name: xhci_interval
+ *
+ * Description:
+ *   Work out the Interval an endpoint context wants.
+ *
+ *   The field is an exponent: the controller services the endpoint every
+ *   2^Interval microframes.  An endpoint descriptor does not say it that
+ *   way, and what it does say depends on how fast the device is, so the
+ *   number cannot simply be copied across.
+ *
+ *   A low or full speed interrupt endpoint counts in frames, so its period
+ *   is bInterval milliseconds, or bInterval * 8 microframes, and the
+ *   exponent is the position of the highest bit of that.  Everything else
+ *   that is periodic already states an exponent, one greater than the one
+ *   wanted here.  Control and bulk endpoints are not periodic and the field
+ *   means nothing to them.
+ *
+ ****************************************************************************/
+
+static uint8_t xhci_interval(uint8_t speed, uint8_t xfrtype,
+                             uint8_t interval)
+{
+  unsigned int exp;
+
+  if (xfrtype != USB_EP_ATTR_XFER_INT && xfrtype != USB_EP_ATTR_XFER_ISOC)
+    {
+      return 0;
+    }
+
+  if ((speed == USB_SPEED_LOW || speed == USB_SPEED_FULL) &&
+      xfrtype == USB_EP_ATTR_XFER_INT)
+    {
+      /* Frames.  Round down to a power of two, and keep it inside what the
+       * specification allows for this kind of endpoint: 2^3 microframes is
+       * one frame, 2^10 is 128 of them.
+       */
+
+      if (interval == 0)
+        {
+          interval = 1;
+        }
+
+      for (exp = 0; (1u << (exp + 1)) <= interval * 8u; exp++);
+
+      if (exp < 3)
+        {
+          exp = 3;
+        }
+      else if (exp > 10)
+        {
+          exp = 10;
+        }
+
+      return exp;
+    }
+
+  /* Already an exponent, counted from one */
+
+  return interval > 0 ? interval - 1 : 0;
+}
+
+/****************************************************************************
  * Name: xhci_epalloc
  *
  * Description:
@@ -3879,7 +3941,8 @@ static int xhci_epalloc(FAR struct usbhost_driver_s *drvr,
   epinfo->epno  = epdesc->addr;
 
 #ifndef CONFIG_USBHOST_INT_DISABLE
-  epinfo->interval  = epdesc->interval;
+  epinfo->interval  = xhci_interval(hport->speed, epdesc->xfrtype,
+                                    epdesc->interval);
 #endif
   epinfo->xfrtype   = epdesc->xfrtype;
   nxsem_init(&epinfo->iocsem, 0, 0);

--- a/drivers/usbhost/usbhost_xhci.c
+++ b/drivers/usbhost/usbhost_xhci.c
@@ -1915,7 +1915,8 @@ static void xhci_context_ctrl(FAR struct usbhost_xhci_s *priv,
 static int xhci_command(FAR struct usbhost_xhci_s *priv,
                         FAR struct xhci_trb_s *trb, uint16_t timeout_ms)
 {
-  int ret;
+  uint32_t cmdtype;
+  int      ret;
 
   /* Lock bus */
 
@@ -1924,6 +1925,10 @@ static int xhci_command(FAR struct usbhost_xhci_s *priv,
     {
       return ret;
     }
+
+  /* Remember what this was before the result overwrites it */
+
+  cmdtype = XHCI_TRB_D2_TYPE_GET(trb->d2);
 
   /* Add command to ring */
 
@@ -1960,7 +1965,8 @@ static int xhci_command(FAR struct usbhost_xhci_s *priv,
     }
   else
     {
-      uerr("event CC = %d\n", XHCI_TRB_D1_CC_GET(trb->d1));
+      uerr("command type %d failed, CC = %d\n", cmdtype,
+           XHCI_TRB_D1_CC_GET(trb->d1));
       ret = -EIO;
     }
 

--- a/drivers/usbhost/usbhost_xhci.c
+++ b/drivers/usbhost/usbhost_xhci.c
@@ -729,8 +729,17 @@ static void xhci_dump_mem(FAR struct usbhost_xhci_s *priv,
   uinfo("Dump xHCI registers: %s\n", msg);
 
   uinfo("=== Host Controller Capability Registers ===\n");
-  xhci_dump_capa_reg(priv, "CAPLENGTH   ", XHCI_CAPLENGTH);
-  xhci_dump_capa_reg(priv, "HCIVERSION  ", XHCI_HCIVERSION);
+
+  /* CAPLENGTH and HCIVERSION share one word, and a register block reached
+   * over a bus that only answers aligned accesses cannot be read at the
+   * odd offset the second one has.  Read the word once and take both from
+   * it.
+   */
+
+  uinfo("\tCAPLENGTH   :\t\t0x%" PRIx32 "\n",
+        xhci_capa_getreg(priv, XHCI_CAPLENGTH) & 0xff);
+  uinfo("\tHCIVERSION  :\t\t0x%" PRIx32 "\n",
+        xhci_capa_getreg(priv, XHCI_CAPLENGTH) >> 16);
   xhci_dump_capa_reg(priv, "HCSPARAMS1  ", XHCI_HCSPARAMS1);
   xhci_dump_capa_reg(priv, "HCSPARAMS2  ", XHCI_HCSPARAMS2);
   xhci_dump_capa_reg(priv, "HCSPARAMS3  ", XHCI_HCSPARAMS3);

--- a/drivers/usbhost/usbhost_xhci.c
+++ b/drivers/usbhost/usbhost_xhci.c
@@ -199,6 +199,7 @@ struct xhci_rhport_s
   /* Root hub port status */
 
   bool                          connected;  /* Connected to device */
+  uint8_t                       enumfail;   /* Consecutive failed enumerations */
   int8_t                        slot;       /* Slot ID associated with this port */
   struct xhci_epinfo_s          ep0;        /* EP0 endpoint info */
   struct usbhost_roothubport_s  hport;      /* This is the hub port description understood
@@ -2882,6 +2883,12 @@ static void xhci_portsc_work(FAR void *arg)
 
                   rhport->connected = true;
 
+                  /* A new device gets the full allowance of attempts,
+                   * whatever the last one that sat here managed.
+                   */
+
+                  rhport->enumfail = 0;
+
                   usbhost_vtrace2(XHCI_VTRACE2_PORTSC_CONNECTED,
                                   rhpndx + 1, priv->pscwait);
 
@@ -3802,6 +3809,18 @@ static int xhci_enumerate(FAR struct usbhost_connection_s *conn,
             {
               xhci_device_deinit(priv, rhport);
             }
+
+          /* Clearing connected below is what makes xhci_wait() return,
+           * so it is also what repeats the attempt.  Leave the port alone
+           * past the limit; a new connection clears the count.
+           */
+
+          if (++rhport->enumfail >= CONFIG_USBHOST_XHCI_ENUM_RETRIES)
+            {
+              syslog(LOG_ERR, "%s: port %d: giving up after %d attempts\n",
+                     priv->name, hport->port + 1, rhport->enumfail);
+              return ret;
+            }
         }
 
       /* If this is a root hub port, then marking the hub port not connected
@@ -3810,6 +3829,17 @@ static int xhci_enumerate(FAR struct usbhost_connection_s *conn,
        */
 
       hport->connected = false;
+    }
+  else
+    {
+#ifdef CONFIG_USBHOST_HUB
+      if (ROOTHUB(hport))
+#endif
+        {
+          FAR struct usbhost_xhci_s *priv = XHCI_PRIV_FROM_CONN(conn);
+
+          priv->rhport[hport->port].enumfail = 0;
+        }
     }
 
   return ret;

--- a/drivers/usbhost/usbhost_xhci.c
+++ b/drivers/usbhost/usbhost_xhci.c
@@ -2804,6 +2804,7 @@ static int xhci_events_poll(FAR struct usbhost_xhci_s *priv)
   uintptr_t              addr;
   uint8_t                type;
   uint32_t               d2;
+  int                    count = 0;
 
   /* Invalidate event ring */
 
@@ -2875,6 +2876,7 @@ static int xhci_events_poll(FAR struct usbhost_xhci_s *priv)
 
       /* Next event */
 
+      count++;
       priv->evnt.i++;
 
       /* Handle ring wrap */
@@ -2891,7 +2893,7 @@ static int xhci_events_poll(FAR struct usbhost_xhci_s *priv)
   addr |= XHCI_ERDP_EHB;
   xhci_runt_putreg_8b(priv, XHCI_ERDP(0), addr);
 
-  return OK;
+  return count;
 }
 
 /****************************************************************************
@@ -2956,6 +2958,29 @@ static void xhci_interrupt_work(FAR void *arg)
   /* Clear pending bits */
 
   priv->pending = 0;
+
+  /* Let interrupts back in, which the handler masked on its way out, and
+   * clear the pending flag in the same write.
+   *
+   * A message signalled interrupt is sent on the flag's clear to set
+   * transition; a wire stays asserted while it is set.  Events that
+   * arrived while this interrupter was masked have already set the flag,
+   * so enabling without clearing leaves a message with nothing to
+   * transition on, and transfers have no timeout.
+   *
+   * Clearing opens its own window: an event delivered between the ring
+   * going empty and this write is discarded.  So drain again, and repeat
+   * if that drain found anything.  A drain that finds nothing is the only
+   * state in which no event can have been lost.
+   */
+
+  do
+    {
+      iman = xhci_runt_getreg(priv, XHCI_IMAN(0));
+      xhci_runt_putreg(priv, XHCI_IMAN(0),
+                       iman | XHCI_IMAN_IE | XHCI_IMAN_IP);
+    }
+  while (xhci_events_poll(priv) > 0);
 }
 
 /****************************************************************************
@@ -2969,10 +2994,22 @@ static void xhci_interrupt_work(FAR void *arg)
 static int xhci_interrupt(int irq, FAR void *context, FAR void *arg)
 {
   FAR struct usbhost_xhci_s *priv = arg;
+  uint32_t                   iman;
 
   /* Get pending interrupts */
 
   priv->pending = xhci_oper_getreg(priv, XHCI_USBSTS);
+
+  /* Silence the interrupter before returning.
+   *
+   * Nothing here clears the condition that raised the interrupt; the work
+   * runs later on a work queue.  On a level triggered line the source is
+   * still asserted on return, so the interrupt re-raises immediately and
+   * the worker never runs.  The worker clears the status and unmasks.
+   */
+
+  iman = xhci_runt_getreg(priv, XHCI_IMAN(0));
+  xhci_runt_putreg(priv, XHCI_IMAN(0), iman & ~XHCI_IMAN_IE);
 
   /* Handle interrupts in worker */
 

--- a/drivers/usbhost/usbhost_xhci.c
+++ b/drivers/usbhost/usbhost_xhci.c
@@ -1810,7 +1810,15 @@ static int xhci_device_init(FAR struct usbhost_xhci_s *priv,
   ret = xhci_cmd_sloten(priv, &slot);
   if (ret < 0 || slot > priv->no_slots)
     {
-      /* Something goes wrong ! */
+      /* A slot the controller cannot address is no more usable than no
+       * slot at all, and the command itself succeeds in that case, so the
+       * caller needs an error either way.
+       */
+
+      if (ret >= 0)
+        {
+          ret = -EINVAL;
+        }
 
       usbhost_vtrace1(XHCI_TRACE1_SLOTEN_FAILED, ret);
       return ret;
@@ -1834,7 +1842,7 @@ static int xhci_device_init(FAR struct usbhost_xhci_s *priv,
   if (ret < 0)
     {
       uerr("ep0 ring init failed\n");
-      return ret;
+      goto errout_with_slot;
     }
 
   rhport->ep0.slot = slot;
@@ -1845,7 +1853,7 @@ static int xhci_device_init(FAR struct usbhost_xhci_s *priv,
   ret = xhci_slot_init(priv, dev);
   if (ret < 0)
     {
-      return ret;
+      goto errout_with_slot;
     }
 
   /* Step 6: Assign and address to the device and enable its Default
@@ -1860,12 +1868,21 @@ static int xhci_device_init(FAR struct usbhost_xhci_s *priv,
   if (ret < 0)
     {
       uerr("failed to set address %d\n", ret);
-      return ret;
+      goto errout_with_slot;
     }
 
   /* Steps 7-12 don't belong here! */
 
   return OK;
+
+errout_with_slot:
+
+  /* Nothing else gives the slot back, and the controller has a fixed
+   * number of them.
+   */
+
+  xhci_device_deinit(priv, rhport);
+  return ret;
 }
 
 /****************************************************************************
@@ -3769,6 +3786,23 @@ static int xhci_enumerate(FAR struct usbhost_connection_s *conn,
   if (ret < 0)
     {
       /* Failed to enumerate */
+
+      /* The device is addressed by now, so it holds a slot, and the retry
+       * below asks for another.
+       */
+
+#ifdef CONFIG_USBHOST_HUB
+      if (ROOTHUB(hport))
+#endif
+        {
+          FAR struct usbhost_xhci_s *priv = XHCI_PRIV_FROM_CONN(conn);
+          FAR struct xhci_rhport_s  *rhport = &priv->rhport[hport->port];
+
+          if (rhport->dev != NULL)
+            {
+              xhci_device_deinit(priv, rhport);
+            }
+        }
 
       /* If this is a root hub port, then marking the hub port not connected
        * will cause xhci_wait() to return and we will try the connection

--- a/drivers/usbhost/usbhost_xhci.c
+++ b/drivers/usbhost/usbhost_xhci.c
@@ -2365,15 +2365,56 @@ static int xhci_normal_setup(FAR struct xhci_rhport_s *rhport,
   FAR struct usbhost_xhci_s *priv = XHCI_PRIV_FROM_RHPORT(rhport);
   struct xhci_trb_s          trb;
 
-  /* Prepare TRB */
+  size_t                     left;
+  size_t                     chunk;
+  uintptr_t                  pa;
+  int                        n = 0;
 
-  trb.d0 = up_addrenv_va_to_pa(buffer);
-  trb.d1 = XHCI_TRB_D1_IRQ_SET(0) | XHCI_TRB_D1_TXLEN_SET(buflen);
-  trb.d2 = XHCI_TRB_D2_IOC | XHCI_TRB_D2_TYPE_SET(XHCI_TRB_TYPE_NORMAL);
+  /* One TRB describes one run of memory, and that run may not cross a 64K
+   * boundary.  A longer transfer, or one starting near the wrong side of a
+   * boundary, becomes several TRBs chained into a single transfer, with
+   * the interrupt asked for only on the last so that one completion
+   * arrives for the whole of it.
+   */
 
-  /* Add TRBs to ring */
+  pa   = up_addrenv_va_to_pa(buffer);
+  left = buflen;
 
-  xhci_add_trb(priv, &epinfo->td, &trb, 1);
+  while (left > 0)
+    {
+      chunk = XHCI_TD_LEN_MAX - (pa & (XHCI_TD_LEN_MAX - 1));
+      if (chunk > left)
+        {
+          chunk = left;
+        }
+
+      if (++n >= XHCI_TD_MAX)
+        {
+          uerr("transfer of %zu needs more TRBs than the ring holds\n",
+               buflen);
+          return -EINVAL;
+        }
+
+      trb.d0 = pa;
+      trb.d1 = XHCI_TRB_D1_IRQ_SET(0) | XHCI_TRB_D1_TXLEN_SET(chunk);
+      trb.d2 = XHCI_TRB_D2_TYPE_SET(XHCI_TRB_TYPE_NORMAL);
+
+      left -= chunk;
+      pa   += chunk;
+
+      /* Chain everything but the last, and interrupt only on the last */
+
+      if (left > 0)
+        {
+          trb.d2 |= XHCI_TRB_D2_CH;
+        }
+      else
+        {
+          trb.d2 |= XHCI_TRB_D2_IOC;
+        }
+
+      xhci_add_trb(priv, &epinfo->td, &trb, 1);
+    }
 
   /* Trigger transfer */
 

--- a/drivers/usbhost/usbhost_xhci.c
+++ b/drivers/usbhost/usbhost_xhci.c
@@ -990,6 +990,19 @@ static void xhci_add_trb(FAR struct usbhost_xhci_s *priv,
                    XHCI_TRB_D2_TYPE_SET(XHCI_TRB_TYPE_LINK);
             }
 
+          /* Carry the chain forward across the join.
+           *
+           * A multi-TRB transfer can reach the end of the ring part way
+           * through, putting the link inside it.  A link without the
+           * chain bit ends the transfer where it stands, and the TRB that
+           * asked for the completion interrupt is never reached.
+           */
+
+          if ((trb[i].d2 & XHCI_TRB_D2_CH) != 0)
+            {
+              d2 |= XHCI_TRB_D2_CH;
+            }
+
           /* Other parameters are already correct for this TRB */
 
           ring->ring[ring->i].d2 = htole32(d2);

--- a/drivers/usbhost/usbhost_xhci.c
+++ b/drivers/usbhost/usbhost_xhci.c
@@ -27,6 +27,7 @@
 #include <assert.h>
 #include <nuttx/debug.h>
 #include <errno.h>
+#include <syslog.h>
 #include <inttypes.h>
 #include <string.h>
 
@@ -358,6 +359,7 @@ static int xhci_ctrl_reset(FAR struct usbhost_xhci_s *priv);
 /* Port management **********************************************************/
 
 static void xhci_probe_ports(FAR struct usbhost_xhci_s *priv);
+static FAR const char *xhci_speed_str(uint32_t portsc);
 static int xhci_port_enable(FAR struct usbhost_xhci_s *priv,
                             FAR struct usbhost_hubport_s *hport);
 
@@ -1495,6 +1497,16 @@ static int xhci_port_enable(FAR struct usbhost_xhci_s *priv,
           return -EINVAL;
         }
     }
+
+  /* Say what turned up, now that the port can answer.
+   *
+   * The speed field only means anything once the port has been reset and
+   * enabled.  A USB2 port reports the reset default, full speed, until
+   * then.
+   */
+
+  syslog(LOG_INFO, "%s: port %d: device attached at %s\n",
+         priv->name, rhpndx + 1, xhci_speed_str(regval));
 
   return OK;
 }
@@ -2733,6 +2745,36 @@ static void xhci_asynch_completion(FAR struct xhci_epinfo_s *epinfo)
 #endif
 
 /****************************************************************************
+ * Name: xhci_speed_str
+ *
+ * Description:
+ *   What a port negotiated, in words.  PORTSC reports a speed ID, not a
+ *   speed.
+ *
+ ****************************************************************************/
+
+static FAR const char *xhci_speed_str(uint32_t portsc)
+{
+  switch (XHCI_PORTSC_PS(portsc))
+    {
+      case XHCI_PORTSC_PS_FULL:
+        return "full speed, 12Mbps";
+      case XHCI_PORTSC_PS_LOW:
+        return "low speed, 1.5Mbps";
+      case XHCI_PORTSC_PS_HIGH:
+        return "high speed, 480Mbps";
+      case XHCI_PORTSC_PS_SUPPER11:
+        return "SuperSpeed, 5Gbps";
+      case XHCI_PORTSC_PS_SUPPER21:
+      case XHCI_PORTSC_PS_SUPPER12:
+      case XHCI_PORTSC_PS_SUPPER22:
+        return "SuperSpeed+, 10Gbps";
+      default:
+        return "an unknown speed";
+    }
+}
+
+/****************************************************************************
  * Name: xhci_portsc_work
  *
  * Description:
@@ -2810,6 +2852,9 @@ static void xhci_portsc_work(FAR void *arg)
 
                   usbhost_vtrace2(XHCI_VTRACE2_PORTSC_DISCONND,
                                   rhpndx + 1, priv->pscwait);
+
+                  syslog(LOG_INFO, "%s: port %d: device removed\n",
+                         priv->name, rhpndx + 1);
 
                   rhport->connected = false;
 

--- a/drivers/usbhost/usbhost_xhci.c
+++ b/drivers/usbhost/usbhost_xhci.c
@@ -27,6 +27,7 @@
 #include <assert.h>
 #include <nuttx/debug.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <string.h>
 
 #include <sys/endian.h>
@@ -81,6 +82,14 @@
  */
 
 #define XHCI_PORT_RESET_MS       (500)
+
+/* How much memory a context occupies, which depends on the stride the
+ * controller asked for.  One entry for the slot and one per endpoint, and
+ * the input context carries its control entry in front of both.
+ */
+
+#define XHCI_DEVCTX_SIZE(priv)   ((1 + XHCI_MAX_ENDPOINTS) * (priv)->ctxsize)
+#define XHCI_INCTX_SIZE(priv)    ((2 + XHCI_MAX_ENDPOINTS) * (priv)->ctxsize)
 #define XHCI_BUFSIZE             (512)
 
 /* Port numbers macros */
@@ -146,6 +155,8 @@ struct xhci_epinfo_s
   size_t             buflen;       /* Buffer length used for transfer */
   FAR uint8_t       *buffer;       /* The caller's buffer, for cache maintenance */
   FAR uint8_t       *bounce;       /* Aligned stand-in for it, or NULL */
+  size_t             dmalen;       /* Length the cache is maintained over */
+  size_t             dmacopy;      /* Length to copy back out of a stand-in */
   bool               dmain;        /* Direction this buffer was prepared for */
   sem_t              iocsem;       /* Semaphore used to wait for transfer completion */
 #ifdef CONFIG_USBHOST_ASYNCH
@@ -251,6 +262,7 @@ struct usbhost_xhci_s
   FAR const struct xhci_bus_ops_s *ops;     /* Bus operations */
   FAR void                     *arg;        /* Bus private data */
   FAR const char               *name;       /* What to call this controller */
+  uint8_t                       ctxsize;    /* Context stride, 32 or 64 bytes */
   uint32_t                      pending;    /* IRQ pending status */
   struct work_s                 work;       /* IRQ work */
   struct work_s                 pscwork;    /* Port status change work */
@@ -418,7 +430,17 @@ static ssize_t xhci_transfer_wait(FAR struct usbhost_xhci_s *priv,
                                   FAR struct xhci_epinfo_s *epinfo);
 static bool xhci_dmacapable(FAR struct usbhost_xhci_s *priv,
                             FAR uint8_t *buffer, size_t buflen);
-static FAR uint8_t *xhci_dma_prepare(FAR struct xhci_epinfo_s *epinfo,
+static uint32_t xhci_speed_id(uint8_t speed);
+static inline FAR struct xhci_slot_ctx_s *
+xhci_in_slot(FAR struct usbhost_xhci_s *priv,
+             FAR struct xhci_input_dev_ctx_s *input);
+static inline FAR struct xhci_ep_ctx_s *
+xhci_in_ep(FAR struct usbhost_xhci_s *priv,
+           FAR struct xhci_input_dev_ctx_s *input, int epidx);
+static inline FAR struct xhci_slot_ctx_s *
+xhci_out_slot(FAR struct xhci_dev_ctx_s *ctx);
+static FAR uint8_t *xhci_dma_prepare(FAR struct usbhost_xhci_s *priv,
+                                     FAR struct xhci_epinfo_s *epinfo,
                                      FAR uint8_t *buffer, size_t buflen,
                                      bool dirin);
 static void xhci_dma_finish(FAR struct xhci_epinfo_s *epinfo);
@@ -1614,7 +1636,7 @@ static int xhci_slot_init(FAR struct usbhost_xhci_s *priv,
    * Initialize all fields to 0.
    */
 
-  memset(dev->input, 0, sizeof(struct xhci_input_dev_ctx_s));
+  memset(dev->input, 0, XHCI_INCTX_SIZE(priv));
 
   /* Step 2. Initialize the Input Control Context by setting the A0 and
    * A1 flags to 1 (Slot flag and EP0 flag).
@@ -1624,9 +1646,16 @@ static int xhci_slot_init(FAR struct usbhost_xhci_s *priv,
            XHCI_IN_CTX1_A(XHCI_EP0_FLAG);
   xhci_context_ctrl(priv, dev, 0, regval);
 
-  /* Step 3. Initialize the Input Slot Context */
+  /* Step 3. Initialize the Input Slot Context.
+   *
+   * The speed field has no valid zero.  This is the only place the
+   * controller learns the device's speed, and one that checks refuses
+   * Address Device with a parameter error without it.
+   */
 
-  regval = XHCI_ST_CTX0_CTXENT_SET(1);
+  regval = XHCI_ST_CTX0_CTXENT_SET(1) |
+           XHCI_ST_CTX0_SPEED_SET(
+             xhci_speed_id(dev->rhport->hport.hport.speed));
 
 #ifdef CONFIG_USBHOST_HUB
   /* TODO:
@@ -1638,7 +1667,7 @@ static int xhci_slot_init(FAR struct usbhost_xhci_s *priv,
 #  warning missing logic
 #endif
 
-  dev->input->slot.ctx[0] = htole32(regval);
+  xhci_in_slot(priv, dev->input)->ctx[0] = htole32(regval);
 
   /* Configure Root Hub Port Number (starts from 1) */
 
@@ -1647,7 +1676,7 @@ static int xhci_slot_init(FAR struct usbhost_xhci_s *priv,
   /* TODO: configure number of ports */
 
   regval |= XHCI_ST_CTX1_PORTS_SET(0);
-  dev->input->slot.ctx[1] = htole32(regval);
+  xhci_in_slot(priv, dev->input)->ctx[1] = htole32(regval);
 
   /* Step 4. the Transfer Ring for the Default Control Endpoint is already
    * allocated.
@@ -1673,7 +1702,7 @@ static int xhci_slot_init(FAR struct usbhost_xhci_s *priv,
 
   DEBUGASSERT(drdp != 0);
   xhci_ep_configure(priv,
-                    &dev->input->ep[0],
+                    xhci_in_ep(priv, dev->input, 0),
                     XHCI_EPTYPE_CTRL, maxpkt,
                     0, drdp,
                     0, 0);
@@ -1682,13 +1711,22 @@ static int xhci_slot_init(FAR struct usbhost_xhci_s *priv,
    * Initialize all fields to 0.
    */
 
-  memset(dev->ctx, 0, sizeof(struct xhci_dev_ctx_s));
+  memset(dev->ctx, 0, XHCI_DEVCTX_SIZE(priv));
 
-  /* Flush Device input context */
+  /* Flush both contexts.
+   *
+   * The output context is the controller's to write, so clearing it must
+   * reach memory: the dirty zeros left in cache are written back later, on
+   * top of what the controller has put there.  The slot state lives in
+   * that context, and losing it fails the next command against the slot.
+   */
+
+  up_flush_dcache((uintptr_t)dev->ctx,
+                  (uintptr_t)dev->ctx + XHCI_DEVCTX_SIZE(priv));
 
   up_flush_dcache((uintptr_t)dev->input,
                   (uintptr_t)dev->input +
-                  sizeof(struct xhci_input_dev_ctx_s));
+                  XHCI_INCTX_SIZE(priv));
 
   /* Step 7. Load the appropriate (Device Slot ID) entry in the Device
    * Context Base Address Array with a pointer to the Output Device
@@ -1826,8 +1864,15 @@ static int xhci_device_deinit(FAR struct usbhost_xhci_s *priv,
 
   rhport->dev->state = XHCI_SLOT_DISABLED;
 
-  memset(rhport->dev->ctx, 0, sizeof(struct xhci_dev_ctx_s));
-  memset(rhport->dev->input, 0, sizeof(struct xhci_input_dev_ctx_s));
+  memset(rhport->dev->ctx, 0, XHCI_DEVCTX_SIZE(priv));
+  memset(rhport->dev->input, 0, XHCI_INCTX_SIZE(priv));
+
+  /* And push both, so nothing is left to be written back later */
+
+  up_flush_dcache((uintptr_t)rhport->dev->ctx,
+                  (uintptr_t)rhport->dev->ctx + XHCI_DEVCTX_SIZE(priv));
+  up_flush_dcache((uintptr_t)rhport->dev->input,
+                  (uintptr_t)rhport->dev->input + XHCI_INCTX_SIZE(priv));
 
   /* Remove reference to a device slot */
 
@@ -1896,8 +1941,8 @@ static void xhci_context_ctrl(FAR struct usbhost_xhci_s *priv,
         }
     }
 
-  dev->input->slot.ctx[0] &= ~XHCI_ST_CTX0_CTXENT_MASK;
-  dev->input->slot.ctx[0] |= XHCI_ST_CTX0_CTXENT_SET(i);
+  xhci_in_slot(priv, dev->input)->ctx[0] &= ~XHCI_ST_CTX0_CTXENT_MASK;
+  xhci_in_slot(priv, dev->input)->ctx[0] |= XHCI_ST_CTX0_CTXENT_SET(i);
 }
 
 /****************************************************************************
@@ -2324,7 +2369,7 @@ static int xhci_control_setup(FAR struct xhci_rhport_s *rhport,
 
   if (buffer)
     {
-      buffer = xhci_dma_prepare(epinfo, buffer, buflen,
+      buffer = xhci_dma_prepare(priv, epinfo, buffer, buflen,
                                 (req->type & USB_REQ_DIR_IN) != 0);
       if (buffer == NULL)
         {
@@ -2405,7 +2450,8 @@ static int xhci_normal_setup(FAR struct xhci_rhport_s *rhport,
 
   /* Make the buffer safe for the controller to reach */
 
-  buffer = xhci_dma_prepare(epinfo, buffer, buflen, epinfo->dirin != 0);
+  buffer = xhci_dma_prepare(priv, epinfo, buffer, buflen,
+                            epinfo->dirin != 0);
   if (buffer == NULL)
     {
       return -ENOMEM;
@@ -2431,8 +2477,8 @@ static int xhci_normal_setup(FAR struct xhci_rhport_s *rhport,
 
       if (++n >= XHCI_TD_MAX)
         {
-          uerr("transfer of %zu needs more TRBs than the ring holds\n",
-               buflen);
+          uerr("transfer of %zu from pa %" PRIxPTR " needs more than %d "
+               "TRBs\n", buflen, pa, XHCI_TD_MAX);
           return -EINVAL;
         }
 
@@ -2489,7 +2535,8 @@ static int xhci_isoc_setup(FAR struct xhci_rhport_s *rhport,
 
   /* Make the buffer safe for the controller to reach */
 
-  buffer = xhci_dma_prepare(epinfo, buffer, buflen, epinfo->dirin != 0);
+  buffer = xhci_dma_prepare(priv, epinfo, buffer, buflen,
+                            epinfo->dirin != 0);
   if (buffer == NULL)
     {
       return -ENOMEM;
@@ -2789,6 +2836,82 @@ static void xhci_portsc_work(FAR void *arg)
 }
 
 /****************************************************************************
+ * Name: xhci_in_slot / xhci_in_ep / xhci_out_slot
+ *
+ * Description:
+ *   Reach into a device context.
+ *
+ *   A context is an array of equally sized entries, and how big they are is
+ *   a property of the controller rather than of the specification: it
+ *   reports either thirty-two or sixty-four bytes, and the wider form is
+ *   the same fields with reserved space after them.  So these are the same
+ *   structures at a different stride, and only the arithmetic to find the
+ *   n'th one has to know which.
+ *
+ *   Output context:  slot, then endpoints 1 upward.
+ *   Input context:   input control, then slot, then endpoints.
+ *
+ *   The first entry of either is at offset zero, so only the ones after it
+ *   need this.
+ *
+ ****************************************************************************/
+
+static inline FAR struct xhci_slot_ctx_s *
+xhci_in_slot(FAR struct usbhost_xhci_s *priv,
+             FAR struct xhci_input_dev_ctx_s *input)
+{
+  return (FAR struct xhci_slot_ctx_s *)((uintptr_t)input + priv->ctxsize);
+}
+
+static inline FAR struct xhci_ep_ctx_s *
+xhci_in_ep(FAR struct usbhost_xhci_s *priv,
+           FAR struct xhci_input_dev_ctx_s *input, int epidx)
+{
+  return (FAR struct xhci_ep_ctx_s *)((uintptr_t)input +
+                                      (epidx + 2) * priv->ctxsize);
+}
+
+static inline FAR struct xhci_slot_ctx_s *
+xhci_out_slot(FAR struct xhci_dev_ctx_s *ctx)
+{
+  return (FAR struct xhci_slot_ctx_s *)ctx;
+}
+
+/****************************************************************************
+ * Name: xhci_speed_id
+ *
+ * Description:
+ *   Turn the speed the USB host stack uses into the one a slot context
+ *   wants, which is a different numbering with no relation to it.
+ *
+ ****************************************************************************/
+
+static uint32_t xhci_speed_id(uint8_t speed)
+{
+  switch (speed)
+    {
+      case USB_SPEED_LOW:
+        return XHCI_SPEED_LOW;
+      case USB_SPEED_FULL:
+        return XHCI_SPEED_FULL;
+      case USB_SPEED_HIGH:
+        return XHCI_SPEED_HIGH;
+      case USB_SPEED_SUPER:
+        return XHCI_SPEED_SUPER;
+      case USB_SPEED_SUPER_PLUS:
+        return XHCI_SPEED_SUPER_PLUS;
+      default:
+
+        /* Nothing else can be described to a controller, and full speed
+         * is the safe answer.
+         */
+
+        uwarn("no speed ID for USB speed %d\n", speed);
+        return XHCI_SPEED_FULL;
+    }
+}
+
+/****************************************************************************
  * Name: xhci_dmacapable
  *
  * Description:
@@ -2842,30 +2965,53 @@ static bool xhci_dmacapable(FAR struct usbhost_xhci_s *priv,
  *
  ****************************************************************************/
 
-static FAR uint8_t *xhci_dma_prepare(FAR struct xhci_epinfo_s *epinfo,
+static FAR uint8_t *xhci_dma_prepare(FAR struct usbhost_xhci_s *priv,
+                                     FAR struct xhci_epinfo_s *epinfo,
                                      FAR uint8_t *buffer, size_t buflen,
                                      bool dirin)
 {
-  size_t line = up_get_dcache_linesize();
+  size_t line      = up_get_dcache_linesize();
+  bool   reachable = xhci_dmacapable(priv, buffer, buflen);
 
-  epinfo->buffer = buffer;
-  epinfo->bounce = NULL;
-  epinfo->dmain  = dirin;
+  epinfo->buffer  = buffer;
+  epinfo->bounce  = NULL;
+  epinfo->dmalen  = buflen;
 
-  /* No cache to maintain, so nothing to arrange */
+  /* How much to bring back afterwards.  This cannot be taken from buflen
+   * at completion time: that field means the length of a data transfer and
+   * control transfers deliberately leave it zero, so a descriptor read
+   * would copy nothing back and the caller would see whatever its buffer
+   * held before.
+   */
 
-  if (line == 0)
+  epinfo->dmacopy = buflen;
+  epinfo->dmain   = dirin;
+
+  /* Nothing to arrange: no cache to maintain, and an address the
+   * controller can be pointed at as it stands.
+   */
+
+  if (line == 0 && reachable)
     {
       return buffer;
     }
 
-  if (((uintptr_t)buffer & (line - 1)) != 0 || (buflen & (line - 1)) != 0)
+  if (!reachable ||
+      ((uintptr_t)buffer & (line - 1)) != 0 || (buflen & (line - 1)) != 0)
     {
       /* The buffer shares a line with something else.  Work in a stand-in
        * that does not.
        */
 
-      epinfo->bounce = kmm_memalign(line, (buflen + line - 1) & ~(line - 1));
+      /* Maintain the whole stand-in, not just the part in use: cache
+       * operations work a line at a time and this chip rejects a partial
+       * range.
+       */
+
+      epinfo->dmalen = line ? ((buflen + line - 1) & ~(line - 1)) : buflen;
+
+      epinfo->bounce = kmm_memalign(line ? line : sizeof(uintptr_t),
+                                    epinfo->dmalen);
       if (epinfo->bounce == NULL)
         {
           return NULL;
@@ -2886,11 +3032,13 @@ static FAR uint8_t *xhci_dma_prepare(FAR struct xhci_epinfo_s *epinfo,
 
   if (dirin)
     {
-      up_invalidate_dcache((uintptr_t)buffer, (uintptr_t)buffer + buflen);
+      up_invalidate_dcache((uintptr_t)buffer,
+                           (uintptr_t)buffer + epinfo->dmalen);
     }
   else
     {
-      up_clean_dcache((uintptr_t)buffer, (uintptr_t)buffer + buflen);
+      up_clean_dcache((uintptr_t)buffer,
+                      (uintptr_t)buffer + epinfo->dmalen);
     }
 
   return buffer;
@@ -2917,11 +3065,12 @@ static void xhci_dma_finish(FAR struct xhci_epinfo_s *epinfo)
 
   if (dirin)
     {
-      up_invalidate_dcache((uintptr_t)dma, (uintptr_t)dma + epinfo->buflen);
+      up_invalidate_dcache((uintptr_t)dma,
+                           (uintptr_t)dma + epinfo->dmalen);
 
       if (epinfo->bounce != NULL && epinfo->buffer != NULL)
         {
-          memcpy(epinfo->buffer, epinfo->bounce, epinfo->buflen);
+          memcpy(epinfo->buffer, epinfo->bounce, epinfo->dmacopy);
         }
     }
 
@@ -3557,8 +3706,11 @@ static int xhci_ep0configure(FAR struct usbhost_driver_s *drvr,
     {
       /* Update max packet size */
 
-      rhport->dev->input->ep[0].ctx1 &= ~XHCI_EP_CTX1_MAXPKT_MASK;
-      rhport->dev->input->ep[0].ctx1 |= XHCI_EP_CTX1_MAXPKT(maxpacketsize);
+      FAR struct xhci_ep_ctx_s *ep0ctx =
+        xhci_in_ep(priv, rhport->dev->input, 0);
+
+      ep0ctx->ctx1 &= ~XHCI_EP_CTX1_MAXPKT_MASK;
+      ep0ctx->ctx1 |= XHCI_EP_CTX1_MAXPKT(maxpacketsize);
 
       /* Add Slot Context and EP0 Context */
 
@@ -3570,13 +3722,17 @@ static int xhci_ep0configure(FAR struct usbhost_driver_s *drvr,
 
       up_flush_dcache((uintptr_t)rhport->dev->input,
                       (uintptr_t)rhport->dev->input +
-                      sizeof(struct xhci_input_dev_ctx_s));
+                      XHCI_INCTX_SIZE(priv));
 
       /* Free mutex before command execution */
 
       nxmutex_unlock(&priv->lock);
 
       ctx = up_addrenv_va_to_pa(rhport->dev->input);
+
+      uinfo("slot %d funcaddr %d speed %d maxpacket %d\n",
+            epinfo->slot, funcaddr, speed, maxpacketsize);
+
       ret = xhci_cmd_evalctx(priv, epinfo->slot, ctx);
     }
 
@@ -3626,6 +3782,12 @@ static int xhci_epalloc(FAR struct usbhost_driver_s *drvr,
   DEBUGASSERT(drvr != 0 && epdesc != NULL && epdesc->hport != NULL
               && ep != NULL);
   hport = epdesc->hport;
+
+  /* Only the tracing alternative below and the hub logic further down use
+   * this, and a configuration may have neither.
+   */
+
+  UNUSED(hport);
 
   /* Terse output only if we are tracing */
 
@@ -3747,7 +3909,7 @@ static int xhci_epalloc(FAR struct usbhost_driver_s *drvr,
    * Max Burst Size set for 0 for now (USB3.0 specific)
    */
 
-  xhci_ep_configure(priv, &dev->input->ep[idx - 1],
+  xhci_ep_configure(priv, xhci_in_ep(priv, dev->input, idx - 1),
                     eptype, epdesc->mxpacketsize, 0,
                     up_addrenv_va_to_pa(epinfo->td.ring),
                     0, epinfo->interval);
@@ -3758,7 +3920,7 @@ static int xhci_epalloc(FAR struct usbhost_driver_s *drvr,
 
   up_flush_dcache((uintptr_t)dev->input,
                   (uintptr_t)dev->input +
-                  sizeof(struct xhci_input_dev_ctx_s));
+                  XHCI_INCTX_SIZE(priv));
 
   /* Configure EP */
 
@@ -4058,13 +4220,6 @@ static int xhci_ctrl_xfer(FAR struct usbhost_driver_s *drvr,
 
   len = xhci_getle16(req->len);
 
-  /* Refuse a buffer the controller cannot reach, as for bulk transfers */
-
-  if (buffer != NULL && len > 0 && !xhci_dmacapable(priv, buffer, len))
-    {
-      return -EFAULT;
-    }
-
   /* Terse output only if we are tracing */
 
 #ifdef CONFIG_USBHOST_TRACE
@@ -4095,13 +4250,14 @@ static int xhci_ctrl_xfer(FAR struct usbhost_driver_s *drvr,
 
           up_invalidate_dcache((uintptr_t)rhport->dev->ctx,
                                (uintptr_t)rhport->dev->ctx +
-                               sizeof(struct xhci_dev_ctx_s));
+                               XHCI_DEVCTX_SIZE(priv));
 
           /* Store USB Device Address assigned by xHCI */
 
           ep0info->devaddr =
-            XHCI_ST_CTX3_ADDR_GET(rhport->dev->ctx->slot.ctx[3]);
-          rhport->dev->input->slot.ctx[3] = rhport->dev->ctx->slot.ctx[3];
+            XHCI_ST_CTX3_ADDR_GET(xhci_out_slot(rhport->dev->ctx)->ctx[3]);
+          xhci_in_slot(priv, rhport->dev->input)->ctx[3] =
+            xhci_out_slot(rhport->dev->ctx)->ctx[3];
         }
 
       return OK;
@@ -4236,16 +4392,6 @@ static ssize_t xhci_transfer(FAR struct usbhost_driver_s *drvr,
   int                        ret;
 
   DEBUGASSERT(priv && rhport && epinfo && buffer && buflen > 0);
-
-  /* Refuse a buffer the controller cannot reach rather than pointing it at
-   * the wrong memory.  A caller that has somewhere better to put the data
-   * will try again with it; the FAT filesystem does exactly that.
-   */
-
-  if (!xhci_dmacapable(priv, buffer, buflen))
-    {
-      return -EFAULT;
-    }
 
   /* We must have exclusive access to the xHCI hardware and data
    * structures.
@@ -4615,12 +4761,14 @@ static int xhci_hw_getparams(FAR struct usbhost_xhci_s *priv)
 
   /* Get data form Host Controller Capability 1 Parameters */
 
+  /* Context entry stride, 32 or 64 bytes as the controller reports.  The
+   * wider form is the same fields with padding.
+   */
+
   regval = xhci_capa_getreg(priv, XHCI_HCCPARAMS1);
-  if (regval & XHCI_HCCPARAMS1_CSZ)
-    {
-      uerr("Only 32 byte Context data structures supported!\n");
-      return -EIO;
-    }
+  priv->ctxsize = (regval & XHCI_HCCPARAMS1_CSZ) ? 64 : 32;
+
+  uinfo("context size = %d\n", priv->ctxsize);
 
   /* Get data from Structural Parameters 1 register */
 
@@ -4787,7 +4935,12 @@ static int xhci_mem_alloc(FAR struct usbhost_xhci_s *priv)
     {
       /* Allocate Device Context */
 
-      priv->devs[i].ctx = kmm_zalloc(sizeof(struct xhci_dev_ctx_s));
+      /* The base address array holds these, and every entry in it must be
+       * 64 byte aligned, so the allocation has to be too.
+       */
+
+      priv->devs[i].ctx = kmm_memalign(XHCI_CTX_ALIGN,
+                                       XHCI_DEVCTX_SIZE(priv));
       if (!priv->devs[i].ctx)
         {
           uerr("dev ctx zalloc failed!\n");
@@ -4799,7 +4952,7 @@ static int xhci_mem_alloc(FAR struct usbhost_xhci_s *priv)
        */
 
       priv->devs[i].input = kmm_memalign((XHCI_PAGE_SIZE / 2),
-                            sizeof(struct xhci_input_dev_ctx_s));
+                            XHCI_INCTX_SIZE(priv));
       if (!priv->devs[i].input)
         {
           uerr("dev input zalloc failed!\n");

--- a/drivers/usbhost/usbhost_xhci.c
+++ b/drivers/usbhost/usbhost_xhci.c
@@ -4545,14 +4545,6 @@ static int xhci_hw_initialize(FAR struct usbhost_xhci_s *priv)
       goto errout;
     }
 
-  /* Configure interrupts */
-
-  ret = xhci_irq_initialize(priv);
-  if (ret < 0)
-    {
-      goto errout;
-    }
-
   /* Halt controller */
 
   ret = xhci_ctrl_halt(priv);
@@ -4697,6 +4689,7 @@ xhci_initialize(FAR const char *name, uintptr_t base,
 {
   FAR struct usbhost_conn_xhci_s *conn = NULL;
   FAR struct usbhost_xhci_s      *priv = NULL;
+  uint32_t                        regval;
   int                             ret;
 
   DEBUGASSERT(name != NULL && base != 0 && ops != NULL &&
@@ -4755,6 +4748,34 @@ xhci_initialize(FAR const char *name, uintptr_t base,
       usbhost_trace1(XHCI_TRACE1_START_FAILED, 0);
       goto errout;
     }
+
+  /* Take the interrupt only now.
+   *
+   * The handler defers to a worker that walks the event ring, and the ring
+   * does not exist until the controller has been started.  A controller
+   * left running by a boot loader can have an interrupt pending the moment
+   * the line is enabled, so attaching any earlier is a race with nothing
+   * to answer it.
+   */
+
+  ret = xhci_irq_initialize(priv);
+  if (ret < 0)
+    {
+      uerr("failed to attach interrupt: %d\n", ret);
+      goto errout;
+    }
+
+  /* Acknowledge anything the controller raised before the handler was
+   * attached.  A message is sent once, on the transition, so a bit set in
+   * that window would never produce another.  Clear them, so the next
+   * event is a fresh assertion.
+   */
+
+  regval = xhci_oper_getreg(priv, XHCI_USBSTS);
+  xhci_oper_putreg(priv, XHCI_USBSTS, regval);
+
+  regval = xhci_runt_getreg(priv, XHCI_IMAN(0));
+  xhci_runt_putreg(priv, XHCI_IMAN(0), regval | XHCI_IMAN_IP);
 
 #ifdef CONFIG_DEBUG_USB_INFO
   xhci_dump_mem(priv, "after init");

--- a/drivers/usbhost/usbhost_xhci.c
+++ b/drivers/usbhost/usbhost_xhci.c
@@ -160,6 +160,16 @@ struct xhci_epinfo_s
   size_t             dmacopy;      /* Length to copy back out of a stand-in */
   bool               dmain;        /* Direction this buffer was prepared for */
   sem_t              iocsem;       /* Semaphore used to wait for transfer completion */
+
+  /* One transfer at a time on an endpoint.  The controller lock below is
+   * released while a transfer is in flight, so it cannot serve this: two
+   * threads would each set up a transfer on the same endpoint and the
+   * second would find iocwait already set.  A device's default control
+   * endpoint is the one that meets this, since every interface driver on
+   * a composite device speaks through it.
+   */
+
+  mutex_t            exclsem;      /* Serialises transfers on this endpoint */
 #ifdef CONFIG_USBHOST_ASYNCH
   usbhost_asynch_t   callback;     /* Transfer complete callback */
   FAR void          *arg;          /* Argument that accompanies the callback */
@@ -3993,6 +4003,7 @@ static int xhci_epalloc(FAR struct usbhost_driver_s *drvr,
 #endif
   epinfo->xfrtype   = epdesc->xfrtype;
   nxsem_init(&epinfo->iocsem, 0, 0);
+  nxmutex_init(&epinfo->exclsem);
 
   /* xhci_epno_get() returns Device Context Index (DCI) */
 
@@ -4008,6 +4019,7 @@ static int xhci_epalloc(FAR struct usbhost_driver_s *drvr,
   if (dev == NULL)
     {
       uerr("no device on port %d\n", RHPNDX(rhport));
+      nxmutex_destroy(&epinfo->exclsem);
       nxsem_destroy(&epinfo->iocsem);
       kmm_free(epinfo);
       return -ENODEV;
@@ -4160,6 +4172,8 @@ static int xhci_epfree(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep)
 
   /* Free the container */
 
+  nxmutex_destroy(&epinfo->exclsem);
+  nxsem_destroy(&epinfo->iocsem);
   kmm_free(epinfo);
   return OK;
 }
@@ -4404,6 +4418,17 @@ static int xhci_ctrl_xfer(FAR struct usbhost_driver_s *drvr,
 
   DEBUGASSERT(rhport != NULL && ep0info != NULL && req != NULL);
 
+  /* One request at a time on this endpoint.  Taken before the controller
+   * lock and held across the wait, so the ordering is always endpoint then
+   * controller and never the reverse.
+   */
+
+  ret = nxmutex_lock(&ep0info->exclsem);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   len = xhci_getle16(req->len);
 
   /* Terse output only if we are tracing */
@@ -4446,6 +4471,7 @@ static int xhci_ctrl_xfer(FAR struct usbhost_driver_s *drvr,
             xhci_out_slot(rhport->dev->ctx)->ctx[3];
         }
 
+      nxmutex_unlock(&ep0info->exclsem);
       return OK;
     }
 
@@ -4456,6 +4482,7 @@ static int xhci_ctrl_xfer(FAR struct usbhost_driver_s *drvr,
   ret = nxmutex_lock(&priv->lock);
   if (ret < 0)
     {
+      nxmutex_unlock(&ep0info->exclsem);
       return ret;
     }
 
@@ -4486,12 +4513,14 @@ static int xhci_ctrl_xfer(FAR struct usbhost_driver_s *drvr,
 
   xhci_dma_finish(ep0info);
 
+  nxmutex_unlock(&ep0info->exclsem);
   return nbytes >= 0 ? OK : (int)nbytes;
 
 errout_with_iocwait:
   ep0info->iocwait = false;
 errout_with_lock:
   nxmutex_unlock(&priv->lock);
+  nxmutex_unlock(&ep0info->exclsem);
   return ret;
 }
 
@@ -4584,6 +4613,16 @@ static ssize_t xhci_transfer(FAR struct usbhost_driver_s *drvr,
 
   DEBUGASSERT(priv && rhport && epinfo && buffer && buflen > 0);
 
+  /* One transfer at a time on this endpoint, taken before the controller
+   * lock and held across the wait.  See the note beside exclsem.
+   */
+
+  ret = nxmutex_lock(&epinfo->exclsem);
+  if (ret < 0)
+    {
+      return (ssize_t)ret;
+    }
+
   /* We must have exclusive access to the xHCI hardware and data
    * structures.
    */
@@ -4591,6 +4630,7 @@ static ssize_t xhci_transfer(FAR struct usbhost_driver_s *drvr,
   ret = nxmutex_lock(&priv->lock);
   if (ret < 0)
     {
+      nxmutex_unlock(&epinfo->exclsem);
       return (ssize_t)ret;
     }
 
@@ -4652,12 +4692,14 @@ static ssize_t xhci_transfer(FAR struct usbhost_driver_s *drvr,
 
   xhci_dma_finish(epinfo);
 
+  nxmutex_unlock(&epinfo->exclsem);
   return nbytes;
 
 errout_with_iocwait:
   epinfo->iocwait = false;
 errout_with_lock:
   nxmutex_unlock(&priv->lock);
+  nxmutex_unlock(&epinfo->exclsem);
   return (ssize_t)ret;
 }
 
@@ -5351,6 +5393,7 @@ static inline int xhci_sw_initialize(FAR struct usbhost_xhci_s *priv)
       rhport->ep0.epno            = 0;
       rhport->ep0.devaddr         = 0;
       nxsem_init(&rhport->ep0.iocsem, 0, 0);
+      nxmutex_init(&rhport->ep0.exclsem);
 
       /* Initialize the public port representation */
 

--- a/drivers/usbhost/usbhost_xhci.c
+++ b/drivers/usbhost/usbhost_xhci.c
@@ -412,9 +412,11 @@ static int xhci_ioc_wait(FAR struct xhci_epinfo_s *epinfo);
 #ifdef CONFIG_USBHOST_ASYNCH
 static inline int xhci_ioc_async_setup(FAR struct xhci_rhport_s *rhport,
                                        FAR struct xhci_epinfo_s *epinfo,
+                                       size_t buflen,
                                        usbhost_asynch_t callback,
                                        FAR void *arg);
-static void xhci_asynch_completion(FAR struct xhci_epinfo_s *epinfo);
+static void xhci_asynch_completion(FAR struct usbhost_xhci_s *priv,
+                                   FAR struct xhci_epinfo_s *epinfo);
 #endif
 static int xhci_control_setup(FAR struct xhci_rhport_s *rhport,
                               FAR struct xhci_epinfo_s *epinfo,
@@ -2645,6 +2647,8 @@ static ssize_t xhci_transfer_wait(FAR struct usbhost_xhci_s *priv,
  * Input Parameters:
  *   epinfo - The IN or OUT endpoint descriptor for the device endpoint on
  *      which the transfer will be performed.
+ *   buflen - The length of the transfer, from which the completion works
+ *      out how much was transferred.
  *   callback - The function to be called when the transfer completes
  *   arg - An arbitrary argument that will be provided with the callback.
  *
@@ -2658,6 +2662,7 @@ static ssize_t xhci_transfer_wait(FAR struct usbhost_xhci_s *priv,
 
 static inline int xhci_ioc_async_setup(FAR struct xhci_rhport_s *rhport,
                                        FAR struct xhci_epinfo_s *epinfo,
+                                       size_t buflen,
                                        usbhost_asynch_t callback,
                                        FAR void *arg)
 {
@@ -2680,6 +2685,7 @@ static inline int xhci_ioc_async_setup(FAR struct xhci_rhport_s *rhport,
       epinfo->iocwait  = false;    /* No synchronous wakeup */
       epinfo->status   = 0;        /* No status yet */
       epinfo->xfrd     = 0;        /* Nothing transferred yet */
+      epinfo->buflen   = buflen;   /* Buffer length */
       epinfo->result   = -EBUSY;   /* Transfer in progress */
       epinfo->callback = callback; /* Asynchronous callback */
       epinfo->arg      = arg;      /* Argument that accompanies the callback */
@@ -2694,10 +2700,11 @@ static inline int xhci_ioc_async_setup(FAR struct xhci_rhport_s *rhport,
  * Name: xhci_asynch_completion
  *
  * Description:
- *   This function is called at the interrupt level when an asynchronous
- *   transfer completes.  It performs the pending callback.
+ *   This function is called from the interrupt work queue when an
+ *   asynchronous transfer completes.  It performs the pending callback.
  *
  * Input Parameters:
+ *   priv - xHCI private state
  *   epinfo - The IN or OUT endpoint descriptor for the device endpoint on
  *      which the transfer was performed.
  *
@@ -2705,21 +2712,26 @@ static inline int xhci_ioc_async_setup(FAR struct xhci_rhport_s *rhport,
  *   None
  *
  * Assumptions:
- *   - Called from the interrupt level
+ *   - Called from the work queue, without the spinlock held
  *
  ****************************************************************************/
 
-static void xhci_asynch_completion(FAR struct xhci_epinfo_s *epinfo)
+static void xhci_asynch_completion(FAR struct usbhost_xhci_s *priv,
+                                   FAR struct xhci_epinfo_s *epinfo)
 {
   usbhost_asynch_t callback;
   ssize_t nbytes;
   FAR void *arg;
+  irqstate_t flags;
   int result;
 
-  DEBUGASSERT(epinfo != NULL && epinfo->iocwait == false &&
-              epinfo->callback != NULL);
+  DEBUGASSERT(epinfo != NULL && epinfo->iocwait == false);
 
-  /* Extract and reset the callback info */
+  /* Extract and reset the callback info, atomically against a concurrent
+   * cancellation.
+   */
+
+  flags = spin_lock_irqsave(&priv->spinlock);
 
   callback         = epinfo->callback;
   arg              = epinfo->arg;
@@ -2730,6 +2742,23 @@ static void xhci_asynch_completion(FAR struct xhci_epinfo_s *epinfo)
   epinfo->arg      = NULL;
   epinfo->result   = OK;
   epinfo->iocwait  = false;
+
+  spin_unlock_irqrestore(&priv->spinlock, flags);
+
+  /* A cancellation that got in first has already done the callback */
+
+  if (callback == NULL)
+    {
+      return;
+    }
+
+  /* Bring back what the controller wrote before anyone reads it.  The
+   * addresses are usable here: a transfer given to DRVR_ASYNCH must use
+   * memory from DRVR_ALLOC, and that is kernel memory, which this work
+   * queue thread can reach.
+   */
+
+  xhci_dma_finish(epinfo);
 
   /* Then perform the callback.  Provide the number of bytes successfully
    * transferred or the negated errno value in the event of a failure.
@@ -3166,6 +3195,9 @@ static void xhci_transfer_complete(FAR struct usbhost_xhci_s *priv,
   uint8_t                   ep   = XHCI_TRB_D2_EP_GET(evt->d2);
   uint8_t                   ret  = XHCI_TRB_D1_CC_GET(evt->d1);
   irqstate_t                flags;
+#ifdef CONFIG_USBHOST_ASYNCH
+  bool                      asynch = false;
+#endif
 
   /* Get EP associated with this transfer */
 
@@ -3227,17 +3259,32 @@ static void xhci_transfer_complete(FAR struct usbhost_xhci_s *priv,
     }
 
 #ifdef CONFIG_USBHOST_ASYNCH
-  /* No.. Is there a pending asynchronous transfer? */
+  /* No.. Is there a pending asynchronous transfer instead?  Decide while
+   * still holding the lock: the moment the waiter above is posted, the
+   * endpoint may be given a new transfer, and that one is not complete.
+   */
 
-  else if (epinfo->callback != NULL)
+  else
     {
-      /* Yes.. perform the callback */
-
-      xhci_asynch_completion(epinfo);
+      asynch = epinfo->callback != NULL;
     }
 #endif
 
   spin_unlock_irqrestore(&priv->spinlock, flags);
+
+#ifdef CONFIG_USBHOST_ASYNCH
+  /* The callback runs outside the spinlock: it is class driver code, and
+   * what it does (queue work, take its own locks) has no business running
+   * with interrupts masked.
+   */
+
+  if (asynch)
+    {
+      /* Perform the callback */
+
+      xhci_asynch_completion(priv, epinfo);
+    }
+#endif
 }
 
 /****************************************************************************
@@ -4674,7 +4721,7 @@ static int xhci_asynch(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep,
 
   /* Set the request for the callback well BEFORE initiating the transfer. */
 
-  ret = xhci_ioc_async_setup(rhport, epinfo, callback, arg);
+  ret = xhci_ioc_async_setup(rhport, epinfo, buflen, callback, arg);
   if (ret != OK)
     {
       goto errout_with_lock;
@@ -4814,9 +4861,13 @@ static int xhci_cancel(FAR struct usbhost_driver_s *drvr, usbhost_ep_t ep)
 
   else
     {
-      /* Yes.. perform the callback */
+      /* Yes.. give back any stand-in buffer, then perform the callback.
+       * The endpoint has been stopped, so the controller is no longer
+       * writing into it.
+       */
 
       DEBUGASSERT(callback != NULL);
+      xhci_dma_finish(epinfo);
       callback(arg, -ESHUTDOWN);
     }
 #endif

--- a/drivers/usbhost/usbhost_xhci.c
+++ b/drivers/usbhost/usbhost_xhci.c
@@ -808,9 +808,16 @@ static int xhci_ring_init(FAR struct xhci_ring_s *ring, size_t len)
       ring->len = len;
     }
 
-  /* Reset data in ring */
+  /* Reset data in ring.
+   *
+   * Clearing dirties every line, and the controller writes into this
+   * memory itself.  Flush now, or a later writeback lands on top of an
+   * event somebody is waiting for.
+   */
 
   memset(ring->ring, 0, ring->len * sizeof(struct xhci_trb_s));
+  up_flush_dcache((uintptr_t)ring->ring,
+                  (uintptr_t)(ring->ring + ring->len));
 
   /* Fill Link TRB */
 
@@ -1112,9 +1119,22 @@ static int xhci_ctrl_start(FAR struct usbhost_xhci_s *priv)
   evnt->size = XHCI_EVENT_MAX;
   evnt->res  = 0;
 
-  /* Flush all memory before write to ERDP so xhci sees correct data */
+  /* Push the structures the controller is about to be pointed at.
+   *
+   * Flush by address: up_flush_dcache_all() is a no-op on architectures
+   * whose cache can only be maintained by address.
+   */
 
-  up_flush_dcache_all();
+  up_flush_dcache((uintptr_t)priv->pg_erst,
+                  (uintptr_t)priv->pg_erst +
+                  sizeof(struct xhci_event_ring_s) * priv->no_erst);
+  up_flush_dcache((uintptr_t)priv->pg_ctx,
+                  (uintptr_t)(priv->pg_ctx + priv->no_slots + 1));
+  if (priv->pg_sb != NULL)
+    {
+      up_flush_dcache((uintptr_t)priv->pg_sb,
+                      (uintptr_t)(priv->pg_sb + priv->no_scratch));
+    }
 
   xhci_runt_putreg_8b(priv, XHCI_ERDP(0),
                       up_addrenv_va_to_pa(priv->evnt.ring));
@@ -1151,9 +1171,12 @@ static int xhci_ctrl_start(FAR struct usbhost_xhci_s *priv)
   regval |= XHCI_IMAN_IE;
   xhci_runt_putreg(priv, XHCI_IMAN(0), regval);
 
-  /* Flush all memory once again */
+  /* And the command ring, whose last entry was just made to point back at
+   * its own beginning.
+   */
 
-  up_flush_dcache_all();
+  up_flush_dcache((uintptr_t)priv->cmd.ring,
+                  (uintptr_t)(priv->cmd.ring + XHCI_CMD_MAX));
 
   /* Turn the host controller ON, enable interrupts and system errors */
 

--- a/drivers/usbhost/usbhost_xhci.c
+++ b/drivers/usbhost/usbhost_xhci.c
@@ -2907,6 +2907,20 @@ static void xhci_interrupt_work(FAR void *arg)
   FAR struct usbhost_xhci_s *priv = arg;
   uint32_t                   iman;
 
+  /* Acknowledge before walking the ring, not after.  An event arriving
+   * during the walk sets the pending bit again, and clearing after the
+   * walk discards it.  Transfers have no timeout, so the one it belonged
+   * to would wait forever.
+   */
+
+  xhci_oper_putreg(priv, XHCI_USBSTS, priv->pending);
+
+  iman = xhci_runt_getreg(priv, XHCI_IMAN(0));
+  if (iman & XHCI_IMAN_IP)
+    {
+      xhci_runt_putreg(priv, XHCI_IMAN(0), iman);
+    }
+
   xhci_events_poll(priv);
 
   /* Port Change Detect */
@@ -2937,18 +2951,6 @@ static void xhci_interrupt_work(FAR void *arg)
   if (priv->pending & XHCI_USBSTS_HCE)
     {
       uinfo("Host Controller Error\n");
-    }
-
-  /* ACK interrupts */
-
-  xhci_oper_putreg(priv, XHCI_USBSTS, priv->pending);
-
-  /* Clear interrupter pending bit */
-
-  iman = xhci_runt_getreg(priv, XHCI_IMAN(0));
-  if (iman & XHCI_IMAN_IP)
-    {
-      xhci_runt_putreg(priv, XHCI_IMAN(0), iman);
     }
 
   /* Clear pending bits */

--- a/drivers/usbhost/usbhost_xhci.h
+++ b/drivers/usbhost/usbhost_xhci.h
@@ -506,6 +506,22 @@
 #define XHCI_ST_CTX0_RTSTR_MASK      (0xfffff << XHCI_ST_CTX0_RTSTR_SHIFT)
 #define XHCI_ST_CTX0_SPEED_SHIFT     (20)                  /* Bits 20:23: Speed */
 #define XHCI_ST_CTX0_SPEED_MASK      (0xf << XHCI_ST_CTX0_SPEED_SHIFT)
+#define XHCI_ST_CTX0_SPEED_SET(x)    (((x) << XHCI_ST_CTX0_SPEED_SHIFT) & \
+                                      XHCI_ST_CTX0_SPEED_MASK)
+
+/* Port Speed IDs, which xHCI numbers its own way rather than USB's.  These
+ * are the values every controller reports in PORTSC and expects back in a
+ * slot context; a device is described to the controller with one of them
+ * and with nothing else, so zero is not a default but an invalid context.
+ *
+ * Reference: Table 7-13: Default USB Speed ID Mapping
+ */
+
+#define XHCI_SPEED_FULL              (1)
+#define XHCI_SPEED_LOW               (2)
+#define XHCI_SPEED_HIGH              (3)
+#define XHCI_SPEED_SUPER             (4)
+#define XHCI_SPEED_SUPER_PLUS        (5)
 #define XHCI_ST_CTX0_MTT             (1 << 25)             /* Bit 25: Multi-TT */
                                                            /* Bit 24: Reserved */
 #define XHCI_ST_CTX0_HUB             (1 << 26)             /* Bit 26: Hub */

--- a/drivers/usbhost/usbhost_xhci.h
+++ b/drivers/usbhost/usbhost_xhci.h
@@ -315,6 +315,17 @@
 #define XHCI_IMOD_IMODI_SHIFT        (0)                   /* Bits 0-15: Interrupt Moderation Interval */
 #define XHCI_IMOD_IMODC_SHIFT        (16)                  /* Bits 16-31: Interrupt Moderation Counter */
 
+/* What to set the moderation interval to, in 250ns units.
+ *
+ * The reset default is 4000, a millisecond, which is far too long to wait
+ * to be told a transfer finished.  Zero is too short: it puts no bound on
+ * how often a controller may interrupt, and a polled device such as a
+ * keyboard on an interrupt endpoint will then occupy a processor.  160 is
+ * 40us, which is what Linux uses.
+ */
+
+#define XHCI_IMOD_DEFAULT            (160)
+
 /* Event Ring Segment Table Size */
 
 #define XHCI_ERSTS_MASK              (0xffff)              /* Bit 0-15: Event Ring Segment Table Size */

--- a/include/nuttx/usb/xhci.h
+++ b/include/nuttx/usb/xhci.h
@@ -62,6 +62,13 @@ struct xhci_bus_ops_s
   /* Undo it, and release anything the bus allocated to make it work */
 
   CODE void (*irq_detach)(FAR void *arg);
+
+  /* Whether the controller may be pointed at a given buffer, which is a
+   * property of the platform.  Leave NULL where every address a caller can
+   * produce is reachable, as a flat address space gives.
+   */
+
+  CODE bool (*dmacapable)(FAR void *arg, FAR uint8_t *buffer, size_t buflen);
 };
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

The first seven commits belong to #19745 and #19860 and are not part of this
change. This PR adds the remaining twenty-one, one fault each.

The driver had only ever run behind QEMU's controller and its message
signalled interrupt, on a host with coherent caches and a flat address space.
These are the faults that reach it once any of that stops being true.

**Interrupts.** The handler returned with the source still asserted, so a level
triggered line re-fired forever and the worker never ran. The event ring was
acknowledged after being walked, discarding anything that arrived during the
walk. The interrupt was attached before the event ring existed, which races a
controller a boot loader left running. The moderation interval was left at its
reset value of 1ms, so every completion paid that. A port was disabled by the
act of probing it, since PORTSC change bits are write-one-to-clear.

**Cache and addressing.** Rings were published with `up_flush_dcache_all()`,
which an architecture that can only maintain by address implements as a barrier
and nothing more, so the controller read stale memory. Data buffers got no
maintenance at all. A buffer that does not own its cache lines now goes through
an aligned stand-in, since maintaining a partial line disturbs whatever shares
it. Whether the controller can reach a buffer is asked of the platform through
a new optional `dmacapable` operation.

**Transfer descriptors.** A Normal TRB describes one run of memory that may not
cross a 64K boundary, and one TRB was programmed regardless of length. A link
TRB reached part way through a multi-TRB transfer was written without the chain
bit, which ends the transfer at the link, so nothing is woken and the read
never returns.

**Device description.** Contexts came in one size only and the wider form was
refused with `-EIO`; the EIC7700X reports it on both of its controllers. The
event ring segment count wrapped to zero above 128 segments. The slot context
never carried the device speed, which has no valid zero.

**Endpoints and slots.** The endpoint interval is an exponent and the
descriptor's period was copied across unconverted, so a low speed keyboard
never enumerated. Asynchronous transfers refused every buffer whose length was
not a whole number of cache lines, which an eight byte HID report never is.
Transfers on one endpoint were not serialised, which a composite device's two
poll threads reach through endpoint 0. A failed enumeration leaked its device
slot and then retried forever.

Two commits cover more than one point and say why in their messages: the
interrupter mask cannot be separated from the unmask that answers it, and the
context stride change touches every context walk, so splitting it further would
produce commits that do not build.

## Impact

`USBHOST_XHCI` users. Required for any controller that is not QEMU's. No
configuration change; `dmacapable` is optional, so a platform that does not
supply it is unaffected.

## Testing

QEMU with `-device qemu-xhci`, built for `qemu-intel64:nsh` with the driver
compiled and linked:

- a `usb-storage` device enumerates as `/dev/sda`, mounts vfat and reads back
  `qemu-xhci-regression-ok`
- behind a `usb-hub`, a `usb-storage` and a `usb-kbd` both enumerate, giving
  `/dev/sda` and `/dev/kbda`, with the file read back and no assertions

EIC7700 EVB, Synopsys DWC3 in host mode, with a real 6-port hub:

```
usb 1-1:   keyboard, driver attached
usb 0-1:   hub, driver attached (USB2.0 Hub, Fresco Logic)
usb 0-1.1: mass storage, driver attached -> /dev/sda
usb 0-1.2: misc, driver attached (SIPEED UARTx4 HS) -> /dev/ttyACM0-3
```

`/dev/sda` mounts as a 59 GB vfat volume and `dd if=/dev/sda bs=512 count=256`
reads at 703 KB/s.

Throughput on that board, doorbell to interrupt 986-1021us before and 13-56us
after the moderation fix:

```
reading 1MiB          before        after
512 byte blocks      166 KB/s     775 KB/s
32 KiB blocks      10666 KB/s   18618 KB/s

mounting a FAT32 volume: 92.7s before, 21.1s after
```

One note for anyone reproducing the keyboard tests: `CONFIG_HIDKBD_STACKSIZE`
defaults to 1024, which is not enough for the polling thread on a 64-bit
target. It overflows and presents as an assertion at the top of `kbdpoll`,
which reports the damage rather than the cause. 3072 is enough; the EIC7700
EVB configuration already uses that. This is unrelated to the changes here.

