### PR TITLE
atomic.h: add __has_include fallback and adjust __ATOMIC_xxx logic

### DIFF
--- a/include/nuttx/atomic.h
+++ b/include/nuttx/atomic.h
@@ -77,13 +77,31 @@ typedef volatile _Atomic int64_t atomic64_t;
 #  endif
 #endif
 
-#ifndef ATOMIC_FUNC
+#ifndef __ATOMIC_RELAXED
 #  define __ATOMIC_RELAXED 0
+#endif
+
+#ifndef __ATOMIC_CONSUME
 #  define __ATOMIC_CONSUME 1
+#endif
+
+#ifndef __ATOMIC_ACQUIRE
 #  define __ATOMIC_ACQUIRE 2
+#endif
+
+#ifndef __ATOMIC_RELEASE
 #  define __ATOMIC_RELEASE 3
+#endif
+
+#ifndef __ATOMIC_ACQ_REL
 #  define __ATOMIC_ACQ_REL 4
+#endif
+
+#ifndef __ATOMIC_SEQ_CST
 #  define __ATOMIC_SEQ_CST 5
+#endif
+
+#ifndef ATOMIC_FUNC
 
 #  define ATOMIC_FUNC(f, n) nx_atomic_##f##_##n
 

--- a/include/nuttx/atomic.h
+++ b/include/nuttx/atomic.h
@@ -36,7 +36,7 @@
 #  endif
 #endif
 
-#if defined(__has_include) && !defined(CONFIG_LIBC_ARCH_ATOMIC)
+#if !defined(CONFIG_LIBC_ARCH_ATOMIC)
 #  if __has_include(<atomic>) && defined(__cplusplus)
 extern "C++"
 {
@@ -57,8 +57,7 @@ extern "C++"
   typedef volatile int32_t atomic_t;
   typedef volatile int64_t atomic64_t;
 }
-#  elif __has_include(<stdatomic.h>) && \
-        ((defined(__cplusplus) && __cplusplus >= 201103L) || \
+#  elif ((defined(__cplusplus) && __cplusplus >= 201103L) || \
          (defined(__STDC_VERSION__) && __STDC_VERSION__ >= 201112L)) && \
          !defined(__STDC_NO_ATOMICS__)
 #    if !defined(__clang__) && defined(__cplusplus)

--- a/include/nuttx/compiler.h
+++ b/include/nuttx/compiler.h
@@ -1426,6 +1426,12 @@
 #  define osentry_function
 #endif
 
+/* Micro about __has_include */
+
+#ifndef __has_include
+#  define __has_include(x) 0
+#endif
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/


### PR DESCRIPTION
## Summary

Two header-only fixes to make `<nuttx/atomic.h>` portable across compilers (including Tasking which lacks `__has_include`):

1. Add `__has_include(x)` fallback macro in `compiler.h` for toolchains that don't define it.
2. Simplify the `__ATOMIC_xxx` memory order constant guards in `atomic.h` so each constant has its own `#ifndef` block, independent of `ATOMIC_FUNC`.

## Stacked PR chain

This is PR 1 of 3 in the atomic rework chain:
- PR 1 (this): atomic.h header fixes
- PR 2: multi-backend atomic implementation (IRQ + hwspinlock + arch)
- PR 3: toolchain builtin atomic + API rename `atomic_fetch_xxx` -> `atomic_xxx`

## Test

CI testbuild across ARM/RISC-V/SIM targets.