### PR TITLE
arch/arm/stm32h5: Fix hanging ADC enable call

### DIFF
--- a/arch/arm/src/stm32h5/stm32_adc.c
+++ b/arch/arm/src/stm32h5/stm32_adc.c
@@ -649,7 +649,12 @@ static void adc_enable(struct stm32_dev_s *priv)
 
   /* Wait for voltage regulator to power up */
 
-  up_udelay(20);
+  /* Datasheet recommends a _minimum_ of 20ms but it will depend
+   * on temperature, supply ramp and whether we've recently
+   * powered up ADC. So give a larger delay for safety.
+   */
+
+  up_udelay(50);
 
   /* Perform single-ended and/or differential calibration if necessary */
 
@@ -679,6 +684,17 @@ static void adc_enable(struct stm32_dev_s *priv)
    * as ADC clock source, this is the same as time taken to execute 4
    * ARM instructions.
    */
+
+  /* ES0565 document (STM32H562/563/573 series) : As noted above, we
+   * can't set ADEN until 4 ADC clock cycles from now. This will depend
+   * on what we use for ADC clock. To ensure we give enough guard time
+   * we are delaying ADEN by at least 1 microsecond. This will ensure
+   * even a slow clock will have enough time before we try to set ADEN.
+   * Also, clear ADRDY to ensure we are waiting for a fresh event.
+   */
+
+  adc_modifyreg(priv, STM32_ADC_ISR_OFFSET, 0, ADC_INT_ADRDY);
+  up_udelay(1);
 
   regval  = adc_getreg(priv, STM32_ADC_CR_OFFSET);
   regval |= ADC_CR_ADEN;


### PR DESCRIPTION
## Summary

Fix an ADC issue that was seen occasionally. Increase+add a delay and "Also, clear ADRDY to ensure we are waiting for a fresh event."

The author explains:

> Posix open() calls to /dev/adc# were hanging often due to the ready loop check at the end of adc_enable() never returning.  According to ES0565 document, at least 4 ADC clock cycles must pass between the time we waited for calibration to end and before we can set ADEN. This will depend on what clock is set for ADC. So to ensure enough time passes, we are adding a short delay (so that even a slow clock will work).  Also, we are clearing the ADRDY flag before hand to ensure we are detecting a fresh event. The delay to wait for the voltage regulator is also increased to account for extra time required in non-ideal conditions.

## Impact

Delays were changed and a register write was added to avoid reading an outdated "ready" value.

The register bit is a read/write bit which is read to detect sample "ready", and written with a 1 to clear it. It is cleared at the end, but it's defensively being cleared in case of an existing value.

## Testing

I have validated this patch in isolation on the custom board by measuring a depleting a capacitor and the voltage source upstream of a diode before and after removing the voltage source.

Custom STM32H5 board with 12 ADC channels. config with:

```
CONFIG_ADC=y
CONFIG_ADC_FIFOSIZE=16
CONFIG_STM32_ADC1=y
CONFIG_EXAMPLES_ADC=y
CONFIG_EXAMPLES_ADC_GROUPSIZE=12
CONFIG_EXAMPLES_ADC_SWTRIG=y
```

Grepping the two channels of interest:

```
4: channel: 4 value: 495
4: channel: 4 value: 495
4: channel: 4 value: 495
...
4: channel: 4 value: 21
4: channel: 4 value: 21
4: channel: 4 value: 21
```

```
11: channel: 14 value: 2357
11: channel: 14 value: 2357
11: channel: 14 value: 2359
...
11: channel: 14 value: 522
11: channel: 14 value: 520
11: channel: 14 value: 518
```