### PR TITLE
arch/x86_64: scope user address helper to addrenv

### DIFF
--- a/arch/x86_64/src/common/pgalloc.h
+++ b/arch/x86_64/src/common/pgalloc.h
@@ -104,6 +104,7 @@ static inline uintptr_t x86_64_pgpaddr(uintptr_t vaddr)
  *
  ****************************************************************************/
 
+#ifdef CONFIG_ARCH_ADDRENV
 static inline bool x86_64_uservaddr(uintptr_t vaddr)
 {
   /* Check if this address is within the range of the virtualized .bss/.data,
@@ -116,6 +117,7 @@ static inline bool x86_64_uservaddr(uintptr_t vaddr)
 #endif
     );
 }
+#endif
 
 /****************************************************************************
  * Name: x86_64_pgwipe


### PR DESCRIPTION
## Summary

x86_64_uservaddr() depends on the address-environment layout and is only consumed by the kernel address-environment path.

## Impact

Guard it with CONFIG_ARCH_ADDRENV so MM_PGALLOC can also be enabled in flat builds.

## Testing

qemu-intel64 builds for flat build with MM_PGALLOC