### PR TITLE
[2/10] libs/libc/elf: Give a shared object a word alignment, not zero.

### DIFF
--- a/libs/libc/elf/elf_load.c
+++ b/libs/libc/elf/elf_load.c
@@ -239,6 +239,20 @@ static void libelf_elfsize(FAR struct mod_loadinfo_s *loadinfo, bool alloc)
         }
     }
 
+  /* An ET_DYN object is sized from its program headers, which give no
+   * section alignment.  A word is enough.
+   */
+
+  if (loadinfo->textalign == 0)
+    {
+      loadinfo->textalign = sizeof(uintptr_t);
+    }
+
+  if (loadinfo->dataalign == 0)
+    {
+      loadinfo->dataalign = sizeof(uintptr_t);
+    }
+
   /* Save the allocation size */
 
   loadinfo->textsize = textsize;


### PR DESCRIPTION
## Summary

`libelf_elfsize()` takes `textalign` and `dataalign` from the section headers, which only the `ET_REL` path walks. An `ET_DYN` object is sized from its program headers instead, so both stay at zero, and the allocation a few lines later asks `lib_memalign()` for that alignment.

Zero is not a valid alignment, and every path that receives it divides by it. `mm_memalign()` accepts zero as a power of two, because `0 & -0` is 0, then takes the `alignment <= MM_ALIGN` branch and evaluates `((uintptr_t)ptr) % alignment` in a `DEBUGASSERT`. With `CONFIG_MM_HEAP_MEMPOOL` and a pool that fits the request the object never reaches that branch and gets `ALIGN_UP(blk, 0)` instead, which is `((blk - 1) / 0) * 0`.

On Cortex-M this is usually invisible: `UDIV` returns zero for a division by zero unless `CCR.DIV_0_TRP` is set, which NuttX does not set. It is a SIGFPE on the simulator, and the mempool path returns a null pointer wherever the division yields zero, which the loader reports as `-ENOMEM`.

Ask for a natural word when the program headers gave nothing. `p_align` is the linker's page granularity, not a section requirement, so honouring it would cost a page per module for no gain.

This is the second of ten PRs that #19673 is being split into, so each can be reviewed on its own. The first four have no FDPIC content at all and do not depend on each other, so they can merge in any order. The remaining six are the FDPIC work itself, one subsystem each, and each is a no-op with `CONFIG_FDPIC` off: loader core, ARM relocations, the callback entry points, the `exec()` path, `DT_NEEDED` through `dlopen()`, then documentation and a board configuration. The others are `[1/10]` #19938, `[3/10]` #19940 and `[4/10]` #19941.

## Impact

Every `ET_DYN` module, which is every shared object opened with `dlopen()`, is allocated through an aligned path rather than a zero one.

No configuration change, no size change beyond the alignment of one allocation.

## Testing

Built for `mps3-an547:picostest`, which is `CONFIG_ELF` with `CONFIG_PIC`. `tools/checkpatch.sh` passes.

Runtime evidence on real hardware follows tomorrow, on an RP2350.
