### PR TITLE
tools/nxstyle: allow a macro taking a block to span several lines 

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -1452,6 +1452,7 @@ int main(int argc, char **argv, char **envp)
   char lastcode;        /* Last code character seen on this line */
   char prevlastcode;    /* Last code character on the preceding line */
   int prevcodeindent;   /* Indentation of the preceding line of code */
+  int stmt_lineindent;  /* Indentation of the line starting that statement */
   bool bfuncbody;       /* True: The outermost brace opened a function body */
   int stmt_indent;      /* Expected indentation of a statement, or -1 */
   int case_indent;      /* Expected indentation of a 'case' label, or -1 */
@@ -1582,6 +1583,7 @@ int main(int argc, char **argv, char **envp)
   lastcode       = '\0';        /* Last code character seen on this line */
   prevlastcode   = '\0';        /* Last code character on the preceding line */
   prevcodeindent = 0;           /* Indentation of the preceding line of code */
+  stmt_lineindent = 0;          /* Indentation where that statement began */
   bfuncbody      = false;       /* True: Inside the body of a function */
   stmt_indent    = 0;           /* Expected indentation of a statement */
   case_indent    = -1;          /* Expected indentation of a 'case' label */
@@ -4041,7 +4043,9 @@ int main(int argc, char **argv, char **envp)
                * that way.
                */
 
-              else if (prevlastcode == ')' && indent == prevcodeindent + 2)
+              else if (prevlastcode == ')' &&
+                       (indent == prevcodeindent + 2 ||
+                        indent == stmt_lineindent + 2))
                 {
                 }
               else if (indent > 0 && dnest == 0 &&
@@ -4134,6 +4138,11 @@ int main(int argc, char **argv, char **envp)
         {
           prevlastcode   = lastcode;
           prevcodeindent = indent;
+
+          if (bstmtstart)
+            {
+              stmt_lineindent = indent;
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

The brace was compared against the line before it rather than the line the statement began on, so a macro broken over two lines was reported.

## Impact

nxstyle fix

## Testing

code below not return nxstyle errors:

```
int demo(int a)
{
  list_for_every_entry(&g_list, node, entry,
                       foo_s, bar_s)
    {
      a++;
    }

  return a;
}

```
