### PR TITLE
stm32f0/l0: Fix HSI48 USB clock recovery configuration.

### DIFF
--- a/arch/arm/src/common/stm32/stm32_hsi48_m0_v1.c
+++ b/arch/arm/src/common/stm32/stm32_hsi48_m0_v1.c
@@ -145,13 +145,13 @@ void stm32_enable_hsi48(enum syncsrc_e syncsrc)
 
   putreg32(regval, STM32_CRS_CFGR);
 
-  /* Set the AUTOTRIMEN bit the CRS_CR register to enables the automatic
-   * hardware adjustment of TRIM bits according to the measured frequency
-   * error between the selected SYNC event.
+  /* Enable the frequency error counter and automatic trimming.  The counter
+   * measures the error against the selected SYNC event; automatic trimming
+   * adjusts the HSI48 TRIM bits from that measurement.
    */
 
   regval  = getreg32(STM32_CRS_CR);
-  regval |= CRS_CR_AUTOTRIMEN;
+  regval |= CRS_CR_CEN | CRS_CR_AUTOTRIMEN;
   putreg32(regval, STM32_CRS_CR);
 }
 

--- a/arch/arm/src/stm32f0/stm32f0_rcc.c
+++ b/arch/arm/src/stm32f0/stm32f0_rcc.c
@@ -248,7 +248,7 @@ static inline void rcc_enableapb1(void)
   regval |= RCC_APB1ENR_CAN1EN;
 #endif
 
-#ifdef CONFIG_STM32_CRS
+#if defined(CONFIG_STM32_CRS) || defined(STM32_USE_HSI48)
   /* Clock recovery system clock enable */
 
   regval |= RCC_APB1ENR_CRSEN;

--- a/arch/arm/src/stm32l0/stm32l0_rcc.c
+++ b/arch/arm/src/stm32l0/stm32l0_rcc.c
@@ -319,7 +319,9 @@ static inline void rcc_enableapb2(void)
 
   regval = getreg32(STM32_RCC_APB2ENR);
 
-#ifdef CONFIG_STM32_SYSCFG
+  /* VREFINT is configured through SYSCFG_CFGR3, so its clock is required */
+
+#if defined(CONFIG_STM32_SYSCFG) || defined(CONFIG_STM32_VREFINT)
   /* SYSCFG clock */
 
   regval |= RCC_APB2ENR_SYSCFGEN;

--- a/arch/arm/src/stm32l0/stm32l0_rcc.c
+++ b/arch/arm/src/stm32l0/stm32l0_rcc.c
@@ -268,7 +268,7 @@ static inline void rcc_enableapb1(void)
   regval |= RCC_APB1ENR_USBEN;
 #endif
 
-#ifdef CONFIG_STM32_CRS
+#if defined(CONFIG_STM32_CRS) || defined(STM32_USE_HSI48)
   /* Clock recovery system clock enable */
 
   regval |= RCC_APB1ENR_CRSEN;

--- a/arch/arm/src/stm32l0/stm32l0_rcc.c
+++ b/arch/arm/src/stm32l0/stm32l0_rcc.c
@@ -744,6 +744,8 @@ static void vrefint_enable(void)
   regval |= SYSCFG_CFGR3_ENBUFVREFINTHSI48;
 #endif
 
+  putreg32(regval, STM32_SYSCFG_CFGR3);
+
   /* Wait for VREFINT ready */
 
   while ((getreg32(STM32_SYSCFG_CFGR3) & SYSCFG_CFGR3_VREFINTRDYF) == 0);

--- a/boards/arm/stm32l0/nucleo-l073rz/include/board.h
+++ b/boards/arm/stm32l0/nucleo-l073rz/include/board.h
@@ -91,7 +91,7 @@
 #if defined(CONFIG_STM32_USB) || defined(CONFIG_STM32_RNG)
 #  define STM32_USE_CLK48       1
 #  define STM32_CLK48_SEL       RCC_CCIPR_CLK48SEL_HSI48
-#  define STM32_HSI48_SYNCSRC   SYNCSRC_NONE
+#  define STM32_HSI48_SYNCSRC   SYNCSRC_USB
 #endif
 
 /* TODO: timers */


### PR DESCRIPTION
## Summary

Fix HSI48 and clock recovery system configuration required for crystal-less USB
device operation on STM32F0 and STM32L0.

The fixes:

- Enable the CRS peripheral clock whenever HSI48 is in use, while retaining
  support for boards that explicitly select CONFIG_STM32_CRS.
- Enable the CRS frequency error counter together with automatic trimming.
- Enable the SYSCFG clock when VREFINT is enabled on STM32L0.
- Write SYSCFG_CFGR3 after setting ENBUFVREFINTHSI48; previously the HSI48
  voltage-reference bit was updated only in a local variable.
- Select USB SOF as the CRS synchronization source for NUCLEO-L073RZ.

Before these changes, USB device registers could appear correctly configured,
and the host could detect the D+ pull-up, but the 48 MHz clock was not usable:
the controller did not latch USB reset in USB_ISTR and never raised its USB
interrupt.

## Impact

- New feature added: NO. Bug fixes only.
- User adaptation required: NO.
- Build impact: NO.
- Hardware impact: YES. STM32F0, STM32L0, and the shared HSI48 M0 helper,
  which also supports STM32U0.
- Documentation update required: NO. Board configuration documentation is
  included with the corresponding board-support PRs.
- Security impact: NO.
- Compatibility impact: Existing HSI48 users retain their selected behavior;
  the CRS is now correctly enabled and able to trim the oscillator.

## Testing

Build host:
- Linux 6.18.33.2-microsoft-standard-WSL2
- arm-none-eabi-gcc 13.2.1

Hardware:
- ST NUCLEO-F072RB
- ST NUCLEO-L073RZ

Before:
- On NUCLEO-L073RZ, SYSCFG_CFGR3 read 0x00000000 because SYSCFG was
  unclocked. USB_ISTR never latched host reset, and USB IRQ 47 never fired.
- Both board USB-device configurations failed enumeration when tested from
  pristine apache/master plus board support.

After:
- NUCLEO-L073RZ: SYSCFG_CFGR3 enables VREFINT and the HSI48 reference;
  CRS_CR enables CEN and AUTOTRIMEN; NSH and USB CDC/ACM enumeration pass.
- NUCLEO-F072RB: NSH and USB CDC/ACM enumeration pass.
- Both results were reproduced from a clean upstream NuttX plus upstream
  NuttX Apps checkout after the signed histories were rebuilt.

Validation:
- ./tools/checkpatch.sh -g apache/master...usb/hsi48-crs-standalone
- File-mode checkpatch passed for all changed files.
- Real hardware build, flash, NSH, and enumeration tests passed on both boards.

## PR verification Self-Check

- [x] This PR introduces one functional area: HSI48/CRS clock recovery fixes.
- [x] All commits include a description, Signed-off-by, and Assisted-by trailers.
- [x] Source passes checkpatch.
- [x] Real hardware build and runtime testing was completed.
- [x] This PR is ready for review.