### PR TITLE
net/local: fix SCM_RIGHTS pointer and memory corruption

### DIFF
--- a/net/local/local_conn.c
+++ b/net/local/local_conn.c
@@ -338,8 +338,7 @@ void local_free(FAR struct local_conn_s *conn)
     {
       if (conn->lc_cfps[i])
         {
-          file_close(conn->lc_cfps[i]);
-          kmm_free(conn->lc_cfps[i]);
+          file_put(conn->lc_cfps[i]);
           conn->lc_cfps[i] = NULL;
         }
     }

--- a/net/local/local_recvmsg.c
+++ b/net/local/local_recvmsg.c
@@ -191,7 +191,7 @@ static void local_recvctl(FAR struct local_conn_s *conn,
     {
       if (peer->lc_cfpcount)
         {
-          memmove(peer->lc_cfps[0], peer->lc_cfps[i],
+          memmove(&peer->lc_cfps[0], &peer->lc_cfps[i],
                   sizeof(FAR void *) * peer->lc_cfpcount);
         }
     }

--- a/net/local/local_sendmsg.c
+++ b/net/local/local_sendmsg.c
@@ -63,6 +63,11 @@ static void local_freectl(FAR struct local_conn_s *conn, int count)
 {
   FAR struct local_conn_s *peer = conn->lc_peer;
 
+  if (peer == NULL)
+    {
+      peer = conn;
+    }
+
   while (count-- > 0)
     {
       file_put(peer->lc_cfps[--peer->lc_cfpcount]);


### PR DESCRIPTION

## Summary

Fix NULL pointer dereference and fix memory corruption by using file_put() instead of file_close() + kmm_free().
Add peer NULL check to local_freectl().


## Impact

Fixes kernel panic and memory corruption after recvmsg(SCM_RIGHTS).

## Testing

Board: qemu_intel64:nsh
Tested with program that exhausts fd table and call recvmsg(SCM_RIGHTS). 