### PR TITLE
Stm32h7 ethernet

### DIFF
--- a/arch/arm/src/common/stm32/Kconfig.eth
+++ b/arch/arm/src/common/stm32/Kconfig.eth
@@ -52,6 +52,27 @@ endif # !STM32_AUTONEG
 
 if STM32_AUTONEG
 
+config STM32_AUTONEG_10FD_ONLY
+	bool "Advertise only 10BASE-T full duplex"
+	default n
+	---help---
+		Restrict the autonegotiation advertisement to 10BASE-T full
+		duplex, so that both ends negotiate that and nothing else.
+
+		The reason to want this is electrical, not economic.  100BASE-TX
+		signalling sits at about 1 V with MLT-3 coding; 10BASE-T uses
+		2.5 V Manchester at a tenth of the frequency, and shrugs off
+		interference that corrupts 100BASE-TX outright.  On a board
+		where another subsystem couples noise into the PHY -- a parallel
+		RGB display sharing the board with the magnetics, say -- a
+		clean 10 Mbps link outperforms a 100 Mbps one that is losing
+		frames to bit errors.
+
+		Restricting the advertisement is not the same as disabling
+		autonegotiation:  a forced MCR leaves the partner to parallel
+		detection, which cannot detect duplex and will pick half --
+		a genuine mismatch that stalls bulk traffic completely.
+
 config STM32_PHYSR
 	int "PHY Status Register Address (decimal)"
 	---help---

--- a/arch/arm/src/stm32h7/stm32_ethernet.c
+++ b/arch/arm/src/stm32h7/stm32_ethernet.c
@@ -1128,6 +1128,17 @@ static struct eth_desc_s *stm32_get_next_txdesc(struct stm32_ethmac_s *priv,
  *
  ****************************************************************************/
 
+static bool stm32_txringfull(FAR struct stm32_ethmac_s *priv)
+{
+  /* The ring is full when the head descriptor still belongs to the DMA.
+   * Transmitting into it anyway corrupts a frame in flight;  with
+   * assertions built in it panics from the RX work queue instead.
+   */
+
+  return (priv->txhead->des3 & ETH_TDES3_RD_OWN) != 0 ||
+         priv->txhead->des0 != 0;
+}
+
 static int stm32_transmit(struct stm32_ethmac_s *priv)
 {
   struct eth_desc_s *txdesc;
@@ -1969,9 +1980,20 @@ static void stm32_receive(struct stm32_ethmac_s *priv)
 
           if (priv->dev.d_len > 0)
             {
-              /* And send the packet */
+              /* Send the reply, unless the TX ring is full. The reply
+               * to received data is almost always an acknowledgement, and
+               * a peer that misses one retransmits;  overwriting a frame
+               * the DMA still owns recovers from nothing.
+               */
 
-              stm32_transmit(priv);
+              if (!stm32_txringfull(priv))
+                {
+                  stm32_transmit(priv);
+                }
+              else
+                {
+                  priv->dev.d_len = 0;
+                }
             }
         }
       else
@@ -1992,9 +2014,20 @@ static void stm32_receive(struct stm32_ethmac_s *priv)
 
           if (priv->dev.d_len > 0)
             {
-              /* And send the packet */
+              /* Send the reply, unless the TX ring is full. The reply
+               * to received data is almost always an acknowledgement, and
+               * a peer that misses one retransmits;  overwriting a frame
+               * the DMA still owns recovers from nothing.
+               */
 
-              stm32_transmit(priv);
+              if (!stm32_txringfull(priv))
+                {
+                  stm32_transmit(priv);
+                }
+              else
+                {
+                  priv->dev.d_len = 0;
+                }
             }
         }
       else
@@ -2015,7 +2048,19 @@ static void stm32_receive(struct stm32_ethmac_s *priv)
 
           if (priv->dev.d_len > 0)
             {
-              stm32_transmit(priv);
+              /* Send the reply, unless the TX ring is full. A peer
+               * that misses an ARP reply asks again;  overwriting a
+               * frame the DMA still owns recovers from nothing.
+               */
+
+              if (!stm32_txringfull(priv))
+                {
+                  stm32_transmit(priv);
+                }
+              else
+                {
+                  priv->dev.d_len = 0;
+                }
             }
         }
       else

--- a/arch/arm/src/stm32h7/stm32_ethernet.c
+++ b/arch/arm/src/stm32h7/stm32_ethernet.c
@@ -33,6 +33,7 @@
 #include <string.h>
 #include <assert.h>
 #include <nuttx/debug.h>
+#include <syslog.h>
 #include <errno.h>
 
 #include <sys/param.h>
@@ -3349,10 +3350,26 @@ static int stm32_phyinit(struct stm32_ethmac_s *priv)
       return -ETIMEDOUT;
     }
 
-  /* Enable auto-negotiation */
+#ifdef CONFIG_STM32_AUTONEG_10FD_ONLY
+  /* Advertise only 10BASE-T full duplex, so that negotiation lands
+   * there on both ends.  See the help text of the option for why a
+   * board would want a slower link on purpose.
+   */
+
+  ret = mdio_write(priv->mdio, CONFIG_STM32_PHYADDR, MII_ADVERTISE,
+                   MII_ADVERTISE_10BASETXFULL | MII_ADVERTISE_CSMA);
+  if (ret < 0)
+    {
+      nerr("ERROR: Failed to write the PHY ANAR: %d\n", ret);
+      return ret;
+    }
+#endif
+
+  /* Enable and restart auto-negotiation */
 
   ret = mdio_write(priv->mdio,
-    CONFIG_STM32_PHYADDR, MII_MCR, MII_MCR_ANENABLE);
+    CONFIG_STM32_PHYADDR, MII_MCR,
+    MII_MCR_ANENABLE | MII_MCR_ANRESTART);
   if (ret < 0)
     {
       nerr("ERROR: Failed to enable auto-negotiation: %d\n", ret);
@@ -3462,7 +3479,12 @@ static int stm32_phyinit(struct stm32_ethmac_s *priv)
   phyval |= MII_MCR_SPEED100;
 #endif
 
-  ret = stm32_phywrite(CONFIG_STM32_PHYADDR, MII_MCR, phyval, 0xffff);
+  /* mdio_write, not stm32_phywrite:  this driver never had the latter.
+   * The call was carried over from the F7 driver and nothing had ever
+   * built this path.
+   */
+
+  ret = mdio_write(priv->mdio, CONFIG_STM32_PHYADDR, MII_MCR, phyval);
   if (ret < 0)
     {
       nerr("ERROR: Failed to write the PHY MCR: %d\n", ret);
@@ -3481,9 +3503,14 @@ static int stm32_phyinit(struct stm32_ethmac_s *priv)
 #endif
 #endif
 
-  ninfo("Duplex: %s Speed: %d MBps\n",
-        priv->fduplex ? "FULL" : "HALF",
-        priv->mbps100 ? 100 : 10);
+  /* Diagnostic: say what was negotiated even without net debug.  A
+   * duplex mismatch looks exactly like a bad cable and nothing else
+   * says which of the two it is.
+   */
+
+  syslog(LOG_INFO, "stm32_eth: link %s-duplex %d Mbps\n",
+         priv->fduplex ? "full" : "half",
+         priv->mbps100 ? 100 : 10);
 
   return OK;
 }


### PR DESCRIPTION
## Summary

Two independent fixes to the STM32H7 Ethernet driver, split out of #19911
at review request.

**Never transmit a reply into a full TX ring**

`stm32_receive()` replies to ARP, IPv4 and IPv6 straight from the RX path
without checking whether a TX descriptor is free. Under sustained load the
reply overwrites a descriptor the DMA still owns and the link stalls until
the interface is reset.

All three reply paths now check `stm32_txringfull()` first. That check has
to consider `des0` as well as the OWN bit: a descriptor already consumed by
the DMA but not yet reclaimed still has its buffer pointer set, and
treating it as free is what corrupts the ring.

**Allow restricting autonegotiation to 10BASE-T full duplex**

New `CONFIG_STM32_AUTONEG_10FD_ONLY`, default n. On a board whose display
generates enough noise to corrupt 100BASE-TX, throughput collapses with
whatever is on the screen. Advertising only 10BASE-T full duplex makes both
ends negotiate a link that survives the interference.

It advertises rather than forcing the MCR, so the two ends still agree. A
forced setting on one side produces a duplex mismatch, which looks exactly
like a bad cable and is much harder to diagnose.

## Impact

No functional change for existing users. Both are confined to
`arch/arm/src/stm32h7/stm32_ethernet.c` and the shared
`arch/arm/src/common/stm32/Kconfig.eth`; the new option defaults to n, so
nothing changes unless a board opts in.

The TX ring guard costs one descriptor read per received packet that gets
a reply.

## Testing

Host: Linux, arm-none-eabi-gcc 13.2.
Board: linum-stm32h753bi (STM32H753BI, 1024x600 RGB panel), `netnsh`.

TX ring: sustained ping flood and TCP transfer while the panel was being
redrawn. Before the change the link stalled and only a reset recovered it.
After, the interface stayed up for the whole run.

Autonegotiation: measured throughput with the panel showing static content
against animated content.

    nsh> ifconfig
    eth0  Link encap:Ethernet HWaddr 00:e0:de:ad:be:ef at RUNNING mtu 1486
          inet addr:192.168.15.4 DRaddr:192.168.15.1 Mask:255.255.255.0

    stm32_eth: link full-duplex 100 Mbps      (default)
    stm32_eth: link full-duplex 10 Mbps       (CONFIG_STM32_AUTONEG_10FD_ONLY=y)

With 100BASE-TX the transfer rate varied by up to 200x depending on screen
content. With the option enabled the link is slower on paper and steady in
practice.