### PR TITLE
[1/10] binfmt/elf: Run a loaded module's constructors.

### DIFF
--- a/binfmt/elf.c
+++ b/binfmt/elf.c
@@ -98,6 +98,10 @@ static int elf_loadbinary(FAR struct binary_s *binp,
                           int nexports)
 {
   struct mod_loadinfo_s loadinfo;
+#if defined(CONFIG_BINFMT_CONSTRUCTORS) && !defined(CONFIG_ARCH_ADDRENV)
+  FAR void (**array)(void);
+  int i;
+#endif
   Elf_Sym sym;
   int ret;
 
@@ -283,6 +287,28 @@ static int elf_loadbinary(FAR struct binary_s *binp,
       dspaces->region = (FAR void *)loadinfo.shdr[loadinfo.gotindex].sh_addr;
       dspaces->crefs = 1;
       binp->picbase = (FAR void *)dspaces;
+    }
+#endif
+
+#if defined(CONFIG_BINFMT_CONSTRUCTORS) && !defined(CONFIG_ARCH_ADDRENV)
+  /* Run the constructors, as libelf_insert() does for dlopen().  An
+   * executable runs its own in crt0.  A module with a PIC base is skipped:
+   * this task holds its own base, not the module's.
+   */
+
+  if (loadinfo.ehdr.e_type != ET_EXEC && binp->picbase == NULL)
+    {
+      array = (FAR void (**)(void))loadinfo.preiarr;
+      for (i = 0; i < loadinfo.nprei; i++)
+        {
+          array[i]();
+        }
+
+      array = (FAR void (**)(void))loadinfo.initarr;
+      for (i = 0; i < loadinfo.ninit; i++)
+        {
+          array[i]();
+        }
     }
 #endif
 


### PR DESCRIPTION
## Summary

`CONFIG_BINFMT_CONSTRUCTORS` has never had any effect on a module loaded through `exec()`. `elf_loadbinary()` records `.preinit_array` and `.init_array` in `binp->mod`, and nothing reads them back, so a C++ module's global objects stay as `.bss` and its constructors are dropped without a word.

This calls the arrays at the end of the load, which is where `libelf_insert()` has always called them for a module that arrives through `dlopen()`.

They cannot run on the task that will run the module: `exec_module()` had a hook for that, `exec_ctors()` through `nxtask_starthook()`, and it went with `CONFIG_SCHED_STARTHOOK`.

This is the first of ten PRs that #19673 is being split into, so each can be reviewed on its own. The first four have no FDPIC content at all and do not depend on each other, so they can merge in any order. The remaining six are the FDPIC work itself, one subsystem each, and each is a no-op with `CONFIG_FDPIC` off: loader core, ARM relocations, the callback entry points, the `exec()` path, `DT_NEEDED` through `dlopen()`, then documentation and a board configuration. The others are `[2/10]` #19939, `[3/10]` #19940 and `[4/10]` #19941.

## Impact

A module with a global constructor now gets it run, where before it was silently skipped. That is a fix, not a break, but it is worth knowing: a module that worked around the gap by initializing from its entry point will find the constructor has already run, and should drop the workaround, since left in place it initializes twice.

A module that reaches its globals through a PIC base register is left alone. The loading task carries its own base, not the module's, so a constructor would address the wrong data. Such a module gets what it got before, which is no constructors at all. Installing the base for the length of one call is a separate problem and comes with the FDPIC work in #19673.

Destructors already run on this path: `elf_unloadbinary()` calls `libelf_uninit()`, which walks `.fini_array`. So the object is destroyed without ever having been constructed, and that asymmetry is the bug.

A module with no constructors is unaffected, as is any configuration with `CONFIG_BINFMT_CONSTRUCTORS` disabled.

## Testing

Built for `mps3-an547:picostest` with `CONFIG_BINFMT_CONSTRUCTORS` enabled, which that configuration does not set by default. `tools/checkpatch.sh` passes.

Runtime evidence on real hardware follows tomorrow, on an RP2350. Help is welcome from anyone with a board that can load an ELF module: enable `CONFIG_BINFMT_CONSTRUCTORS` and run `apps/examples/sotest` or `apps/examples/module` with a module that has a global constructor. No FDPIC, no special toolchain and no filesystem support are needed.

