### PR TITLE
tools/nxstyle: recognise typedef'd type names in declarations

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -1360,6 +1360,27 @@ static bool white_content_list(const char *ident, int lineno)
 }
 
 /********************************************************************************
+ * Name: check_type_name
+ *
+ * Description:
+ *   Return true if the identifier at line[ndx] ends in '_t'.
+ *
+ ********************************************************************************/
+
+static bool check_type_name(const char *line, int ndx)
+{
+  int i = ndx;
+
+  while (isalnum((int)line[i]) != 0 || line[i] == '_')
+    {
+      i++;
+    }
+
+  return i >= ndx + 3 && line[i] == ' ' &&
+         line[i - 1] == 't' && line[i - 2] == '_';
+}
+
+/********************************************************************************
  * Name: check_keyword
  *
  * Description:
@@ -2231,7 +2252,8 @@ int main(int argc, char **argv, char **envp)
 
       else if (inasm == 0)
         {
-          if (strncmp(&line[indent], "auto ", 5) == 0 ||
+          if (check_type_name(line, indent) ||
+                   strncmp(&line[indent], "auto ", 5) == 0 ||
                    strncmp(&line[indent], "bool ", 5) == 0 ||
                    strncmp(&line[indent], "char ", 5) == 0 ||
                    strncmp(&line[indent], "CODE ", 5) == 0 ||


### PR DESCRIPTION
## Summary

The fixed list of type names holds neither uint64_t nor any NuttX typedef, so declarations using them went unchecked.

## Impact

nxstyle standard

## Testing

```c
int demo(int a)
{
  uint64_t x, y;
  irqstate_t flags;

  x = a;
  y = 1;
  flags = 0;
  return (int)(x + y + flags);
}
```

Before: clean.  After:

```
7a5f4c0228.c:20:13: error: Multiple data definitions
```
