### PR TITLE
fs/shm: Add a flag FS_SHMFS_NO_ALIGN to remove SHM alignment

### DIFF
--- a/fs/shm/Kconfig
+++ b/fs/shm/Kconfig
@@ -19,4 +19,14 @@ config FS_SHMFS_VFS_PATH
 		The path to where shared memory objects will exist in the VFS
 		namespace.
 
+config FS_SHMFS_NO_ALIGN
+	bool "Skip cache-line alignment/padding of shm objects"
+	default n
+	---help---
+		Skip cache-line alignment of the shm object metadata header and
+		the object length. Saves RAM in FLAT builds where shm objects
+		are never used as DMA targets and no cache maintenance is
+		performed on their contents. Callers that need DMA-safe shm
+		buffers must not enable this.
+
 endif # FS_SHMFS

--- a/fs/shm/shmfs_alloc.c
+++ b/fs/shm/shmfs_alloc.c
@@ -53,7 +53,11 @@ FAR struct shmfs_object_s *shmfs_alloc_object(size_t length)
 
   size_t hdr_size = sizeof(struct shmfs_object_s);
   size_t alloc_size = length;
+#ifdef CONFIG_FS_SHMFS_NO_ALIGN
+  size_t cachesize = 0;
+#else
   size_t cachesize = up_get_dcache_linesize();
+#endif
 
   if (cachesize > 0)
     {
@@ -83,7 +87,11 @@ FAR struct shmfs_object_s *shmfs_alloc_object(size_t length)
   object = fs_heap_zalloc(sizeof(struct shmfs_object_s));
   if (object)
     {
+#ifdef CONFIG_FS_SHMFS_NO_ALIGN
+      size_t cachesize = 0;
+#else
       size_t cachesize = up_get_dcache_linesize();
+#endif
 
       if (cachesize > 0)
         {


### PR DESCRIPTION
## Summary

Add a flag to drop SHM object cache alignment. This can be used on small systems to save RAM if the SHM object doesn't need to be cache-aligned. On a CONFIG_BUILD_FLAT, saves ~24 bytes per object.

## Impact

No impact on existing boards, added configuration flag to save some RAM on a system using lots of SHM objects.

## Testing

With my custom SW, having a few hundred SHM objects on a Pixhawk 5x (stm32f7) HW, CONFIG_BUILD_FLAT:

CONFIG_FS_SHMFS_NO_ALIGN=y:

```
nsh> cat /proc/meminfo
      total       used       free    maxused    maxfree  nused  nfree name
     419860     383948      35912     386392      33688   1600      4 Umem
    2097152    2097152          0          0     13      0 Prog
```

CONFIG_FS_SHMFS_NO_ALIGN=n:

```
nsh> cat /proc/meminfo
      total       used       free    maxused    maxfree  nused  nfree name
     419796     387964      31832     387688      31744   1542      5 Umem
    2097152    2097152          0          0     13      0 Prog
```

So the RAM saving gets up to ~5kB
