### PR TITLE
arch/risc-v/espressif: fix SoftAP-only build of the Wi-Fi event handler

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_wifi_event_handler.c
+++ b/arch/risc-v/src/common/espressif/esp_wifi_event_handler.c
@@ -97,6 +97,7 @@ static bool g_wifi_handler_registered;
  *
  ****************************************************************************/
 
+#ifdef ESP_WLAN_HAS_STA
 static void esp_reconnect_work_cb(void *arg)
 {
   UNUSED(arg);
@@ -113,6 +114,7 @@ static void esp_reconnect_work_cb(void *arg)
       wlerr("Failed to reconnect to Wi-Fi on callback\n");
     }
 }
+#endif /* ESP_WLAN_HAS_STA */
 
 /****************************************************************************
  * Name: esp_wifi_event_handler


### PR DESCRIPTION
## Summary

`CONFIG_ESPRESSIF_WIFI_SOFTAP` alone does not build on RISC-V:

```
esp_wifi_event_handler.c:105:8: error: 'g_sta_reconnect' undeclared
```

`esp_reconnect_work_cb()` dereferences `g_sta_reconnect`, which is declared
only under `ESP_WLAN_HAS_STA`. Since `esp_wlan_netdev.h` selects the modes
with `#elif`, a SoftAP-only configuration leaves `ESP_WLAN_HAS_STA` undefined
and the reference is orphaned.

I introduced this myself in #19725: the guard was added to the Xtensa copy of
the same file but not to the RISC-V one. This commit adds it, matching what
Xtensa already does.

## Impact

Any RISC-V Espressif target built as a pure SoftAP. CI does not catch it: no
RISC-V defconfig in tree selects SoftAP-only (the two that do,
`esp32-devkitc:softap` and `esp32s3-m5-cardputer:softap`, are Xtensa), and the
only "softap" entry in `tools/ci/testlist/*.dat` is `esp32-c3-zero:sta_softap`,
which is STA+AP and therefore compiles.

## Testing

`esp32c6-devkitc` on current master, all three Wi-Fi modes:

| Config | Mode | Before | After |
|---|---|---|---|
| `esp32c6-devkitc:wifi` + SoftAP | SoftAP only | fails | builds |
| `esp32c6-devkitc:wifi` | STA | builds | builds |
| `esp32c6-devkitc:sta_softap` | STA + SoftAP | builds | builds |

`tools/checkpatch.sh -m -g` passes.
