### PR TITLE
x86_64/intel64: make framebuffer setup recoverable

### DIFF
--- a/arch/x86_64/src/intel64/intel64_fb.c
+++ b/arch/x86_64/src/intel64/intel64_fb.c
@@ -73,7 +73,7 @@ static int intel64_getplaneinfo(struct fb_vtable_s *vtable,
 
 /* Helpers */
 
-static uint8_t intel64_fb_getfmt(uint8_t bpp, uint8_t type);
+static int intel64_fb_getfmt(uint8_t bpp, uint8_t type);
 static void intel64_fb_clear(void);
 
 /****************************************************************************
@@ -142,14 +142,14 @@ static int intel64_getplaneinfo(struct fb_vtable_s *vtable,
  * Name: intel64_fb_getfmt
  ****************************************************************************/
 
-static uint8_t intel64_fb_getfmt(uint8_t bpp, uint8_t type)
+static int intel64_fb_getfmt(uint8_t bpp, uint8_t type)
 {
   if (type != MULTIBOOT_FRAMEBUFFER_TYPE_RGB)
     {
       /* Only RGB type supported */
 
       gerr("ERROR: not supported type=%d\n", type);
-      PANIC();
+      return -ENOTSUP;
     }
 
   switch (bpp)
@@ -172,7 +172,7 @@ static uint8_t intel64_fb_getfmt(uint8_t bpp, uint8_t type)
       default:
         {
           gerr("ERROR: not supported BPP=%d\n", bpp);
-          PANIC();
+          return -ENOTSUP;
         }
     }
 }
@@ -216,6 +216,7 @@ int up_fbinitialize(int display)
   struct multiboot_tag_framebuffer *fbt = g_mb_fb_tag;
   struct multiboot_fb_s            *fb  = &g_fb;
   uint64_t map_size;
+  int ret;
 
   UNUSED(display);
 
@@ -232,11 +233,17 @@ int up_fbinitialize(int display)
 
   /* Get video info */
 
+  ret = intel64_fb_getfmt(fbt->common.framebuffer_bpp,
+                          fbt->common.framebuffer_type);
+  if (ret < 0)
+    {
+      return ret;
+    }
+
   fb->videoinfo.xres    = fbt->common.framebuffer_width;
   fb->videoinfo.yres    = fbt->common.framebuffer_height;
   fb->videoinfo.nplanes = 1;
-  fb->videoinfo.fmt     = intel64_fb_getfmt(fbt->common.framebuffer_bpp,
-                                            fbt->common.framebuffer_type);
+  fb->videoinfo.fmt     = ret;
 
   /* Get plane info */
 
@@ -262,9 +269,13 @@ int up_fbinitialize(int display)
                   HUGE_PAGE_SIZE_1G;
     }
 
-  up_map_region(fb->baseaddr, map_size,
-                X86_PAGE_WR | X86_PAGE_PRESENT |
-                X86_PAGE_NOCACHE | X86_PAGE_GLOBAL);
+  ret = up_map_region(fb->baseaddr, map_size,
+                      X86_PAGE_WR | X86_PAGE_PRESENT |
+                      X86_PAGE_NOCACHE | X86_PAGE_GLOBAL);
+  if (ret < 0)
+    {
+      return ret;
+    }
 
   /* Clear frambufer */
 


### PR DESCRIPTION
## Summary

Return unsupported-format and mapping errors to board bring-up instead of panicking, so a serial console can remain usable when no suitable framebuffer exists.

## Impact

don't panic when framebuffer initialization fails, useful for debugging

## Testing

Intel NUC 12 hardware
