### PR TITLE
arm/stm32: Decode saved M0 USB setup requests.

### DIFF
--- a/arch/arm/src/common/stm32/stm32_usbdev_m0_v1.c
+++ b/arch/arm/src/common/stm32/stm32_usbdev_m0_v1.c
@@ -1685,20 +1685,13 @@ static void stm32_ep0setup(struct stm32_usbdev_s *priv)
       stm32_copyfrompma((uint8_t *)&priv->ctrl, stm32_geteprxaddr(EP0),
                         USB_SIZEOF_CTRLREQ);
 
-      /* And extract the little-endian 16-bit values to host order */
+      /* Is this an OUT setup request with a data phase? */
 
-      value.w = GETUINT16(priv->ctrl.value);
-      index.w = GETUINT16(priv->ctrl.index);
-      len.w   = GETUINT16(priv->ctrl.len);
-
-      uinfo("SETUP: type=%02x req=%02x value=%04x index=%04x len=%04x\n",
-            priv->ctrl.type, priv->ctrl.req, value.w, index.w, len.w);
-
-      /* Is this an setup with OUT and data of length > 0 */
-
-      if (USB_REQ_ISOUT(priv->ctrl.type) && len.w > 0)
+      if (USB_REQ_ISOUT(priv->ctrl.type) &&
+          GETUINT16(priv->ctrl.len) > 0)
         {
-          usbtrace(TRACE_INTDECODE(STM32_TRACEINTID_EP0SETUPOUT), len.w);
+          usbtrace(TRACE_INTDECODE(STM32_TRACEINTID_EP0SETUPOUT),
+                   GETUINT16(priv->ctrl.len));
 
           /* At this point priv->ctrl is the setup packet. */
 
@@ -1710,6 +1703,17 @@ static void stm32_ep0setup(struct stm32_usbdev_s *priv)
           priv->ep0state = EP0STATE_SETUP_READY;
         }
     }
+
+  /* Extract the little-endian 16-bit values from the saved SETUP request.
+   * This function may be called again after receiving an OUT data phase.
+   */
+
+  value.w = GETUINT16(priv->ctrl.value);
+  index.w = GETUINT16(priv->ctrl.index);
+  len.w   = GETUINT16(priv->ctrl.len);
+
+  uinfo("SETUP: type=%02x req=%02x value=%04x index=%04x len=%04x\n",
+        priv->ctrl.type, priv->ctrl.req, value.w, index.w, len.w);
 
   /* Dispatch any non-standard requests */
 


### PR DESCRIPTION
## Summary

- Decode the saved USB SETUP request fields whenever `stm32_ep0setup()` processes the request.
- `stm32_ep0setup()` may be entered again after receiving an OUT data phase. Previously, the local `value`, `index`, and `len` fields were only initialized during the first invocation.
- This could use uninitialized values when completing an OUT control transfer.
- Clang detects this path and fails builds using `-Werror=maybe-uninitialized`.
- This fix is required by apache/nuttx#19910.

## Impact

- Is new functionality added? NO.
- Is existing functionality changed? YES. STM32 M0 USB control requests with an OUT data phase consistently decode their saved SETUP request.
- Impact on user? NO.
- Impact on build? YES. STM32 M0 USB configurations now build successfully with Clang when maybe-uninitialized warnings are treated as errors.
- Impact on hardware? Limited to the common STM32 M0 USB device driver.
- Impact on documentation? NO.
- Impact on security? NO.
- Impact on compatibility? NO.

## Testing

I confirm that the changes were verified locally and work as intended.

- Target: STM32L0, `nucleo-l073rz:usb-cdc`
- GNU Arm Embedded GCC build: PASS
- Clang build using `ghcr.io/apache/nuttx/apache-nuttx-ci-linux`: PASS
- `checkpatch.sh`, codespell, and cvt2utf: PASS
- Hardware programming and boot: PASS
- NSH operation and USB functionality: PASS

Before this change, the Clang build failed with:

```text
error: 'value.w' may be used uninitialized
error: 'len.w' may be used uninitialized
cc1: all warnings being treated as errors
