### PR TITLE
drivers/net: fix gcc16 memory access for igc, igb and e1000

### DIFF
--- a/drivers/net/e1000.c
+++ b/drivers/net/e1000.c
@@ -318,6 +318,12 @@ static const struct netdev_ops_s g_e1000_ops =
  * Private Functions
  *****************************************************************************/
 
+/* The device requires 32-bit register accesses, but volatile does not pin
+ * the access width: GCC 16 narrows a 32-bit load feeding a single bit test
+ * into a byte load.  Launder the value through a register with an empty
+ * asm, on loads and stores both, to force the full-width access.
+ */
+
 /*****************************************************************************
  * Name: e1000_getreg_mem
  *****************************************************************************/
@@ -325,8 +331,11 @@ static const struct netdev_ops_s g_e1000_ops =
 static uint32_t e1000_getreg_mem(FAR struct e1000_driver_s *priv,
                                  unsigned int offset)
 {
-  uintptr_t addr = priv->base + offset;
-  return *((FAR volatile uint32_t *)addr);
+  uintptr_t addr   = priv->base + offset;
+  uint32_t  regval = *((FAR volatile uint32_t *)addr);
+
+  __asm__ __volatile__("" : "+r"(regval));
+  return regval;
 }
 
 /*****************************************************************************
@@ -338,6 +347,8 @@ static void e1000_putreg_mem(FAR struct e1000_driver_s *priv,
                              uint32_t value)
 {
   uintptr_t addr = priv->base + offset;
+
+  __asm__ __volatile__("" : "+r"(value));
   *((FAR volatile uint32_t *)addr) = value;
 }
 

--- a/drivers/net/igb.c
+++ b/drivers/net/igb.c
@@ -274,6 +274,12 @@ static const struct netdev_ops_s g_igb_ops =
  * Private Functions
  *****************************************************************************/
 
+/* The device requires 32-bit register accesses, but volatile does not pin
+ * the access width: GCC 16 narrows a 32-bit load feeding a single bit test
+ * into a byte load.  Launder the value through a register with an empty
+ * asm, on loads and stores both, to force the full-width access.
+ */
+
 /*****************************************************************************
  * Name: igb_getreg_mem
  *****************************************************************************/
@@ -281,8 +287,11 @@ static const struct netdev_ops_s g_igb_ops =
 static uint32_t igb_getreg_mem(FAR struct igb_driver_s *priv,
                                unsigned int offset)
 {
-  uintptr_t addr = priv->base + offset;
-  return *((FAR volatile uint32_t *)addr);
+  uintptr_t addr   = priv->base + offset;
+  uint32_t  regval = *((FAR volatile uint32_t *)addr);
+
+  __asm__ __volatile__("" : "+r"(regval));
+  return regval;
 }
 
 /*****************************************************************************
@@ -294,6 +303,8 @@ static void igb_putreg_mem(FAR struct igb_driver_s *priv,
                            uint32_t value)
 {
   uintptr_t addr = priv->base + offset;
+
+  __asm__ __volatile__("" : "+r"(value));
   *((FAR volatile uint32_t *)addr) = value;
 }
 

--- a/drivers/net/igc.c
+++ b/drivers/net/igc.c
@@ -270,6 +270,12 @@ static const struct netdev_ops_s g_igc_ops =
  * Private Functions
  *****************************************************************************/
 
+/* The device requires 32-bit register accesses, but volatile does not pin
+ * the access width: GCC 16 narrows a 32-bit load feeding a single bit test
+ * into a byte load.  Launder the value through a register with an empty
+ * asm, on loads and stores both, to force the full-width access.
+ */
+
 /*****************************************************************************
  * Name: igc_getreg_mem
  *****************************************************************************/
@@ -277,8 +283,11 @@ static const struct netdev_ops_s g_igc_ops =
 static uint32_t igc_getreg_mem(FAR struct igc_driver_s *priv,
                                unsigned int offset)
 {
-  uintptr_t addr = priv->base + offset;
-  return *((FAR volatile uint32_t *)addr);
+  uintptr_t addr   = priv->base + offset;
+  uint32_t  regval = *((FAR volatile uint32_t *)addr);
+
+  __asm__ __volatile__("" : "+r"(regval));
+  return regval;
 }
 
 /*****************************************************************************
@@ -290,6 +299,8 @@ static void igc_putreg_mem(FAR struct igc_driver_s *priv,
                            uint32_t value)
 {
   uintptr_t addr = priv->base + offset;
+
+  __asm__ __volatile__("" : "+r"(value));
   *((FAR volatile uint32_t *)addr) = value;
 }
 


### PR DESCRIPTION
## Summary

- drivers/net/e1000: Access registers at the required width
- drivers/net/igb: Access registers at the required width
- drivers/net/igc: Access registers at the required width

## Impact

fix gcc16 issues

## Testing

qemu intel64 NICs works with gcc16
