### PR TITLE
drivers/pinctrl, drivers/clk: Add debug output levels.

### DIFF
--- a/Kconfig
+++ b/Kconfig
@@ -2395,6 +2395,38 @@ config DEBUG_PINCTRL_INFO
 
 endif # DEBUG_PINCTRL
 
+config DEBUG_CLK
+	bool "CLK Debug Features"
+	default n
+	depends on CLK
+	---help---
+		Enable CLK debug features.
+
+if DEBUG_CLK
+
+config DEBUG_CLK_ERROR
+	bool "CLK Error Output"
+	default n
+	depends on DEBUG_ERROR
+	---help---
+		Enable CLK driver error output to SYSLOG.
+
+config DEBUG_CLK_WARN
+	bool "CLK Warnings Output"
+	default n
+	depends on DEBUG_WARN
+	---help---
+		Enable CLK driver warning output to SYSLOG.
+
+config DEBUG_CLK_INFO
+	bool "CLK Informational Output"
+	default n
+	depends on DEBUG_INFO
+	---help---
+		Enable CLK driver informational output to SYSLOG.
+
+endif # DEBUG_CLK
+
 config DEBUG_IPC
 	bool "IPC (Inter-Process Communication) Debug Features"
 	default n

--- a/Kconfig
+++ b/Kconfig
@@ -2363,6 +2363,38 @@ config DEBUG_RESET_INFO
 
 endif # DEBUG_RESET
 
+config DEBUG_PINCTRL
+	bool "PINCTRL Debug Features"
+	default n
+	depends on PINCTRL
+	---help---
+		Enable PINCTRL debug features.
+
+if DEBUG_PINCTRL
+
+config DEBUG_PINCTRL_ERROR
+	bool "PINCTRL Error Output"
+	default n
+	depends on DEBUG_ERROR
+	---help---
+		Enable PINCTRL driver error output to SYSLOG.
+
+config DEBUG_PINCTRL_WARN
+	bool "PINCTRL Warnings Output"
+	default n
+	depends on DEBUG_WARN
+	---help---
+		Enable PINCTRL driver warning output to SYSLOG.
+
+config DEBUG_PINCTRL_INFO
+	bool "PINCTRL Informational Output"
+	default n
+	depends on DEBUG_INFO
+	---help---
+		Enable PINCTRL driver informational output to SYSLOG.
+
+endif # DEBUG_PINCTRL
+
 config DEBUG_IPC
 	bool "IPC (Inter-Process Communication) Debug Features"
 	default n

--- a/include/nuttx/debug.h
+++ b/include/nuttx/debug.h
@@ -959,6 +959,24 @@
 #  define rstinfo     _none
 #endif
 
+#ifdef CONFIG_DEBUG_PINCTRL_ERROR
+#  define pinctrlerr  _err
+#else
+#  define pinctrlerr  _none
+#endif
+
+#ifdef CONFIG_DEBUG_PINCTRL_WARN
+#  define pinctrlwarn _warn
+#else
+#  define pinctrlwarn _none
+#endif
+
+#ifdef CONFIG_DEBUG_PINCTRL_INFO
+#  define pinctrlinfo _info
+#else
+#  define pinctrlinfo _none
+#endif
+
 #ifdef CONFIG_DEBUG_IPC_ERROR
 #  define ipcerr       _err
 #else

--- a/include/nuttx/debug.h
+++ b/include/nuttx/debug.h
@@ -977,6 +977,24 @@
 #  define pinctrlinfo _none
 #endif
 
+#ifdef CONFIG_DEBUG_CLK_ERROR
+#  define clkerr      _err
+#else
+#  define clkerr      _none
+#endif
+
+#ifdef CONFIG_DEBUG_CLK_WARN
+#  define clkwarn     _warn
+#else
+#  define clkwarn     _none
+#endif
+
+#ifdef CONFIG_DEBUG_CLK_INFO
+#  define clkinfo     _info
+#else
+#  define clkinfo     _none
+#endif
+
 #ifdef CONFIG_DEBUG_IPC_ERROR
 #  define ipcerr       _err
 #else


### PR DESCRIPTION
## Summary

Neither the pinctrl nor the clock framework has debug output of its own, so a
provider reporting a pad it could not configure, or a clock it could not
register, has to reach for the bare `_err()` and `_info()` macros. Those are
gated only by `DEBUG_ERROR` and `DEBUG_INFO`, so their output cannot be turned
off without silencing every subsystem that has not been given its own level.

This adds `CONFIG_DEBUG_PINCTRL` and `CONFIG_DEBUG_CLK`, each with the usual
three levels, and the matching `pinctrlerr()`/`pinctrlwarn()`/`pinctrlinfo()`
and `clkerr()`/`clkwarn()`/`clkinfo()` macros. Both follow the shape of the
`DEBUG_RESET` block they sit beside, and both are placed next to it in
`Kconfig` and in `include/nuttx/debug.h`.

One commit each, so either can be taken on its own.

## Impact

None until something uses them. Nothing selects the new symbols, they default
to `n`, and each depends on its subsystem being enabled, so the build is
unchanged for every existing configuration. Additions only: no existing line is
modified.

## Testing

`sim:nsh` configured with `CLK`, `PINCTRL`, `DEBUG_CLK`, `DEBUG_PINCTRL` and
both `_INFO` levels enabled: kconfig parses, all six symbols appear in the
resulting `.config`, and the image builds.

```
CONFIG_DEBUG_PINCTRL=y
CONFIG_DEBUG_PINCTRL_INFO=y
CONFIG_DEBUG_CLK=y
CONFIG_DEBUG_CLK_INFO=y
```

Also built with the symbols left at their defaults, which is a no-op change.
