### PR TITLE
arch/arm/stm32: Make Ethernet TX watchdog timeout configurable

### DIFF
--- a/arch/arm/src/common/stm32/Kconfig.eth
+++ b/arch/arm/src/common/stm32/Kconfig.eth
@@ -309,3 +309,11 @@ config STM32_ETH_NTXDESC
 	default 4
 	---help---
 		Number of TX DMA descriptors to use.
+
+config STM32_ETH_TXTIMEOUT
+	int "TX watchdog timeout (seconds)"
+	depends on STM32_ETHMAC
+	default 60
+	---help---
+		Seconds before the TX watchdog resets the MAC when a transmission
+		does not complete.

--- a/arch/arm/src/common/stm32/stm32_eth_m3m4_v1.c
+++ b/arch/arm/src/common/stm32/stm32_eth_m3m4_v1.c
@@ -252,6 +252,9 @@
 #ifndef CONFIG_STM32_ETH_NTXDESC
 #  define CONFIG_STM32_ETH_NTXDESC 4
 #endif
+#ifndef CONFIG_STM32_ETH_TXTIMEOUT
+#  define CONFIG_STM32_ETH_TXTIMEOUT 60
+#endif
 
 /* We need at least one more free buffer than transmit buffers */
 
@@ -285,9 +288,9 @@
 
 /* Timing *******************************************************************/
 
-/* TX timeout = 1 minute */
+/* TX timeout */
 
-#define STM32_TXTIMEOUT   (60*CLK_TCK)
+#define STM32_TXTIMEOUT   (CONFIG_STM32_ETH_TXTIMEOUT*CLK_TCK)
 
 /* PHY reset/configuration delays in milliseconds */
 

--- a/arch/arm/src/common/stm32/stm32_eth_m3m4_v1.c
+++ b/arch/arm/src/common/stm32/stm32_eth_m3m4_v1.c
@@ -1717,7 +1717,7 @@ static void stm32_receive(struct stm32_ethmac_s *priv)
 #ifdef CONFIG_NET_PKT
       /* When packet sockets are enabled, feed the frame into the tap */
 
-     pkt_input(&priv->dev);
+      pkt_input(&priv->dev);
 #endif
 
       /* Check if the packet is a valid size for the network buffer
@@ -2138,7 +2138,7 @@ static int stm32_interrupt(int irq, void *context, void *arg)
            * expiration and the deferred interrupt processing.
            */
 
-           wd_cancel(&priv->txtimeout);
+          wd_cancel(&priv->txtimeout);
         }
 
       /* Schedule to perform the interrupt processing on the worker thread. */
@@ -2277,6 +2277,7 @@ static int stm32_ifup(struct net_driver_s *dev)
       /* Transfer time from system low-resolution timer to PTP basetime */
 
       struct timespec ts;
+
       clock_gettime(CLOCK_REALTIME, &ts);
       up_rtc_settime(&ts);
       g_rtc_enabled = true;
@@ -2336,6 +2337,7 @@ static int stm32_ifdown(struct net_driver_s *dev)
       /* Transfer back to system low-resolution timer */
 
       struct timespec ts;
+
       up_rtc_gettime(&ts);
       g_rtc_enabled = false;
       clock_settime(CLOCK_REALTIME, &ts);
@@ -2832,6 +2834,7 @@ static int stm32_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
         {
           struct mii_ioctl_data_s *req =
         (struct mii_ioctl_data_s *)((uintptr_t)arg);
+
           req->phy_id = CONFIG_STM32_PHYADDR;
           ret = OK;
         }
@@ -2841,6 +2844,7 @@ static int stm32_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
         {
           struct mii_ioctl_data_s *req =
         (struct mii_ioctl_data_s *)((uintptr_t)arg);
+
           ret = stm32_phyread(req->phy_id, req->reg_num, &req->val_out);
         }
         break;
@@ -2849,6 +2853,7 @@ static int stm32_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
         {
           struct mii_ioctl_data_s *req =
         (struct mii_ioctl_data_s *)((uintptr_t)arg);
+
           ret = stm32_phywrite(req->phy_id, req->reg_num, req->val_in);
         }
         break;
@@ -3310,7 +3315,7 @@ static int stm32_phyinit(struct stm32_ethmac_s *priv)
   ret = stm32_phywrite(CONFIG_STM32_PHYADDR, MII_MCR, phyval);
   if (ret < 0)
     {
-     nerr("ERROR: Failed to write the PHY MCR: %d\n", ret);
+      nerr("ERROR: Failed to write the PHY MCR: %d\n", ret);
       return ret;
     }
 
@@ -3776,26 +3781,26 @@ static void stm32_eth_ptp_convert_rxtime(struct stm32_ethmac_s *priv)
                      &priv->dev.d_rxtime);
 
 #else
-    {
-      struct timespec realtime;
-      uint64_t ptptime;
-      irqstate_t flags;
+  {
+    struct timespec realtime;
+    uint64_t ptptime;
+    irqstate_t flags;
 
-      /* Sample PTP and CLOCK_REALTIME close to each other */
+    /* Sample PTP and CLOCK_REALTIME close to each other */
 
-      clock_gettime(CLOCK_REALTIME, &realtime);
-      flags = spin_lock_irqsave(&g_rtc_lock);
-      ptptime = stm32_eth_ptp_gettime();
-      spin_unlock_irqrestore(&g_rtc_lock, flags);
+    clock_gettime(CLOCK_REALTIME, &realtime);
+    flags = spin_lock_irqsave(&g_rtc_lock);
+    ptptime = stm32_eth_ptp_gettime();
+    spin_unlock_irqrestore(&g_rtc_lock, flags);
 
-      /* Compute how much time has elapsed since packet reception
-       * and add that to current time.
-       */
+    /* Compute how much time has elapsed since packet reception
+     * and add that to current time.
+     */
 
-      timestamp = ptptime - timestamp;
-      ptp_to_timespec(timestamp, &rxtime);
-      clock_timespec_add(&rxtime, &realtime, &priv->dev.d_rxtime);
-    }
+    timestamp = ptptime - timestamp;
+    ptp_to_timespec(timestamp, &rxtime);
+    clock_timespec_add(&rxtime, &realtime, &priv->dev.d_rxtime);
+  }
 #endif /* CONFIG_STM32_ETH_PTP_RTC_HIRES */
 }
 #endif /* CONFIG_STM32_ETH_TIMESTAMP_RX */

--- a/arch/arm/src/stm32f7/stm32_ethernet.c
+++ b/arch/arm/src/stm32f7/stm32_ethernet.c
@@ -1763,7 +1763,7 @@ static void stm32_receive(struct stm32_ethmac_s *priv)
 #ifdef CONFIG_NET_PKT
       /* When packet sockets are enabled, feed the frame into the tap */
 
-     pkt_input(&priv->dev);
+      pkt_input(&priv->dev);
 #endif
 
       /* Check if the packet is a valid size for the network buffer
@@ -2196,7 +2196,7 @@ static int stm32_interrupt(int irq, void *context, void *arg)
            * expiration and the deferred interrupt processing.
            */
 
-           wd_cancel(&priv->txtimeout);
+          wd_cancel(&priv->txtimeout);
         }
 
       DEBUGASSERT(work_available(&priv->irqwork));
@@ -2843,55 +2843,58 @@ static int stm32_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
   int ret;
 
   switch (cmd)
-  {
+    {
 #ifdef CONFIG_NETDEV_PHY_IOCTL
 #ifdef CONFIG_ARCH_PHY_INTERRUPT
-  case SIOCMIINOTIFY: /* Set up for PHY event notifications */
-    {
-      struct mii_ioctl_notify_s *req =
-        (struct mii_ioctl_notify_s *)((uintptr_t)arg);
-
-      ret = phy_notify_subscribe(dev->d_ifname, req->pid, &req->event);
-      if (ret == OK)
+      case SIOCMIINOTIFY: /* Set up for PHY event notifications */
         {
-          /* Enable PHY link up/down interrupts */
+          struct mii_ioctl_notify_s *req =
+            (struct mii_ioctl_notify_s *)((uintptr_t)arg);
 
-          ret = stm32_phyintenable(priv);
+          ret = phy_notify_subscribe(dev->d_ifname, req->pid, &req->event);
+          if (ret == OK)
+            {
+              /* Enable PHY link up/down interrupts */
+
+              ret = stm32_phyintenable(priv);
+            }
         }
-    }
-    break;
+        break;
 #endif
 
-  case SIOCGMIIPHY: /* Get MII PHY address */
-    {
-      struct mii_ioctl_data_s *req =
-        (struct mii_ioctl_data_s *)((uintptr_t)arg);
-      req->phy_id = CONFIG_STM32_PHYADDR;
-      ret = OK;
-    }
-    break;
+      case SIOCGMIIPHY: /* Get MII PHY address */
+        {
+          struct mii_ioctl_data_s *req =
+            (struct mii_ioctl_data_s *)((uintptr_t)arg);
 
-  case SIOCGMIIREG: /* Get register from MII PHY */
-    {
-      struct mii_ioctl_data_s *req =
-        (struct mii_ioctl_data_s *)((uintptr_t)arg);
-      ret = stm32_phyread(req->phy_id, req->reg_num, &req->val_out);
-    }
-    break;
+          req->phy_id = CONFIG_STM32_PHYADDR;
+          ret = OK;
+        }
+        break;
 
-  case SIOCSMIIREG: /* Set register in MII PHY */
-    {
-      struct mii_ioctl_data_s *req =
-        (struct mii_ioctl_data_s *)((uintptr_t)arg);
-      ret = stm32_phywrite(req->phy_id, req->reg_num, req->val_in);
-    }
-    break;
+      case SIOCGMIIREG: /* Get register from MII PHY */
+        {
+          struct mii_ioctl_data_s *req =
+            (struct mii_ioctl_data_s *)((uintptr_t)arg);
+
+          ret = stm32_phyread(req->phy_id, req->reg_num, &req->val_out);
+        }
+        break;
+
+      case SIOCSMIIREG: /* Set register in MII PHY */
+        {
+          struct mii_ioctl_data_s *req =
+            (struct mii_ioctl_data_s *)((uintptr_t)arg);
+
+          ret = stm32_phywrite(req->phy_id, req->reg_num, req->val_in);
+        }
+        break;
 #endif /* CONFIG_NETDEV_PHY_IOCTL */
 
-  default:
-    ret = -ENOTTY;
-    break;
-  }
+      default:
+        ret = -ENOTTY;
+        break;
+    }
 
   return ret;
 }
@@ -3322,7 +3325,7 @@ static int stm32_phyinit(struct stm32_ethmac_s *priv)
   ret = stm32_phywrite(CONFIG_STM32_PHYADDR, MII_MCR, phyval);
   if (ret < 0)
     {
-     nerr("ERROR: Failed to write the PHY MCR: %d\n", ret);
+      nerr("ERROR: Failed to write the PHY MCR: %d\n", ret);
       return ret;
     }
 

--- a/arch/arm/src/stm32f7/stm32_ethernet.c
+++ b/arch/arm/src/stm32f7/stm32_ethernet.c
@@ -213,6 +213,9 @@
 #ifndef CONFIG_STM32_ETH_NTXDESC
 #  define CONFIG_STM32_ETH_NTXDESC 4
 #endif
+#ifndef CONFIG_STM32_ETH_TXTIMEOUT
+#  define CONFIG_STM32_ETH_TXTIMEOUT 60
+#endif
 
 /* We need at least one more free buffer than transmit buffers */
 
@@ -280,9 +283,9 @@
 
 /* Timing *******************************************************************/
 
-/* TX timeout = 1 minute */
+/* TX timeout */
 
-#define STM32_TXTIMEOUT   (60*CLK_TCK)
+#define STM32_TXTIMEOUT   (CONFIG_STM32_ETH_TXTIMEOUT*CLK_TCK)
 
 /* PHY reset/configuration delays in milliseconds */
 

--- a/arch/arm/src/stm32h5/stm32_ethernet.c
+++ b/arch/arm/src/stm32h5/stm32_ethernet.c
@@ -1711,6 +1711,7 @@ static int stm32_recvframe(struct stm32_ethmac_s *priv)
           else
             {
               bool err = ((rxdesc->des3 & ETH_RDES3_WB_ES) != 0);
+
               priv->segments++;
 
               /* Check if there is only one segment in the frame */
@@ -1895,7 +1896,7 @@ static void stm32_receive(struct stm32_ethmac_s *priv)
        * tap
        */
 
-     pkt_input(&priv->dev);
+      pkt_input(&priv->dev);
 #endif
 
       /* Check if the packet is a valid size for the network buffer
@@ -2995,6 +2996,7 @@ static int stm32_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
         {
           struct mii_ioctl_data_s *req =
             (struct mii_ioctl_data_s *)((uintptr_t)arg);
+
           req->phy_id = CONFIG_STM32_PHYADDR;
           ret = OK;
         }
@@ -3004,6 +3006,7 @@ static int stm32_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
         {
           struct mii_ioctl_data_s *req =
             (struct mii_ioctl_data_s *)((uintptr_t)arg);
+
           ret = stm32_phyread(req->phy_id, req->reg_num, &req->val_out);
         }
         break;
@@ -3012,6 +3015,7 @@ static int stm32_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
         {
           struct mii_ioctl_data_s *req =
             (struct mii_ioctl_data_s *)((uintptr_t)arg);
+
           ret = stm32_phywrite(req->phy_id, req->reg_num, req->val_in,
                                0xffff);
         }

--- a/arch/arm/src/stm32h5/stm32_ethernet.c
+++ b/arch/arm/src/stm32h5/stm32_ethernet.c
@@ -206,6 +206,9 @@
 #ifndef CONFIG_STM32_ETH_NTXDESC
 #  define CONFIG_STM32_ETH_NTXDESC 4
 #endif
+#ifndef CONFIG_STM32_ETH_TXTIMEOUT
+#  define CONFIG_STM32_ETH_TXTIMEOUT 60
+#endif
 
 /* We need at least one more free buffer than transmit buffers */
 
@@ -266,9 +269,9 @@
 
 /* Timing *******************************************************************/
 
-/* TX timeout = 1 minute */
+/* TX timeout */
 
-#define STM32_TXTIMEOUT   (60*CLK_TCK)
+#define STM32_TXTIMEOUT   (CONFIG_STM32_ETH_TXTIMEOUT*CLK_TCK)
 
 /* PHY reset/configuration delays in milliseconds */
 

--- a/arch/arm/src/stm32h7/stm32_ethernet.c
+++ b/arch/arm/src/stm32h7/stm32_ethernet.c
@@ -290,6 +290,9 @@
 #ifndef CONFIG_STM32_ETH_NTXDESC
 #  define CONFIG_STM32_ETH_NTXDESC 4
 #endif
+#ifndef CONFIG_STM32_ETH_TXTIMEOUT
+#  define CONFIG_STM32_ETH_TXTIMEOUT 60
+#endif
 
 /* We need at least one more free buffer than transmit buffers */
 
@@ -350,9 +353,9 @@
 
 /* Timing *******************************************************************/
 
-/* TX timeout = 1 minute */
+/* TX timeout */
 
-#define STM32_TXTIMEOUT   (60*CLK_TCK)
+#define STM32_TXTIMEOUT   (CONFIG_STM32_ETH_TXTIMEOUT*CLK_TCK)
 
 /* PHY reset/configuration delays in milliseconds */
 

--- a/arch/arm/src/stm32h7/stm32_ethernet.c
+++ b/arch/arm/src/stm32h7/stm32_ethernet.c
@@ -1963,7 +1963,7 @@ static void stm32_receive(struct stm32_ethmac_s *priv)
        * tap
        */
 
-     pkt_input(&priv->dev);
+      pkt_input(&priv->dev);
 #endif
 
       /* Check if the packet is a valid size for the network buffer
@@ -3097,6 +3097,7 @@ static int stm32_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
         {
           struct mii_ioctl_data_s *req =
             (struct mii_ioctl_data_s *)((uintptr_t)arg);
+
           req->phy_id = CONFIG_STM32_PHYADDR;
           ret = OK;
         }
@@ -3106,6 +3107,7 @@ static int stm32_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
         {
           struct mii_ioctl_data_s *req =
             (struct mii_ioctl_data_s *)((uintptr_t)arg);
+
           ret = mdio_read(priv->mdio,
             req->phy_id, req->reg_num, &req->val_out);
         }
@@ -3115,6 +3117,7 @@ static int stm32_ioctl(struct net_driver_s *dev, int cmd, unsigned long arg)
         {
           struct mii_ioctl_data_s *req =
             (struct mii_ioctl_data_s *)((uintptr_t)arg);
+
           ret = mdio_write(priv->mdio,
             req->phy_id, req->reg_num, req->val_in);
         }


### PR DESCRIPTION
## Summary

The STM32 Ethernet MAC drivers hard-code a 60-second TX watchdog timeout. While this is a reasonable general default, certain board designs and use-cases require a shorter or longer value.

Introduce `CONFIG_STM32_ETH_TXTIMEOUT` via the shared `Kconfig.eth` with a `#ifndef fallback`. The default is kept at 60 seconds to preserve existing behavior.

## Impact

The existing defaults are kept as previously, thus not having any impact on existing setups.

## Testing

- Tested in the context of PX4 using a STM32H743VIH6
- Set `CONFIG_STM32_ETH_TXTIMEOUT=5`
- Connection in this case is direct MAC to MAC with a Linux PC
- Brought the Linux side down and check that after 5s NuttX does a re-init of the network