### PR TITLE
[4/10] libs/libc/elf: Translate link-time addresses through one place.

### DIFF
--- a/libs/libc/elf/elf.h
+++ b/libs/libc/elf/elf.h
@@ -238,6 +238,34 @@ int libelf_reallocbuffer(FAR struct mod_loadinfo_s *loadinfo,
 
 int libelf_freebuffers(FAR struct mod_loadinfo_s *loadinfo);
 
+/****************************************************************************
+ * Name: libelf_addr
+ *
+ * Description:
+ *   Translate a link-time address in a loaded object to the address it
+ *   occupies now.  An address below the data segment's link-time base
+ *   belongs to text, anything at or above it to data.
+ *
+ * Input Parameters:
+ *   loadinfo - Load state information
+ *   vaddr    - The link-time address to translate
+ *
+ * Returned Value:
+ *   The run-time address.
+ *
+ ****************************************************************************/
+
+static inline uintptr_t libelf_addr(FAR struct mod_loadinfo_s *loadinfo,
+                                    uintptr_t vaddr)
+{
+  if (loadinfo->datasec != 0 && vaddr >= loadinfo->datasec)
+    {
+      return loadinfo->datastart + (vaddr - loadinfo->datasec);
+    }
+
+  return loadinfo->textalloc + vaddr;
+}
+
 #ifdef CONFIG_ARCH_ADDRENV
 
 /****************************************************************************

--- a/libs/libc/elf/elf_bind.c
+++ b/libs/libc/elf/elf_bind.c
@@ -831,7 +831,7 @@ static int libelf_relocatedyn(FAR struct module_s *modp,
                         return ret;
                       }
 
-                    addr = rel->r_offset + loadinfo->textalloc;
+                    addr = libelf_addr(loadinfo, rel->r_offset);
 
                     if (reldata.relrela[idx_rel] == 1)
                       {
@@ -848,23 +848,15 @@ static int libelf_relocatedyn(FAR struct module_s *modp,
                   0
                 };
 
-              addr = rel->r_offset - loadinfo->datasec + loadinfo->datastart;
+              addr = libelf_addr(loadinfo, rel->r_offset);
 
               if (reldata.relrela[idx_rel] == 1)
                 {
                   addr += rela->r_addend;
                 }
 
-              if ((*(FAR uint32_t *)addr) < loadinfo->datasec)
-                {
-                  dynsym.st_value = *(FAR uint32_t *)addr +
-                                    loadinfo->textalloc;
-                }
-              else
-                {
-                  dynsym.st_value = *(FAR uint32_t *)addr -
-                                    loadinfo->datasec + loadinfo->datastart;
-                }
+              dynsym.st_value = libelf_addr(loadinfo,
+                                            *(FAR uint32_t *)addr);
 
               ret = up_relocate(rel, &dynsym, addr, ARCH_ELFDATA_PARM);
             }
@@ -968,23 +960,20 @@ int libelf_bind(FAR struct module_s *modp,
                 loadinfo->dsymtabidx = i;
                 break;
               case SHT_INIT_ARRAY:
-                loadinfo->initarr = loadinfo->shdr[i].sh_addr -
-                                    loadinfo->datasec +
-                                    loadinfo->datastart;
+                loadinfo->initarr = libelf_addr(loadinfo,
+                                                loadinfo->shdr[i].sh_addr);
                 loadinfo->ninit = loadinfo->shdr[i].sh_size /
                                   sizeof(uintptr_t);
                 break;
               case SHT_FINI_ARRAY:
-                loadinfo->finiarr = loadinfo->shdr[i].sh_addr -
-                                    loadinfo->datasec +
-                                    loadinfo->datastart;
+                loadinfo->finiarr = libelf_addr(loadinfo,
+                                                loadinfo->shdr[i].sh_addr);
                 loadinfo->nfini = loadinfo->shdr[i].sh_size /
                                   sizeof(uintptr_t);
                 break;
               case SHT_PREINIT_ARRAY:
-                loadinfo->preiarr = loadinfo->shdr[i].sh_addr -
-                                    loadinfo->datasec +
-                                    loadinfo->datastart;
+                loadinfo->preiarr = libelf_addr(loadinfo,
+                                                loadinfo->shdr[i].sh_addr);
                 loadinfo->nprei = loadinfo->shdr[i].sh_size /
                                   sizeof(uintptr_t);
                 break;

--- a/libs/libc/elf/elf_bind.c
+++ b/libs/libc/elf/elf_bind.c
@@ -815,38 +815,38 @@ static int libelf_relocatedyn(FAR struct module_s *modp,
 
               if (sym[idx_sym].st_shndx == SHN_UNDEF)
                 {
-                    FAR void *ep;
+                  FAR void *ep;
 
-                    ep = libelf_findglobal(modp, loadinfo, symhdr,
-                                           &sym[idx_sym]);
-                    if ((ep == NULL) && (ELF_ST_BIND(sym[idx_sym].st_info)
-                        != STB_WEAK))
-                      {
-                        berr("ERROR: Unable to resolve addr of ext ref %s\n",
-                             loadinfo->iobuffer);
-                        ret = -EINVAL;
-                        lib_free(sym);
-                        lib_free(rels);
-                        lib_free(dyn);
-                        return ret;
-                      }
+                  ep = libelf_findglobal(modp, loadinfo, symhdr,
+                                         &sym[idx_sym]);
+                  if ((ep == NULL) && (ELF_ST_BIND(sym[idx_sym].st_info)
+                      != STB_WEAK))
+                    {
+                      berr("ERROR: Unable to resolve addr of ext ref %s\n",
+                           loadinfo->iobuffer);
+                      ret = -EINVAL;
+                      lib_free(sym);
+                      lib_free(rels);
+                      lib_free(dyn);
+                      return ret;
+                    }
 
-                    addr = libelf_addr(loadinfo, rel->r_offset);
+                  addr = libelf_addr(loadinfo, rel->r_offset);
 
-                    if (reldata.relrela[idx_rel] == 1)
-                      {
-                        addr += rela->r_addend;
-                      }
+                  if (reldata.relrela[idx_rel] == 1)
+                    {
+                      addr += rela->r_addend;
+                    }
 
-                    *(FAR uintptr_t *)addr = (uintptr_t)ep;
+                  *(FAR uintptr_t *)addr = (uintptr_t)ep;
                 }
             }
           else
             {
               Elf_Sym dynsym =
-                {
-                  0
-                };
+              {
+                0
+              };
 
               addr = libelf_addr(loadinfo, rel->r_offset);
 
@@ -943,6 +943,7 @@ int libelf_bind(FAR struct module_s *modp,
       /* Get the index to the relocation section */
 
       int infosec = loadinfo->shdr[i].sh_info;
+
       if (infosec >= loadinfo->ehdr.e_shnum)
         {
           continue;
@@ -1074,6 +1075,7 @@ errout_with_addrenv:
   if (loadinfo->addrenv != NULL)
     {
       int status = libelf_addrenv_restore(loadinfo);
+
       if (status < 0)
         {
           berr("ERROR: libelf_addrenv_restore() failed: %d\n", status);


### PR DESCRIPTION
## Summary

The `ET_DYN` path computes run-time addresses from link-time ones in five places, each open-coding the arithmetic, and two of them disagree about how. `libelf_relocatedyn()` adds `textalloc` to a relocation's `r_offset` in one branch and subtracts `datasec` before adding `datastart` in the next, while the value translation a few lines down picks between those two forms with an explicit test on `datasec`.

This collects that into `libelf_addr()`, which makes the test once: an address below the data segment's link-time base belongs to text, anything at or above it to data.

It changes nothing today. `datastart - datasec` is `textalloc` for the way an object is placed now, so both forms reduce to the same arithmetic. They stop being the same once text and data are placed independently, which is what an FDPIC object requires, and having the translation in one function is what makes that possible without auditing every open-coded expression again.

This is the fourth of the PRs that #19673 is being split into, so each can be reviewed on its own. `[1/10]` #19938 is withdrawn: the bug it described is not real, because a relocatable module already runs its constructors from `crt0`. `[2/10]` #19939 is merged. `[3/10]` #19940 is independent of this one and they can merge in any order. The rest are the FDPIC work itself, one subsystem each, and each is a no-op with `CONFIG_FDPIC` off: loader core `[5/10]` #19942, ARM relocations, the callback entry points, the `exec()` path, `DT_NEEDED` through `dlopen()`, then documentation and a board configuration.

## Impact

None intended. Pure refactor, no behaviour change, no configuration change.

## Testing

Built for `mps3-an547:picostest`, which is `CONFIG_ELF` with `CONFIG_PIC`.

There is no hardware for this series, so the runtime evidence is emulated. `mps2-an500:xipfs` runs the whole execute-in-place loader under QEMU with no board, and that is where the module load path is exercised.
