### PR TITLE
sched/clock: fix stale CLOCK_MONOTONIC on SCHED_TICKLESS

### DIFF
--- a/sched/clock/clock_gettime.c
+++ b/sched/clock/clock_gettime.c
@@ -97,18 +97,11 @@ int nxclock_gettime(clockid_t clock_id, FAR struct timespec *tp)
       return -EINVAL;
     }
 
-  if (clock_id == CLOCK_MONOTONIC)
+  if (clock_id == CLOCK_MONOTONIC || clock_id == CLOCK_BOOTTIME)
     {
-      /* The the time elapsed since the timer was initialized at power on
-       * reset, excluding the time that the system is suspended.
-       */
-
-      clock_ticks2time(tp, clock_get_sched_ticks());
-    }
-  else if (clock_id == CLOCK_BOOTTIME)
-    {
-      /* The the time elapsed since the timer was initialized at power on
-       * reset, including the time that the system is suspended..
+      /* The time elapsed since the timer was initialized at power on
+       * reset.  Must be a live read: the sched tick counter is frozen
+       * while no timeout is armed on SCHED_TICKLESS.
        */
 
       clock_systime_timespec(tp);


### PR DESCRIPTION
## Summary

clock_gettime(CLOCK_MONOTONIC) reads g_system_ticks, which is only refreshed when a timer expiration is processed.  On SCHED_TICKLESS an idle system has no timeout armed, so the clock returns 0 before the first expiration and a frozen value afterwards.
    
This regressed in commit c7b6442974, which switched CLOCK_MONOTONIC to the sched tick counter to exclude suspended time. Excluding suspend time needs explicit accounting maintained by PM code, the tick counter cannot provide it on tickless.
    
Restore the live read. On non-tickless builds clock_systime_timespec() falls back to the same tick counter, so behavior there is unchanged.
    
## Impact

fix issue from https://github.com/apache/nuttx/pull/17199#discussion_r3806567534

## Testing

verified on qemu-intel64, nrf52840-dk and rv-virt.

CPython 3.13 REPL on `qemu-intel64:python` (SCHED_TICKLESS, TSC deadline timer), system idle at the prompt between reads:

1. without this fix:
  
  ```python
  >>> import time
  >>> time.monotonic()                          # ~5 s after boot
  0.0
  >>> time.monotonic()                          # ~5 s later
  0.0
  >>> time.clock_gettime(time.CLOCK_BOOTTIME)   # wall clock is fine
  15.31824313
  ``` 
  
2. with this fix:
  
  ```python
  >>> import time
  >>> time.monotonic()                                                                                                                                                                                                                                                           
  10.226251524                                                                                                                                                                                                                                                                   
  >>> time.monotonic()                                                                                                                                                                                                                                                           
  15.279083686                                                                                                                                                                                                                                                                   
  >>> time.clock_gettime(time.CLOCK_BOOTTIME)                                                                                                                                                                                                                                    
  15.332810769                                                                                                                                                                                                                                                                   
  ``` 