### PR TITLE
arch/stm32: remove dead IRQ code

### DIFF
--- a/arch/arm/src/common/stm32/stm32_irq_m0_v1.c
+++ b/arch/arm/src/common/stm32/stm32_irq_m0_v1.c
@@ -213,14 +213,6 @@ void up_irqinitialize(void)
 
   stm32_dumpnvic("initial", NR_IRQS);
 
-  /* Initialize logic to support a second level of interrupt decoding for
-   * configured pin interrupts.
-   */
-
-#ifdef CONFIG_STM32_GPIOIRQ
-  stm32_gpioirqinitialize();
-#endif
-
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
 
   /* And finally, enable interrupts */

--- a/arch/arm/src/stm32f7/stm32_config.h
+++ b/arch/arm/src/stm32f7/stm32_config.h
@@ -36,32 +36,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-/* GPIO IRQs ****************************************************************/
-
-#ifndef CONFIG_STM32_GPIO_IRQ
-#  undef CONFIG_STM32_GPIOA_IRQ
-#  undef CONFIG_STM32_GPIOB_IRQ
-#  undef CONFIG_STM32_GPIOC_IRQ
-#  undef CONFIG_STM32_GPIOD_IRQ
-#  undef CONFIG_STM32_GPIOE_IRQ
-#endif
-
-#if STM32_NPORTS < 1
-#  undef CONFIG_STM32_GPIOA_IRQ
-#endif
-#if STM32_NPORTS < 2
-#  undef CONFIG_STM32_GPIOB_IRQ
-#endif
-#if STM32_NPORTS < 3
-#  undef CONFIG_STM32_GPIOC_IRQ
-#endif
-#if STM32_NPORTS < 4
-#  undef CONFIG_STM32_GPIOD_IRQ
-#endif
-#if STM32_NPORTS < 5
-#  undef CONFIG_STM32_GPIOE_IRQ
-#endif
-
 /* UARTs ********************************************************************/
 
 /* Don't enable UARTs not supported by the chip. */

--- a/arch/arm/src/stm32f7/stm32_irq.c
+++ b/arch/arm/src/stm32f7/stm32_irq.c
@@ -40,10 +40,6 @@
 #include "ram_vectors.h"
 #include "arm_internal.h"
 
-#ifdef CONFIG_STM32_GPIO_IRQ
-#  include "stm32_gpio.h"
-#endif
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -398,14 +394,6 @@ void up_irqinitialize(void)
   stm32_dumpnvic("initial", NR_IRQS);
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
-  /* Initialize logic to support a second level of interrupt decoding for
-   * GPIO pins.
-   */
-
-#ifdef CONFIG_STM32_GPIO_IRQ
-  stm32_gpioirqinitialize();
-#endif
-
   /* And finally, enable interrupts */
 
   arm_color_intstack();
@@ -446,14 +434,6 @@ void up_disable_irq(int irq)
           putreg32(regval, regaddr);
         }
     }
-#ifdef CONFIG_STM32_GPIO_IRQ
-  else
-    {
-      /* Maybe it is a (derived) GPIO IRQ */
-
-      stm32_gpioirqdisable(irq);
-    }
-#endif
 
 #if 0 /* Might be useful in early bring-up */
   stm32_dumpnvic("disable", irq);
@@ -493,14 +473,6 @@ void up_enable_irq(int irq)
           putreg32(regval, regaddr);
         }
     }
-#ifdef CONFIG_STM32_GPIO_IRQ
-  else
-    {
-      /* Maybe it is a (derived) GPIO IRQ */
-
-      stm32_gpioirqenable(irq);
-    }
-#endif
 
 #if 0 /* Might be useful in early bring-up */
   stm32_dumpnvic("enable", irq);

--- a/arch/arm/src/stm32h7/stm32_irq.c
+++ b/arch/arm/src/stm32h7/stm32_irq.c
@@ -40,10 +40,6 @@
 #include "ram_vectors.h"
 #include "arm_internal.h"
 
-#ifdef CONFIG_STM32_GPIO_IRQ
-#  include "stm32_gpio.h"
-#endif
-
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -400,14 +396,6 @@ void up_irqinitialize(void)
   stm32_dumpnvic("initial", NR_IRQS);
 
 #ifndef CONFIG_SUPPRESS_INTERRUPTS
-  /* Initialize logic to support a second level of interrupt decoding for
-   * GPIO pins.
-   */
-
-#ifdef CONFIG_STM32_GPIO_IRQ
-  stm32_gpioirqinitialize();
-#endif
-
   /* And finally, enable interrupts */
 
   arm_color_intstack();
@@ -448,14 +436,6 @@ void up_disable_irq(int irq)
           putreg32(regval, regaddr);
         }
     }
-#ifdef CONFIG_STM32_GPIO_IRQ
-  else
-    {
-      /* Maybe it is a (derived) GPIO IRQ */
-
-      stm32_gpioirqdisable(irq);
-    }
-#endif
 
 #if 0 /* Might be useful in early bring-up */
   stm32_dumpnvic("disable", irq);
@@ -495,14 +475,6 @@ void up_enable_irq(int irq)
           putreg32(regval, regaddr);
         }
     }
-#ifdef CONFIG_STM32_GPIO_IRQ
-  else
-    {
-      /* Maybe it is a (derived) GPIO IRQ */
-
-      stm32_gpioirqenable(irq);
-    }
-#endif
 
 #if 0 /* Might be useful in early bring-up */
   stm32_dumpnvic("enable", irq);


### PR DESCRIPTION
## Summary

remove dead, never used STM32 IRQ code

## Impact

remove dead code

## Testing

CI