### PR TITLE
include/cxx/{cstdlib,cmath}: Provide std::abs(float) overloads

### DIFF
--- a/include/cxx/cmath
+++ b/include/cxx/cmath
@@ -40,6 +40,7 @@
 #else
 
 #  include <math.h>
+#  include <nuttx/std_abs.h>
 
 #  if !defined(FLT_EVAL_METHOD) && defined(__FLT_EVAL_METHOD__)
 #    define FLT_EVAL_METHOD __FLT_EVAL_METHOD__

--- a/include/cxx/cstdlib
+++ b/include/cxx/cstdlib
@@ -29,6 +29,7 @@
 
 #include <nuttx/config.h>
 #include <stdlib.h>
+#include <nuttx/std_abs.h>
 
 //***************************************************************************
 // Namespace

--- a/include/cxx/nuttx/std_abs.h
+++ b/include/cxx/nuttx/std_abs.h
@@ -1,0 +1,95 @@
+/****************************************************************************
+ * include/cxx/nuttx/std_abs.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_CXX_BITS_STD_ABS
+#define __INCLUDE_CXX_BITS_STD_ABS
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#undef abs
+
+/****************************************************************************
+ * External functions
+ ****************************************************************************/
+
+extern "C"
+{
+  extern int abs(int);
+  extern long labs(long);
+  extern long long llabs(long long);
+
+#ifdef CONFIG_HAVE_FLOAT
+  extern float fabsf(float);
+#endif
+#ifdef CONFIG_HAVE_DOUBLE
+  extern double fabs(double);
+#endif
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+  extern long double fabsl(long double);
+#endif
+}
+
+/****************************************************************************
+ * Namespace
+ ****************************************************************************/
+
+namespace std
+{
+    using ::abs;
+
+    inline long abs(long x)
+    {
+      return ::labs(x);
+    }
+
+    inline long long abs(long long x)
+    {
+      return ::llabs(x);
+    }
+
+#ifdef CONFIG_HAVE_FLOAT
+    inline float abs(float x)
+    {
+      return ::fabsf(x);
+    }
+#endif
+
+#ifdef CONFIG_HAVE_DOUBLE
+    inline double abs(double x)
+    {
+      return ::fabs(x);
+    }
+#endif
+
+#ifdef CONFIG_HAVE_LONG_DOUBLE
+    inline long double abs(long double x)
+    {
+      return ::fabsl(x);
+    }
+#endif
+}
+
+#endif /* __INCLUDE_CXX_BITS_STD_ABS */


### PR DESCRIPTION
## Summary

The new overloads of `std::abs` added to `cstdlib` and `cmath` are defined as specified by the C++ standard: https://en.cppreference.com/cpp/numeric/math/fabs

Without these new definitions the `int std::abs(int)` function, provided by `using ::abs`, was selected for all argument types resulting in a truncation of the result.

## Impact

Improved compatibility with the C++ standard

## Testing

```
#include <cstdio>
#include <cstdlib>
#include <float.h>

extern "C" int main(int argc, FAR char *argv[]) {
  printf("FLT_MAX = %f\n", FLT_MAX);
  printf("DBL_MAX = %f\n", DBL_MAX);
  printf("INT_MAX = %d\n", INT_MAX);
  printf("LONG_MAX = %ld\n", LONG_MAX);
  printf("LLONG_MAX = %lld\n", LLONG_MAX);

  printf("::abs(FLT_MAX) = %d\n", ::abs(4.2));
  printf("::abs(DBL_MAX) = %d\n", ::abs(4.2));
  printf("::abs(INT_MAX) = %d\n", ::abs(INT_MAX));
  printf("::abs(LONG_MAX) = %ld\n", ::abs(LONG_MAX));
  printf("::abs(LLONG_MAX) = %lld\n", ::abs(LLONG_MAX));
  printf("std::abs(FLT_MAX) = %f\n", std::abs(FLT_MAX));
  printf("std::abs(DBL_MAX) = %f\n", std::abs(DBL_MAX));
  printf("std::abs(INT_MAX) = %d\n", std::abs(INT_MAX));
  printf("std::abs(LONG_MAX) = %ld\n", std::abs(LONG_MAX));
  printf("std::abs(LLONG_MAX) = %lld\n", std::abs(LLONG_MAX));

  return 0;
}
```

Without the changes running this program results in the following output:

```
FLT_MAX = 340282346638529000000000000000000000000.000000
DBL_MAX = 179769313486232000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.000000
INT_MAX = 2147483647
LONG_MAX = 2147483647
LLONG_MAX = 9223372036854775807
::abs(FLT_MAX) = 4
::abs(DBL_MAX) = 4
::abs(INT_MAX) = 2147483647
::abs(LONG_MAX) = 2147483647
::abs(LLONG_MAX) = 19327352830
std::abs(FLT_MAX) = 0.000000
std::abs(DBL_MAX) = 0.000000
std::abs(INT_MAX) = 2147483647
std::abs(LONG_MAX) = 2147483647
std::abs(LLONG_MAX) = 19327352830
```

That is compliant for `::abs` but not for `std::abs`.

With the changes the right overloads of `std::abs` are selected and the output is:

```
FLT_MAX = 340282346638529000000000000000000000000.000000
DBL_MAX = 179769313486232000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.000000
INT_MAX = 2147483647
LONG_MAX = 2147483647
LLONG_MAX = 9223372036854775807
::abs(FLT_MAX) = 4
::abs(DBL_MAX) = 4
::abs(INT_MAX) = 2147483647
::abs(LONG_MAX) = 2147483647
::abs(LLONG_MAX) = 19327352830
std::abs(FLT_MAX) = 340282346638529000000000000000000000000.000000
std::abs(DBL_MAX) = 179769313486232000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000.000000
std::abs(INT_MAX) = 2147483647
std::abs(LONG_MAX) = 2147483647
std::abs(LLONG_MAX) = 9223372036854775807
```

Tested with the `qemu-armv7a:nsh` config