### PR TITLE
arch/x86_64: support more than 4 CPU

### DIFF
--- a/arch/x86_64/src/common/x86_64_allocateheap.c
+++ b/arch/x86_64/src/common/x86_64_allocateheap.c
@@ -39,8 +39,6 @@
  * Pre-processor Definitions
  ****************************************************************************/
 
-#define IDLE_STACK_SIZE CONFIG_IDLETHREAD_STACKSIZE
-
 #if CONFIG_IDLETHREAD_STACKSIZE % 16 != 0
 #  error CONFIG_IDLETHREAD_STACKSIZE must be aligned to 16
 #endif
@@ -57,28 +55,8 @@
  * Public Functions
  ****************************************************************************/
 
-static const uintptr_t g_idle_stackalloc = (uintptr_t)_ebss +
-  CONFIG_IDLETHREAD_STACKSIZE * CONFIG_SMP_NCPUS;
-
-const uintptr_t g_idle_topstack[CONFIG_SMP_NCPUS] =
-{
-  (uintptr_t)g_idle_stackalloc + (1 * IDLE_STACK_SIZE) - 16,
-#if CONFIG_SMP_NCPUS > 1
-  (uintptr_t)g_idle_stackalloc + (2 * IDLE_STACK_SIZE) - 16,
-#endif
-#if CONFIG_SMP_NCPUS > 2
-  (uintptr_t)g_idle_stackalloc + (3 * IDLE_STACK_SIZE) - 16,
-#endif
-#if CONFIG_SMP_NCPUS > 3
-  (uintptr_t)g_idle_stackalloc + (4 * IDLE_STACK_SIZE) - 16,
-#endif
-#if CONFIG_SMP_NCPUS > 4
-  (uintptr_t)g_idle_stackalloc + (5 * IDLE_STACK_SIZE) - 16,
-#endif
-#if CONFIG_SMP_NCPUS > 5
-#  error missing logic
-#endif
-};
+const uintptr_t g_idle_topstack = (uintptr_t)_ebss +
+  (uintptr_t)CONFIG_IDLETHREAD_STACKSIZE * (CONFIG_SMP_NCPUS + 1) - 16;
 
 /****************************************************************************
  * Name: up_allocate_heap
@@ -106,7 +84,7 @@ void up_allocate_heap(void **heap_start, size_t *heap_size)
 
   board_autoled_on(LED_HEAPALLOCATE);
 
-  topstack = g_idle_topstack[CONFIG_SMP_NCPUS - 1] + 8;
+  topstack = x86_64_idle_topstack(CONFIG_SMP_NCPUS - 1) + 8;
 
   /* Calculate the end of .bss section */
 

--- a/arch/x86_64/src/common/x86_64_allocateheap.c
+++ b/arch/x86_64/src/common/x86_64_allocateheap.c
@@ -56,7 +56,7 @@
  ****************************************************************************/
 
 const uintptr_t g_idle_topstack = (uintptr_t)_ebss +
-  (uintptr_t)CONFIG_IDLETHREAD_STACKSIZE * (CONFIG_SMP_NCPUS + 1) - 16;
+                                  CONFIG_IDLETHREAD_STACKSIZE - 16;
 
 /****************************************************************************
  * Name: up_allocate_heap

--- a/arch/x86_64/src/common/x86_64_internal.h
+++ b/arch/x86_64/src/common/x86_64_internal.h
@@ -145,12 +145,11 @@ typedef void (*up_vector_t)(void);
 
 #ifndef __ASSEMBLY__
 
-/* This is the beginning of heap as provided from up_head.S. This is the
- * first address in DRAM after the loaded program+bss+idle stack.  The
- * end of the heap is CONFIG_RAM_END
+/* Top of the CPU0 idle stack.  The remaining CPU idle stacks are
+ * contiguous.
  */
 
-extern const uintptr_t g_idle_topstack[];
+extern const uintptr_t g_idle_topstack;
 
 /* Address of the saved user stack pointer */
 
@@ -179,6 +178,12 @@ extern uint8_t _etbss[];           /* End+1 of .tbss */
 /****************************************************************************
  * Inline Functions
  ****************************************************************************/
+
+static inline uintptr_t x86_64_idle_topstack(int cpu)
+{
+  return g_idle_topstack +
+         (uintptr_t)cpu * CONFIG_IDLETHREAD_STACKSIZE;
+}
 
 static inline void x86_64_cpuid(uint32_t leaf, uint32_t subleaf,
                                 uint32_t *eax, uint32_t *ebx,

--- a/arch/x86_64/src/intel64/intel64_cpuidlestack.c
+++ b/arch/x86_64/src/intel64/intel64_cpuidlestack.c
@@ -90,7 +90,7 @@ int up_cpu_idlestack(int cpu, struct tcb_s *tcb, size_t stack_size)
 
   /* Get the top of the stack */
 
-  stack_alloc          = (uintptr_t)g_idle_topstack[cpu] -
+  stack_alloc          = x86_64_idle_topstack(cpu) -
                          CONFIG_IDLETHREAD_STACKSIZE;
   tcb->adj_stack_size  = stack_size - 8;
   tcb->stack_alloc_ptr = (void *)stack_alloc;

--- a/arch/x86_64/src/intel64/intel64_head.S
+++ b/arch/x86_64/src/intel64/intel64_head.S
@@ -61,12 +61,10 @@
 #define X86_XSAVE_XCOMPBC_OFFSET   520
 #define X86_XSAVE_RESERVED0_OFFSET 528
 
-/* Memory Map: _sbss is the start of the BSS region (see ld.script) _ebss is
- * the end of the BSS region (see ld.script). The idle task stack starts at
- * the end of BSS and is of size CONFIG_IDLETHREAD_STACKSIZE.  The IDLE thread
- * is the thread that the system boots on and, eventually, becomes the idle,
- * do nothing task that runs only when there is nothing else to run.  The
- * heap continues from there until the end of memory.  See g_idle_topstack below.
+/* Memory Map: _sbss is the start of the BSS region, _ebss is the end of the
+ * BSS region.  One idle task stack is reserved for each configured CPU.  The
+ * heap follows the reserved idle stack area and continues until the end of
+ * memory.  See g_idle_topstack below.
  */
 
 /****************************************************************************
@@ -87,7 +85,7 @@
 	.global    __nxstart                       /* __nxstart is defined elsewhere */
 	.global    nx_start                        /* nx_start is defined elsewhere */
 	.global    x86_64_ap_boot                  /* x86_64_ap_boot is defined elsewhere */
-	.global    g_idle_topstack                 /* The end of the idle stack, the start of the heap */
+	.global    g_idle_topstack                 /* Top of the CPU0 idle stack */
 	.global    g_mb_info_struct
 	.global    g_mb_magic
 	.global    g_cpu_count
@@ -413,10 +411,10 @@ ap_start:
 
 	/* Setup AP stack */
 	movabs  $g_idle_topstack,    %rbx
-	movl    %edi, %eax
-	imul    $8, %eax, %eax
-	add     %rax, %rbx
 	mov     (%rbx),   %rsp
+	movl    %edi, %eax
+	imulq   $CONFIG_IDLETHREAD_STACKSIZE, %rax, %rax
+	add     %rax, %rsp
 
 	/* Move initial RSP below IDLE TCB regs */
 	sub     $XCPTCONTEXT_SIZE, %rsp

--- a/arch/x86_64/src/intel64/intel64_head.S
+++ b/arch/x86_64/src/intel64/intel64_head.S
@@ -420,7 +420,7 @@ ap_start:
 
 	/* Move initial RSP below IDLE TCB regs */
 	sub     $XCPTCONTEXT_SIZE, %rsp
-	and     $(~XCPTCONTEXT_SIZE), %rsp
+	and     $(~(XCPTCONTEXT_ALIGN - 1)), %rsp
 
 	/* Jump to ap_start routine */
 	movabs  $x86_64_ap_boot,   %rbx

--- a/arch/x86_64/src/intel64/intel64_initialstate.c
+++ b/arch/x86_64/src/intel64/intel64_initialstate.c
@@ -82,6 +82,7 @@ void up_initial_state(struct tcb_s *tcb)
     {
       char *stack_ptr = (char *)(x86_64_idle_topstack(0) -
                                  CONFIG_IDLETHREAD_STACKSIZE);
+
       tcb->stack_alloc_ptr = stack_ptr;
       tcb->stack_base_ptr  = stack_ptr;
       tcb->adj_stack_size  = CONFIG_IDLETHREAD_STACKSIZE;

--- a/arch/x86_64/src/intel64/intel64_initialstate.c
+++ b/arch/x86_64/src/intel64/intel64_initialstate.c
@@ -80,7 +80,7 @@ void up_initial_state(struct tcb_s *tcb)
 
   if (tcb->pid == IDLE_PROCESS_ID)
     {
-      char *stack_ptr = (char *)(g_idle_topstack[0] -
+      char *stack_ptr = (char *)(x86_64_idle_topstack(0) -
                                  CONFIG_IDLETHREAD_STACKSIZE);
       tcb->stack_alloc_ptr = stack_ptr;
       tcb->stack_base_ptr  = stack_ptr;

--- a/arch/x86_64/src/intel64/intel64_start.c
+++ b/arch/x86_64/src/intel64/intel64_start.c
@@ -92,8 +92,9 @@ static void x86_64_mb2_config(void)
 
           case MULTIBOOT_TAG_TYPE_ACPI_OLD:
             {
-              struct multiboot_tag_old_acpi *acpi
-                  = (struct multiboot_tag_old_acpi *)tag;
+              struct multiboot_tag_old_acpi *acpi =
+                (struct multiboot_tag_old_acpi *)tag;
+
               g_acpi_rsdp = (uintptr_t)acpi->rsdp;
               break;
             }
@@ -102,6 +103,7 @@ static void x86_64_mb2_config(void)
             {
               struct multiboot_tag_new_acpi *acpi =
                 (struct multiboot_tag_new_acpi *)tag;
+
               g_acpi_rsdp = (uintptr_t)acpi->rsdp;
               break;
             }

--- a/arch/x86_64/src/intel64/intel64_start.c
+++ b/arch/x86_64/src/intel64/intel64_start.c
@@ -163,10 +163,10 @@ void __nxstart(void)
 #ifdef CONFIG_SCHED_THREAD_LOCAL
   /* Make sure that FS_BASE is not null */
 
-  write_fsbase((uintptr_t)(g_idle_topstack[0] -
-                           CONFIG_IDLETHREAD_STACKSIZE +
-                           sizeof(struct tls_info_s) +
-                           (_END_TBSS - _START_TDATA)));
+  write_fsbase(x86_64_idle_topstack(0) -
+               CONFIG_IDLETHREAD_STACKSIZE +
+               sizeof(struct tls_info_s) +
+               (_END_TBSS - _START_TDATA));
 #endif
 
   /* Low-level, pre-OS initialization */


### PR DESCRIPTION
## Summary

- arch/x86_64: fix AP initial stack alignment 
- arch/x86_64: generalize intel64 idle stacks 
- arch/x86_64: drop unused gap below the intel64 idle stacks

## Impact

support more than 4 CPU for intel64

## Testing

intel64 with 12 CPUs enabled