### PR TITLE
atomic: hwspinlock backend for cxd56, rp2040, lc823450

### DIFF
--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -382,6 +382,8 @@ config ARCH_CHIP_RP2040
 	select ARCH_BOARD_COMMON
 	select ARCH_HAVE_CUSTOM_TESTSET
 	select ARCH_USBDEV_STALLQUEUE if USBDEV
+	select LIBC_ATOMIC_IRQ if !SMP
+	select LIBC_ATOMIC_HWSPINLOCK if SMP
 	---help---
 		Raspberry Pi RP2040 architectures (ARM dual Cortex-M0+).
 

--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -1064,7 +1064,7 @@ config ARCH_ARMV6M
 	bool
 	default n
 	select ARCH_HAVE_CPUINFO
-	select LIBC_ATOMIC_IRQ
+	select LIBC_ATOMIC_IRQ if !LIBC_ATOMIC_HWSPINLOCK
 
 config ARCH_CORTEXM0
 	bool

--- a/arch/arm/src/cxd56xx/CMakeLists.txt
+++ b/arch/arm/src/cxd56xx/CMakeLists.txt
@@ -40,7 +40,8 @@ set(SRCS
     cxd56_powermgr.c
     cxd56_farapi.c
     cxd56_sysctl.c
-    cxd56_hwspinlock.c)
+    cxd56_hwspinlock.c
+    cxd56_atomic.c)
 
 if(CONFIG_SMP)
   list(APPEND SRCS cxd56_cpuidlestack.c)

--- a/arch/arm/src/cxd56xx/CMakeLists.txt
+++ b/arch/arm/src/cxd56xx/CMakeLists.txt
@@ -39,7 +39,8 @@ set(SRCS
     cxd56_icc.c
     cxd56_powermgr.c
     cxd56_farapi.c
-    cxd56_sysctl.c)
+    cxd56_sysctl.c
+    cxd56_hwspinlock.c)
 
 if(CONFIG_SMP)
   list(APPEND SRCS cxd56_cpuidlestack.c)

--- a/arch/arm/src/cxd56xx/Kconfig
+++ b/arch/arm/src/cxd56xx/Kconfig
@@ -1429,6 +1429,12 @@ config CXD56_TESTSET_WITH_HWSEM
 
 endif # CXD56_TESTSET
 
+config CXD56_ATOMIC_WITH_HWSEM
+	bool "Use atomic based on hardware semaphore"
+	default !CXD56_USE_SYSBUS
+	depends on SMP
+	select LIBC_ATOMIC_HWSPINLOCK
+
 config CXD56_USE_SYSBUS
 	bool "Use the system bus for the data section"
 	default y

--- a/arch/arm/src/cxd56xx/Make.defs
+++ b/arch/arm/src/cxd56xx/Make.defs
@@ -39,6 +39,7 @@ CHIP_CSRCS += cxd56_icc.c
 CHIP_CSRCS += cxd56_powermgr.c
 CHIP_CSRCS += cxd56_farapi.c
 CHIP_CSRCS += cxd56_sysctl.c
+CHIP_CSRCS += cxd56_hwspinlock.c
 
 ifeq ($(CONFIG_SMP),y)
 CHIP_CSRCS += cxd56_cpuidlestack.c

--- a/arch/arm/src/cxd56xx/Make.defs
+++ b/arch/arm/src/cxd56xx/Make.defs
@@ -39,6 +39,7 @@ CHIP_CSRCS += cxd56_icc.c
 CHIP_CSRCS += cxd56_powermgr.c
 CHIP_CSRCS += cxd56_farapi.c
 CHIP_CSRCS += cxd56_sysctl.c
+CHIP_CSRCS += cxd56_atomic.c
 CHIP_CSRCS += cxd56_hwspinlock.c
 
 ifeq ($(CONFIG_SMP),y)

--- a/arch/arm/src/cxd56xx/cxd56_atomic.c
+++ b/arch/arm/src/cxd56xx/cxd56_atomic.c
@@ -1,0 +1,50 @@
+/****************************************************************************
+ * arch/arm/src/cxd56xx/cxd56_atomic.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/hwspinlock/hwspinlock.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define SPH_SMP  13
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+extern const struct hwspinlock_ops_s g_cxd56_hwspinlock_ops;
+
+struct hwspinlock_dev_s g_atomic_hwspinlock =
+{
+  .id       = SPH_SMP,
+  .priority = 0,
+  .ops      = &g_cxd56_hwspinlock_ops
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/

--- a/arch/arm/src/cxd56xx/cxd56_hwspinlock.c
+++ b/arch/arm/src/cxd56xx/cxd56_hwspinlock.c
@@ -1,0 +1,63 @@
+/****************************************************************************
+ * arch/arm/src/cxd56xx/cxd56_hwspinlock.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/hwspinlock/hwspinlock.h>
+
+#include "arm_internal.h"
+#include "hardware/cxd56_sph.h"
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static bool cxd56_hwspinlock_trylock(struct hwspinlock_dev_s *dev);
+static void cxd56_hwspinlock_unlock(struct hwspinlock_dev_s *dev);
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const struct hwspinlock_ops_s g_cxd56_hwspinlock_ops =
+{
+  .trylock = cxd56_hwspinlock_trylock,
+  .unlock  = cxd56_hwspinlock_unlock
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static bool cxd56_hwspinlock_trylock(struct hwspinlock_dev_s *dev)
+{
+  uint32_t sphlocked = ((up_cpu_index() + 2) << 16) | 0x1;
+
+  putreg32(REQ_LOCK, CXD56_SPH_REQ(dev->id));
+
+  return getreg32(CXD56_SPH_STS(dev->id)) == sphlocked;
+}
+
+static void cxd56_hwspinlock_unlock(struct hwspinlock_dev_s *dev)
+{
+  putreg32(REQ_UNLOCK, CXD56_SPH_REQ(dev->id));
+}

--- a/arch/arm/src/cxd56xx/cxd56_sph.c
+++ b/arch/arm/src/cxd56xx/cxd56_sph.c
@@ -270,9 +270,11 @@ int cxd56_sphinitialize(const char *devname)
   int ret;
   int i;
 
-  /* No. 0-2 and (14)-15 semaphores are reserved by other system. */
+  /* No. 0-2 and (13)-15 semaphores are reserved by other system. */
 
-#ifdef CONFIG_CXD56_TESTSET
+#if defined(CONFIG_CXD56_ATOMIC_WITH_HWSEM)
+  for (i = 3; i < 13; i++)
+#elif defined(CONFIG_CXD56_TESTSET_WITH_HWSEM)
   for (i = 3; i < 14; i++)
 #else
   for (i = 3; i < 15; i++)

--- a/arch/arm/src/lc823450/Make.defs
+++ b/arch/arm/src/lc823450/Make.defs
@@ -124,3 +124,4 @@ endif
 ifeq ($(CONFIG_ARM_MPU),y)
 CHIP_CSRCS += lc823450_mpuinit2.c
 endif
+CHIP_CSRCS += lc823450_atomic.c

--- a/arch/arm/src/lc823450/Make.defs
+++ b/arch/arm/src/lc823450/Make.defs
@@ -25,6 +25,7 @@ include armv7-m/Make.defs
 CHIP_CSRCS  = lc823450_allocateheap2.c lc823450_start.c lc823450_irq.c lc823450_timer.c
 CHIP_CSRCS += lc823450_lowputc.c lc823450_serial.c lc823450_clockconfig.c
 CHIP_CSRCS += lc823450_syscontrol.c lc823450_gpio.c
+CHIP_CSRCS += lc823450_hwspinlock.c
 
 # Configuration-dependent LC823450 files
 

--- a/arch/arm/src/lc823450/lc823450_atomic.c
+++ b/arch/arm/src/lc823450/lc823450_atomic.c
@@ -1,0 +1,50 @@
+/****************************************************************************
+ * arch/arm/src/lc823450/lc823450_atomic.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/hwspinlock/hwspinlock.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define LC823450_MUTEX_REG  0
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+extern const struct hwspinlock_ops_s g_lc823450_hwspinlock_ops;
+
+struct hwspinlock_dev_s g_atomic_hwspinlock =
+{
+  .id       = LC823450_MUTEX_REG,
+  .priority = 0,
+  .ops      = &g_lc823450_hwspinlock_ops
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/

--- a/arch/arm/src/lc823450/lc823450_hwspinlock.c
+++ b/arch/arm/src/lc823450/lc823450_hwspinlock.c
@@ -1,0 +1,75 @@
+/****************************************************************************
+ * arch/arm/src/lc823450/lc823450_hwspinlock.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/hwspinlock/hwspinlock.h>
+
+#include "arm_internal.h"
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define LC823450_MUTEX_REG_BASE  0x40005000
+#define LC823450_MUTEX_REG_LEN   4
+#define LC823450_MUTEX_REG_ADDR(id) \
+  (LC823450_MUTEX_REG_BASE + (id) * LC823450_MUTEX_REG_LEN)
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static bool lc823450_hwspinlock_trylock(struct hwspinlock_dev_s *dev);
+static void lc823450_hwspinlock_unlock(struct hwspinlock_dev_s *dev);
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const struct hwspinlock_ops_s g_lc823450_hwspinlock_ops =
+{
+  .trylock = lc823450_hwspinlock_trylock,
+  .unlock  = lc823450_hwspinlock_unlock
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static bool lc823450_hwspinlock_trylock(struct hwspinlock_dev_s *dev)
+{
+  uint32_t val;
+
+  val = (up_cpu_index() << 16) | 0x1;
+  putreg32(val, LC823450_MUTEX_REG_ADDR(dev->id));
+
+  return getreg32(LC823450_MUTEX_REG_ADDR(dev->id)) == val;
+}
+
+static void lc823450_hwspinlock_unlock(struct hwspinlock_dev_s *dev)
+{
+  uint32_t val;
+
+  val = (up_cpu_index() << 16) | 0x0;
+  putreg32(val, LC823450_MUTEX_REG_ADDR(dev->id));
+}

--- a/arch/arm/src/rp2040/Make.defs
+++ b/arch/arm/src/rp2040/Make.defs
@@ -104,3 +104,4 @@ ifneq ($(PICO_SDK_PATH),)
 include chip/boot2/Make.defs
 endif
 endif
+CHIP_CSRCS += rp2040_atomic.c

--- a/arch/arm/src/rp2040/Make.defs
+++ b/arch/arm/src/rp2040/Make.defs
@@ -35,6 +35,7 @@ CHIP_CSRCS += rp2040_pio.c
 CHIP_CSRCS += rp2040_clock.c
 CHIP_CSRCS += rp2040_xosc.c
 CHIP_CSRCS += rp2040_pll.c
+CHIP_CSRCS += rp2040_hwspinlock.c
 
 ifeq ($(CONFIG_SMP),y)
 CHIP_CSRCS += rp2040_cpustart.c

--- a/arch/arm/src/rp2040/rp2040_atomic.c
+++ b/arch/arm/src/rp2040/rp2040_atomic.c
@@ -1,0 +1,50 @@
+/****************************************************************************
+ * arch/arm/src/rp2040/rp2040_atomic.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/hwspinlock/hwspinlock.h>
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+#define RP2040_HWSPINLOCK  0
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+extern const struct hwspinlock_ops_s g_rp2040_hwspinlock_ops;
+
+struct hwspinlock_dev_s g_atomic_hwspinlock =
+{
+  .id       = RP2040_HWSPINLOCK,
+  .priority = 0,
+  .ops      = &g_rp2040_hwspinlock_ops
+};
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/

--- a/arch/arm/src/rp2040/rp2040_hwspinlock.c
+++ b/arch/arm/src/rp2040/rp2040_hwspinlock.c
@@ -1,0 +1,59 @@
+/****************************************************************************
+ * arch/arm/src/rp2040/rp2040_hwspinlock.c
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/hwspinlock/hwspinlock.h>
+
+#include "arm_internal.h"
+#include "hardware/rp2040_sio.h"
+
+/****************************************************************************
+ * Private Function Prototypes
+ ****************************************************************************/
+
+static bool rp2040_hwspinlock_trylock(struct hwspinlock_dev_s *dev);
+static void rp2040_hwspinlock_unlock(struct hwspinlock_dev_s *dev);
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+const struct hwspinlock_ops_s g_rp2040_hwspinlock_ops =
+{
+  .trylock = rp2040_hwspinlock_trylock,
+  .unlock  = rp2040_hwspinlock_unlock
+};
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+static bool rp2040_hwspinlock_trylock(struct hwspinlock_dev_s *dev)
+{
+  return getreg32(RP2040_SIO_SPINLOCK(dev->id));
+}
+
+static void rp2040_hwspinlock_unlock(struct hwspinlock_dev_s *dev)
+{
+  putreg32(0, RP2040_SIO_SPINLOCK(dev->id));
+}

--- a/include/nuttx/hwspinlock/hwspinlock.h
+++ b/include/nuttx/hwspinlock/hwspinlock.h
@@ -28,8 +28,7 @@
  ****************************************************************************/
 
 #include <nuttx/compiler.h>
-#include <nuttx/spinlock.h>
-
+#include <nuttx/irq.h>
 #include <stdbool.h>
 
 /****************************************************************************
@@ -40,16 +39,15 @@ struct hwspinlock_dev_s;
 
 struct hwspinlock_ops_s
 {
-  CODE bool (*trylock)(FAR struct hwspinlock_dev_s *dev,
-                       int id, int priority);
-  CODE void (*relax)(FAR struct hwspinlock_dev_s *dev,
-                     int id, int priority);
-  CODE void (*unlock)(FAR struct hwspinlock_dev_s *dev, int id);
+  CODE bool (*trylock)(FAR struct hwspinlock_dev_s *dev);
+  CODE void (*relax)(FAR struct hwspinlock_dev_s *dev);
+  CODE void (*unlock)(FAR struct hwspinlock_dev_s *dev);
 };
 
 struct hwspinlock_dev_s
 {
-  spinlock_t lock;
+  int id;
+  int priority;
   FAR const struct hwspinlock_ops_s *ops;
 };
 
@@ -65,57 +63,53 @@ extern "C"
 #define EXTERN extern
 #endif
 
-static inline bool hwspin_trylock(FAR struct hwspinlock_dev_s *dev,
-                                  int id, int priority)
+static inline bool hwspin_trylock(FAR struct hwspinlock_dev_s *dev)
 {
-  return dev->ops->trylock(dev, id, priority);
+  return dev->ops->trylock(dev);
 }
 
 static inline bool hwspin_trylock_irqsave(FAR struct hwspinlock_dev_s *dev,
-                                          int id, int priority,
                                           FAR irqstate_t *flags)
 {
-  *flags = spin_lock_irqsave(&dev->lock);
-  if (hwspin_trylock(dev, id, priority))
+  *flags = up_irq_save();
+  if (hwspin_trylock(dev))
     {
       return true;
     }
 
-  spin_unlock_irqrestore(&dev->lock, *flags);
+  up_irq_restore(*flags);
   return false;
 }
 
-static inline void hwspin_lock(FAR struct hwspinlock_dev_s *dev,
-                               int id, int priority)
+static inline void hwspin_lock(FAR struct hwspinlock_dev_s *dev)
 {
-  while (!dev->ops->trylock(dev, id, priority))
+  while (!dev->ops->trylock(dev))
     {
       if (dev->ops->relax)
         {
-          dev->ops->relax(dev, id, priority);
+          dev->ops->relax(dev);
         }
     }
 }
 
 static inline irqstate_t
-hwspin_lock_irqsave(FAR struct hwspinlock_dev_s *dev,
-                    int id, int priority)
+hwspin_lock_irqsave(FAR struct hwspinlock_dev_s *dev)
 {
-  irqstate_t flags = spin_lock_irqsave(&dev->lock);
-  hwspin_lock(dev, id, priority);
+  irqstate_t flags = up_irq_save();
+  hwspin_lock(dev);
   return flags;
 }
 
-static inline void hwspin_unlock(FAR struct hwspinlock_dev_s *dev, int id)
+static inline void hwspin_unlock(FAR struct hwspinlock_dev_s *dev)
 {
-  dev->ops->unlock(dev, id);
+  dev->ops->unlock(dev);
 }
 
 static inline void hwspin_unlock_restore(FAR struct hwspinlock_dev_s *dev,
-                                         int id, irqstate_t flags)
+                                         irqstate_t flags)
 {
-  hwspin_unlock(dev, id);
-  spin_unlock_irqrestore(&dev->lock, flags);
+  hwspin_unlock(dev);
+  up_irq_restore(flags);
 }
 
 #ifdef __cplusplus

--- a/libs/libc/machine/CMakeLists.txt
+++ b/libs/libc/machine/CMakeLists.txt
@@ -22,8 +22,8 @@
 
 add_subdirectory(${CONFIG_ARCH})
 
-if(CONFIG_LIBC_ATOMIC_IRQ)
-  target_sources(c PRIVATE arch_atomic_irq.c)
+if(CONFIG_LIBC_ATOMIC_IRQ OR CONFIG_LIBC_ATOMIC_HWSPINLOCK)
+  target_sources(c PRIVATE arch_atomic.c)
 endif()
 
 target_sources(c PRIVATE arch_atomic64.c)

--- a/libs/libc/machine/Kconfig
+++ b/libs/libc/machine/Kconfig
@@ -9,21 +9,27 @@
 
 menu "Architecture-Specific Support"
 
-config LIBC_ATOMIC_IRQ
-	bool
-	default n
-	---help---
-		atomic function by irq disable/enable
-
 config LIBC_ATOMIC_ARCH
 	bool
 	default n
 	---help---
 		arch_atomic by arch instruction
 
+config LIBC_ATOMIC_HWSPINLOCK
+	bool
+	default n
+	---help---
+		arch_atomic by chip hwspinlock
+
+config LIBC_ATOMIC_IRQ
+	bool
+	default n
+	---help---
+		atomic function by irq disable/enable
+
 config LIBC_ATOMIC_TOOLCHAIN
 	bool
-	default y if !LIBC_ATOMIC_IRQ && !LIBC_ATOMIC_ARCH
+	default y if !LIBC_ATOMIC_ARCH && !LIBC_ATOMIC_HWSPINLOCK && !LIBC_ATOMIC_IRQ
 	default n
 	---help---
 		atomic function from toolchain

--- a/libs/libc/machine/Make.defs
+++ b/libs/libc/machine/Make.defs
@@ -20,8 +20,8 @@
 #
 ############################################################################
 
-ifeq ($(CONFIG_LIBC_ATOMIC_IRQ),y)
-  CSRCS += arch_atomic_irq.c
+ifneq ($(filter y,$(CONFIG_LIBC_ATOMIC_IRQ)$(CONFIG_LIBC_ATOMIC_HWSPINLOCK)),)
+  CSRCS += arch_atomic.c
 endif
 
 CSRCS += arch_atomic64.c

--- a/libs/libc/machine/arch_atomic.c
+++ b/libs/libc/machine/arch_atomic.c
@@ -1,5 +1,5 @@
 /****************************************************************************
- * libs/libc/machine/arch_atomic_irq.c
+ * libs/libc/machine/arch_atomic.c
  *
  * SPDX-License-Identifier: Apache-2.0
  *
@@ -30,6 +30,9 @@
 #include <stdint.h>
 #include <nuttx/irq.h>
 #include <nuttx/macro.h>
+#if defined(CONFIG_LIBC_ATOMIC_HWSPINLOCK)
+#  include <nuttx/hwspinlock/hwspinlock.h>
+#endif
 
 #include "arch_atomic.h"
 
@@ -37,6 +40,19 @@
  * Private Functions
  ****************************************************************************/
 
+#if defined(CONFIG_LIBC_ATOMIC_HWSPINLOCK)
+extern struct hwspinlock_dev_s g_atomic_hwspinlock;
+
+static inline irqstate_t atomic_lock(void)
+{
+  return hwspin_lock_irqsave(&g_atomic_hwspinlock);
+}
+
+static inline void atomic_unlock(irqstate_t flags)
+{
+  hwspin_unlock_restore(&g_atomic_hwspinlock, flags);
+}
+#elif defined(CONFIG_LIBC_ATOMIC_IRQ)
 static inline irqstate_t atomic_lock(void)
 {
   return up_irq_save();
@@ -46,6 +62,7 @@ static inline void atomic_unlock(irqstate_t flags)
 {
   up_irq_restore(flags);
 }
+#endif
 
 /****************************************************************************
  * Public Functions


### PR DESCRIPTION
## Summary

Add hwspinlock-based atomic backend for multi-core capable chips:

- Add hwspinlock driver implementations for cxd56, rp2040, and lc823450
- Implement atomic operations using hwspinlock when `LIBC_ATOMIC_HWSPINLOCK` is selected
- Rename `arch_atomic_irq.c` back to `arch_atomic.c` with combined IRQ + hwspinlock implementation

This PR depends on #19867 (multi-backend framework + builtin + API rename).

## Stacked PR chain

Depends on #19867. This is PR 3 of 3:
- #19866: atomic.h header fixes
- #19867: multi-backend framework + builtin + API rename
- #19868 (this): hwspinlock backend for cxd56, rp2040, lc823450

## Test

 testbuild across RP2040/CXD56XX/LC823450

