### PR TITLE
arch/risc-v: Add nonblock timeout support for LP-Mailbox

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_lp_mailbox.c
+++ b/arch/risc-v/src/common/espressif/esp_lp_mailbox.c
@@ -24,6 +24,9 @@
 
 #include <nuttx/config.h>
 
+#include <errno.h>
+#include <fcntl.h>
+
 #include <nuttx/arch.h>
 #include <nuttx/irq.h>
 
@@ -162,7 +165,7 @@ static int esp_lp_mailbox_read(struct file *filep,
 {
   struct inode *inode = filep->f_inode;
   struct esp_lp_mailbox_priv_s *priv = inode->i_private;
-  lp_message_t msg;
+  uint32_t timeout =  (filep->f_oflags & O_NONBLOCK) ? 0 : UINT32_MAX;
   int i = 0;
   int ret = OK;
   lp_message_t recv;
@@ -171,10 +174,19 @@ static int esp_lp_mailbox_read(struct file *filep,
 
   while (i < buflen)
     {
-      ret = lp_core_mailbox_receive(priv->mailbox, &recv, UINT32_MAX);
+      ret = lp_core_mailbox_receive(priv->mailbox, &recv, timeout);
       if (ret != OK)
         {
-          ferr("Failed to receive %dth byte\n", i + 1);
+          if (i == 0 && (filep->f_oflags & O_NONBLOCK) != 0)
+            {
+              return -EAGAIN;
+            }
+
+          if ((filep->f_oflags & O_NONBLOCK) == 0)
+            {
+              ferr("Failed to receive %dth byte\n", i + 1);
+            }
+
           return i;
         }
 
@@ -296,15 +308,15 @@ static int esp_lp_mailbox_ioctl(struct file *filep,
               priv->async_op = true;
             }
 
-            if (ret != OK)
-              {
-                priv->async_op = false;
-                ferr("Could not register callback-%lx to lp-mailbox!\n",
-                      (uint32_t)handler);
-                return ERROR;
-              }
+          if (ret != OK)
+            {
+              priv->async_op = false;
+              ferr("Could not register callback-%lx to lp-mailbox!\n",
+                    (uint32_t)handler);
+              return ERROR;
+            }
 
-            priv->handler = handler;
+          priv->handler = handler;
           break;
         }
 


### PR DESCRIPTION
## Summary

<!-- This field should contain a summary of the changes. It will be pre-filled with the commit's message and descriptions. Adjust it accordingly -->

* arch/risc-v: Add nonblock timeout support for LP-Mailbox

Add nonblock timeout support for LP-Mailbox for esp32[-c6|-p4]

## Impact
<!-- Please fill the following sections with YES/NO and provide a brief explanation -->

Impact on user: Yes, users can use LP-Mailbox more capable
<!-- Does it impact user's applications? How? -->

Impact on build: No
<!-- Does it impact on building NuttX? How? (please describe the required changes on the build system) -->

Impact on hardware: Yes, LP-Mailbox driver can do nonblock read
<!-- Does it impact a specific hardware supported by NuttX? -->

Impact on documentation: No
<!-- Does it impact the existing documentation? Please provide additional documentation to reflect that -->

Impact on security: No
<!-- Does it impact NuttX's security? -->

Impact on compatibility: No
<!-- Does it impact compatibility between previous and current versions? Is this a breaking change? -->

## Testing
<!-- Please provide all the testing procedure. Consider that upstream reviewers should be able to reproduce the same testing performed internally -->

`esp32p4-function-ev-board:ulp` config used with these options:

```
CONFIG_ESPRESSIF_LP_MAILBOX=y
```


### Building
<!-- Provide how to build the test for each SoC being tested -->


Command to build:

```
make -j distclean && ./tools/configure.sh esp32p4-function-ev-board:ulp && kconfig-tweak -e CONFIG_ESPRESSIF_LP_MAILBOX && make olddefconfig -s -j && make -j && make flash ESPTOOL_PORT=/dev/ttyUSB0
```

### Running
<!-- Provide how to run the test for each SoC being tested -->

Custom app used to test:

- Tree view:
```
   nuttxspace/
   ├── nuttx/
   └── apps/
   └── ulp_mailbox/
       └── Makefile
       └── Kconfig
       └── ulp_mailbox.c   // HP Application
       └── ulp/ 
           └── Makefile   // LP Core Makefile
           └── ulp_main.c // LP Core Application
```


- Contents in Makefile:
```
   include $(APPDIR)/Make.defs

   PROGNAME  = $(CONFIG_EXAMPLES_ULP_MAILBOX_PROGNAME)
   PRIORITY  = $(CONFIG_EXAMPLES_ULP_MAILBOX_PRIORITY)
   STACKSIZE = $(CONFIG_EXAMPLES_ULP_MAILBOX_STACKSIZE)
   MODULE    = $(CONFIG_EXAMPLES_ULP_MAILBOX)

   MAINSRC = ulp_mailbox.c

   include $(APPDIR)/Application.mk

   include ulp/Makefile
```

- Contents in Kconfig:
```
   config EXAMPLES_ULP_MAILBOX
     bool "ULP Mailbox Example"
     default n
```

- Contents in ulp_mailbox.c:
```
#include <nuttx/config.h>
#include <errno.h>
#include <fcntl.h>
#include <inttypes.h>
#include <stdio.h>
#include <unistd.h>

#include <nuttx/fs/ioctl.h>
#include <sys/ioctl.h>

#include "ulp/ulp/ulp_main.h"
#include "ulp/ulp/ulp_code.h"


int main(int argc, char *argv[])
{
  int fd;
  int mailbox;
  uint8_t data = 0;
  int ret = OK;
  int prev_data;

  fd = open("/dev/ulp", O_WRONLY);
  if (fd < 0)
    {
      printf("Failed to open ULP: %d\n", errno);
      return -1;
    }

  write(fd, ulp_mailbox_bin, ulp_mailbox_bin_len);

  mailbox = open("/dev/lp_mailbox", O_RDWR);
  if (mailbox < 0)
    {
      printf("Failed to open LP Mailbox: %d\n", errno);
      return -1;
    }

  /* Waiting for a while to let ULP start to run */

  sleep(3);
  for (int i = 0; i < 2; i++)
    {
      ret = write(mailbox, &data, 1);
      if (ret != 1)
        {
          printf("Failed to send data\n");
          return ERROR;
        }

      prev_data = data;
      ret = read(mailbox, &data, 1);
      if (ret != 1 || (prev_data + 1 != data))
        {
          printf("Failed to read data\n");
          return ERROR;
        }
      else
        {
          printf("Read data: %d\n", data);
        }

      sleep(1);
    }

  printf("All done.\n");
  return OK;
}
```

- Contents in ulp/Makefile:
```
  ULP_APP_NAME = ulp_mailbox
  ULP_APP_FOLDER = $(APPDIR)$(DELIM)ulp_mailbox$(DELIM)ulp
  ULP_APP_C_SRCS = ulp_main.c

  include $(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)common$(DELIM)espressif$(DELIM)ulp_makefile.mk
```

- Contents in ulp/ulp_main.c:
```
#include <stdint.h>
#include "nuttx/config.h"
#include <stdbool.h>
#include <stdint.h>
#include "ulp_lp_core_utils.h"
#include "ulp_lp_core_mailbox.h"

#define nop()   __asm__ __volatile__ ("nop")

static lp_mailbox_t mailbox;

int main(void)
{
  lp_core_mailbox_init(&mailbox, NULL);
  lp_message_t message;
  esp_err_t ret;

  while (1)
    {
      ret = lp_core_mailbox_receive(mailbox, &message, UINT32_MAX);

      if (ret == ESP_OK)
        {
          message = message + 1;
          ret = lp_core_mailbox_send(mailbox, message, UINT32_MAX);
        }

      for (int i = 0; i < 100; i++)
        {
          nop();
        }
    }

  return 0;
}
```

### Results
<!-- Provide tests' results and runtime logs -->

Output should look like this:

```
nsh> ls /dev
/dev:
...
 lp_mailbox
...
nsh> custom_app
Read data: 1
Read data: 2
All done.
nsh> 
```