### PR TITLE
libs/libc/elf: Add C++ support for loadable ELF modules

### DIFF
--- a/binfmt/binfmt_execmodule.c
+++ b/binfmt/binfmt_execmodule.c
@@ -361,6 +361,12 @@ int exec_module(FAR struct binary_s *binp,
 
 #ifdef CONFIG_BINFMT_LOADABLE
   tcb->group->tg_bininfo = binp;
+#  ifdef CONFIG_LIBC_ELF
+  if (tcb->group->tg_info != NULL)
+    {
+      tcb->group->tg_info->ta_bininfo = binp;
+    }
+#  endif
 #endif
 
   /* Then activate the task at the provided priority */

--- a/include/nuttx/lib/elf.h
+++ b/include/nuttx/lib/elf.h
@@ -198,6 +198,9 @@ struct module_s
   uint16_t  ninit;                       /* Number of entries in .init_array */
   uintptr_t finiarr;                     /* .fini_array */
   uint16_t  nfini;                       /* Number of entries in .fini_array */
+#ifdef CONFIG_LIBC_ELF_EH_FRAME
+  uintptr_t ehframe;                     /* .eh_frame */
+#endif
 };
 
 /* This struct provides a description of the currently loaded instantiation
@@ -237,6 +240,9 @@ struct mod_loadinfo_s
   uintptr_t     initarr;     /* .init_array */
   uintptr_t     finiarr;     /* .fini_array */
   uintptr_t     preiarr;     /* .preinit_array */
+#ifdef CONFIG_LIBC_ELF_EH_FRAME
+  uintptr_t     ehframe;     /* .eh_frame */
+#endif
   uint16_t      ninit;       /* Number of .init_array entries */
   uint16_t      nfini;       /* Number of .fini_array entries */
   uint16_t      nprei;       /* Number of .preinit_array entries */

--- a/include/nuttx/tls.h
+++ b/include/nuttx/tls.h
@@ -123,6 +123,10 @@ struct pthread_atfork_s
 };
 #endif
 
+#if defined(CONFIG_BINFMT_LOADABLE) && defined(CONFIG_LIBC_ELF)
+struct binary_s;
+#endif
+
 struct task_info_s
 {
   mutex_t         ta_lock;
@@ -144,6 +148,10 @@ struct task_info_s
 #endif
 #ifdef CONFIG_FILE_STREAM
   struct streamlist ta_streamlist; /* Holds C buffered I/O info */
+#endif
+
+#if defined(CONFIG_BINFMT_LOADABLE) && defined(CONFIG_LIBC_ELF)
+  FAR struct binary_s *ta_bininfo; /* Loadable binary information */
 #endif
 
 #ifdef CONFIG_PTHREAD_ATFORK

--- a/libs/libc/elf/Kconfig
+++ b/libs/libc/elf/Kconfig
@@ -116,4 +116,13 @@ config LIBC_ELF_EXIDX_SECTNAME
 
 		This is needed to support exception handling on loadable ELF modules.
 
+config LIBC_ELF_EH_FRAME
+	bool "Register DWARF EH frames for ELF modules"
+	default n
+	depends on CXX_EXCEPTION && ARCH_SIM && HOST_X86_64
+	---help---
+		Register loadable ELF module .eh_frame sections with the host
+		DWARF unwinder.  This is needed by C++ exceptions on the x86_64
+		SIM target.
+
 endmenu # Module library configuration

--- a/libs/libc/elf/elf_bind.c
+++ b/libs/libc/elf/elf_bind.c
@@ -41,6 +41,14 @@
 #include "elf/elf.h"
 
 /****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef CONFIG_LIBC_ELF_EH_FRAME
+extern void __register_frame(FAR void *begin);
+#endif
+
+/****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
 
@@ -55,6 +63,35 @@
 #else
 #  define ARCH_ELFDATA_DEF
 #  define ARCH_ELFDATA_PARM NULL
+#endif
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_LIBC_ELF_EH_FRAME
+static void libelf_register_eh_frame(FAR struct module_s *modp,
+                                     FAR struct mod_loadinfo_s *loadinfo)
+{
+  int ret;
+
+  ret = libelf_findsection(loadinfo, ".eh_frame");
+  if (ret < 0)
+    {
+      return;
+    }
+
+  if (loadinfo->shdr[ret].sh_addr == 0 || loadinfo->shdr[ret].sh_size == 0)
+    {
+      return;
+    }
+
+  loadinfo->ehframe = loadinfo->shdr[ret].sh_addr;
+  modp->ehframe = loadinfo->ehframe;
+  __register_frame((FAR void *)modp->ehframe);
+}
+#else
+#  define libelf_register_eh_frame(m,l)
 #endif
 
 /****************************************************************************
@@ -1065,6 +1102,8 @@ int libelf_bind(FAR struct module_s *modp,
     {
       up_coherent_dcache(loadinfo->datastart, loadinfo->datasize);
     }
+
+  libelf_register_eh_frame(modp, loadinfo);
 
 #ifdef CONFIG_ARCH_USE_SEPARATED_SECTION
   for (i = 0; loadinfo->ehdr.e_type == ET_REL && i < loadinfo->ehdr.e_shnum;

--- a/libs/libc/elf/elf_remove.c
+++ b/libs/libc/elf/elf_remove.c
@@ -32,6 +32,14 @@
 #include <nuttx/lib/elf.h>
 
 /****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef CONFIG_LIBC_ELF_EH_FRAME
+extern void __deregister_frame(FAR void *begin);
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -62,7 +70,7 @@ int libelf_uninit(FAR struct module_s *modp)
   /* Is there an uninitializer? */
 
   array = (FAR void (**)(void))modp->finiarr;
-  for (i = 0; i < modp->nfini; i++)
+  for (i = modp->nfini - 1; i >= 0; i--)
     {
       array[i]();
     }
@@ -92,6 +100,14 @@ int libelf_uninit(FAR struct module_s *modp)
       modp->modinfo.nexports      = 0;
 #endif
     }
+
+#ifdef CONFIG_LIBC_ELF_EH_FRAME
+  if (modp->ehframe != 0)
+    {
+      __deregister_frame((FAR void *)modp->ehframe);
+      modp->ehframe = 0;
+    }
+#endif
 
   /* Release resources held by the module */
 

--- a/libs/libc/elf/elf_unload.c
+++ b/libs/libc/elf/elf_unload.c
@@ -36,6 +36,14 @@
 #include "elf/elf.h"
 
 /****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifdef CONFIG_LIBC_ELF_EH_FRAME
+extern void __deregister_frame(FAR void *begin);
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -55,6 +63,14 @@
 
 int libelf_unload(FAR struct mod_loadinfo_s *loadinfo)
 {
+#ifdef CONFIG_LIBC_ELF_EH_FRAME
+  if (loadinfo->ehframe != 0)
+    {
+      __deregister_frame((FAR void *)loadinfo->ehframe);
+      loadinfo->ehframe = 0;
+    }
+#endif
+
   /* Free all working buffers */
 
   libelf_freebuffers(loadinfo);

--- a/libs/libc/elf/gnu-elf.ld.in
+++ b/libs/libc/elf/gnu-elf.ld.in
@@ -66,6 +66,21 @@ SECTIONS
       _erodata = . ;
     }
 
+  .eh_frame :
+    {
+      KEEP(*(.eh_frame))
+      KEEP(*(.eh_frame.*))
+      LONG(0)
+      . = ALIGN(SECTIONS_ALIGN);
+    }
+
+  .gcc_except_table :
+    {
+      *(.gcc_except_table)
+      *(.gcc_except_table.*)
+      . = ALIGN(SECTIONS_ALIGN);
+    }
+
   .data DATA :
     {
       _sdata = . ;

--- a/libs/libc/machine/sim/arch_elf64.c
+++ b/libs/libc/machine/sim/arch_elf64.c
@@ -170,6 +170,12 @@ int up_relocateadd(const Elf64_Rela *rel, const Elf64_Sym *sym,
 
   switch (relotype)
     {
+      case R_X86_64_NONE:
+
+        /* No relocation is needed for this entry. */
+
+        break;
+
       case R_X86_64_64: /* S + A */
         *(uint64_t *)addr = sym->st_value + rel->r_addend;
         break;

--- a/libs/libc/sched/task_startup.c
+++ b/libs/libc/sched/task_startup.c
@@ -28,12 +28,88 @@
 
 #include <sched.h>
 #include <stdlib.h>
+#include <stdbool.h>
 #include <assert.h>
 #include <nuttx/debug.h>
+#include <nuttx/sched.h>
+#include <nuttx/tls.h>
+
+#ifdef CONFIG_BINFMT_LOADABLE
+#  include <nuttx/binfmt/binfmt.h>
+#endif
 
 #include "libc.h"
 
 #ifndef CONFIG_BUILD_KERNEL
+
+/****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#if defined(CONFIG_BINFMT_LOADABLE) && defined(CONFIG_LIBC_ELF)
+static void nxtask_binfmt_initialize(void)
+{
+  FAR struct task_info_s *info = task_get_info();
+  FAR struct binary_s *binp;
+  FAR void (**array)(void);
+  uint16_t ninit;
+  int i;
+
+  binp = info == NULL ? NULL : info->ta_bininfo;
+  if (binp == NULL || binp->mod.initarr == 0 || binp->mod.ninit == 0)
+    {
+      return;
+    }
+
+  array = (FAR void (**)(void))binp->mod.initarr;
+  ninit = binp->mod.ninit;
+  binp->mod.ninit = 0;
+
+  for (i = 0; i < ninit; i++)
+    {
+      array[i]();
+    }
+}
+
+static void nxtask_binfmt_finalize(void)
+{
+  FAR struct task_info_s *info = task_get_info();
+  FAR struct binary_s *binp;
+  FAR void (**array)(void);
+  uint16_t nfini;
+  int i;
+
+  binp = info == NULL ? NULL : info->ta_bininfo;
+  if (binp == NULL || binp->mod.finiarr == 0 || binp->mod.nfini == 0)
+    {
+      return;
+    }
+
+  array = (FAR void (**)(void))binp->mod.finiarr;
+  nfini = binp->mod.nfini;
+  binp->mod.nfini = 0;
+
+  for (i = nfini - 1; i >= 0; i--)
+    {
+      array[i]();
+    }
+}
+
+#if CONFIG_LIBC_MAX_EXITFUNS > 0
+static bool nxtask_binfmt_has_fini_array(void)
+{
+  FAR struct task_info_s *info = task_get_info();
+  FAR struct binary_s *binp;
+
+  binp = info == NULL ? NULL : info->ta_bininfo;
+  return binp != NULL && binp->mod.finiarr != 0 && binp->mod.nfini > 0;
+}
+#endif
+#else
+#  define nxtask_binfmt_initialize()
+#  define nxtask_binfmt_finalize()
+#  define nxtask_binfmt_has_fini_array() false
+#endif
 
 /****************************************************************************
  * Public Functions
@@ -57,6 +133,8 @@
 
 void nxtask_startup(main_t entrypt, int argc, FAR char *argv[])
 {
+  int ret;
+
   DEBUGASSERT(entrypt);
 
   /* If C++ initialization for static constructors is supported, then do
@@ -64,12 +142,24 @@ void nxtask_startup(main_t entrypt, int argc, FAR char *argv[])
    */
 
   lib_cxx_initialize();
+  nxtask_binfmt_initialize();
+
+#if defined(CONFIG_BINFMT_LOADABLE) && defined(CONFIG_LIBC_ELF) && \
+    CONFIG_LIBC_MAX_EXITFUNS > 0
+  if (nxtask_binfmt_has_fini_array())
+    {
+      atexit(nxtask_binfmt_finalize);
+    }
+#endif
 
   /* Call the 'main' entry point passing argc and argv, calling exit()
    * if/when the task returns.
    */
 
-  exit(entrypt(argc, argv));
+  ret = entrypt(argc, argv);
+  nxtask_binfmt_finalize();
+
+  exit(ret);
 }
 
 #endif /* !CONFIG_BUILD_KERNEL */


### PR DESCRIPTION
Loadable ELF tasks currently do not run module init/fini arrays when they are executed through the binfmt path. This is enough for many C modules, but C++ modules rely on those arrays for global constructors and destructors, so objects with static storage duration are not initialized or finalized correctly.

C++ exceptions on the x86_64 SIM target also need the module DWARF unwind data to be visible to the host unwinder. The loaded .eh_frame section is relocated by the ELF loader, but it is not registered with libgcc unwinder state, so stack unwinding through a loaded module cannot find the FDEs needed for C++ catch handling.

Run loadable ELF init arrays from nxtask_startup() before entering the task main function and run fini arrays when the task returns or exits. The fini array count is cleared before callbacks are invoked so the same module destructors are not called twice on normal return followed by binfmt unload.

Add an optional CONFIG_LIBC_ELF_EH_FRAME path for x86_64 SIM that registers a loaded module .eh_frame section after relocation and deregisters it on unload or failed load cleanup. Keep the option disabled by default and limited to SIM, where the host DWARF unwinder APIs are available.

Preserve .eh_frame and .gcc_except_table in the loadable ELF linker script so exception metadata remains available after module linking. Also accept R_X86_64_NONE as a no-op relocation in the SIM x86_64 relocator; some C++ objects can contain those entries and rejecting them prevents otherwise valid modules from loading.

The apps-side loadelf demo and stress tests are carried in the companion apps commit:

  https://github.com/LingaoM/nuttx-apps/commit/1c75943922f5dfb3818ddb8594c9d3f1a0b9bd87

Testing:

  Host:

    Ubuntu 22.04 x86_64

  Board/config:

    apps-side sim/loadelfdemo

  Apps test code:

    https://github.com/LingaoM/nuttx-apps/commit/1c75943922f5dfb3818ddb8594c9d3f1a0b9bd87

  Configuration highlights:

    CONFIG_ELF=y
    CONFIG_LIBC_EXECFUNCS=y
    CONFIG_EXECFUNCS_HAVE_SYMTAB=y
    # CONFIG_EXECFUNCS_SYSTEM_SYMTAB is not set
    CONFIG_BINFMT_CONSTRUCTORS=y
    CONFIG_CXX_EXCEPTION=y
    CONFIG_CXX_RTTI=y
    CONFIG_CXX_WCHAR=y
    CONFIG_LIBC_ELF_EH_FRAME=y
    CONFIG_LIBCXXNONE=y
    CONFIG_LIBMINIABI=y
    CONFIG_SIM_TOOLCHAIN_GCC=y

  Build and export:

    make distclean
    ./tools/configure.sh -l ../nuttx-apps/sim/loadelfdemo
    make olddefconfig KCONFIG_OLDDEFCONFIG="python3 -m olddefconfig"
    make -j16
    make export

  External ELF samples built from the NuttX export:

    make -C ../nuttx-apps/examples/loadelfdemo/samples/loadelf_sample \
      clean install check
    make -C ../nuttx-apps/examples/loadelfdemo/samples/loadelf_cpp_stress \
      clean install check

  Runtime test:

    printf 'loadelfdemo loadelf_sample 10 20 30\n\
    loadelfdemo loadelf_sample 1 2\n\
    loadelfdemo loadelf_cpp_stress\n\
    poweroff\n' | timeout 80s ./nuttx

  Observed result:

    loadelf_sample loaded successfully twice, with the second run reusing the
    existing /system/bin mount. loadelf_cpp_stress passed all checks including
    global constructors, STL containers, RTTI, exceptions, iostream, regex,
    filesystem, thread/condition_variable, future/async, and global destructor
    execution.

<img width="1634" height="1638" alt="image" src="https://github.com/user-attachments/assets/ebc05130-e04e-4bb7-8901-7533805a95ed" />
