### PR TITLE
net/udp: notify POLLIN after queuing read-ahead

### DIFF
--- a/net/udp/udp_callback.c
+++ b/net/udp/udp_callback.c
@@ -27,6 +27,7 @@
 #include <nuttx/config.h>
 #if defined(CONFIG_NET) && defined(CONFIG_NET_UDP)
 
+#include <poll.h>
 #include <stdint.h>
 #include <string.h>
 #include <nuttx/debug.h>
@@ -44,6 +45,37 @@
 /****************************************************************************
  * Private Functions
  ****************************************************************************/
+
+/****************************************************************************
+ * Name: udp_readahead_signal_poll
+ *
+ * Description:
+ *   Notify UDP poll/select waiters only after read-ahead data is available.
+ *
+ ****************************************************************************/
+
+static void udp_readahead_signal_poll(FAR struct udp_conn_s *conn)
+{
+  FAR struct udp_poll_s *info;
+  int i;
+
+  for (i = 0; i < CONFIG_NET_UDP_NPOLLWAITERS; i++)
+    {
+      info = &conn->pollinfo[i];
+
+      if (info->conn != conn || info->fds == NULL)
+        {
+          continue;
+        }
+
+      if ((info->fds->events & POLLIN) == 0)
+        {
+          continue;
+        }
+
+      poll_notify(&info->fds, 1, POLLIN);
+    }
+}
 
 /****************************************************************************
  * Name: udp_datahandler
@@ -269,6 +301,11 @@ net_dataevent(FAR struct net_driver_s *dev, FAR struct udp_conn_s *conn,
    */
 
   recvlen = udp_datahandler(dev, conn, buffer, buflen);
+  if (recvlen > 0)
+    {
+      udp_readahead_signal_poll(conn);
+    }
+
   if (recvlen < buflen)
     {
       /* There is no handler to receive new data and there are no free

--- a/net/udp/udp_netpoll.c
+++ b/net/udp/udp_netpoll.c
@@ -79,12 +79,10 @@ static uint32_t udp_poll_eventhandler(FAR struct net_driver_s *dev,
     {
       pollevent_t eventset = 0;
 
-      /* Check for data or connection availability events. */
-
-      if ((flags & UDP_NEWDATA) != 0)
-        {
-          eventset |= POLLIN;
-        }
+      /* UDP readability follows buffered read-ahead data.  Defer POLLIN
+       * notification until udp_datahandler() has queued the datagram into
+       * conn->readahead.
+       */
 
       /* Check for loss of connection events. */
 


### PR DESCRIPTION
## Summary\n- defer UDP  readiness until the datagram has been queued into \n- keep  and existing immediate readahead checks unchanged\n- align / readiness with what  can actually consume\n\n## Problem\n currently raises  as soon as  is seen in the callback path. However, the datagram is only queued into UDP read-ahead later in  via . That allows a waiter to wake up before  has consumable data buffered.\n\n## Fix\nThis change removes the early  notification from  and notifies UDP poll/select waiters only after  has queued the datagram into .\n\n## Validation\nThis was validated on a downstream NuttX-based target by tracing the UDP callback path and confirming the ordering changed from:\n\n- poll/select wake\n- queue into read-ahead\n\nto:\n\n- queue into read-ahead\n- poll/select wake\n\nwhich eliminated an observed early-wakeup race on a loopback UDP control socket.