### PR TITLE
arch/arm/stm32h5: SPI higher non-DMA throughput, enable SPI DMA support

### DIFF
--- a/arch/arm/src/stm32h5/stm32.h
+++ b/arch/arm/src/stm32h5/stm32.h
@@ -47,6 +47,7 @@
 #include "stm32_lowputc.h"
 #include "stm32_pwr.h"
 #include "stm32_rcc.h"
+#include "stm32_spi.h"
 #include "stm32_tim.h"
 #include "stm32_uart.h"
 #include "stm32_usbfs.h"

--- a/arch/arm/src/stm32h5/stm32_spi.c
+++ b/arch/arm/src/stm32h5/stm32_spi.c
@@ -284,6 +284,7 @@ struct stm32_spidev_s
   uint32_t         spiclock;     /* Clocking for the SPI module */
   uint8_t          spiirq;       /* SPI IRQ number */
 #ifdef CONFIG_STM32_SPI_DMA
+  bool             usedma;       /* Whether DMA shall be used for this SPI instance */
   volatile uint8_t rxresult;     /* Result of the RX DMA */
   volatile uint8_t txresult;     /* Result of the RX DMA */
 #ifdef CONFIG_SPI_TRIGGER
@@ -372,9 +373,14 @@ static int         spi_hwfeatures(struct spi_dev_s *dev,
                                   spi_hwfeatures_t features);
 #endif
 static uint32_t    spi_send(struct spi_dev_s *dev, uint32_t wd);
-static void        spi_exchange(struct spi_dev_s *dev,
-                                const void *txbuffer, void *rxbuffer,
-                                size_t nwords);
+static void        spi_exchange_nodma(struct spi_dev_s *dev,
+                                      const void *txbuffer, void *rxbuffer,
+                                      size_t nwords);
+#ifdef CONFIG_STM32_SPI_DMA
+static void        spi_exchange_dma(struct spi_dev_s *dev,
+                                    const void *txbuffer, void *rxbuffer,
+                                    size_t nwords);
+#endif
 #ifdef CONFIG_SPI_TRIGGER
 static int         spi_trigger(struct spi_dev_s *dev);
 #endif
@@ -420,7 +426,11 @@ static const struct spi_ops_s g_sp1iops =
 #endif
   .send              = spi_send,
 #ifdef CONFIG_SPI_EXCHANGE
-  .exchange          = spi_exchange,
+#  ifdef CONFIG_STM32_SPI1_DMA
+  .exchange          = spi_exchange_dma,
+#  else
+  .exchange          = spi_exchange_nodma,
+#  endif
 #else
   .sndblock          = spi_sndblock,
   .recvblock         = spi_recvblock,
@@ -450,6 +460,7 @@ static struct stm32_spidev_s g_spi1dev =
   .spiclock = STM32_SPI1_FREQUENCY,
   .spiirq   = STM32_IRQ_SPI1,
 #ifdef CONFIG_STM32_SPI1_DMA
+  .usedma   = true,
   .rxreq    = GPDMA_REQ_SPI1_RX,
   .txreq    = GPDMA_REQ_SPI1_TX,
 #  if defined(SPI1_DMABUFSIZE_ADJUSTED)
@@ -493,7 +504,11 @@ static const struct spi_ops_s g_sp2iops =
 #endif
   .send              = spi_send,
 #ifdef CONFIG_SPI_EXCHANGE
-  .exchange          = spi_exchange,
+#  ifdef CONFIG_STM32_SPI2_DMA
+  .exchange          = spi_exchange_dma,
+#  else
+  .exchange          = spi_exchange_nodma,
+#  endif
 #else
   .sndblock          = spi_sndblock,
   .recvblock         = spi_recvblock,
@@ -523,6 +538,7 @@ static struct stm32_spidev_s g_spi2dev =
   .spiclock = STM32_SPI2_FREQUENCY,
   .spiirq   = STM32_IRQ_SPI2,
 #ifdef CONFIG_STM32_SPI2_DMA
+  .usedma   = true,
   .rxreq    = GPDMA_REQ_SPI2_RX,
   .txreq    = GPDMA_REQ_SPI2_TX,
 #  if defined(SPI2_DMABUFSIZE_ADJUSTED)
@@ -566,7 +582,11 @@ static const struct spi_ops_s g_sp3iops =
 #endif
   .send              = spi_send,
 #ifdef CONFIG_SPI_EXCHANGE
-  .exchange          = spi_exchange,
+#  ifdef CONFIG_STM32_SPI3_DMA
+  .exchange          = spi_exchange_dma,
+#  else
+  .exchange          = spi_exchange_nodma,
+#  endif
 #else
   .sndblock          = spi_sndblock,
   .recvblock         = spi_recvblock,
@@ -596,6 +616,7 @@ static struct stm32_spidev_s g_spi3dev =
   .spiclock = STM32_SPI3_FREQUENCY,
   .spiirq   = STM32_IRQ_SPI3,
 #ifdef CONFIG_STM32_SPI3_DMA
+  .usedma   = true,
   .rxreq    = GPDMA_REQ_SPI3_RX,
   .txreq    = GPDMA_REQ_SPI3_TX,
 #  if defined(SPI3_DMABUFSIZE_ADJUSTED)
@@ -639,7 +660,11 @@ static const struct spi_ops_s g_sp4iops =
 #endif
   .send              = spi_send,
 #ifdef CONFIG_SPI_EXCHANGE
-  .exchange          = spi_exchange,
+#  ifdef CONFIG_STM32_SPI4_DMA
+  .exchange          = spi_exchange_dma,
+#  else
+  .exchange          = spi_exchange_nodma,
+#  endif
 #else
   .sndblock          = spi_sndblock,
   .recvblock         = spi_recvblock,
@@ -669,6 +694,7 @@ static struct stm32_spidev_s g_spi4dev =
   .spiclock = STM32_SPI4_FREQUENCY,
   .spiirq   = STM32_IRQ_SPI4,
 #ifdef CONFIG_STM32_SPI4_DMA
+  .usedma   = true,
   .rxreq    = GPDMA_REQ_SPI4_RX,
   .txreq    = GPDMA_REQ_SPI4_TX,
 #  if defined(SPI4_DMABUFSIZE_ADJUSTED)
@@ -712,7 +738,11 @@ static const struct spi_ops_s g_sp5iops =
 #endif
   .send              = spi_send,
 #ifdef CONFIG_SPI_EXCHANGE
-  .exchange          = spi_exchange,
+#  ifdef CONFIG_STM32_SPI5_DMA
+  .exchange          = spi_exchange_dma,
+#  else
+  .exchange          = spi_exchange_nodma,
+#  endif
 #else
   .sndblock          = spi_sndblock,
   .recvblock         = spi_recvblock,
@@ -742,6 +772,7 @@ static struct stm32_spidev_s g_spi5dev =
   .spiclock = STM32_SPI5_FREQUENCY,
   .spiirq   = STM32_IRQ_SPI5,
 #ifdef CONFIG_STM32_SPI5_DMA
+  .usedma   = true,
   .rxreq    = GPDMA_REQ_SPI5_RX,
   .txreq    = GPDMA_REQ_SPI5_TX,
 #  if defined(SPI5_DMABUFSIZE_ADJUSTED)
@@ -785,7 +816,11 @@ static const struct spi_ops_s g_sp6iops =
 #endif
   .send              = spi_send,
 #ifdef CONFIG_SPI_EXCHANGE
-  .exchange          = spi_exchange,
+#  ifdef CONFIG_STM32_SPI6_DMA
+  .exchange          = spi_exchange_dma,
+#  else
+  .exchange          = spi_exchange_nodma,
+#  endif
 #else
   .sndblock          = spi_sndblock,
   .recvblock         = spi_recvblock,
@@ -816,6 +851,7 @@ static struct stm32_spidev_s g_spi6dev =
   .spiclock = STM32_SPI6_FREQUENCY,
   .spiirq   = STM32_IRQ_SPI6,
 #ifdef CONFIG_STM32_SPI6_DMA
+  .usedma   = true,
   .rxreq    = GPDMA_REQ_SPI6_RX,
   .txreq    = GPDMA_REQ_SPI6_TX,
 #  if defined(SPI6_DMABUFSIZE_ADJUSTED)
@@ -1160,8 +1196,11 @@ static int spi_interrupt(int irq, void *context, void *arg)
 
       /* Set result and release wait semaphore */
 #ifdef CONFIG_STM32_SPI_DMA
-      priv->txresult = 0x80;
-      nxsem_post(&priv->txsem);
+      if (priv->usedma)
+        {
+          priv->txresult = 0x80;
+          nxsem_post(&priv->txsem);
+        }
 #endif
     }
 
@@ -1891,6 +1930,7 @@ static int spi_hwfeatures(struct spi_dev_s *dev,
 #endif
 
 #ifdef CONFIG_SPI_TRIGGER
+#  ifdef CONFIG_STM32_SPI_DMA
 /* Turn deferred trigger mode on or off.  Only applicable for DMA mode. If a
  * transfer is deferred then the DMA will not actually be triggered until a
  * subsequent call to SPI_TRIGGER to set it off. The thread will be waiting
@@ -1898,6 +1938,8 @@ static int spi_hwfeatures(struct spi_dev_s *dev,
  */
 
   priv->defertrig = ((features & HWFEAT_TRIGGER) != 0);
+#  endif
+
   features &= ~HWFEAT_TRIGGER;
 #endif
 
@@ -1987,7 +2029,7 @@ static uint32_t spi_send(struct spi_dev_s *dev, uint32_t wd)
 }
 
 /****************************************************************************
- * Name: spi_exchange (no DMA).  aka spi_exchange_nodma
+ * Name: spi_exchange_nodma
  *
  * Description:
  *   Exchange a block of data on SPI without using DMA
@@ -2007,16 +2049,9 @@ static uint32_t spi_send(struct spi_dev_s *dev, uint32_t wd)
  *
  ****************************************************************************/
 
-#if !defined(CONFIG_STM32_SPI_DMA) || defined(CONFIG_STM32_DMACAPABLE) || \
-     defined(CONFIG_STM32_SPI_DMATHRESHOLD)
-#if !defined(CONFIG_STM32_SPI_DMA)
-static void spi_exchange(struct spi_dev_s *dev, const void *txbuffer,
-                         void *rxbuffer, size_t nwords)
-#else
 static void spi_exchange_nodma(struct spi_dev_s *dev,
                                const void *txbuffer, void *rxbuffer,
                                size_t nwords)
-#endif
 {
   struct stm32_spidev_s *priv = (struct stm32_spidev_s *)dev;
   DEBUGASSERT(priv && priv->spibase);
@@ -2167,10 +2202,6 @@ static void spi_exchange_nodma(struct spi_dev_s *dev,
   while ((spi_getreg(priv, STM32_SPI_SR_OFFSET) & SPI_SR_SUSP) == 0);
 }
 
-#endif /* !CONFIG_STM32_SPI_DMA || CONFIG_STM32_DMACAPABLE ||
-        * CONFIG_STM32_SPI_DMATHRESHOLD
-        */
-
 /****************************************************************************
  * Name: spi_exchange (with DMA capability)
  *
@@ -2193,8 +2224,8 @@ static void spi_exchange_nodma(struct spi_dev_s *dev,
  ****************************************************************************/
 
 #ifdef CONFIG_STM32_SPI_DMA
-static void spi_exchange(struct spi_dev_s *dev, const void *txbuffer,
-                         void *rxbuffer, size_t nwords)
+static void spi_exchange_dma(struct spi_dev_s *dev, const void *txbuffer,
+                             void *rxbuffer, size_t nwords)
 {
   struct stm32_spidev_s *priv = (struct stm32_spidev_s *)dev;
   struct stm32_gpdma_cfg_s rxdmacfg;
@@ -2356,6 +2387,7 @@ static void spi_exchange(struct spi_dev_s *dev, const void *txbuffer,
           spi_dmarxstart(priv);
           spi_dmatxstart(priv);
           spi_enable(priv, true);
+          spi_modifyreg(priv, STM32_SPI_IFCR_OFFSET, 0, SPI_IFCR_SUSPC);
           spi_modifyreg(priv, STM32_SPI_CR1_OFFSET, 0, SPI_CR1_CSTART);
         }
       else
@@ -2370,6 +2402,7 @@ static void spi_exchange(struct spi_dev_s *dev, const void *txbuffer,
       spi_dmarxstart(priv);
       spi_dmatxstart(priv);
       spi_enable(priv, true);
+      spi_modifyreg(priv, STM32_SPI_IFCR_OFFSET, 0, SPI_IFCR_SUSPC);
       spi_modifyreg(priv, STM32_SPI_CR1_OFFSET, 0, SPI_CR1_CSTART);
 #endif
 
@@ -2474,8 +2507,21 @@ static void spi_sndblock(struct spi_dev_s *dev,
                          const void *txbuffer,
                          size_t nwords)
 {
+#ifdef CONFIG_STM32_SPI_DMA
+  struct stm32_spidev_s *priv = (struct stm32_spidev_s *)dev;
+#endif
+
   spiinfo("txbuffer=%p nwords=%d\n", txbuffer, nwords);
-  return spi_exchange(dev, txbuffer, NULL, nwords);
+#ifdef CONFIG_STM32_SPI_DMA
+  if (priv->usedma)
+    {
+      return spi_exchange_dma(dev, txbuffer, NULL, nwords);
+    }
+  else
+#endif
+    {
+      return spi_exchange_nodma(dev, txbuffer, NULL, nwords);
+    }
 }
 #endif
 
@@ -2504,8 +2550,21 @@ static void spi_recvblock(struct spi_dev_s *dev,
                           void *rxbuffer,
                           size_t nwords)
 {
+#ifdef CONFIG_STM32_SPI_DMA
+  struct stm32_spidev_s *priv = (struct stm32_spidev_s *)dev;
+#endif
+
   spiinfo("rxbuffer=%p nwords=%d\n", rxbuffer, nwords);
-  return spi_exchange(dev, NULL, rxbuffer, nwords);
+#ifdef CONFIG_STM32_SPI_DMA
+  if (priv->usedma)
+    {
+      return spi_exchange_dma(dev, NULL, rxbuffer, nwords);
+    }
+  else
+#endif
+    {
+      return spi_exchange_nodma(dev, NULL, rxbuffer, nwords);
+    }
 }
 #endif
 
@@ -2675,18 +2734,21 @@ static void spi_bus_initialize(struct stm32_spidev_s *priv)
 
   priv->rxdma = NULL;
   priv->txdma = NULL;
-  if (priv->config != SIMPLEX_TX)
+  if (priv->usedma)
     {
-      priv->rxdma = stm32_dmachannel(GPDMA_TTYPE_P2M);
-      DEBUGASSERT(priv->rxdma);
-      spi_modifyreg(priv, STM32_SPI_CFG1_OFFSET, 0, SPI_CFG1_RXDMAEN);
-    }
+      if (priv->config != SIMPLEX_TX)
+        {
+          priv->rxdma = stm32_dmachannel(GPDMA_TTYPE_P2M);
+          DEBUGASSERT(priv->rxdma);
+          spi_modifyreg(priv, STM32_SPI_CFG1_OFFSET, 0, SPI_CFG1_RXDMAEN);
+        }
 
-  if (priv->config != SIMPLEX_RX)
-    {
-      priv->txdma = stm32_dmachannel(GPDMA_TTYPE_M2P);
-      DEBUGASSERT(priv->txdma);
-      spi_modifyreg(priv, STM32_SPI_CFG1_OFFSET, 0, SPI_CFG1_TXDMAEN);
+      if (priv->config != SIMPLEX_RX)
+        {
+          priv->txdma = stm32_dmachannel(GPDMA_TTYPE_M2P);
+          DEBUGASSERT(priv->txdma);
+          spi_modifyreg(priv, STM32_SPI_CFG1_OFFSET, 0, SPI_CFG1_TXDMAEN);
+        }
     }
 #endif
 

--- a/arch/arm/src/stm32h5/stm32_spi.c
+++ b/arch/arm/src/stm32h5/stm32_spi.c
@@ -303,6 +303,7 @@ struct stm32_spidev_s
   uint32_t         actual;       /* Actual clock frequency */
   int8_t           nbits;        /* Width of word in bits */
   uint8_t          mode;         /* Mode 0,1,2,3 */
+  uint8_t          depth;        /* Depth of RX/TX fifo in bytes */
 #ifdef CONFIG_PM
   struct pm_callback_s pm_cb;    /* PM callbacks */
 #endif
@@ -455,6 +456,7 @@ static struct stm32_spidev_s g_spi1dev =
   .txsem    = SEM_INITIALIZER(0),
 #endif
   .lock     = NXMUTEX_INITIALIZER,
+  .depth    = 16,
 #ifdef CONFIG_PM
   .pm_cb.prepare = spi_pm_prepare,
 #endif
@@ -527,6 +529,7 @@ static struct stm32_spidev_s g_spi2dev =
   .txsem    = SEM_INITIALIZER(0),
 #endif
   .lock     = NXMUTEX_INITIALIZER,
+  .depth    = 16,
 #ifdef CONFIG_PM
   .pm_cb.prepare = spi_pm_prepare,
 #endif
@@ -599,6 +602,7 @@ static struct stm32_spidev_s g_spi3dev =
   .txsem    = SEM_INITIALIZER(0),
 #endif
   .lock     = NXMUTEX_INITIALIZER,
+  .depth    = 16,
 #ifdef CONFIG_PM
   .pm_cb.prepare = spi_pm_prepare,
 #endif
@@ -671,6 +675,7 @@ static struct stm32_spidev_s g_spi4dev =
   .txsem    = SEM_INITIALIZER(0),
 #endif
   .lock     = NXMUTEX_INITIALIZER,
+  .depth    = 8,
 #ifdef CONFIG_PM
   .pm_cb.prepare = spi_pm_prepare,
 #endif
@@ -743,6 +748,7 @@ static struct stm32_spidev_s g_spi5dev =
   .txsem    = SEM_INITIALIZER(0),
 #endif
   .lock     = NXMUTEX_INITIALIZER,
+  .depth    = 8,
 #ifdef CONFIG_PM
   .pm_cb.prepare = spi_pm_prepare,
 #endif
@@ -816,6 +822,7 @@ static struct stm32_spidev_s g_spi6dev =
   .txsem    = SEM_INITIALIZER(0),
 #endif
   .lock     = NXMUTEX_INITIALIZER,
+  .depth    = 8,
 #ifdef CONFIG_PM
   .pm_cb.prepare = spi_pm_prepare,
 #endif
@@ -2012,6 +2019,17 @@ static void spi_exchange_nodma(struct spi_dev_s *dev,
   spi_modifyreg(priv, STM32_SPI_CFG1_OFFSET, SPI_CFG1_RXDMAEN |
                                              SPI_CFG1_TXDMAEN, 0);
 
+  /* Clear suspend flag */
+
+  spi_modifyreg(priv, STM32_SPI_IFCR_OFFSET, 0, SPI_IFCR_SUSPC);
+
+  /* Master transfer start */
+
+  if (priv->config != SIMPLEX_RX)
+    {
+      spi_modifyreg(priv, STM32_SPI_CR1_OFFSET, 0, SPI_CR1_CSTART);
+    }
+
   /* 8- or 16-bit mode? */
 
   if (priv->nbits > 8)
@@ -2021,8 +2039,9 @@ static void spi_exchange_nodma(struct spi_dev_s *dev,
       const uint16_t *src  = (const uint16_t *)txbuffer;
             uint16_t *dest = (uint16_t *)rxbuffer;
             uint16_t  word;
-
-      while (nwords-- > 0)
+            size_t n_tx_words = 0;
+            size_t n_rx_words = 0;
+      while (n_tx_words < nwords)
         {
           /* Get the next word to write.  Is there a source buffer? */
 
@@ -2037,7 +2056,33 @@ static void spi_exchange_nodma(struct spi_dev_s *dev,
 
           /* Exchange one word */
 
-          word = (uint16_t)spi_send(dev, (uint32_t)word);
+          spi_writeword(priv, (uint32_t)word);
+          n_tx_words++;
+
+          /* Only read after we have preloaded the TX Fifo so we can TX/RX
+           * at the same time. This is important at high SPI baud rates
+           */
+
+          if (n_tx_words - n_rx_words == (priv->depth / 2))
+            {
+              word = (uint16_t)spi_readword(priv);
+              n_rx_words++;
+
+              /* Is there a buffer to receive the return value? */
+
+              if (dest)
+                {
+                  *dest++ = word;
+                }
+            }
+        }
+
+      /* Read the last of the data */
+
+      while (n_rx_words < nwords)
+        {
+          word = (uint16_t)spi_readword(priv);
+          n_rx_words++;
 
           /* Is there a buffer to receive the return value? */
 
@@ -2049,13 +2094,13 @@ static void spi_exchange_nodma(struct spi_dev_s *dev,
     }
   else
     {
-      /* 8-bit mode */
-
       const uint8_t *src  = (const uint8_t *)txbuffer;
-            uint8_t *dest = (uint8_t *)rxbuffer;
-            uint8_t  word;
+      uint8_t *dest = (uint8_t *)rxbuffer;
+      uint8_t  word;
+      size_t n_tx_words = 0;
+      size_t n_rx_words = 0;
 
-      while (nwords-- > 0)
+      while (n_tx_words < nwords)
         {
           /* Get the next word to write.  Is there a source buffer? */
 
@@ -2070,7 +2115,33 @@ static void spi_exchange_nodma(struct spi_dev_s *dev,
 
           /* Exchange one word */
 
-          word = (uint8_t)spi_send(dev, (uint32_t)word);
+          spi_writebyte(priv, word);
+          n_tx_words++;
+
+          /* Only read after we have preloaded the TX Fifo so we can TX/RX
+           * at the same time. This is important at high SPI baud rates
+           */
+
+          if (n_tx_words - n_rx_words == priv->depth)
+            {
+              word = spi_readbyte(priv);
+              n_rx_words++;
+
+              /* Is there a buffer to receive the return value? */
+
+              if (dest)
+                {
+                  *dest++ = word;
+                }
+            }
+        }
+
+      /* Read the last of the data */
+
+      while (n_rx_words < nwords)
+        {
+          word = spi_readbyte(priv);
+          n_rx_words++;
 
           /* Is there a buffer to receive the return value? */
 
@@ -2080,6 +2151,11 @@ static void spi_exchange_nodma(struct spi_dev_s *dev,
             }
         }
     }
+
+  /* Suspend */
+
+  spi_modifyreg(priv, STM32_SPI_CR1_OFFSET, 0, SPI_CR1_CSUSP);
+  while ((spi_getreg(priv, STM32_SPI_SR_OFFSET) & SPI_SR_SUSP) == 0);
 }
 
 #endif /* !CONFIG_STM32_SPI_DMA || CONFIG_STM32_DMACAPABLE ||

--- a/arch/arm/src/stm32h5/stm32_spi.c
+++ b/arch/arm/src/stm32h5/stm32_spi.c
@@ -109,34 +109,39 @@
 
 #  if defined(CONFIG_SPI_DMAPRIO)
 #    define SPI_DMA_PRIO  CONFIG_SPI_DMAPRIO
-#  elif defined(DMA_SCR_PRIMED)
-#    define SPI_DMA_PRIO  DMA_SCR_PRILO
+#  elif defined(GPDMACFG_PRIO_LM)
+#    define SPI_DMA_PRIO  GPDMACFG_PRIO_LL
 #  else
 #    error "Unknown STM32 DMA"
 #  endif
 
-#  if (SPI_DMA_PRIO & ~DMA_SCR_PL_MASK) != 0
+#  if SPI_DMA_PRIO != GPDMACFG_PRIO_LL && SPI_DMA_PRIO != GPDMACFG_PRIO_LM \
+      && SPI_DMA_PRIO != GPMDACFG_PRIO_LH && SPI_DMA_PRIO != GPDMACFG_PRIO_H
 #    error "Illegal value for CONFIG_SPI_DMAPRIO"
 #  endif
 
-/* DMA channel configuration */
-#  define SPI_RXDMA16_CONFIG        (SPI_DMA_PRIO|DMA_SCR_MSIZE_16BITS|DMA_SCR_PSIZE_16BITS|DMA_SCR_MINC|DMA_SCR_DIR_P2M)
-#  define SPI_RXDMA8_CONFIG         (SPI_DMA_PRIO|DMA_SCR_MSIZE_8BITS |DMA_SCR_PSIZE_8BITS |DMA_SCR_MINC|DMA_SCR_DIR_P2M)
-#  define SPI_RXDMA16NULL_CONFIG    (SPI_DMA_PRIO|DMA_SCR_MSIZE_8BITS |DMA_SCR_PSIZE_16BITS             |DMA_SCR_DIR_P2M)
-#  define SPI_RXDMA8NULL_CONFIG     (SPI_DMA_PRIO|DMA_SCR_MSIZE_8BITS |DMA_SCR_PSIZE_8BITS              |DMA_SCR_DIR_P2M)
-#  define SPI_TXDMA16_CONFIG        (SPI_DMA_PRIO|DMA_SCR_MSIZE_16BITS|DMA_SCR_PSIZE_16BITS|DMA_SCR_MINC|DMA_SCR_DIR_M2P)
-#  define SPI_TXDMA8_CONFIG         (SPI_DMA_PRIO|DMA_SCR_MSIZE_8BITS |DMA_SCR_PSIZE_8BITS |DMA_SCR_MINC|DMA_SCR_DIR_M2P)
-#  define SPI_TXDMA16NULL_CONFIG    (SPI_DMA_PRIO|DMA_SCR_MSIZE_8BITS |DMA_SCR_PSIZE_16BITS             |DMA_SCR_DIR_M2P)
-#  define SPI_TXDMA8NULL_CONFIG     (SPI_DMA_PRIO|DMA_SCR_MSIZE_8BITS |DMA_SCR_PSIZE_8BITS              |DMA_SCR_DIR_M2P)
+/* DMA channel configuration.
+ * For RX, memory is the destination (DDW)
+ * and peripheral is the source (SDW).
+ * For TX, it's the opposite.
+ */
+#  define SPI_RXDMA16_CONFIG        (GPDMA_CXTR1_DDW_LOG2_HW  |GPDMA_CXTR1_SDW_LOG2_HW  |GPDMA_CXTR1_DINC)
+#  define SPI_RXDMA8_CONFIG         (GPDMA_CXTR1_DDW_LOG2_BYTE|GPDMA_CXTR1_SDW_LOG2_BYTE|GPDMA_CXTR1_DINC)
+#  define SPI_RXDMA16NULL_CONFIG    (GPDMA_CXTR1_DDW_LOG2_BYTE|GPDMA_CXTR1_SDW_LOG2_HW                   )
+#  define SPI_RXDMA8NULL_CONFIG     (GPDMA_CXTR1_DDW_LOG2_BYTE|GPDMA_CXTR1_SDW_LOG2_BYTE                 )
+#  define SPI_TXDMA16_CONFIG        (GPDMA_CXTR1_DDW_LOG2_HW  |GPDMA_CXTR1_SDW_LOG2_HW  |GPDMA_CXTR1_SINC)
+#  define SPI_TXDMA8_CONFIG         (GPDMA_CXTR1_DDW_LOG2_BYTE|GPDMA_CXTR1_SDW_LOG2_BYTE|GPDMA_CXTR1_SINC)
+#  define SPI_TXDMA16NULL_CONFIG    (GPDMA_CXTR1_DDW_LOG2_HW  |GPDMA_CXTR1_SDW_LOG2_BYTE                 )
+#  define SPI_TXDMA8NULL_CONFIG     (GPDMA_CXTR1_DDW_LOG2_BYTE|GPDMA_CXTR1_SDW_LOG2_BYTE                 )
 
-/* If built with CONFIG_ARMV7M_DCACHE Buffers need to be aligned and
- * multiples of ARMV7M_DCACHE_LINESIZE
+/* If built with CONFIG_ARMV8M_DCACHE Buffers need to be aligned and
+ * multiples of ARMV8M_DCACHE_LINESIZE
  */
 
-#  if defined(CONFIG_ARMV7M_DCACHE)
-#    define SPIDMA_BUFFER_MASK   (ARMV7M_DCACHE_LINESIZE - 1)
+#  if defined(CONFIG_ARMV8M_DCACHE)
+#    define SPIDMA_BUFFER_MASK   (ARMV8M_DCACHE_LINESIZE - 1)
 #    define SPIDMA_SIZE(b) (((b) + SPIDMA_BUFFER_MASK) & ~SPIDMA_BUFFER_MASK)
-#    define SPIDMA_BUF_ALIGN   aligned_data(ARMV7M_DCACHE_LINESIZE)
+#    define SPIDMA_BUF_ALIGN   aligned_data(ARMV8M_DCACHE_LINESIZE)
 #  else
 #    define SPIDMA_SIZE(b)  (b)
 #    define SPIDMA_BUF_ALIGN
@@ -285,8 +290,8 @@ struct stm32_spidev_s
   bool             defertrig;    /* Flag indicating that trigger should be deferred */
   bool             trigarmed;    /* Flag indicating that the trigger is armed */
 #endif
-  uint32_t         rxch;         /* The RX DMA channel number */
-  uint32_t         txch;         /* The TX DMA channel number */
+  uint16_t         rxreq;        /* The RX GPDMA request number */
+  uint16_t         txreq;        /* The TX GPDMA request number */
   uint8_t          *rxbuf;       /* The RX DMA buffer */
   uint8_t          *txbuf;       /* The TX DMA buffer */
   size_t           buflen;       /* The DMA buffer length */
@@ -294,8 +299,8 @@ struct stm32_spidev_s
   DMA_HANDLE       txdma;        /* DMA channel handle for TX transfers */
   sem_t            rxsem;        /* Wait for RX DMA to complete */
   sem_t            txsem;        /* Wait for TX DMA to complete */
-  uint32_t         txccr;        /* DMA control register for TX transfers */
-  uint32_t         rxccr;        /* DMA control register for RX transfers */
+  uint32_t         txtr1;        /* DMA channel transfer register for TX transfers */
+  uint32_t         rxtr1;        /* DMA channel transfer register for RX transfers */
 #endif
   bool             initialized;  /* Has SPI interface been initialized */
   mutex_t          lock;         /* Held while chip is selected for mutual exclusion */
@@ -339,12 +344,12 @@ static void        spi_dmarxsetup(struct stm32_spidev_s *priv,
                                   void *rxbuffer,
                                   void *rxdummy,
                                   size_t nwords,
-                                  stm32_dmacfg_t *dmacfg);
+                                  struct stm32_gpdma_cfg_s *dmacfg);
 static void        spi_dmatxsetup(struct stm32_spidev_s *priv,
                                   const void *txbuffer,
                                   const void *txdummy,
                                   size_t nwords,
-                                  stm32_dmacfg_t *dmacfg);
+                                  struct stm32_gpdma_cfg_s *dmacfg);
 static inline void spi_dmarxstart(struct stm32_spidev_s *priv);
 static inline void spi_dmatxstart(struct stm32_spidev_s *priv);
 #endif
@@ -445,8 +450,8 @@ static struct stm32_spidev_s g_spi1dev =
   .spiclock = STM32_SPI1_FREQUENCY,
   .spiirq   = STM32_IRQ_SPI1,
 #ifdef CONFIG_STM32_SPI1_DMA
-  .rxch     = DMAMAP_SPI1_RX,
-  .txch     = DMAMAP_SPI1_TX,
+  .rxreq    = GPDMA_REQ_SPI1_RX,
+  .txreq    = GPDMA_REQ_SPI1_TX,
 #  if defined(SPI1_DMABUFSIZE_ADJUSTED)
   .rxbuf    = g_spi1_rxbuf,
   .txbuf    = g_spi1_txbuf,
@@ -518,8 +523,8 @@ static struct stm32_spidev_s g_spi2dev =
   .spiclock = STM32_SPI2_FREQUENCY,
   .spiirq   = STM32_IRQ_SPI2,
 #ifdef CONFIG_STM32_SPI2_DMA
-  .rxch     = DMAMAP_SPI2_RX,
-  .txch     = DMAMAP_SPI2_TX,
+  .rxreq    = GPDMA_REQ_SPI2_RX,
+  .txreq    = GPDMA_REQ_SPI2_TX,
 #  if defined(SPI2_DMABUFSIZE_ADJUSTED)
   .rxbuf    = g_spi2_rxbuf,
   .txbuf    = g_spi2_txbuf,
@@ -591,8 +596,8 @@ static struct stm32_spidev_s g_spi3dev =
   .spiclock = STM32_SPI3_FREQUENCY,
   .spiirq   = STM32_IRQ_SPI3,
 #ifdef CONFIG_STM32_SPI3_DMA
-  .rxch     = DMAMAP_SPI3_RX,
-  .txch     = DMAMAP_SPI3_TX,
+  .rxreq    = GPDMA_REQ_SPI3_RX,
+  .txreq    = GPDMA_REQ_SPI3_TX,
 #  if defined(SPI3_DMABUFSIZE_ADJUSTED)
   .rxbuf    = g_spi3_rxbuf,
   .txbuf    = g_spi3_txbuf,
@@ -664,8 +669,8 @@ static struct stm32_spidev_s g_spi4dev =
   .spiclock = STM32_SPI4_FREQUENCY,
   .spiirq   = STM32_IRQ_SPI4,
 #ifdef CONFIG_STM32_SPI4_DMA
-  .rxch     = DMAMAP_SPI4_RX,
-  .txch     = DMAMAP_SPI4_TX,
+  .rxreq    = GPDMA_REQ_SPI4_RX,
+  .txreq    = GPDMA_REQ_SPI4_TX,
 #  if defined(SPI4_DMABUFSIZE_ADJUSTED)
   .rxbuf    = g_spi4_rxbuf,
   .txbuf    = g_spi4_txbuf,
@@ -737,8 +742,8 @@ static struct stm32_spidev_s g_spi5dev =
   .spiclock = STM32_SPI5_FREQUENCY,
   .spiirq   = STM32_IRQ_SPI5,
 #ifdef CONFIG_STM32_SPI5_DMA
-  .rxch     = DMAMAP_SPI5_RX,
-  .txch     = DMAMAP_SPI5_TX,
+  .rxreq    = GPDMA_REQ_SPI5_RX,
+  .txreq    = GPDMA_REQ_SPI5_TX,
 #  if defined(SPI5_DMABUFSIZE_ADJUSTED)
   .rxbuf    = g_spi5_rxbuf,
   .txbuf    = g_spi5_txbuf,
@@ -811,8 +816,8 @@ static struct stm32_spidev_s g_spi6dev =
   .spiclock = STM32_SPI6_FREQUENCY,
   .spiirq   = STM32_IRQ_SPI6,
 #ifdef CONFIG_STM32_SPI6_DMA
-  .rxch     = DMAMAP_SPI6_RX,
-  .txch     = DMAMAP_SPI6_TX,
+  .rxreq    = GPDMA_REQ_SPI6_RX,
+  .txreq    = GPDMA_REQ_SPI6_TX,
 #  if defined(SPI6_DMABUFSIZE_ADJUSTED)
   .rxbuf    = g_spi6_rxbuf,
   .txbuf    = g_spi6_txbuf,
@@ -1298,13 +1303,13 @@ static void spi_dmarxcallback(DMA_HANDLE handle, uint8_t isr, void *arg)
 #ifdef CONFIG_STM32_SPI_DMA
 static void spi_dmarxsetup(struct stm32_spidev_s *priv,
                            void *rxbuffer, void *rxdummy,
-                           size_t nwords, stm32_dmacfg_t *dmacfg)
+                           size_t nwords, struct stm32_gpdma_cfg_s *dmacfg)
 {
   /* Can't receive in tx only mode */
 
   if (priv->config == SIMPLEX_TX)
     {
-      priv->rxccr = 0;
+      priv->rxtr1 = 0;
       return;
     }
 
@@ -1316,12 +1321,12 @@ static void spi_dmarxsetup(struct stm32_spidev_s *priv,
 
       if (rxbuffer)
         {
-          priv->rxccr = SPI_RXDMA16_CONFIG;
+          priv->rxtr1 = SPI_RXDMA16_CONFIG;
         }
       else
         {
           rxbuffer    = rxdummy;
-          priv->rxccr = SPI_RXDMA16NULL_CONFIG;
+          priv->rxtr1 = SPI_RXDMA16NULL_CONFIG;
         }
     }
   else
@@ -1330,22 +1335,24 @@ static void spi_dmarxsetup(struct stm32_spidev_s *priv,
 
       if (rxbuffer)
         {
-          priv->rxccr = SPI_RXDMA8_CONFIG;
+          priv->rxtr1 = SPI_RXDMA8_CONFIG;
         }
       else
         {
           rxbuffer    = rxdummy;
-          priv->rxccr = SPI_RXDMA8NULL_CONFIG;
+          priv->rxtr1 = SPI_RXDMA8NULL_CONFIG;
         }
     }
 
   /* Configure the RX DMA */
 
-  dmacfg->paddr = priv->spibase + STM32_SPI_RXDR_OFFSET;
-  dmacfg->maddr = (uint32_t)rxbuffer;
-  dmacfg->ndata = nwords;
-  dmacfg->cfg1  = priv->rxccr;
-  dmacfg->cfg2  = 0;
+  dmacfg->src_addr   = priv->spibase + STM32_SPI_RXDR_OFFSET;
+  dmacfg->dest_addr  = (uint32_t)rxbuffer;
+  dmacfg->ntransfers = nwords;
+  dmacfg->tr1        = priv->rxtr1;
+  dmacfg->request    = priv->rxreq;
+  dmacfg->priority   = SPI_DMA_PRIO;
+  dmacfg->mode       = 0;
 }
 #endif
 
@@ -1360,13 +1367,13 @@ static void spi_dmarxsetup(struct stm32_spidev_s *priv,
 #ifdef CONFIG_STM32_SPI_DMA
 static void spi_dmatxsetup(struct stm32_spidev_s *priv,
                            const void *txbuffer, const void *txdummy,
-                           size_t nwords, stm32_dmacfg_t *dmacfg)
+                           size_t nwords, struct stm32_gpdma_cfg_s *dmacfg)
 {
   /* Can't transmit in rx only mode */
 
   if (priv->config == SIMPLEX_RX)
     {
-      priv->txccr = 0;
+      priv->txtr1 = 0;
       return;
     }
 
@@ -1378,12 +1385,12 @@ static void spi_dmatxsetup(struct stm32_spidev_s *priv,
 
       if (txbuffer)
         {
-          priv->txccr = SPI_TXDMA16_CONFIG;
+          priv->txtr1 = SPI_TXDMA16_CONFIG;
         }
       else
         {
           txbuffer    = txdummy;
-          priv->txccr = SPI_TXDMA16NULL_CONFIG;
+          priv->txtr1 = SPI_TXDMA16NULL_CONFIG;
         }
     }
   else
@@ -1392,20 +1399,22 @@ static void spi_dmatxsetup(struct stm32_spidev_s *priv,
 
       if (txbuffer)
         {
-          priv->txccr = SPI_TXDMA8_CONFIG;
+          priv->txtr1 = SPI_TXDMA8_CONFIG;
         }
       else
         {
           txbuffer    = txdummy;
-          priv->txccr = SPI_TXDMA8NULL_CONFIG;
+          priv->txtr1 = SPI_TXDMA8NULL_CONFIG;
         }
     }
 
-  dmacfg->paddr = priv->spibase + STM32_SPI_TXDR_OFFSET;
-  dmacfg->maddr = (uint32_t)txbuffer;
-  dmacfg->ndata = nwords;
-  dmacfg->cfg1  = priv->txccr;
-  dmacfg->cfg2  = 0;
+  dmacfg->src_addr   = (uint32_t)txbuffer;
+  dmacfg->dest_addr  = priv->spibase + STM32_SPI_TXDR_OFFSET;
+  dmacfg->ntransfers = nwords;
+  dmacfg->tr1        = priv->txtr1;
+  dmacfg->request    = priv->txreq;
+  dmacfg->priority   = SPI_DMA_PRIO;
+  dmacfg->mode       = 0;
 }
 #endif
 
@@ -2188,10 +2197,10 @@ static void spi_exchange(struct spi_dev_s *dev, const void *txbuffer,
                          void *rxbuffer, size_t nwords)
 {
   struct stm32_spidev_s *priv = (struct stm32_spidev_s *)dev;
-  stm32_dmacfg_t rxdmacfg;
-  stm32_dmacfg_t txdmacfg;
-  static uint8_t rxdummy[ARMV7M_DCACHE_LINESIZE]
-    aligned_data(ARMV7M_DCACHE_LINESIZE);
+  struct stm32_gpdma_cfg_s rxdmacfg;
+  struct stm32_gpdma_cfg_s txdmacfg;
+  static uint8_t rxdummy[ARMV8M_DCACHE_LINESIZE]
+    aligned_data(ARMV8M_DCACHE_LINESIZE);
   static const uint16_t txdummy = 0xffff;
   void *orig_rxbuffer = rxbuffer;
 
@@ -2668,14 +2677,14 @@ static void spi_bus_initialize(struct stm32_spidev_s *priv)
   priv->txdma = NULL;
   if (priv->config != SIMPLEX_TX)
     {
-      priv->rxdma = stm32_dmachannel(priv->rxch);
+      priv->rxdma = stm32_dmachannel(GPDMA_TTYPE_P2M);
       DEBUGASSERT(priv->rxdma);
       spi_modifyreg(priv, STM32_SPI_CFG1_OFFSET, 0, SPI_CFG1_RXDMAEN);
     }
 
   if (priv->config != SIMPLEX_RX)
     {
-      priv->txdma = stm32_dmachannel(priv->txch);
+      priv->txdma = stm32_dmachannel(GPDMA_TTYPE_M2P);
       DEBUGASSERT(priv->txdma);
       spi_modifyreg(priv, STM32_SPI_CFG1_OFFSET, 0, SPI_CFG1_TXDMAEN);
     }

--- a/boards/arm/stm32h5/nucleo-h563zi/include/board.h
+++ b/boards/arm/stm32h5/nucleo-h563zi/include/board.h
@@ -183,6 +183,10 @@
 
 #endif /* CONFIG_STM32_USE_HSE*/
 
+/* Select the SPI1 clock and tell driver the frequency */
+#define STM32_RCC_CCIPR3_SPI1SEL  RCC_CCIPR3_SPI1SEL_PLL1QCK
+#define STM32_SPI1_FREQUENCY      STM32_PLL1Q_FREQUENCY
+
 /* Enable CLK48; get it from HSI48 */
 
 #if defined(CONFIG_STM32_USBFS) || defined(CONFIG_STM32_RNG)
@@ -331,6 +335,15 @@
 #define BUTTON_USER_BIT    (1 << BUTTON_USER)
 
 /* Alternate function pin selections ****************************************/
+
+/* SPI1: Arduino Connector CN7 */
+
+#define GPIO_SPI1_NSS   (GPIO_OUTPUT|GPIO_SPEED_2MHZ| \
+                         GPIO_PUSHPULL|GPIO_OUTPUT_SET| \
+                         GPIO_PORTD|GPIO_PIN14)             /* PD14 */
+#define GPIO_SPI1_SCK   (GPIO_SPI1_SCK_1|GPIO_SPEED_50MHZ)  /* PA5  */
+#define GPIO_SPI1_MISO  (GPIO_SPI1_MISO_3)                  /* PG9  */
+#define GPIO_SPI1_MOSI  (GPIO_SPI1_MOSI_2|GPIO_SPEED_50MHZ) /* PB5  */
 
 /* ADC GPIOs ****************************************************************/
 

--- a/boards/arm/stm32h5/nucleo-h563zi/src/Make.defs
+++ b/boards/arm/stm32h5/nucleo-h563zi/src/Make.defs
@@ -34,6 +34,10 @@ ifeq ($(CONFIG_ARCH_BUTTONS),y)
 CSRCS += stm32_buttons.c
 endif
 
+ifeq ($(CONFIG_STM32_SPI),y)
+CSRCS += stm32_spi.c
+endif
+
 ifeq ($(CONFIG_ADC),y)
 CSRCS += stm32_adc.c
 endif

--- a/boards/arm/stm32h5/nucleo-h563zi/src/nucleo-h563zi.h
+++ b/boards/arm/stm32h5/nucleo-h563zi/src/nucleo-h563zi.h
@@ -115,6 +115,31 @@
 
 int stm32_bringup(void);
 
+#ifdef CONFIG_STM32_SPI
+/****************************************************************************
+ * Name: stm32_spiregister
+ *
+ * Description:
+ *   Called to register spi character driver of initialized
+ *   spi device for the Nucleo-L432KC board.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SPI_DRIVER
+void stm32_spiregister(void);
+#endif
+
+/****************************************************************************
+ * Name: stm32_spiinitialize
+ *
+ * Description:
+ *   Called to configure SPI chip select GPIO pins.
+ *
+ ****************************************************************************/
+
+void stm32_spiinitialize(void);
+#endif /* CONFIG_STM32_SPI */
+
 /****************************************************************************
  * Name: stm32_adc_setup
  *

--- a/boards/arm/stm32h5/nucleo-h563zi/src/stm32_bringup.c
+++ b/boards/arm/stm32h5/nucleo-h563zi/src/stm32_bringup.c
@@ -146,6 +146,18 @@ int stm32_bringup(void)
 # endif
 #endif
 
+#ifdef CONFIG_STM32_SPI
+  /* Cannot call at board init because irq_attach would be called before
+   * before irq_initialize is called.
+   */
+
+  stm32_spiinitialize();
+
+#ifdef CONFIG_SPI_DRIVER
+  stm32_spiregister();
+#endif
+#endif /* CONFIG_STM32_SPI */
+
 #ifdef CONFIG_PWM
   /* Initialize PWM and register the PWM device. */
 

--- a/boards/arm/stm32h5/nucleo-h563zi/src/stm32_spi.c
+++ b/boards/arm/stm32h5/nucleo-h563zi/src/stm32_spi.c
@@ -1,0 +1,187 @@
+/****************************************************************************
+ * boards/arm/stm32h5/nucleo-h563zi/src/stm32_spi.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <nuttx/debug.h>
+#include <errno.h>
+
+#include <nuttx/spi/spi.h>
+#include <nuttx/spi/spi_transfer.h>
+#include <arch/board/board.h>
+
+#include "chip.h"
+#include <stm32.h>
+
+#include "nucleo-h563zi.h"
+
+/****************************************************************************
+ * Public Data
+ ****************************************************************************/
+
+/* Global driver instances */
+
+#ifdef CONFIG_STM32_SPI1
+struct spi_dev_s *g_spi1;
+#endif
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: stm32_spiregister
+ *
+ * Description:
+ *   Called to register spi character driver of
+ *   initialized spi device for the Nucleo-H563ZI board.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SPI_DRIVER
+void stm32_spiregister(void)
+{
+#ifdef CONFIG_STM32_SPI1
+      int ret = spi_register(g_spi1, 1);
+      if (ret < 0)
+        {
+          spierr("ERROR: FAILED to register driver of SPI port 1\n");
+        }
+#endif
+}
+#endif
+
+/****************************************************************************
+ * Name: stm32_spiinitialize
+ *
+ * Description:
+ *   Called to configure SPI chip select GPIO pins for the Nucleo-H563ZI
+ *   board.
+ *
+ ****************************************************************************/
+
+void stm32_spiinitialize(void)
+{
+  /* NOTE: Clocking for SPI1 was already provided in stm32_rcc.c.
+   *       Configurations of SPI pins is performed in stm32_spi.c.
+   *       Here, we only initialize chip select pins unique to the board
+   *       architecture.
+   */
+
+#ifdef CONFIG_STM32_SPI1
+  /* Configure SPI1-based devices */
+
+  g_spi1 = stm32_spibus_initialize(1);
+  if (!g_spi1)
+    {
+      spierr("ERROR: FAILED to initialize SPI port 1\n");
+    }
+  else
+    {
+      spiinfo("INFO: SPI port 1 initialized\n");
+    }
+
+  /* Setup CS, EN & IRQ line IOs */
+
+  stm32_configgpio(GPIO_SPI1_NSS);
+#endif
+}
+
+/****************************************************************************
+ * Name:  stm32_spi1select and stm32_spi1status
+ *
+ * Description:
+ *   The external functions, stm32_spi1select and stm32_spi1status
+ *   must be provided by board-specific logic.  They are implementations of
+ *   the select and status methods of the SPI interface defined by struct
+ *   spi_ops_s (see include/nuttx/spi/spi.h). All other methods (including
+ *   up_spiinitialize()) are provided by common STM32 logic.  To use this
+ *   common SPI logic on your board:
+ *
+ *   1. Provide logic in stm32_board_initialize() to configure SPI chip
+ *      select pins.
+ *   2. Provide stm32_spi1select() and stm32_spi1status() functions
+ *      in your board-specific logic.  These functions will perform chip
+ *      selection and status operations using GPIOs in the way your board is
+ *      configured.
+ *   3. Add a calls to up_spiinitialize() in your low level application
+ *      initialization logic
+ *   4. The handle returned by up_spiinitialize() may then be used to bind
+ *      the SPI driver to higher level logic (e.g., calling
+ *      mmcsd_spislotinitialize(), for example, will bind the SPI driver to
+ *      the SPI MMC/SD driver).
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_STM32_SPI1
+void stm32_spi1select(struct spi_dev_s *dev, uint32_t devid,
+                        bool selected)
+{
+  spiinfo("devid: %08X CS: %s\n", (int)devid,
+          selected ? "assert" : "de-assert");
+
+  stm32_gpiowrite(GPIO_SPI1_NSS, !selected);
+}
+
+uint8_t stm32_spi1status(struct spi_dev_s *dev, uint32_t devid)
+{
+  return 0;
+}
+#endif
+
+/****************************************************************************
+ * Name: stm32_spi1cmddata
+ *
+ * Description:
+ *   Set or clear the SH1101A A0 or SD1306 D/C n bit to select data (true)
+ *   or command (false). This function must be provided by platform-specific
+ *   logic. This is an implementation of the cmddata method of the SPI
+ *   interface defined by struct spi_ops_s (see include/nuttx/spi/spi.h).
+ *
+ * Input Parameters:
+ *
+ *   spi - SPI device that controls the bus the device that requires the CMD/
+ *         DATA selection.
+ *   devid - If there are multiple devices on the bus, this selects which one
+ *         to select cmd or data.  NOTE:  This design restricts, for example,
+ *         one one SPI display per SPI bus.
+ *   cmd - true: select command; false: select data
+ *
+ * Returned Value:
+ *   OK on success or negative error code
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_SPI_CMDDATA
+#ifdef CONFIG_STM32_SPI1
+int stm32_spi1cmddata(struct spi_dev_s *dev, uint32_t devid, bool cmd)
+{
+  return -ENODEV;
+}
+#endif
+#endif /* CONFIG_SPI_CMDDATA */


### PR DESCRIPTION
## Summary

Use the hardware SPI FIFO in non-DMA exchange to parallelize SPI transmission and word enqueuing. There is less time between transmitted words on the bus so throughput is increased. Alternate between the send and receive FIFOs so that data is not lost.

The DMA support in the stm32h5 SPI driver did not compile because it was copied from stm32h7 whose DMA API is incompatible with stm32h5. Port DMA support to the driver.

Fix some issues in the driver that made it buggy when both non-DMA and DMA instances coexisted.

Initialize SPI1 on nucleo-h563zi and register an spi chardev at /dev/spi1 when the configs are enabled.

## Impact

SPI non-DMA exchanges are more efficient and not racy anymore.

SPI DMA builds now. The porting was done in a way that does not change the behavior from stm32h7 to stm32h5.

## Testing

Besides the below reproducibility info, this has been used on custom hardware for some months.

`nucleo-h563zi:nsh` with the following enabled:

!!! **apps/system/spi/spitool.h MAX_LINELEN set to 256** !!!

```
CONFIG_LINE_MAX=256
CONFIG_STM32_DMA1=y
CONFIG_STM32_SPI1=y
CONFIG_STM32_SPI1_DMA=y
CONFIG_STM32_SPI1_DMA_BUFFER=128
CONFIG_SYSTEM_SPITOOL=y
```

Each commit was exercised with spitool. A jumper connected MOSI and MISO - CN7 pin 12 and 14 so the transmitted data loops back. The density of transmitted words was compared on an oscilloscope.

```
nsh> spi exch -b1 -f16000000 -x110 aabbccddeeff001122334455667788991234567890abcdef2143658709badcfeaabbccddeeff0011aabbccddeeff001122334455667788991234567890abcdef2143658709badcfeaabbccddeeff0011aabbccddeeff001122334455667788991234567890abcdef2143658709ba
Sending:	AA BB CC DD EE FF 00 11 22 33 44 55 66 77 88 99 12 34 56 78 90 AB CD EF 21 43 65 87 09 BA DC FE AA BB CC DD EE FF 00 11 AA BB CC DD EE FF 00 11 22 33 44 55 66 77 88 99 12 34 56 78 90 AB CD EF 21 43 65 87 09 BA DC FE AA BB CC DD EE FF 00 11 AA BB CC DD EE FF 00 11 22 33 44 55 66 77 88 99 12 34 56 78 90 AB CD EF 21 43 65 87 09 BA 
Received:	AA BB CC DD EE FF 00 11 22 33 44 55 66 77 88 99 12 34 56 78 90 AB CD EF 21 43 65 87 09 BA DC FE AA BB CC DD EE FF 00 11 AA BB CC DD EE FF 00 11 22 33 44 55 66 77 88 99 12 34 56 78 90 AB CD EF 21 43 65 87 09 BA DC FE AA BB CC DD EE FF 00 11 AA BB CC DD EE FF 00 11 22 33 44 55 66 77 88 99 12 34 56 78 90 AB CD EF 21 43 65 87 09 BA
```

**Before**

There is 75.324 us between transmitted bytes.

**After FIFO usage improvement**

There is 3.5116 us between transmitted bytes.

**With DMA enabled**

There is no gap between transmitted bytes.