### PR TITLE
arch/arm/stm32h5: Fix SPI4 macro verification

### DIFF
--- a/arch/arm/src/stm32h5/stm32_spi.c
+++ b/arch/arm/src/stm32h5/stm32_spi.c
@@ -221,18 +221,18 @@
 #  endif
 #endif /* SPI3 */
 
-#if defined(CONFIG_STM32_SPI1)
-#  ifndef STM32_SPI1_FREQUENCY
-#    error Must define STM32_SPI1_FREQUENCY in board.h
+#if defined(CONFIG_STM32_SPI4)
+#  ifndef STM32_SPI4_FREQUENCY
+#    error Must define STM32_SPI4_FREQUENCY in board.h
 #  else
-#    if STM32_SPI1_FREQUENCY > SPI_MAX_KER_CK
-#      error Not supported SPI1 frequency
+#    if STM32_SPI4_FREQUENCY > SPI_MAX_KER_CK
+#      error Not supported SPI4 frequency
 #    endif
 #  endif
-#  ifndef STM32_RCC_CCIPR3_SPI1SEL
-#    error Must define STM32_RCC_CCIPR3_SPI1SEL in board.h
+#  ifndef STM32_RCC_CCIPR3_SPI4SEL
+#    error Must define STM32_RCC_CCIPR3_SPI4SEL in board.h
 #  endif
-#endif /* SPI1 */
+#endif /* SPI4 */
 
 #if defined(CONFIG_STM32_SPI5)
 #  ifndef STM32_SPI5_FREQUENCY


### PR DESCRIPTION
## Summary

The C preprocessor is used to check SPI frequency and clock source for each SPI peripheral. SPI1-3 and 5-6 were checked correctly, but SPI4 was not. Instead, SPI1 was checked a second time.

## Impact

SPI4 macros will be checked correctly, and duplicate errors for missing SPI1 values will not be shown.

## Testing

Before, with SPI1, SPI4, and SPI5 enabled, but no clock selection macros:

```
.../nuttx/arch/arm/src/stm32h5/stm32_spi.c:188:6: error: #error Must define STM32_RCC_CCIPR3_SPI1SEL in board.h
  188 | #    error Must define STM32_RCC_CCIPR3_SPI1SEL in board.h
      |      ^~~~~
.../nuttx/arch/arm/src/stm32h5/stm32_spi.c:227:6: error: #error Must define STM32_RCC_CCIPR3_SPI1SEL in board.h
  227 | #    error Must define STM32_RCC_CCIPR3_SPI1SEL in board.h
      |      ^~~~~
.../nuttx/arch/arm/src/stm32h5/stm32_spi.c:240:6: error: #error Must define STM32_RCC_CCIPR3_SPI5SEL in board.h
  240 | #    error Must define STM32_RCC_CCIPR3_SPI5SEL in board.h
      |      ^~~~~

```

After:

```
.../nuttx/arch/arm/src/stm32h5/stm32_spi.c:188:6: error: #error Must define STM32_RCC_CCIPR3_SPI1SEL in board.h
  188 | #    error Must define STM32_RCC_CCIPR3_SPI1SEL in board.h
      |      ^~~~~
.../nuttx/arch/arm/src/stm32h5/stm32_spi.c:227:6: error: #error Must define STM32_RCC_CCIPR3_SPI4SEL in board.h
  227 | #    error Must define STM32_RCC_CCIPR3_SPI4SEL in board.h
      |      ^~~~~
.../nuttx/arch/arm/src/stm32h5/stm32_spi.c:240:6: error: #error Must define STM32_RCC_CCIPR3_SPI5SEL in board.h
  240 | #    error Must define STM32_RCC_CCIPR3_SPI5SEL in board.h
```