### PR TITLE
graphics/nxterm: add some missing features

### DIFF
--- a/graphics/nxterm/nxterm.h
+++ b/graphics/nxterm/nxterm.h
@@ -61,7 +61,7 @@
 
 /* VT100 escape sequence processing */
 
-#define VT100_MAX_SEQUENCE 3
+#define VT100_MAX_SEQUENCE 32
 
 /****************************************************************************
  * Public Types

--- a/graphics/nxterm/nxterm_putc.c
+++ b/graphics/nxterm/nxterm_putc.c
@@ -51,10 +51,11 @@ void nxterm_putc(FAR struct nxterm_state_s *priv, uint8_t ch)
   FAR const struct nxterm_bitmap_s *bm;
   int lineheight;
 
-  /* Ignore carriage returns */
+  /* Handle carriage returns */
 
   if (ch == '\r')
     {
+      priv->fpos.x = priv->spwidth;
       return;
     }
 
@@ -170,5 +171,22 @@ void nxterm_showcursor(FAR struct nxterm_state_s *priv)
 
 void nxterm_hidecursor(FAR struct nxterm_state_s *priv)
 {
+  int i;
+
   nxterm_hidechar(priv, &priv->cursor);
+
+  /* A cursor moved into an existing line is drawn on top of a saved glyph.
+   * Restore that glyph after erasing the cursor so command-line editing does
+   * not leave a hole in the displayed text.
+   */
+
+  for (i = priv->nchars - 1; i >= 0; i--)
+    {
+      if (priv->bm[i].pos.x == priv->cursor.pos.x &&
+          priv->bm[i].pos.y == priv->cursor.pos.y)
+        {
+          nxterm_fillchar(priv, NULL, &priv->bm[i]);
+          break;
+        }
+    }
 }

--- a/graphics/nxterm/nxterm_vt100.c
+++ b/graphics/nxterm/nxterm_vt100.c
@@ -51,6 +51,8 @@ struct vt100_sequence_s
  ****************************************************************************/
 
 static int nxterm_erasetoeol(FAR struct nxterm_state_s *priv);
+static int nxterm_cursorleft(FAR struct nxterm_state_s *priv);
+static int nxterm_cursorright(FAR struct nxterm_state_s *priv);
 
 /****************************************************************************
  * Private Data
@@ -63,12 +65,23 @@ static int nxterm_erasetoeol(FAR struct nxterm_state_s *priv);
 /* <esc>[K is the VT100 command erases to the end of the line. */
 
 static const char g_erasetoeol[] = VT100_CLEAREOL;
+static const char g_cursorleft[] =
+{
+  ASCII_ESC, '[', 'D'
+};
+
+static const char g_cursorright[] =
+{
+  ASCII_ESC, '[', 'C'
+};
 
 /* The list of all VT100 sequences supported by the emulation */
 
 static const struct vt100_sequence_s g_vt100sequences[] =
 {
   {g_erasetoeol, nxterm_erasetoeol, sizeof(g_erasetoeol)},
+  {g_cursorleft, nxterm_cursorleft, sizeof(g_cursorleft)},
+  {g_cursorright, nxterm_cursorright, sizeof(g_cursorright)},
   {NULL, NULL, 0}
 };
 
@@ -92,7 +105,90 @@ static const struct vt100_sequence_s g_vt100sequences[] =
 
 static int nxterm_erasetoeol(FAR struct nxterm_state_s *priv)
 {
-  /* Does nothing yet (other than consume the sequence) */
+  struct nxgl_rect_s bounds;
+  uint16_t dst;
+  uint16_t src;
+
+  bounds.pt1.x = priv->fpos.x;
+  bounds.pt1.y = priv->fpos.y;
+  bounds.pt2.x = priv->wndo.wsize.w - 1;
+  bounds.pt2.y = priv->fpos.y + priv->fheight - 1;
+
+  priv->ops->fill(priv, &bounds, priv->wndo.wcolor);
+
+  /* Discard every saved glyph covered by the erased portion of this line.
+   * Keeping the bitmap list in sync is necessary for later redraw events.
+   */
+
+  for (src = 0, dst = 0; src < priv->nchars; src++)
+    {
+      if (priv->bm[src].pos.y == priv->fpos.y &&
+          priv->bm[src].pos.x >= priv->fpos.x)
+        {
+          continue;
+        }
+
+      if (dst != src)
+        {
+          priv->bm[dst] = priv->bm[src];
+        }
+
+      dst++;
+    }
+
+  priv->nchars = dst;
+
+  return OK;
+}
+
+/****************************************************************************
+ * Name: nxterm_cursorleft
+ ****************************************************************************/
+
+static int nxterm_cursorleft(FAR struct nxterm_state_s *priv)
+{
+  nxgl_coord_t x = priv->spwidth;
+  uint16_t i;
+
+  /* Find the closest saved glyph to the left on the current line. */
+
+  for (i = 0; i < priv->nchars; i++)
+    {
+      if (priv->bm[i].pos.y == priv->fpos.y &&
+          priv->bm[i].pos.x < priv->fpos.x &&
+          priv->bm[i].pos.x > x)
+        {
+          x = priv->bm[i].pos.x;
+        }
+    }
+
+  priv->fpos.x = x;
+  return OK;
+}
+
+/****************************************************************************
+ * Name: nxterm_cursorright
+ ****************************************************************************/
+
+static int nxterm_cursorright(FAR struct nxterm_state_s *priv)
+{
+  FAR const struct nxfonts_glyph_s *glyph;
+  int i;
+
+  /* Prefer the most recently rendered glyph when editing has overdrawn a
+   * character at the same location.
+   */
+
+  for (i = priv->nchars - 1; i >= 0; i--)
+    {
+      if (priv->bm[i].pos.y == priv->fpos.y &&
+          priv->bm[i].pos.x == priv->fpos.x)
+        {
+          glyph = nxf_cache_getglyph(priv->fcache, priv->bm[i].code);
+          priv->fpos.x += glyph == NULL ? priv->spwidth : glyph->width;
+          break;
+        }
+    }
 
   return OK;
 }

--- a/graphics/nxterm/nxterm_vt100.c
+++ b/graphics/nxterm/nxterm_vt100.c
@@ -53,6 +53,8 @@ struct vt100_sequence_s
 static int nxterm_erasetoeol(FAR struct nxterm_state_s *priv);
 static int nxterm_cursorleft(FAR struct nxterm_state_s *priv);
 static int nxterm_cursorright(FAR struct nxterm_state_s *priv);
+static enum nxterm_vt100state_e
+  nxterm_sgr(FAR struct nxterm_state_s *priv, int seqsize);
 
 /****************************************************************************
  * Private Data
@@ -194,6 +196,45 @@ static int nxterm_cursorright(FAR struct nxterm_state_s *priv)
 }
 
 /****************************************************************************
+ * Name: nxterm_sgr
+ *
+ * Description:
+ *   Consume an ANSI Select Graphic Rendition sequence.  NxTerm does not
+ *   currently support changing text attributes, but consuming the sequence
+ *   prevents unsupported color controls from being rendered as text.
+ *
+ ****************************************************************************/
+
+static enum nxterm_vt100state_e
+nxterm_sgr(FAR struct nxterm_state_s *priv, int seqsize)
+{
+  int i;
+
+  if (seqsize < 2 || priv->seq[0] != ASCII_ESC || priv->seq[1] != '[')
+    {
+      return VT100_ABORT;
+    }
+
+  for (i = 2; i < seqsize; i++)
+    {
+      char ch = priv->seq[i];
+
+      if (ch == 'm')
+        {
+          priv->nseq = 0;
+          return VT100_PROCESSED;
+        }
+
+      if ((ch < '0' || ch > '9') && ch != ';' && ch != ':')
+        {
+          return VT100_ABORT;
+        }
+    }
+
+  return seqsize < VT100_MAX_SEQUENCE ? VT100_CONSUMED : VT100_ABORT;
+}
+
+/****************************************************************************
  * Name: nxterm_vt100part
  *
  * Description:
@@ -287,6 +328,16 @@ static enum nxterm_vt100state_e nxterm_vt100seq(
        */
 
       return VT100_CONSUMED;
+    }
+
+  /* SGR parameters are variable-length.  Consume these sequences even
+   * though NxTerm does not yet implement their visual attributes.
+   */
+
+  ret = nxterm_sgr(priv, seqsize);
+  if (ret != VT100_ABORT)
+    {
+      return ret;
     }
 
   /* We get here on a failure.  The buffer sequence is not part of any


### PR DESCRIPTION
## Summary

- graphics/nxterm: support command-line cursor editing 
- graphics/nxterm: consume SGR escape sequences 

## Impact

improvements for nxterm

## Testing

Intel NUC 12 with python interactive interpreter on display:

<img width="3072" height="2305" alt="image" src="https://github.com/user-attachments/assets/2da079ee-913b-4741-9222-da3be41bbb6b" />
