### PR TITLE
arch/arm/src/imxrt: Keep FlexCAN TX mailbox allocation in order.

### DIFF
--- a/arch/arm/src/imxrt/imxrt_flexcan.c
+++ b/arch/arm/src/imxrt/imxrt_flexcan.c
@@ -517,6 +517,50 @@ static void imxrt_reset(struct imxrt_driver_s *priv);
  ****************************************************************************/
 
 /****************************************************************************
+ * Function: imxrt_txmb_next
+ *
+ * Description:
+ *   Pick the mailbox to load the next frame into.
+ *
+ *   Every frame of a multi-frame transport transfer carries the same CAN
+ *   ID, and FlexCAN breaks an arbitration tie between mailboxes holding
+ *   equal IDs by taking the lowest mailbox number.  Handing out the
+ *   lowest *free* mailbox therefore lets a frame loaded into a
+ *   just-drained low mailbox win arbitration against older frames still
+ *   pending in higher ones, and the receiver sees the transfer out of
+ *   order.
+ *
+ *   Only ever hand out a mailbox above every pending one, and wrap back to
+ *   the bottom once the ring has drained.
+ *
+ * Input Parameters:
+ *   priv  - Reference to the driver state structure
+ *
+ * Returned Value:
+ *   The mailbox index to use, or TOTALMBCOUNT if none is available.
+ *
+ ****************************************************************************/
+
+static uint32_t imxrt_txmb_next(struct imxrt_driver_s *priv)
+{
+  uint32_t mbi  = RXMBCOUNT + 1;
+  uint32_t next = RXMBCOUNT + 1;
+
+  while (mbi < TOTALMBCOUNT)
+    {
+      struct mb_s *mb = flexcan_get_mb(priv, mbi);
+      if (mb->cs.code == CAN_TXMB_DATAORREMOTE)
+        {
+          next = mbi + 1;
+        }
+
+      mbi++;
+    }
+
+  return next;
+}
+
+/****************************************************************************
  * Function: imxrt_txringfull
  *
  * Description:
@@ -533,21 +577,7 @@ static void imxrt_reset(struct imxrt_driver_s *priv);
 
 static bool imxrt_txringfull(struct imxrt_driver_s *priv)
 {
-  uint32_t mbi = RXMBCOUNT + 1;
-  struct mb_s *mb;
-
-  while (mbi < TOTALMBCOUNT)
-    {
-      mb = flexcan_get_mb(priv, mbi);
-      if (mb->cs.code != CAN_TXMB_DATAORREMOTE)
-        {
-          return 0;
-        }
-
-      mbi++;
-    }
-
-  return 1;
+  return imxrt_txmb_next(priv) >= TOTALMBCOUNT;
 }
 
 /****************************************************************************
@@ -586,33 +616,20 @@ static int imxrt_transmit(struct imxrt_driver_s *priv)
   uint32_t txmb = 0;
 #endif
 
-  mbi = RXMBCOUNT + 1;
-  mb_bit = 1 << mbi;
+  mbi = imxrt_txmb_next(priv);
 
-  while (mbi < TOTALMBCOUNT)
-    {
-      /* Check whether message buffer is not currently transmitting */
-
-      struct mb_s *mb = flexcan_get_mb(priv, mbi);
-      if (mb->cs.code != CAN_TXMB_DATAORREMOTE)
-        {
-          putreg32(mb_bit, priv->base + IMXRT_CAN_IFLAG1_OFFSET);
-          break;
-        }
-
-      mb_bit <<= 1;
-      mbi++;
-#ifdef CONFIG_NET_CAN_RAW_TX_DEADLINE
-      txmb++;
-#endif
-    }
-
-  if (mbi == TOTALMBCOUNT)
+  if (mbi >= TOTALMBCOUNT)
     {
       nwarn("No TX MB available mbi %" PRIi32 "\n", mbi);
       NETDEV_TXERRORS(&priv->dev);
       return 0;       /* No transmission for you! */
     }
+
+  mb_bit = 1 << mbi;
+  putreg32(mb_bit, priv->base + IMXRT_CAN_IFLAG1_OFFSET);
+#ifdef CONFIG_NET_CAN_RAW_TX_DEADLINE
+  txmb = mbi - (RXMBCOUNT + 1);
+#endif
 
 #ifdef CONFIG_NET_CAN_RAW_TX_DEADLINE
   struct timespec ts;

--- a/arch/arm/src/imxrt/imxrt_flexcan.c
+++ b/arch/arm/src/imxrt/imxrt_flexcan.c
@@ -1560,19 +1560,19 @@ static int imxrt_ioctl(struct net_driver_s *dev, int cmd,
             }
 
           if (priv->canfd_capable)
-          {
-            data_timing.bitrate = req->data_bitrate;
-            data_timing.samplep = req->data_samplep;
+            {
+              data_timing.bitrate = req->data_bitrate;
+              data_timing.samplep = req->data_samplep;
 
-            if (ret == OK && imxrt_bitratetotimeseg(&data_timing, 10, 1))
-              {
-                ret = OK;
-              }
-            else
-              {
-                ret = -EINVAL;
-              }
-          }
+              if (ret == OK && imxrt_bitratetotimeseg(&data_timing, 10, 1))
+                {
+                  ret = OK;
+                }
+              else
+                {
+                  ret = -EINVAL;
+                }
+            }
 
           if (ret == OK)
             {
@@ -1580,9 +1580,9 @@ static int imxrt_ioctl(struct net_driver_s *dev, int cmd,
 
               priv->arbi_timing = arbi_timing;
               if (priv->canfd_capable)
-              {
-                priv->data_timing = data_timing;
-              }
+                {
+                  priv->data_timing = data_timing;
+                }
             }
         }
         break;
@@ -1762,8 +1762,8 @@ static int imxrt_initialize(struct imxrt_driver_s *priv)
    *  transmitting the package, hence we write 0x3.
    */
 
-      struct mb_s *buffer = flexcan_get_mb(priv, RXMBCOUNT);
-      buffer->cs.code = 0x3;
+  struct mb_s *buffer = flexcan_get_mb(priv, RXMBCOUNT);
+  buffer->cs.code = 0x3;
 
   for (i = RXMBCOUNT + 1; i < TOTALMBCOUNT; i++)
     {
@@ -1908,97 +1908,97 @@ int imxrt_caninitialize(int intf)
   switch (intf)
     {
 #ifdef CONFIG_IMXRT_FLEXCAN1
-    case 1:
-      imxrt_clockall_can1();
-      imxrt_clockall_can1_serial();
-      priv               = &g_flexcan1;
-      memset(priv, 0, sizeof(struct imxrt_driver_s));
-      priv->base         = IMXRT_CAN1_BASE;
-      priv->config       = &imxrt_flexcan1_config;
+      case 1:
+        imxrt_clockall_can1();
+        imxrt_clockall_can1_serial();
+        priv               = &g_flexcan1;
+        memset(priv, 0, sizeof(struct imxrt_driver_s));
+        priv->base         = IMXRT_CAN1_BASE;
+        priv->config       = &imxrt_flexcan1_config;
 #  if defined(CONFIG_NET_CAN_CANFD) && defined(CONFIG_IMXRT_FLEXCAN1_FD)
-      priv->canfd_capable = true;
-      priv->mb_address_offset = 14;
+        priv->canfd_capable = true;
+        priv->mb_address_offset = 14;
 #  else
-      priv->canfd_capable = false;
-      priv->mb_address_offset = 0;
+        priv->canfd_capable = false;
+        priv->mb_address_offset = 0;
 #  endif
 
-      /* Default bitrate configuration */
+        /* Default bitrate configuration */
 
 #  if defined(CONFIG_NET_CAN_CANFD) && defined(CONFIG_IMXRT_FLEXCAN1_FD)
-      priv->arbi_timing.bitrate = CONFIG_FLEXCAN1_ARBI_BITRATE;
-      priv->arbi_timing.samplep = CONFIG_FLEXCAN1_ARBI_SAMPLEP;
-      priv->data_timing.bitrate = CONFIG_FLEXCAN1_DATA_BITRATE;
-      priv->data_timing.samplep = CONFIG_FLEXCAN1_DATA_SAMPLEP;
+        priv->arbi_timing.bitrate = CONFIG_FLEXCAN1_ARBI_BITRATE;
+        priv->arbi_timing.samplep = CONFIG_FLEXCAN1_ARBI_SAMPLEP;
+        priv->data_timing.bitrate = CONFIG_FLEXCAN1_DATA_BITRATE;
+        priv->data_timing.samplep = CONFIG_FLEXCAN1_DATA_SAMPLEP;
 #  else
-      priv->arbi_timing.bitrate = CONFIG_FLEXCAN1_BITRATE;
-      priv->arbi_timing.samplep = CONFIG_FLEXCAN1_SAMPLEP;
+        priv->arbi_timing.bitrate = CONFIG_FLEXCAN1_BITRATE;
+        priv->arbi_timing.samplep = CONFIG_FLEXCAN1_SAMPLEP;
 #  endif
-      break;
+        break;
 #endif
 
 #ifdef CONFIG_IMXRT_FLEXCAN2
-    case 2:
-      imxrt_clockall_can2();
-      imxrt_clockall_can2_serial();
-      priv         = &g_flexcan2;
-      memset(priv, 0, sizeof(struct imxrt_driver_s));
-      priv->base   = IMXRT_CAN2_BASE;
-      priv->config = &imxrt_flexcan2_config;
+      case 2:
+        imxrt_clockall_can2();
+        imxrt_clockall_can2_serial();
+        priv         = &g_flexcan2;
+        memset(priv, 0, sizeof(struct imxrt_driver_s));
+        priv->base   = IMXRT_CAN2_BASE;
+        priv->config = &imxrt_flexcan2_config;
 #  if defined(CONFIG_NET_CAN_CANFD) && defined(CONFIG_IMXRT_FLEXCAN2_FD)
-      priv->canfd_capable = true;
-      priv->mb_address_offset = 14;
+        priv->canfd_capable = true;
+        priv->mb_address_offset = 14;
 #  else
-      priv->canfd_capable = false;
-      priv->mb_address_offset = 0;
+        priv->canfd_capable = false;
+        priv->mb_address_offset = 0;
 #  endif
 
-      /* Default bitrate configuration */
+        /* Default bitrate configuration */
 
 #  if defined(CONFIG_NET_CAN_CANFD) && defined(CONFIG_IMXRT_FLEXCAN2_FD)
-      priv->arbi_timing.bitrate = CONFIG_FLEXCAN2_ARBI_BITRATE;
-      priv->arbi_timing.samplep = CONFIG_FLEXCAN2_ARBI_SAMPLEP;
-      priv->data_timing.bitrate = CONFIG_FLEXCAN2_DATA_BITRATE;
-      priv->data_timing.samplep = CONFIG_FLEXCAN2_DATA_SAMPLEP;
+        priv->arbi_timing.bitrate = CONFIG_FLEXCAN2_ARBI_BITRATE;
+        priv->arbi_timing.samplep = CONFIG_FLEXCAN2_ARBI_SAMPLEP;
+        priv->data_timing.bitrate = CONFIG_FLEXCAN2_DATA_BITRATE;
+        priv->data_timing.samplep = CONFIG_FLEXCAN2_DATA_SAMPLEP;
 #  else
-      priv->arbi_timing.bitrate = CONFIG_FLEXCAN2_BITRATE;
-      priv->arbi_timing.samplep = CONFIG_FLEXCAN2_SAMPLEP;
+        priv->arbi_timing.bitrate = CONFIG_FLEXCAN2_BITRATE;
+        priv->arbi_timing.samplep = CONFIG_FLEXCAN2_SAMPLEP;
 #  endif
-      break;
+        break;
 #endif
 
 #ifdef CONFIG_IMXRT_FLEXCAN3
-    case 3:
-      imxrt_clockall_can3();
-      imxrt_clockall_can3_serial();
-      priv         = &g_flexcan3;
-      memset(priv, 0, sizeof(struct imxrt_driver_s));
-      priv->base   = IMXRT_CAN3_BASE;
-      priv->config = &imxrt_flexcan3_config;
+      case 3:
+        imxrt_clockall_can3();
+        imxrt_clockall_can3_serial();
+        priv         = &g_flexcan3;
+        memset(priv, 0, sizeof(struct imxrt_driver_s));
+        priv->base   = IMXRT_CAN3_BASE;
+        priv->config = &imxrt_flexcan3_config;
 #  ifdef CONFIG_NET_CAN_CANFD
-      priv->canfd_capable = true;
-      priv->mb_address_offset = 14;
+        priv->canfd_capable = true;
+        priv->mb_address_offset = 14;
 #  else
-      priv->canfd_capable = false;
-      priv->mb_address_offset = 0;
+        priv->canfd_capable = false;
+        priv->mb_address_offset = 0;
 #  endif
 
-      /* Default bitrate configuration */
+        /* Default bitrate configuration */
 
 #  ifdef CONFIG_NET_CAN_CANFD
-      priv->arbi_timing.bitrate = CONFIG_FLEXCAN3_ARBI_BITRATE;
-      priv->arbi_timing.samplep = CONFIG_FLEXCAN3_ARBI_SAMPLEP;
-      priv->data_timing.bitrate = CONFIG_FLEXCAN3_DATA_BITRATE;
-      priv->data_timing.samplep = CONFIG_FLEXCAN3_DATA_SAMPLEP;
+        priv->arbi_timing.bitrate = CONFIG_FLEXCAN3_ARBI_BITRATE;
+        priv->arbi_timing.samplep = CONFIG_FLEXCAN3_ARBI_SAMPLEP;
+        priv->data_timing.bitrate = CONFIG_FLEXCAN3_DATA_BITRATE;
+        priv->data_timing.samplep = CONFIG_FLEXCAN3_DATA_SAMPLEP;
 #  else
-      priv->arbi_timing.bitrate = CONFIG_FLEXCAN3_BITRATE;
-      priv->arbi_timing.samplep = CONFIG_FLEXCAN3_SAMPLEP;
+        priv->arbi_timing.bitrate = CONFIG_FLEXCAN3_BITRATE;
+        priv->arbi_timing.samplep = CONFIG_FLEXCAN3_SAMPLEP;
 #  endif
-      break;
+        break;
 #endif
 
-    default:
-      return -ENODEV;
+      default:
+        return -ENODEV;
     }
 
   if (!imxrt_bitratetotimeseg(&priv->arbi_timing, 1, 0))


### PR DESCRIPTION
## Summary

* **Why:** `imxrt_transmit()` picks the lowest free TX mailbox. FlexCAN breaks an arbitration tie between mailboxes holding *equal* CAN IDs by taking the lowest mailbox number, so refilling a just-drained low mailbox while older frames are still pending in higher ones puts the newer frame on the wire first. `imxrt_txdone_work()` re-polls after each individual TX completion, which is exactly the condition that triggers it.
* **What:** `arch/arm/src/imxrt/imxrt_flexcan.c`, TX mailbox selection only.
* **How:** a new `imxrt_txmb_next()` returns a mailbox above every pending one and wraps back to the bottom only once the ring has drained, so a newer frame can never win arbitration against an older one. `imxrt_txringfull()` is expressed in terms of it. Ordering then holds for any transfer length; the cost is that the ring stalls at a wrap rather than refilling immediately.
* Every frame of a multi-frame transport transfer carries the same CAN ID, so any such protocol is affected. On DroneCAN the receiver sees a broken toggle bit and discards the transfer.
* A second commit fixes pre-existing nxstyle violations in the same file, per CONTRIBUTING.md section 2.1. It is whitespace only — `git diff -w` against its parent is empty, and the resulting binary is byte-identical.

## Impact

* **New feature?** NO. Bug fix.
* **Impact on user?** NO — no API, Kconfig or behaviour change to adapt to. Multi-frame CAN traffic that was silently corrupted now arrives intact.
* **Impact on build?** NO.
* **Impact on hardware?** YES — `arch/arm/src/imxrt` only, any i.MX RT board using FlexCAN via SocketCAN. `s32k1xx_flexcan.c` and `s32k3xx_flexcan.c` select a mailbox the same way and appear to share the defect, but I have no S32K hardware and have deliberately left them alone.
* **Impact on documentation?** NO.
* **Impact on security?** NO.
* **Impact on compatibility?** NO.

## Testing

I confirm that changes are verified on local setup and works as intended:

* **Build Host:** Linux x86_64, arm-none-eabi-gcc 13.2.1 20231009
* **Target:** ARM, i.MX RT1176 (ARK FMU-v6XRT), FlexCAN1 at 1 Mbit, SocketCAN + DroneCAN

**How to reproduce:** put an i.MX RT board on a CAN bus with a second node, have the board publish a message large enough to need several frames, and decode CAN-ID plus tail byte per frame with an analyser. Frames of one transfer arrive out of order, so the toggle bit breaks and the receiver drops the transfer. The second node acts as the control — its own multi-frame transfers stay intact, which places the fault on the i.MX RT transmit path rather than the bus.

Measured with an ARK X20 GNSS node (node 124) and a CUAV Babel as the analyser. `incomplete` counts transfers whose frames never all arrived; `togerr` counts toggle-bit violations, i.e. reordering.

Testing logs before change:

```
# BEFORE  17455 frames / 60.0s (291 fps)
 src stream                            frames  xfers  multi incomplete  togerr   loss%
   1 20030 remoteid.BasicID               240     60     60          0       4    6.67
   1 20031 remoteid.Location              360     60     60          2      47   81.67
   1 1081 indication.LightsCommand        600    600      0          0       0    0.00
   1 341 protocol.NodeStatus               60     60      0          0       0    0.00
 124 1063 gnss.Fix2                      6000    600    600          0       0    0.00
 124 1061 gnss.Auxiliary                 1800    600    600          0       0    0.00
bad transfers by source node: {1: 53, 124: 0}
```

Only the i.MX RT board's multi-frame streams are affected; its single-frame streams and every stream from node 124 — including 600 ten-frame `gnss.Fix2` transfers — are clean.

Testing logs after change:

```
# AFTER  35513 frames / 120.0s (296 fps)
 src stream                            frames  xfers  multi incomplete  togerr   loss%
   1 20030 remoteid.BasicID               480    120    120          0       0    0.00
   1 20031 remoteid.Location              720    120    120          0       0    0.00
   1 20033 remoteid.System                600    120    120          0       0    0.00
   1 1081 indication.LightsCommand       1198   1198      0          0       0    0.00
   1 341 protocol.NodeStatus              120    120      0          0       0    0.00
 124 1063 gnss.Fix2                     12010   1201   1201          0       0    0.00
 124 1061 gnss.Auxiliary                 3603   1201   1201          0       0    0.00
bad transfers by source node: {1: 0, 124: 0}
```

Driver counters after the change, sampled twice 45 s apart to show nothing is accumulating:

```
CAN1 status:
	HW errors: 0
	IO errors: 0
	RX frames: 47623   ->   62863
	TX frames: ...
UAVCAN node status:
	Transfer errors:   4   ->   4      (static; incurred during the reflash reboot)
	RX transfers:   8580   ->  11324
```

This patch alone fixes the 4-frame stream and takes the 6-frame one from 81.7% to 40%. The remainder was two further bugs above this driver, fixed separately in PX4 (a frame discarded rather than retried when the ring is full, and a TX queue bypass). The "after" figures above are with all three applied — this patch is necessary but not on its own sufficient for that particular stack.

Build log:

```
$ make ark_fmu-v6xrt_default
Memory region         Used Size  Region Size  %age Used
           flash:     2336728 B      3968 KB     57.51%
            sram:      107668 B      1792 KB      5.87%
            itcm:      217120 B       256 KB     82.82%
```

`./tools/checkpatch.sh -c -u -m -g master..HEAD` → `✔️ All checks pass.`
