### PR TITLE
[5/10] libs/libc/elf: Load an FDPIC object.

### DIFF
--- a/arch/Kconfig
+++ b/arch/Kconfig
@@ -725,6 +725,13 @@ config ARCH_HAVE_ELF_EXECUTABLE
 	bool
 	default n
 
+config ARCH_HAVE_ELF_FDPIC
+	bool
+	default n
+	---help---
+		The architecture has a PIC base register and the ELF relocations
+		that an FDPIC object uses.
+
 config ARCH_HAVE_TRUSTZONE
 	bool
 	default n

--- a/arch/arm/Kconfig
+++ b/arch/arm/Kconfig
@@ -1096,6 +1096,7 @@ config ARCH_ARMV7M
 	default n
 	select ARCH_HAVE_CPUINFO
 	select ARCH_HAVE_DEBUG
+	select ARCH_HAVE_ELF_FDPIC
 	select ARCH_HAVE_PERF_EVENTS
 
 config ARCH_CORTEXM3
@@ -1245,6 +1246,7 @@ config ARCH_ARMV8M
 	default n
 	select ARCH_HAVE_CPUINFO
 	select ARCH_HAVE_DEBUG
+	select ARCH_HAVE_ELF_FDPIC
 	select ARCH_HAVE_PERF_EVENTS
 
 config ARCH_CORTEXM23

--- a/arch/arm/include/arch.h
+++ b/arch/arm/include/arch.h
@@ -79,6 +79,45 @@ do { \
   ); \
 } while (0)
 
+#ifdef CONFIG_FDPIC
+
+/****************************************************************************
+ * Name: up_fdpic_invoke
+ *
+ * Description:
+ *   Call a module entry point with the module data base in the PIC base
+ *   register.  Put the caller data base back after the call.
+ *
+ * Input Parameters:
+ *   arg   - The one word argument, passed in r0.
+ *   entry - The code address to enter.
+ *   got   - The module data base to install.
+ *
+ ****************************************************************************/
+
+static inline void up_fdpic_invoke(uintptr_t arg, uintptr_t entry,
+                                   uintptr_t got)
+{
+  register uintptr_t r0v __asm__ ("r0") = arg;
+
+  /* arg is already in r0.  r4 goes on the stack with the PIC register to
+   * keep the push aligned to 8 bytes.
+   */
+
+  __asm__ __volatile__
+  (
+    "push {r4, " PIC_REG_STRING "}\n"   /* Save the caller's base       */
+    "mov " PIC_REG_STRING ", %[got]\n"  /* Install the module's base    */
+    "blx %[entry]\n"                    /* Enter the module             */
+    "pop {r4, " PIC_REG_STRING "}\n"    /* Restore the caller's base    */
+    : "+r" (r0v)
+    : [entry] "r" (entry), [got] "r" (got)
+    : "r1", "r2", "r3", "r12", "lr", "cc", "memory"
+  );
+}
+
+#endif /* CONFIG_FDPIC */
+
 #endif /* CONFIG_PIC */
 
 #ifdef CONFIG_ARCH_ADDRENV

--- a/arch/arm/include/elf.h
+++ b/arch/arm/include/elf.h
@@ -41,6 +41,11 @@
 
 #define EM_ARCH                  EM_ARM
 
+/* An object built for the FDPIC ABI says so in the OS/ABI byte. */
+
+#define ELF_IS_FDPIC(ehdr) \
+  ((ehdr)->e_ident[EI_OSABI] == ELFOSABI_ARM_FDPIC)
+
 /* Table 4-2, ARM-specific e_flags */
 
 #define EF_ARM_EABI_MASK         0xff000000
@@ -205,6 +210,18 @@
 #define R_ARM_ME_TOO             128           /* Obsolete */
 #define R_ARM_THM_TLS_DESCSEQ16  129           /* Thumb16 */
 #define R_ARM_THM_TLS_DESCSEQ32  130           /* Thumb32 */
+
+/* FDPIC relocations.  Values from the ARM FDPIC ABI as implemented by
+ * binutils (include/elf/arm.h).
+ */
+
+#define R_ARM_GOTFUNCDESC        161           /* Data      GOT entry holding a descriptor */
+#define R_ARM_GOTOFFFUNCDESC     162           /* Data      GOT-relative descriptor */
+#define R_ARM_FUNCDESC           163           /* Data      Address of a descriptor */
+#define R_ARM_FUNCDESC_VALUE     164           /* Data      The descriptor itself: {code, GOT} */
+#define R_ARM_TLS_GD32_FDPIC     165           /* Data */
+#define R_ARM_TLS_LDM32_FDPIC    166           /* Data */
+#define R_ARM_TLS_IE32_FDPIC     167           /* Data */
 
 /* Processor specific values for the Phdr p_type field.  */
 

--- a/binfmt/Kconfig
+++ b/binfmt/Kconfig
@@ -60,6 +60,38 @@ config ELF_STACKSIZE
 	default DEFAULT_TASK_STACKSIZE
 	---help---
 		This is the default stack size that will be used when starting ELF binaries.
+
+config FDPIC
+	bool "FDPIC modules"
+	default n
+	select PIC
+	depends on ARCH_HAVE_ELF_FDPIC
+	---help---
+		Load ELF modules built for the FDPIC ABI.
+
+		An FDPIC module places its read-only and writable segments
+		independently, so its text can be executed directly out of flash
+		while only the writable segment is copied to RAM, once per running
+		instance.  A filesystem that can show its media, such as XIPFS or
+		ROMFS, gives that result.  On any other filesystem the loader copies
+		the text to RAM, and the module runs but shares nothing.
+
+		Building a module needs an arm-uclinuxfdpiceabi linker.  The stock
+		arm-none-eabi compiler emits correct FDPIC objects for both C and
+		C++, so only the link needs it.
+
+		What this adds over the position independent ELF support already
+		present is a function pointer that carries its own data base, as a
+		two word descriptor rather than a bare code address.  That is what
+		lets a module be called back on a thread it did not create, such as
+		the work queue worker that runs a SIGEV_THREAD notification.
+
+		Selecting this makes ten libc and sched entry points that can
+		accept a callback from a module resolve such a descriptor before
+		storing or branching to it.  Each costs a register read and a
+		branch on a path that is not hot.
+
+		This implementation covers ARM Thumb-2.
 endif
 endif
 

--- a/binfmt/elf.c
+++ b/binfmt/elf.c
@@ -139,7 +139,7 @@ static int elf_loadbinary(FAR struct binary_s *binp,
 
   /* Bind the program to the exported symbol table */
 
-  if (loadinfo.ehdr.e_type == ET_REL || loadinfo.gotindex >= 0)
+  if (loadinfo.ehdr.e_type == ET_REL || loadinfo.gotsize != 0)
     {
       ret = libelf_bind(&binp->mod, &loadinfo, exports, nexports);
       if (ret != 0)
@@ -270,7 +270,7 @@ static int elf_loadbinary(FAR struct binary_s *binp,
 
   libelf_dumpentrypt(&loadinfo);
 #ifdef CONFIG_PIC
-  if (loadinfo.gotindex >= 0)
+  if (loadinfo.gotsize != 0)
     {
       FAR struct dspace_s *dspaces = kmm_zalloc(sizeof(struct dspace_s));
 
@@ -280,7 +280,7 @@ static int elf_loadbinary(FAR struct binary_s *binp,
           goto errout_with_load;
         }
 
-      dspaces->region = (FAR void *)loadinfo.shdr[loadinfo.gotindex].sh_addr;
+      dspaces->region = (FAR void *)loadinfo.gotbase;
       dspaces->crefs = 1;
       binp->picbase = (FAR void *)dspaces;
     }

--- a/boards/arm/mps/mps3-an547/src/mps3_bringup.c
+++ b/boards/arm/mps/mps3-an547/src/mps3_bringup.c
@@ -147,7 +147,7 @@ int board_boot_image(const char *path, uint32_t hdr_size)
     }
 
   bss = libelf_findsection(&loadinfo, ".bss");
-  got = loadinfo.shdr[loadinfo.gotindex].sh_addr;
+  got = loadinfo.gotbase;
   msp = loadinfo.shdr[bss].sh_addr + loadinfo.shdr[bss].sh_size +
         CONFIG_IDLETHREAD_STACKSIZE;
 

--- a/fs/Kconfig
+++ b/fs/Kconfig
@@ -94,6 +94,17 @@ config PSEUDOFS_ATTRIBUTES
 		Enable support for attributes(e.g. mode, uid, gid and time)
 		in the pseudo file system.
 
+config FS_PIN
+	bool
+	default n
+	---help---
+		Selected by a file system that can pin a file's blocks in place and
+		hand out their media address, so that a module's read-only segment
+		can be executed where it already lies instead of being copied.
+
+		The pin is held for as long as the module is loaded and given back
+		when it is unloaded.
+
 config FS_PERMISSION
 	bool "Enable UNIX Filesystem Permission Support"
 	default n

--- a/fs/xipfs/Kconfig
+++ b/fs/xipfs/Kconfig
@@ -7,6 +7,7 @@ config FS_XIPFS
 	bool "XIPFS contiguous execute-in-place file system"
 	default n
 	depends on !DISABLE_MOUNTPOINT && MTD
+	select FS_PIN
 	---help---
 		Enable support for XIPFS, a file system that stores each file as a
 		single physically contiguous, erase-block aligned extent on memory

--- a/include/elf.h
+++ b/include/elf.h
@@ -279,6 +279,12 @@
 #define DT_TEXTREL         22         /* d_un=ignored */
 #define DT_JMPREL          23         /* d_un=d_ptr */
 #define DT_BINDNOW         24         /* d_un=ignored */
+#define DT_INIT_ARRAY      25         /* d_un=d_ptr */
+#define DT_FINI_ARRAY      26         /* d_un=d_ptr */
+#define DT_INIT_ARRAYSZ    27         /* d_un=d_val */
+#define DT_FINI_ARRAYSZ    28         /* d_un=d_val */
+#define DT_PREINIT_ARRAY   32         /* d_un=d_ptr */
+#define DT_PREINIT_ARRAYSZ 33         /* d_un=d_val */
 #define DT_LOPROC          0x70000000 /* d_un=unspecified */
 #define DT_HIPROC          0x7fffffff /* d_un= unspecified */
 

--- a/include/elf.h
+++ b/include/elf.h
@@ -149,6 +149,7 @@
 #define ELFOSABI_MODESTO   11    /* Novell Modesto.  */
 #define ELFOSABI_OPENBSD   12    /* OpenBSD.  */
 #define ELFOSABI_ARM_AEABI 64    /* ARM EABI */
+#define ELFOSABI_ARM_FDPIC 65    /* ARM FDPIC */
 #define ELFOSABI_ARM       97    /* ARM */
 #define ELFOSABI_STANDALONE 255  /* Standalone (embedded) application */
 

--- a/include/nuttx/elf.h
+++ b/include/nuttx/elf.h
@@ -37,6 +37,12 @@
 
 #define ELF_PRARGSZ    (80)  /* Number of chars for args */
 
+/* An architecture that has no FDPIC ABI recognises no FDPIC object. */
+
+#ifndef ELF_IS_FDPIC
+#  define ELF_IS_FDPIC(ehdr) false
+#endif
+
 /****************************************************************************
  * Public Types
  ****************************************************************************/

--- a/include/nuttx/fdpic.h
+++ b/include/nuttx/fdpic.h
@@ -1,0 +1,129 @@
+/****************************************************************************
+ * include/nuttx/fdpic.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_NUTTX_FDPIC_H
+#define __INCLUDE_NUTTX_FDPIC_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+
+#include <nuttx/arch.h>
+#include <nuttx/compiler.h>
+
+/****************************************************************************
+ * Public Types
+ ****************************************************************************/
+
+/* A function descriptor: what a function pointer is under FDPIC.  The
+ * firmware branches to a code address; a module passes one of these.
+ */
+
+struct fdpic_desc_s
+{
+  uintptr_t entry;      /* Address of the code */
+  uintptr_t got;        /* Data base to install before branching */
+};
+
+/****************************************************************************
+ * Inline Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_FDPIC
+
+/****************************************************************************
+ * Name: fdpic_base
+ *
+ * Description:
+ *   The data base of the calling context, from the PIC base register.
+ *   Non-zero means the caller is an FDPIC module, zero means firmware.
+ *
+ ****************************************************************************/
+
+static inline uintptr_t fdpic_base(void)
+{
+  uintptr_t base;
+
+  up_getpicbase(&base);
+  return base;
+}
+
+/****************************************************************************
+ * Name: fdpic_callback
+ *
+ * Description:
+ *   Resolve a function pointer from a caller that may be an FDPIC module.
+ *   Only the entry point is taken: the data base is already in the register.
+ *
+ * Input Parameters:
+ *   fn - The pointer as it was received.
+ *
+ * Returned Value:
+ *   An address that can be branched to directly.
+ *
+ ****************************************************************************/
+
+static inline FAR void *fdpic_callback(FAR void *fn)
+{
+  if (fn != NULL && fdpic_base() != 0)
+    {
+      return (FAR void *)((FAR struct fdpic_desc_s *)fn)->entry;
+    }
+
+  return fn;
+}
+
+/****************************************************************************
+ * Name: fdpic_invoke
+ *
+ * Description:
+ *   Call a resolved module entry point with the module data base in the PIC
+ *   base register.  For a callback that runs on a shared thread, which
+ *   carries no module base.  Elsewhere fdpic_callback() is enough.
+ *
+ * Input Parameters:
+ *   arg   - The one word argument.
+ *   entry - The code address to enter, already resolved from the descriptor.
+ *   got   - The module data base to install.
+ *
+ ****************************************************************************/
+
+static inline void fdpic_invoke(uintptr_t arg, uintptr_t entry,
+                                uintptr_t got)
+{
+  up_fdpic_invoke(arg, entry, got);
+}
+
+#else
+
+#  define fdpic_base()       (0)
+#  define fdpic_callback(fn) (fn)
+#  define fdpic_invoke(arg, entry, got) \
+          ((void)(got), (((CODE void (*)(uintptr_t))(uintptr_t)(entry))(arg)))
+
+#endif /* CONFIG_FDPIC */
+
+#endif /* __INCLUDE_NUTTX_FDPIC_H */

--- a/include/nuttx/lib/elf.h
+++ b/include/nuttx/lib/elf.h
@@ -44,6 +44,19 @@
 #  define CONFIG_LIBC_ELF_MAXDEPEND  0
 #endif
 
+/* A compacting filesystem gives its media address with a pin that holds the
+ * blocks in place.  The loader holds the pin through a file reference,
+ * because the unload runs on another task.
+ *
+ * That reference is taken with file_get() and file_dup2(), which are kernel
+ * side, so this is for the copy of libc that runs there.
+ */
+
+#if defined(CONFIG_FS_PIN) && \
+    (defined(CONFIG_BUILD_FLAT) || defined(__KERNEL__))
+#  define HAVE_LIBC_ELF_PIN 1
+#endif
+
 #ifndef CONFIG_LIBC_ELF_ALIGN_LOG2
 #  define CONFIG_LIBC_ELF_ALIGN_LOG2 2
 #endif
@@ -123,6 +136,7 @@ typedef CODE int (*mod_uninitializer_t)(FAR void *arg);
  *   nexports      - The number of symbols in the exported symbol table.
  */
 
+struct file;
 struct symtab_s;
 struct mod_info_s
 {
@@ -251,6 +265,16 @@ struct mod_loadinfo_s
                               * romfs/tmps, we can try get xipbase,
                               * skip the copy.
                               */
+
+  /* True if e_ident[EI_OSABI] marked this an FDPIC object. */
+
+  bool          fdpic;
+
+#ifdef HAVE_LIBC_ELF_PIN
+  /* The file the pin is held through, handed to the module once it loads. */
+
+  FAR struct file *pinfile;
+#endif
 
   /* Address environment.
    *

--- a/include/nuttx/lib/elf.h
+++ b/include/nuttx/lib/elf.h
@@ -168,6 +168,8 @@ typedef CODE int (*mod_initializer_t)(FAR struct mod_info_s *modinfo);
 struct module_s;
 typedef CODE int (*mod_callback_t)(FAR struct module_s *modp, FAR void *arg);
 
+struct fdpic_desc_s;
+
 /* This describes the file to be loaded. */
 
 struct module_s
@@ -275,6 +277,20 @@ struct mod_loadinfo_s
 
   FAR struct file *pinfile;
 #endif
+
+  /* The object's data base, from DT_PLTGOT.  An FDPIC module runs with this
+   * in the PIC base register.
+   */
+
+  uintptr_t     gotbase;
+
+  /* Pool of function descriptors behind the writable segment.  Reserved
+   * when the segment is sized, and bounded by the relocation count.
+   */
+
+  FAR struct fdpic_desc_s *descpool;
+  uint16_t      ndesc;       /* Capacity */
+  uint16_t      usedesc;     /* Next free slot */
 
   /* Address environment.
    *

--- a/include/nuttx/lib/elf.h
+++ b/include/nuttx/lib/elf.h
@@ -262,7 +262,6 @@ struct mod_loadinfo_s
   uint16_t      buflen;      /* size of iobuffer[] */
   int           filfd;       /* Descriptor for the file being loaded */
   int           nexports;    /* ET_DYN - Number of symbols exported */
-  int           gotindex;    /* Index to the GOT section */
   uintptr_t     xipbase;     /* if elf is position independent, and use
                               * romfs/tmps, we can try get xipbase,
                               * skip the copy.
@@ -278,11 +277,14 @@ struct mod_loadinfo_s
   FAR struct file *pinfile;
 #endif
 
-  /* The object's data base, from DT_PLTGOT.  An FDPIC module runs with this
-   * in the PIC base register.
+  /* The object's GOT.  gotbase is where it ended up: the placed address of
+   * .got, or DT_PLTGOT for an FDPIC object, which runs with it in the PIC
+   * base register.  gotsize is the extent of .got, and is also what says
+   * the object has one at all.
    */
 
   uintptr_t     gotbase;
+  size_t        gotsize;
 
   /* Pool of function descriptors behind the writable segment.  Reserved
    * when the segment is sized, and bounded by the relocation count.

--- a/libs/libc/elf/elf.h
+++ b/libs/libc/elf/elf.h
@@ -349,4 +349,26 @@ int libelf_addrenv_restore(FAR struct mod_loadinfo_s *loadinfo);
 void libelf_addrenv_free(FAR struct mod_loadinfo_s *loadinfo);
 
 #endif /* CONFIG_ARCH_ADDRENV */
+
+#ifdef HAVE_LIBC_ELF_PIN
+
+/****************************************************************************
+ * Name: libelf_pinrelease
+ *
+ * Description:
+ *   Give back an XIP pin that the loader took, and the file that holds it.
+ *   Does nothing if the loader took no pin.
+ *
+ * Input Parameters:
+ *   pinfile - The held file.  Cleared on return.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void libelf_pinrelease(FAR struct file **pinfile);
+
+#endif
+
 #endif /* __LIBS_LIBC_LIBC_ELF_LIBC_ELF_H */

--- a/libs/libc/elf/elf_bind.c
+++ b/libs/libc/elf/elf_bind.c
@@ -35,6 +35,7 @@
 #include <nuttx/arch.h>
 #include <nuttx/cache.h>
 #include <nuttx/elf.h>
+#include <nuttx/symtab.h>
 #include <nuttx/lib/elf.h>
 
 #include "libc.h"
@@ -637,7 +638,9 @@ static int libelf_relocateadd(FAR struct module_s *modp,
 
 static int libelf_relocatedyn(FAR struct module_s *modp,
                               FAR struct mod_loadinfo_s *loadinfo,
-                              int relidx)
+                              int relidx,
+                              FAR const struct symtab_s *exports,
+                              int nexports)
 {
   FAR Elf_Shdr *shdr = &loadinfo->shdr[relidx];
   FAR Elf_Shdr *symhdr;
@@ -868,6 +871,26 @@ static int libelf_relocatedyn(FAR struct module_s *modp,
 
                   ep = libelf_findglobal(modp, loadinfo, symhdr,
                                          &sym[idx_sym]);
+
+                  /* libelf_findglobal() searches only the registered
+                   * symbols.  A module from exec() has its own export
+                   * table, and an FDPIC module imports its libc there.
+                   */
+
+                  if (ep == NULL && exports != NULL)
+                    {
+                      FAR const struct symtab_s *sm;
+
+                      sm = symtab_findbyname(exports,
+                                             (FAR char *)
+                                             loadinfo->iobuffer,
+                                             nexports);
+                      if (sm != NULL)
+                        {
+                          ep = (FAR void *)sm->sym_value;
+                        }
+                    }
+
                   if ((ep == NULL) && (ELF_ST_BIND(sym[idx_sym].st_info)
                       != STB_WEAK))
                     {
@@ -888,6 +911,37 @@ static int libelf_relocatedyn(FAR struct module_s *modp,
                     }
 
                   *(FAR uintptr_t *)addr = (uintptr_t)ep;
+                }
+              else if (loadinfo->fdpic)
+                {
+                  /* A relocation naming a symbol inside this object.  A
+                   * pointer to a static function is emitted against the
+                   * section symbol, so the offset, Thumb bit included, is
+                   * the addend and must not come from the patched word.
+                   */
+
+                  Elf_Sym defsym = sym[idx_sym];
+
+                  defsym.st_value = libelf_addr(loadinfo,
+                                                sym[idx_sym].st_value);
+
+                  addr = libelf_addr(loadinfo, rel->r_offset);
+
+                  if (reldata.relrela[idx_rel] == 1)
+                    {
+                      addr += rela->r_addend;
+                    }
+
+                  ret = up_relocate(rel, &defsym, addr, ARCH_ELFDATA_PARM);
+                  if (ret < 0)
+                    {
+                      berr("ERROR: Section %d reloc %d: "
+                           "Relocation failed: %d\n", relidx, i, ret);
+                      lib_free(sym);
+                      lib_free(rels);
+                      lib_free(dyn);
+                      return ret;
+                    }
                 }
             }
           else
@@ -1004,7 +1058,8 @@ int libelf_bind(FAR struct module_s *modp,
           switch (loadinfo->shdr[i].sh_type)
             {
               case SHT_DYNAMIC:
-                ret = libelf_relocatedyn(modp, loadinfo, i);
+                ret = libelf_relocatedyn(modp, loadinfo, i,
+                                         exports, nexports);
                 break;
               case SHT_DYNSYM:
                 loadinfo->dsymtabidx = i;

--- a/libs/libc/elf/elf_bind.c
+++ b/libs/libc/elf/elf_bind.c
@@ -712,11 +712,60 @@ static int libelf_relocatedyn(FAR struct module_s *modp,
           case DT_PLTRELSZ:
             reldata.relsz[I_PLT] = dyn[i].d_un.d_val;
             break;
+          case DT_PLTGOT:
+
+            /* The object's data base.  Every function descriptor built
+             * for it names this base.
+             */
+
+            loadinfo->gotbase = dyn[i].d_un.d_ptr;
+            break;
+
+          /* The constructor and destructor tables.  Section headers are
+           * optional, so the dynamic tags are the authoritative copy.
+           */
+
+          case DT_INIT_ARRAY:
+            loadinfo->initarr = libelf_addr(loadinfo, dyn[i].d_un.d_ptr);
+            break;
+
+          case DT_INIT_ARRAYSZ:
+            loadinfo->ninit = dyn[i].d_un.d_val / sizeof(uintptr_t);
+            break;
+
+          case DT_FINI_ARRAY:
+            loadinfo->finiarr = libelf_addr(loadinfo, dyn[i].d_un.d_ptr);
+            break;
+
+          case DT_FINI_ARRAYSZ:
+            loadinfo->nfini = dyn[i].d_un.d_val / sizeof(uintptr_t);
+            break;
+
+          case DT_PREINIT_ARRAY:
+            loadinfo->preiarr = libelf_addr(loadinfo, dyn[i].d_un.d_ptr);
+            break;
+
+          case DT_PREINIT_ARRAYSZ:
+            loadinfo->nprei = dyn[i].d_un.d_val / sizeof(uintptr_t);
+            break;
+
           case DT_PLTREL:
             if (dyn[i].d_un.d_val == DT_REL)
               {
                 reldata.relentsz[I_PLT] = sizeof(Elf_Rel);
                 reldata.relrela[I_PLT] = 0;
+              }
+            else if (loadinfo->fdpic)
+              {
+                /* The ARM FDPIC ABI is REL throughout.  RELA entries are
+                 * longer, so walking them as REL reads the wrong place.
+                 */
+
+                berr("ERROR: FDPIC object claims RELA PLT relocations\n");
+                lib_free(sym);
+                lib_free(rels);
+                lib_free(dyn);
+                return -ENOEXEC;
               }
             else
               {

--- a/libs/libc/elf/elf_bind.c
+++ b/libs/libc/elf/elf_bind.c
@@ -337,7 +337,7 @@ static int libelf_relocate(FAR struct module_s *modp,
 
       /* Calculate the relocation address. */
 
-      if (loadinfo->gotindex >= 0)
+      if (loadinfo->gotsize != 0)
         {
           if (sym->st_shndx == SHN_UNDEF)
             {
@@ -345,8 +345,7 @@ static int libelf_relocate(FAR struct module_s *modp,
                * to the value of the symbol.
                */
 
-              FAR Elf_Shdr *gotsec = &loadinfo->shdr[loadinfo->gotindex];
-              FAR uintptr_t *gotaddr = (FAR uintptr_t *)(gotsec->sh_addr +
+              FAR uintptr_t *gotaddr = (FAR uintptr_t *)(loadinfo->gotbase +
                 *((FAR uintptr_t *)(dstsec->sh_addr + rel->r_offset)));
 
               *gotaddr = sym->st_value;

--- a/libs/libc/elf/elf_insert.c
+++ b/libs/libc/elf/elf_insert.c
@@ -247,9 +247,21 @@ static int libelf_loadsymtab(FAR struct module_s *modp,
       if (sym[i].st_shndx != SHN_UNDEF &&
           sym[i].st_shndx < loadinfo->ehdr.e_shnum)
         {
-          FAR Elf_Shdr *s = &loadinfo->shdr[sym[i].st_shndx];
+          if (loadinfo->ehdr.e_type == ET_DYN)
+            {
+              /* A shared object's symbol value is already the full
+               * link-time address.  It only needs translating onto where
+               * the object was placed.
+               */
 
-          sym[i].st_value = sym[i].st_value + s->sh_addr;
+              sym[i].st_value = libelf_addr(loadinfo, sym[i].st_value);
+            }
+          else
+            {
+              FAR Elf_Shdr *s = &loadinfo->shdr[sym[i].st_shndx];
+
+              sym[i].st_value = sym[i].st_value + s->sh_addr;
+            }
         }
     }
 

--- a/libs/libc/elf/elf_insert.c
+++ b/libs/libc/elf/elf_insert.c
@@ -85,6 +85,7 @@ void libelf_dumploadinfo(FAR struct mod_loadinfo_s *loadinfo)
       for (i = 0; i < loadinfo->ehdr.e_shnum; i++)
         {
           FAR Elf_Shdr *shdr = &loadinfo->shdr[i];
+
           binfo("Sections %d:\n", i);
 #  ifdef CONFIG_ARCH_USE_SEPARATED_SECTION
           if (loadinfo->ehdr.e_type == ET_REL)
@@ -420,27 +421,27 @@ FAR void *libelf_insert(FAR const char *filename, FAR const char *modname)
       case ET_REL :
       case ET_DYN :
 
-          /* Process any preinit_array entries */
+        /* Process any preinit_array entries */
 
-          array = (FAR void (**)(void))loadinfo.preiarr;
-          for (i = 0; i < loadinfo.nprei; i++)
-            {
-              array[i]();
-            }
+        array = (FAR void (**)(void))loadinfo.preiarr;
+        for (i = 0; i < loadinfo.nprei; i++)
+          {
+            array[i]();
+          }
 
-          /* Process any init_array entries */
+        /* Process any init_array entries */
 
-          array = (FAR void (**)(void))loadinfo.initarr;
-          for (i = 0; i < loadinfo.ninit; i++)
-            {
-              array[i]();
-            }
+        array = (FAR void (**)(void))loadinfo.initarr;
+        for (i = 0; i < loadinfo.ninit; i++)
+          {
+            array[i]();
+          }
 
-          modp->initarr = loadinfo.initarr;
-          modp->ninit = loadinfo.ninit;
-          modp->finiarr = loadinfo.finiarr;
-          modp->nfini = loadinfo.nfini;
-          break;
+        modp->initarr = loadinfo.initarr;
+        modp->ninit = loadinfo.ninit;
+        modp->finiarr = loadinfo.finiarr;
+        modp->nfini = loadinfo.nfini;
+        break;
     }
 
   /* Add the new module entry to the registry */

--- a/libs/libc/elf/elf_load.c
+++ b/libs/libc/elf/elf_load.c
@@ -408,6 +408,7 @@ static inline int libelf_loadfile(FAR struct mod_loadinfo_s *loadinfo)
               else
                 {
                   size_t bsssize = phdr->p_memsz - phdr->p_filesz;
+
                   ret = libelf_read(loadinfo, data, phdr->p_filesz,
                                     phdr->p_offset);
                   memset(data + phdr->p_filesz, 0, bsssize);

--- a/libs/libc/elf/elf_load.c
+++ b/libs/libc/elf/elf_load.c
@@ -243,8 +243,9 @@ static void libelf_elfsize(FAR struct mod_loadinfo_s *loadinfo, bool alloc)
     }
 
   /* Reserve the descriptor pool.  R_ARM_FUNCDESC asks the loader to
-   * manufacture a descriptor after the segment is placed, and the
-   * relocation count bounds how many.
+   * manufacture a descriptor after the segment is placed, and a library
+   * publishes one per exported function for dlsym().  The relocation and
+   * dynamic symbol counts bound how many.
    */
 
   if (loadinfo->fdpic)
@@ -255,7 +256,8 @@ static void libelf_elfsize(FAR struct mod_loadinfo_s *loadinfo, bool alloc)
         {
           FAR Elf_Shdr *shdr = &loadinfo->shdr[i];
 
-          if (shdr->sh_type == SHT_REL && shdr->sh_entsize != 0)
+          if ((shdr->sh_type == SHT_REL || shdr->sh_type == SHT_DYNSYM) &&
+              shdr->sh_entsize != 0)
             {
               nrels += shdr->sh_size / shdr->sh_entsize;
             }

--- a/libs/libc/elf/elf_load.c
+++ b/libs/libc/elf/elf_load.c
@@ -29,6 +29,7 @@
 #include <sys/param.h>
 #include <sys/types.h>
 
+#include <inttypes.h>
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
@@ -40,6 +41,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/lib/elf.h>
+#include <nuttx/fs/fs.h>
 #include <nuttx/fs/ioctl.h>
 
 #include "libc.h"
@@ -364,6 +366,13 @@ static inline int libelf_loadfile(FAR struct mod_loadinfo_s *loadinfo)
             {
               if (phdr->p_flags & PF_X)
                 {
+                  if (loadinfo->fdpic && loadinfo->xipbase != 0)
+                    {
+                      /* Mapped, not copied. */
+
+                      continue;
+                    }
+
                   ret = libelf_read(loadinfo, buffer_data_address(text),
                                     phdr->p_filesz,
                                     phdr->p_offset);
@@ -540,8 +549,111 @@ skipload:
 }
 
 /****************************************************************************
+ * Name: libelf_xipacquire
+ *
+ * Description:
+ *   Ask the filesystem for the address of this file on its media, so the
+ *   read-only part of the object can run where it lies.  Ask for a pin
+ *   first: a compacting filesystem is not safe without one.  Do not ask at
+ *   all if this build cannot hold a pin.
+ *
+ * Returned Value:
+ *   Zero if an address was obtained, a negated errno otherwise.  Callers
+ *   that can live without one may ignore the failure.
+ *
+ ****************************************************************************/
+
+#ifdef HAVE_LIBC_ELF_PIN
+static int libelf_pinhold(FAR struct mod_loadinfo_s *loadinfo)
+{
+  FAR struct file *filep;
+  int ret;
+
+  /* The descriptor belongs to the task that called the loader, and the
+   * unload runs on another task.  Hold the file instead.
+   */
+
+  loadinfo->pinfile = lib_zalloc(sizeof(struct file));
+  if (loadinfo->pinfile == NULL)
+    {
+      return -ENOMEM;
+    }
+
+  ret = file_get(loadinfo->filfd, &filep);
+  if (ret >= 0)
+    {
+      ret = file_dup2(filep, loadinfo->pinfile);
+      file_put(filep);
+    }
+
+  if (ret < 0)
+    {
+      lib_free(loadinfo->pinfile);
+      loadinfo->pinfile = NULL;
+    }
+
+  return ret;
+}
+
+#endif
+
+static int libelf_xipacquire(FAR struct mod_loadinfo_s *loadinfo)
+{
+  uintptr_t base = 0;
+
+#ifdef HAVE_LIBC_ELF_PIN
+  if (ioctl(loadinfo->filfd, XIPFSIOC_PIN, (unsigned long)&base) >= 0)
+    {
+      int ret = libelf_pinhold(loadinfo);
+
+      if (ret < 0)
+        {
+          berr("ERROR: Failed to hold the pinned file: %d\n", ret);
+          ioctl(loadinfo->filfd, XIPFSIOC_UNPIN, 0);
+          return ret;
+        }
+
+      loadinfo->xipbase = base;
+      binfo("pinned xipbase %" PRIxPTR "\n", loadinfo->xipbase);
+      return OK;
+    }
+#endif
+
+  if (ioctl(loadinfo->filfd, FIOC_XIPBASE, (unsigned long)&base) >= 0)
+    {
+      loadinfo->xipbase = base;
+      binfo("can use xipbase %" PRIxPTR "\n", loadinfo->xipbase);
+      return OK;
+    }
+
+  return -ENOTTY;
+}
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
+
+#ifdef HAVE_LIBC_ELF_PIN
+/****************************************************************************
+ * Name: libelf_pinrelease
+ *
+ * Description:
+ *   Give back an XIP pin and the file it was held through, so the
+ *   filesystem can reclaim the extent.
+ *
+ ****************************************************************************/
+
+void libelf_pinrelease(FAR struct file **pinfile)
+{
+  if (*pinfile != NULL)
+    {
+      file_ioctl(*pinfile, XIPFSIOC_UNPIN, 0);
+      file_close(*pinfile);
+      lib_free(*pinfile);
+      *pinfile = NULL;
+    }
+}
+#endif
 
 /****************************************************************************
  * Name: libelf_load
@@ -559,6 +671,7 @@ skipload:
 int libelf_load(FAR struct mod_loadinfo_s *loadinfo)
 {
   int ret;
+  int i;
 
   binfo("loadinfo: %p\n", loadinfo);
   DEBUGASSERT(loadinfo && loadinfo->filfd >= 0);
@@ -576,11 +689,7 @@ int libelf_load(FAR struct mod_loadinfo_s *loadinfo)
   if (loadinfo->gotindex >= 0)
     {
       binfo("GOT section found! index %d\n", loadinfo->gotindex);
-      if (ioctl(loadinfo->filfd, FIOC_XIPBASE,
-                (unsigned long)&loadinfo->xipbase) >= 0)
-        {
-          binfo("can use xipbase %zu\n", loadinfo->xipbase);
-        }
+      libelf_xipacquire(loadinfo);
     }
 
   /* Determine total size to allocate */
@@ -647,21 +756,96 @@ int libelf_load(FAR struct mod_loadinfo_s *loadinfo)
     }
   else if (loadinfo->ehdr.e_type == ET_DYN)
     {
-      loadinfo->textalloc = (uintptr_t)lib_memalign(loadinfo->textalign,
-                                                    loadinfo->textsize +
-                                                    loadinfo->datasize +
-                                                    loadinfo->segpad);
-
-      if (!loadinfo->textalloc)
+      if (loadinfo->fdpic)
         {
-          berr("ERROR: Failed to allocate memory for the module\n");
-          ret = -ENOMEM;
-          goto errout_with_buffers;
-        }
+          /* The two segments are placed independently, thus only the
+           * writable segment is allocated, once per instance.
+           */
 
-      loadinfo->datastart = loadinfo->textalloc +
-                            loadinfo->textsize +
-                            loadinfo->segpad;
+          if (loadinfo->xipbase != 0)
+            {
+              /* The text stays on the media.  The media address is the base
+               * of the file, thus add the file offset of the segment.
+               */
+
+              for (i = 0; i < loadinfo->ehdr.e_phnum; i++)
+                {
+                  FAR Elf_Phdr *phdr = &loadinfo->phdr[i];
+
+                  if (phdr->p_type == PT_LOAD &&
+                      (phdr->p_flags & PF_X) != 0)
+                    {
+                      loadinfo->textalloc = loadinfo->xipbase +
+                                            phdr->p_offset;
+                      break;
+                    }
+                }
+            }
+          else if (loadinfo->textsize > 0)
+            {
+              /* The filesystem cannot show its media, thus copy the text
+               * to RAM.  The instances no longer share it.
+               */
+
+#  if defined(CONFIG_ARCH_USE_TEXT_HEAP) && \
+      defined(CONFIG_ARCH_USE_SEPARATED_SECTION)
+              loadinfo->textalloc = (uintptr_t)
+                                    up_textheap_memalign(".text",
+                                                         loadinfo->textalign,
+                                                         loadinfo->textsize);
+#  elif defined(CONFIG_ARCH_USE_TEXT_HEAP)
+              loadinfo->textalloc = (uintptr_t)
+                                    up_textheap_memalign(loadinfo->textalign,
+                                                         loadinfo->textsize);
+#  else
+              loadinfo->textalloc = (uintptr_t)
+                                    lib_memalign(loadinfo->textalign,
+                                                 loadinfo->textsize);
+#  endif
+              if (loadinfo->textalloc == 0)
+                {
+                  berr("ERROR: Failed to allocate the module's text\n");
+                  ret = -ENOMEM;
+                  goto errout_with_buffers;
+                }
+            }
+
+          if (loadinfo->datasize > 0)
+            {
+              loadinfo->datastart =
+                (uintptr_t)lib_memalign(loadinfo->dataalign,
+                                        loadinfo->datasize);
+              if (!loadinfo->datastart)
+                {
+                  berr("ERROR: Failed to allocate the module's data\n");
+                  ret = -ENOMEM;
+                  goto errout_with_buffers;
+                }
+            }
+        }
+      else
+        {
+          /* Everything else keeps text and data adjacent: one allocation,
+           * data behind text.
+           */
+
+          loadinfo->textalloc = (uintptr_t)
+                                lib_memalign(loadinfo->textalign,
+                                             loadinfo->textsize +
+                                             loadinfo->datasize +
+                                             loadinfo->segpad);
+
+          if (!loadinfo->textalloc)
+            {
+              berr("ERROR: Failed to allocate memory for the module\n");
+              ret = -ENOMEM;
+              goto errout_with_buffers;
+            }
+
+          loadinfo->datastart = loadinfo->textalloc +
+                                loadinfo->textsize +
+                                loadinfo->segpad;
+        }
     }
 
 #endif /* CONFIG_LIBC_ELF_LOADTO_LMA */
@@ -732,11 +916,7 @@ int libelf_load_with_addrenv(FAR struct mod_loadinfo_s *loadinfo)
   if (loadinfo->gotindex >= 0)
     {
       binfo("GOT section found! index %d\n", loadinfo->gotindex);
-      if (ioctl(loadinfo->filfd, FIOC_XIPBASE,
-                (unsigned long)&loadinfo->xipbase) >= 0)
-        {
-          binfo("can use xipbase %zu\n", loadinfo->xipbase);
-        }
+      libelf_xipacquire(loadinfo);
     }
 
   /* Determine total size to allocate */

--- a/libs/libc/elf/elf_load.c
+++ b/libs/libc/elf/elf_load.c
@@ -40,6 +40,7 @@
 #include <nuttx/debug.h>
 
 #include <nuttx/arch.h>
+#include <nuttx/fdpic.h>
 #include <nuttx/lib/elf.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/fs/ioctl.h>
@@ -239,6 +240,31 @@ static void libelf_elfsize(FAR struct mod_loadinfo_s *loadinfo, bool alloc)
                 }
             }
         }
+    }
+
+  /* Reserve the descriptor pool.  R_ARM_FUNCDESC asks the loader to
+   * manufacture a descriptor after the segment is placed, and the
+   * relocation count bounds how many.
+   */
+
+  if (loadinfo->fdpic)
+    {
+      size_t nrels = 0;
+
+      for (i = 0; i < loadinfo->ehdr.e_shnum; i++)
+        {
+          FAR Elf_Shdr *shdr = &loadinfo->shdr[i];
+
+          if (shdr->sh_type == SHT_REL && shdr->sh_entsize != 0)
+            {
+              nrels += shdr->sh_size / shdr->sh_entsize;
+            }
+        }
+
+      loadinfo->ndesc = nrels;
+      datasize += nrels * sizeof(struct fdpic_desc_s);
+
+      binfo("fdpic: reserving %zu descriptors behind the data\n", nrels);
     }
 
   /* An ET_DYN object is sized from its program headers, which give no
@@ -822,6 +848,14 @@ int libelf_load(FAR struct mod_loadinfo_s *loadinfo)
                   goto errout_with_buffers;
                 }
             }
+
+          /* The pool was reserved at the end of the segment when it was
+           * sized, so it starts that many descriptors back from the end.
+           */
+
+          loadinfo->descpool = (FAR struct fdpic_desc_s *)
+                               (loadinfo->datastart + loadinfo->datasize) -
+                               loadinfo->ndesc;
         }
       else
         {

--- a/libs/libc/elf/elf_load.c
+++ b/libs/libc/elf/elf_load.c
@@ -366,13 +366,19 @@ static void libelf_set_emptysect_vma(FAR struct mod_loadinfo_s *loadinfo,
  *   Read the section data into memory. Section addresses in the shdr[] are
  *   updated to point to the corresponding position in the memory.
  *
+ * Input Parameters:
+ *   loadinfo - The load state.
+ *   gotidx   - Section index of .got, which the caller has already looked
+ *              up, or a negative value if the object has none.
+ *
  * Returned Value:
  *   0 (OK) is returned on success and a negated errno is returned on
  *   failure.
  *
  ****************************************************************************/
 
-static inline int libelf_loadfile(FAR struct mod_loadinfo_s *loadinfo)
+static inline int libelf_loadfile(FAR struct mod_loadinfo_s *loadinfo,
+                                  int gotidx)
 {
   FAR uint8_t *text = (FAR uint8_t *)loadinfo->textalloc;
   FAR uint8_t *data = (FAR uint8_t *)loadinfo->datastart;
@@ -546,13 +552,29 @@ skipload:
         }
     }
 
-  /* Update GOT table */
+  /* Note the GOT.  The sections are placed by now, thus .got carries the
+   * address it will be read at.  An FDPIC object's sections are never
+   * placed, and libelf_bind() takes its base from DT_PLTGOT instead.
+   */
 
-  if (loadinfo->gotindex >= 0)
+  if (gotidx >= 0)
     {
-      FAR Elf_Shdr *gotshdr = &loadinfo->shdr[loadinfo->gotindex];
-      FAR uintptr_t *got = (FAR uintptr_t *)gotshdr->sh_addr;
-      FAR uintptr_t *end = got + gotshdr->sh_size / sizeof(uintptr_t);
+      loadinfo->gotsize = loadinfo->shdr[gotidx].sh_size;
+
+      if (!loadinfo->fdpic)
+        {
+          loadinfo->gotbase = loadinfo->shdr[gotidx].sh_addr;
+        }
+    }
+
+  /* Update GOT table.  An FDPIC object's entries are relocated through its
+   * own relocations, so there is nothing to do for one here.
+   */
+
+  if (loadinfo->gotbase != 0)
+    {
+      FAR uintptr_t *got = (FAR uintptr_t *)loadinfo->gotbase;
+      FAR uintptr_t *end = got + loadinfo->gotsize / sizeof(uintptr_t);
 
       for (; got < end; got++)
         {
@@ -699,6 +721,7 @@ void libelf_pinrelease(FAR struct file **pinfile)
 
 int libelf_load(FAR struct mod_loadinfo_s *loadinfo)
 {
+  int gotidx;
   int ret;
   int i;
 
@@ -714,10 +737,15 @@ int libelf_load(FAR struct mod_loadinfo_s *loadinfo)
       goto errout_with_buffers;
     }
 
-  loadinfo->gotindex = libelf_findsection(loadinfo, ".got");
-  if (loadinfo->gotindex >= 0)
+  /* An object with a GOT is position independent, thus its read-only part
+   * may be able to stay where the filesystem holds it.  Keep the index:
+   * libelf_loadfile() notes the section once it has placed it.
+   */
+
+  gotidx = libelf_findsection(loadinfo, ".got");
+  if (gotidx >= 0)
     {
-      binfo("GOT section found! index %d\n", loadinfo->gotindex);
+      binfo("GOT section found! index %d\n", gotidx);
       libelf_xipacquire(loadinfo);
     }
 
@@ -889,7 +917,7 @@ int libelf_load(FAR struct mod_loadinfo_s *loadinfo)
 
   /* Load ELF section data into memory */
 
-  ret = libelf_loadfile(loadinfo);
+  ret = libelf_loadfile(loadinfo, gotidx);
   if (ret < 0)
     {
       berr("ERROR: libelf_loadfile failed: %d\n", ret);
@@ -935,6 +963,7 @@ errout_with_buffers:
 #ifdef CONFIG_ARCH_ADDRENV
 int libelf_load_with_addrenv(FAR struct mod_loadinfo_s *loadinfo)
 {
+  int gotidx;
   int ret;
 
   binfo("loadinfo: %p\n", loadinfo);
@@ -949,10 +978,15 @@ int libelf_load_with_addrenv(FAR struct mod_loadinfo_s *loadinfo)
       goto errout_with_buffers;
     }
 
-  loadinfo->gotindex = libelf_findsection(loadinfo, ".got");
-  if (loadinfo->gotindex >= 0)
+  /* An object with a GOT is position independent, thus its read-only part
+   * may be able to stay where the filesystem holds it.  Keep the index:
+   * libelf_loadfile() notes the section once it has placed it.
+   */
+
+  gotidx = libelf_findsection(loadinfo, ".got");
+  if (gotidx >= 0)
     {
-      binfo("GOT section found! index %d\n", loadinfo->gotindex);
+      binfo("GOT section found! index %d\n", gotidx);
       libelf_xipacquire(loadinfo);
     }
 
@@ -980,7 +1014,7 @@ int libelf_load_with_addrenv(FAR struct mod_loadinfo_s *loadinfo)
       goto errout_with_buffers;
     }
 
-  ret = libelf_loadfile(loadinfo);
+  ret = libelf_loadfile(loadinfo, gotidx);
   if (ret < 0)
     {
       berr("ERROR: libelf_loadfile failed: %d\n", ret);

--- a/libs/libc/elf/elf_loadhdrs.c
+++ b/libs/libc/elf/elf_loadhdrs.c
@@ -29,6 +29,7 @@
 #include <assert.h>
 #include <errno.h>
 #include <nuttx/debug.h>
+#include <nuttx/elf.h>
 
 #include <nuttx/lib/elf.h>
 
@@ -65,6 +66,23 @@ int libelf_loadhdrs(FAR struct mod_loadinfo_s *loadinfo)
   DEBUGASSERT(loadinfo->phdr == NULL);
 
   /* Verify that there are sections */
+
+  /* The architecture knows how an FDPIC object announces itself.  Ask it
+   * once.
+   */
+
+  loadinfo->fdpic = ELF_IS_FDPIC(&loadinfo->ehdr);
+
+  /* A module is a shared object.  An FDPIC object that is anything else
+   * would be placed through the wrong path.
+   */
+
+  if (loadinfo->fdpic && loadinfo->ehdr.e_type != ET_DYN)
+    {
+      berr("ERROR: FDPIC object is not a shared object: e_type=%u\n",
+           loadinfo->ehdr.e_type);
+      return -ENOEXEC;
+    }
 
   if (loadinfo->ehdr.e_shnum < 1)
     {

--- a/libs/libc/elf/elf_symbols.c
+++ b/libs/libc/elf/elf_symbols.c
@@ -107,7 +107,11 @@ static int libelf_symname(FAR struct mod_loadinfo_s *loadinfo,
 
   if (sym->st_name == 0)
     {
-      berr("ERROR: Symbol has no name\n");
+      /* Not a failure.  A section symbol has no name, and
+       * libelf_findsymbol() meets these routinely and checks for -ESRCH.
+       */
+
+      binfo("Symbol has no name\n");
       return -ESRCH;
     }
 

--- a/libs/libc/elf/elf_symbols.c
+++ b/libs/libc/elf/elf_symbols.c
@@ -451,7 +451,7 @@ int libelf_symvalue(FAR struct module_s *modp,
                 (uintptr_t)(sym->st_value + secbase));
 
           sym->st_value += secbase;
-          if (loadinfo->gotindex >= 0)
+          if (loadinfo->gotsize != 0)
             {
               sym->st_value -= loadinfo->shdr[sym->st_shndx].sh_offset;
             }

--- a/libs/libc/elf/elf_symbols.c
+++ b/libs/libc/elf/elf_symbols.c
@@ -34,6 +34,7 @@
 #include <nuttx/debug.h>
 
 #include <nuttx/symtab.h>
+#include <nuttx/fdpic.h>
 #include <nuttx/lib/elf.h>
 
 #include "libc.h"
@@ -542,6 +543,25 @@ int libelf_insertsymtab(FAR struct module_s *modp,
                       strdup((FAR char *)loadinfo->iobuffer);
                   symbol[j].sym_value =
                       (FAR const void *)(uintptr_t)sym[i].st_value;
+
+                  /* Publish an FDPIC function as a descriptor, so dlsym()
+                   * hands back something callable.  Only here does st_info
+                   * still say what is a function.
+                   */
+
+                  if (loadinfo->fdpic &&
+                      ELF_ST_TYPE(sym[i].st_info) == STT_FUNC &&
+                      loadinfo->usedesc < loadinfo->ndesc)
+                    {
+                      FAR struct fdpic_desc_s *desc =
+                        loadinfo->descpool + loadinfo->usedesc++;
+
+                      desc->entry = sym[i].st_value;
+                      desc->got   = loadinfo->gotbase;
+
+                      symbol[j].sym_value = (FAR const void *)desc;
+                    }
+
                   j++;
                 }
             }

--- a/libs/libc/elf/elf_symbols.c
+++ b/libs/libc/elf/elf_symbols.c
@@ -220,6 +220,7 @@ static int libelf_symcallback(FAR struct module_s *modp, FAR void *arg)
 
 #if CONFIG_LIBC_ELF_MAXDEPEND > 0
       int ret = libelf_depend(exportinfo->modp, modp);
+
       if (ret < 0)
         {
           berr("ERROR: libelf_depend failed: %d\n", ret);
@@ -354,108 +355,108 @@ int libelf_symvalue(FAR struct module_s *modp,
 
   switch (sym->st_shndx)
     {
-    case SHN_COMMON:
-      {
-        /* NuttX ELF modules should be compiled with -fno-common. */
+      case SHN_COMMON:
+        {
+          /* NuttX ELF modules should be compiled with -fno-common. */
 
-        berr("ERROR: SHN_COMMON: Re-compile with -fno-common\n");
-        return -ENOSYS;
-      }
+          berr("ERROR: SHN_COMMON: Re-compile with -fno-common\n");
+          return -ENOSYS;
+        }
 
-    case SHN_ABS:
-      {
-        /* st_value already holds the correct value */
+      case SHN_ABS:
+        {
+          /* st_value already holds the correct value */
 
-        binfo("SHN_ABS: st_value=%08lx\n", (long)sym->st_value);
-        return OK;
-      }
+          binfo("SHN_ABS: st_value=%08lx\n", (long)sym->st_value);
+          return OK;
+        }
 
-    case SHN_UNDEF:
-      {
-        /* Get the name of the undefined symbol */
+      case SHN_UNDEF:
+        {
+          /* Get the name of the undefined symbol */
 
-        ret = libelf_symname(loadinfo, sym, sh_offset);
-        if (ret < 0)
-          {
-            /* There are a few relocations for a few architectures that do
-             * no depend upon a named symbol.  We don't know if that is the
-             * case here, but return and special error to the caller to
-             * indicate the nameless symbol.
-             */
+          ret = libelf_symname(loadinfo, sym, sh_offset);
+          if (ret < 0)
+            {
+              /* There are a few relocations for a few architectures that do
+               * no depend upon a named symbol.  We don't know if that is the
+               * case here, but return and special error to the caller to
+               * indicate the nameless symbol.
+               */
 
-            berr("ERROR: SHN_UNDEF: Failed to get symbol name: %d\n", ret);
-            return ret;
-          }
+              berr("ERROR: SHN_UNDEF: Failed to get symbol name: %d\n", ret);
+              return ret;
+            }
 
-        /* First check if the symbol is exported by an installed module.
-         * Newest modules are installed at the head of the list.  Therefore,
-         * if the symbol is exported by numerous modules, then the most
-         * recently installed will take precedence.
-         */
+          /* First check if the symbol is exported by an installed module.
+           * Newest modules are installed at the head of the list.  So if
+           * the symbol is exported by numerous modules, then the most
+           * recently installed will take precedence.
+           */
 
-        exportinfo.name   = (FAR const char *)loadinfo->iobuffer;
-        exportinfo.modp   = modp;
-        exportinfo.symbol = NULL;
+          exportinfo.name   = (FAR const char *)loadinfo->iobuffer;
+          exportinfo.modp   = modp;
+          exportinfo.symbol = NULL;
 
-        ret = libelf_registry_foreach(libelf_symcallback,
-                                      (FAR void *)&exportinfo);
-        if (ret < 0)
-          {
-            berr("ERROR: libelf_symcallback failed: %d\n", ret);
-            return ret;
-          }
+          ret = libelf_registry_foreach(libelf_symcallback,
+                                        (FAR void *)&exportinfo);
+          if (ret < 0)
+            {
+              berr("ERROR: libelf_symcallback failed: %d\n", ret);
+              return ret;
+            }
 
-        symbol = exportinfo.symbol;
+          symbol = exportinfo.symbol;
 
-        /* If the symbol is not exported by any module, then check if the
-         * base code exports a symbol of this name.
-         */
+          /* If the symbol is not exported by any module, then check if the
+           * base code exports a symbol of this name.
+           */
 
-        if (symbol == NULL)
-          {
-            symbol = symtab_findbyname(exports, exportinfo.name,
-                                       nexports);
-          }
+          if (symbol == NULL)
+            {
+              symbol = symtab_findbyname(exports, exportinfo.name,
+                                         nexports);
+            }
 
-        /* Was the symbol found from any exporter? */
+          /* Was the symbol found from any exporter? */
 
-        if (symbol == NULL)
-          {
-            berr("ERROR: SHN_UNDEF: Exported symbol \"%s\" not found\n",
-                 loadinfo->iobuffer);
-            return -ENOENT;
-          }
+          if (symbol == NULL)
+            {
+              berr("ERROR: SHN_UNDEF: Exported symbol \"%s\" not found\n",
+                   loadinfo->iobuffer);
+              return -ENOENT;
+            }
 
-        /* Yes... add the exported symbol value to the ELF symbol tablei
-         * entry
-         */
+          /* Yes... add the exported symbol value to the ELF symbol tablei
+           * entry
+           */
 
-        binfo("SHN_UNDEF: name=%s "
-              "%08" PRIxPTR "+%08" PRIxPTR "=%08" PRIxPTR "\n",
-              loadinfo->iobuffer,
-              (uintptr_t)sym->st_value, (uintptr_t)symbol->sym_value,
-              (uintptr_t)(sym->st_value + (uintptr_t)symbol->sym_value));
+          binfo("SHN_UNDEF: name=%s "
+                "%08" PRIxPTR "+%08" PRIxPTR "=%08" PRIxPTR "\n",
+                loadinfo->iobuffer,
+                (uintptr_t)sym->st_value, (uintptr_t)symbol->sym_value,
+                (uintptr_t)(sym->st_value + (uintptr_t)symbol->sym_value));
 
-        sym->st_value += ((uintptr_t)symbol->sym_value);
-      }
-      break;
+          sym->st_value += ((uintptr_t)symbol->sym_value);
+        }
+        break;
 
-    default:
-      {
-        secbase = loadinfo->shdr[sym->st_shndx].sh_addr;
+      default:
+        {
+          secbase = loadinfo->shdr[sym->st_shndx].sh_addr;
 
-        binfo("Other[%d]: %08" PRIxPTR "+%08" PRIxPTR "=%08" PRIxPTR "\n",
-              sym->st_shndx,
-              (uintptr_t)sym->st_value, secbase,
-              (uintptr_t)(sym->st_value + secbase));
+          binfo("Other[%d]: %08" PRIxPTR "+%08" PRIxPTR "=%08" PRIxPTR "\n",
+                sym->st_shndx,
+                (uintptr_t)sym->st_value, secbase,
+                (uintptr_t)(sym->st_value + secbase));
 
-        sym->st_value += secbase;
-        if (loadinfo->gotindex >= 0)
-          {
-            sym->st_value -= loadinfo->shdr[sym->st_shndx].sh_offset;
-          }
-      }
-      break;
+          sym->st_value += secbase;
+          if (loadinfo->gotindex >= 0)
+            {
+              sym->st_value -= loadinfo->shdr[sym->st_shndx].sh_offset;
+            }
+        }
+        break;
     }
 
   return OK;
@@ -596,6 +597,7 @@ static int findep(FAR const void *c1, FAR const void *c2)
 {
   FAR const struct eptable_s *m1 = (FAR const struct eptable_s *)c1;
   FAR const struct eptable_s *m2 = (FAR const struct eptable_s *)c2;
+
   return strcmp((FAR const char *)m1->epname, (FAR const char *)m2->epname);
 }
 

--- a/libs/libc/elf/elf_unload.c
+++ b/libs/libc/elf/elf_unload.c
@@ -59,6 +59,17 @@ int libelf_unload(FAR struct mod_loadinfo_s *loadinfo)
 
   libelf_freebuffers(loadinfo);
 
+#ifdef HAVE_LIBC_ELF_PIN
+  /* Give the pin back if the loader took one, so the filesystem can
+   * reclaim the extent.
+   */
+
+  if (loadinfo->pinfile != NULL)
+    {
+      libelf_pinrelease(&loadinfo->pinfile);
+    }
+#endif
+
 #ifdef CONFIG_ARCH_ADDRENV
   if (loadinfo->addrenv != NULL)
     {
@@ -68,9 +79,35 @@ int libelf_unload(FAR struct mod_loadinfo_s *loadinfo)
 #endif
   /* Release memory holding the relocated ELF image */
 
-  /* ET_DYN has a single allocation so we only free textalloc */
+  /* An FDPIC object placed its two segments separately.  Free each one.  If
+   * the text stayed on the media, it was never allocated, thus leave it.
+   */
 
-  if (loadinfo->ehdr.e_type != ET_DYN)
+  if (loadinfo->fdpic)
+    {
+      if (loadinfo->textalloc != 0 && loadinfo->xipbase == 0)
+        {
+#ifdef CONFIG_ARCH_USE_TEXT_HEAP
+          up_textheap_free((FAR void *)loadinfo->textalloc);
+#else
+          lib_free((FAR void *)loadinfo->textalloc);
+#endif
+        }
+
+      if (loadinfo->datastart != 0)
+        {
+          lib_free((FAR void *)loadinfo->datastart);
+          loadinfo->datastart = 0;
+        }
+
+      loadinfo->textalloc = 0;
+      loadinfo->textsize  = 0;
+      loadinfo->datasize  = 0;
+    }
+
+  /* Any other ET_DYN has a single allocation so we only free textalloc */
+
+  else if (loadinfo->ehdr.e_type != ET_DYN)
     {
 #ifdef CONFIG_ARCH_USE_SEPARATED_SECTION
       int i;


### PR DESCRIPTION
## Summary

Fifth of the PRs that #19673 is being split into. This is the loader side: enough for the ELF loader to place an FDPIC object and bind it. The ARM relocations are `[6/10]`, the callback entry points `[7/10]`, the `exec()` path `[8/10]`, `DT_NEEDED` `[9/10]`, documentation and a board configuration `[10/10]`.

An FDPIC object places its two `PT_LOAD` segments independently, so its read-only segment runs where the filesystem already holds it and only the writable segment is copied to RAM, once per running instance. Several instances of one module therefore share one copy of the text. A filesystem that cannot show its media gets the text copied to RAM instead, so the module still runs but shares nothing.

The first commit adds `CONFIG_FDPIC`, `ARCH_HAVE_ELF_FDPIC` and `include/nuttx/fdpic.h`, so the four that follow each build on their own.

The read-only segment needs the filesystem to hold its blocks still. A compacting filesystem such as XIPFS gives its media address together with a pin, which the loader holds through a file reference, because the unload runs on a different task from the load.

The last commit is style only. CI feeds nxstyle the diff hunks with three lines of context, so style errors that are older than this series, in the lines around every hunk, fail the check job. They are a switch body indented two columns too deep, an initializer brace one level in, and declarations with no blank line after them.

## Impact

`CONFIG_FDPIC` defaults off and no in-tree configuration sets it, so nothing changes for anyone yet. With it off the four loader commits compile to what they were.

`[4/10]` #19941 has merged, so this is six commits on master.

## Testing

`mps3-an547:picostest` builds with `CONFIG_FDPIC` both on and off, and `mps3-an547:bl` builds, which is every configuration in the tree since none sets the option. `tools/checkpatch.sh -c -u -m -g` passes over the whole branch.

`mps3-an547:bl` is the one to keep an eye on: it sets `CONFIG_ARCH_USE_SEPARATED_SECTION`, and `CONFIG_LIBC_ELF` pulls in `ARCH_USE_TEXT_HEAP`, which selects the three argument `up_textheap_memalign()`. #19673 calls the two argument form there and fails to build; that is fixed in the commit that adds the call.

There is no hardware for this series, so the runtime evidence is emulated. A module cannot be relocated until `[6/10]`, so the runs that matter are the umbrella's, on QEMU `mps2-an500`: 131/131, 34/34 and 7/7, with the logs in #19673.
