### PR TITLE
tools/nxstyle: allow CPython API identifiers

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -218,6 +218,8 @@ static const char *g_white_prefix[] =
   "ub32",    /* Ref:  include/fixedmath.h */
   "lua_",    /* Ref:  apps/interpreters/lua/lua-5.x.x/src/lua.h */
   "luaL_",   /* Ref:  apps/interpreters/lua/lua-5.x.x/src/lauxlib.h */
+  "PyMem_",  /* Ref:  apps/interpreters/python */
+  "PyOS_",   /* Ref:  apps/interpreters/python */
   "Ba",      /* Ref:  apps/netutils/xedge/BAS/examples/xedge/src/xedge.h */
   "Thread",  /* Ref:  apps/netutils/xedge/BAS/examples/xedge/src/xedge.h */
   "LThread", /* Ref:  apps/netutils/xedge/BAS/examples/xedge/src/xedge.h */


### PR DESCRIPTION

## Summary

CPython exposes mixed-case PyMem_* and PyOS_* names that applications cannot rename.

## Impact

fix CI in https://github.com/apache/nuttx-apps/pull/3746

## Testing

CI
