### PR TITLE
Documentation/nxinit: document boot reason property and compound cmds

### DIFF
--- a/Documentation/applications/system/nxinit/index.rst
+++ b/Documentation/applications/system/nxinit/index.rst
@@ -89,6 +89,49 @@ forwards ``setprop`` to the action manager.
 - Property triggers are checked when the property is created or its value
   is updated (e.g., property:a=b is checked when a's value changes).
 
+Built-in Properties
+====================
+
+NXInit sets one built-in property on its own, before the ``boot`` event
+fires:
+
+- ``sys.boot.reason``: the cause of the last board reset. It is queried
+  once at startup via ``boardctl(BOARDIOC_RESET_CAUSE, ...)``; applications
+  do not need to set it themselves. This requires
+  ``CONFIG_BOARDCTL_RESET_CAUSE`` and a board-provided
+  ``board_reset_cause()`` implementation.
+
+  - If ``CONFIG_BOARDCTL_RESET_CAUSE`` is not enabled, ``sys.boot.reason``
+    is never set, so any trigger referencing it (e.g.
+    ``property:sys.boot.reason=...``) simply never matches; there is no
+    dedicated "unset" value to trigger on.
+  - If ``CONFIG_BOARDCTL_RESET_CAUSE`` is enabled but the ``boardctl()``
+    call itself fails (the board reports an error), NXInit aborts startup.
+
+  The value has one of two forms:
+
+  1. ``<cause>,<subreason>`` for hardware reset causes, where
+     ``<subreason>`` is a numeric flag (e.g. the watchdog timer index):
+     ``cold``, ``watchdog``, ``undervoltage``, ``warm``, ``powerkey``,
+     ``lowpower``, ``unknown``. For example, a watchdog reset from timer 4
+     sets the property to ``watchdog,4``.
+  2. A single soft-reset reason string, for software-triggered resets
+     (``BOARDIOC_RESETCAUSE_CPU_SOFT``): ``reboot``, ``assert``,
+     ``kernel_panic``, ``bootloader``, ``recovery``, ``factory_reset``,
+     ``factory_reset_inquiry``, ``thermal``.
+
+  Since the property is matched with ``fnmatch`` and alternatives can be
+  separated with ``|``, a trigger can match on the cause, the subreason, or
+  a set of soft-reset reasons:
+
+  .. code-block::
+
+      on init && property:sys.boot.reason=watchdog,4
+          ...
+
+      on init && property:sys.boot.reason=bootloader|recovery|thermal
+          ...
+
 Commands
 ========
 The commands supported by an action fall into three types: the built-in
@@ -104,6 +147,24 @@ The following is an explanation of some of NXInit's built-in commands.
 - File Operations: mkdir (create directories with configurable permissions,
   owner, and encryption settings), copy/write (copy files/write file content).
 - Others: trigger (trigger events).
+
+Compound Commands
+------------------
+
+A single line inside an action body may chain multiple commands with
+``&&`` and ``||``, using the familiar shell short-circuit semantics: the
+next command in an ``&&`` chain only runs if the previous one exited with
+status 0 (success), and the next command in an ``||`` chain only runs if
+the previous one exited non-zero (failure). A quoted argument
+(``"..."``) may contain ``&&``/``||`` without being treated as an
+operator.
+
+.. code-block::
+
+    on boot
+        echo "start" && hello && echo "done"
+        ls /missing || echo "not found"
+        echo "A" && echo "B" || echo "fallback"
 
 Examples
 ========


### PR DESCRIPTION
## Summary

Reviewers on [apps#3751](https://github.com/apache/nuttx-apps/pull/3751) (support compound command and resetcause-based triggers) asked for documentation of the new features. This adds two sections to `Documentation/applications/system/nxinit/index.rst`:

- **Built-in Properties**: describes the `sys.boot.reason` property set by NXInit at startup from `BOARDIOC_RESET_CAUSE`, its two value forms (hardware cause with numeric subreason, or software reset reason string), and the behavior when `CONFIG_BOARDCTL_RESET_CAUSE` is disabled or the `boardctl()` call fails.
- **Compound Commands**: describes the `&&` / `||` short-circuit semantics for chaining commands on a single action line, including quoting behavior.

## Impact

Documentation only. No code, config, or behavior changes.

## Testing

Build Host: Linux x86_64, Sphinx 8.1.3, Python 3

Built the `applications/system/nxinit` doc page standalone with the repo's Sphinx config:

```
$ python3 -m sphinx -b html -c . applications/system/nxinit /tmp/nxinit_docbuild
Running Sphinx v8.1.3
...
build succeeded.
The HTML pages are in .../tmp/nxinit_docbuild.
```

No RST syntax/build errors. Also ran `tools/checkpatch.sh -f` on the changed file:

```
$ ./tools/checkpatch.sh -f Documentation/applications/system/nxinit/index.rst
✔️ All checks pass.
```

Marked as draft pending review from [@linguini1](https://github.com/linguini1) and [@cederom](https://github.com/cederom) on the original request in apps#3751.