### PR TITLE
sched/sporadic: fix policy switch and cross-task setparam

### DIFF
--- a/sched/sched/sched_setparam.c
+++ b/sched/sched/sched_setparam.c
@@ -45,14 +45,14 @@
 #ifdef CONFIG_SCHED_SPORADIC
 static inline_function
 int set_sporadic_param(FAR const struct sched_param *param,
-                       FAR struct tcb_s *rtcb, FAR struct tcb_s *tcb)
+                       FAR struct tcb_s *tcb)
 {
   irqstate_t flags;
   int ret = OK;
 
   /* Update parameters associated with SCHED_SPORADIC */
 
-  if ((rtcb->flags & TCB_FLAG_POLICY_MASK) == TCB_FLAG_SCHED_SPORADIC)
+  if ((tcb->flags & TCB_FLAG_POLICY_MASK) == TCB_FLAG_SCHED_SPORADIC)
     {
       FAR struct sporadic_s *sporadic;
       clock_t repl_ticks;
@@ -104,7 +104,7 @@ int set_sporadic_param(FAR const struct sched_param *param,
 
                   tcb->timeslice         = budget_ticks;
 
-                  sporadic = rtcb->sporadic;
+                  sporadic = tcb->sporadic;
                   DEBUGASSERT(sporadic != NULL);
 
                   sporadic->hi_priority  = param->sched_priority;
@@ -136,7 +136,7 @@ int set_sporadic_param(FAR const struct sched_param *param,
   return ret;
 }
 #else
-#  define set_sporadic_param(p, r, t) OK
+#  define set_sporadic_param(p, t) OK
 #endif
 
 /****************************************************************************
@@ -216,7 +216,7 @@ int nxsched_set_param(pid_t pid, FAR const struct sched_param *param)
 
       if (ret >= 0)
         {
-          ret = set_sporadic_param(param, rtcb, tcb);
+          ret = set_sporadic_param(param, tcb);
         }
 
       /* Then perform the reprioritization */
@@ -271,6 +271,7 @@ int nxsched_set_param(pid_t pid, FAR const struct sched_param *param)
 int sched_setparam(pid_t pid, FAR const struct sched_param *param)
 {
   int ret = nxsched_set_param(pid, param);
+
   if (ret < 0)
     {
       set_errno(-ret);

--- a/sched/sched/sched_setscheduler.c
+++ b/sched/sched/sched_setscheduler.c
@@ -87,7 +87,7 @@ int process_sporadic(FAR struct tcb_s *tcb,
       if (repl_ticks < budget_ticks)
 #endif
         {
-          /* Initialize/reset current sporadic scheduling */
+          /* Initialize or reset current sporadic scheduling */
 
           if ((tcb->flags & TCB_FLAG_POLICY_MASK) ==
               TCB_FLAG_SCHED_SPORADIC)
@@ -103,6 +103,7 @@ int process_sporadic(FAR struct tcb_s *tcb,
 
           if (ret >= 0)
             {
+              tcb->flags            &= ~TCB_FLAG_POLICY_MASK;
               tcb->flags            |= TCB_FLAG_SCHED_SPORADIC;
               tcb->timeslice         = budget_ticks;
 
@@ -212,7 +213,6 @@ int nxsched_set_scheduler(pid_t pid, int policy,
            */
 
           flags = enter_critical_section();
-          tcb->flags &= ~TCB_FLAG_POLICY_MASK;
 
           switch (policy)
             {
@@ -229,6 +229,7 @@ int nxsched_set_scheduler(pid_t pid, int policy,
 
                 /* Save the FIFO scheduling parameters */
 
+                tcb->flags     &= ~TCB_FLAG_POLICY_MASK;
                 tcb->flags     |= TCB_FLAG_SCHED_FIFO;
 #if CONFIG_RR_INTERVAL > 0 || defined(CONFIG_SCHED_SPORADIC)
                 tcb->timeslice  = 0;
@@ -250,6 +251,7 @@ int nxsched_set_scheduler(pid_t pid, int policy,
 
                 /* Save the round robin scheduling parameters */
 
+                tcb->flags     &= ~TCB_FLAG_POLICY_MASK;
                 tcb->flags     |= TCB_FLAG_SCHED_RR;
                 tcb->timeslice  = MSEC2TICK(CONFIG_RR_INTERVAL);
                 break;
@@ -314,6 +316,7 @@ int sched_setscheduler(pid_t pid, int policy,
                        FAR const struct sched_param *param)
 {
   int ret = nxsched_set_scheduler(pid, policy, param);
+
   if (ret < 0)
     {
       set_errno(-ret);


### PR DESCRIPTION
## Summary

This PR fixes two bugs in the SCHED_SPORADIC handling of the scheduler, both found while testing sporadic policy switching:
 
1. **sched_setscheduler()**: The policy flag bits were cleared *before* the `switch (policy)` statement. Since `TCB_FLAG_SCHED_FIFO` is 0, the checks for "was the task previously SCHED_SPORADIC" inside the SCHED_FIFO/SCHED_RR cases could never be true. As a result `nxsched_stop_sporadic()` was never called when a sporadic task switched to another policy, leaking the `sporadic` state and its replenishment timers; a sporadic-to-sporadic reconfiguration ran `nxsched_initialize_sporadic()` instead of reset, leaking the old state. The flags are now cleared only after the previous policy has been evaluated.

2. **sched_setparam()**: `set_sporadic_param()` tested `rtcb` (the calling task) instead of `tcb` (the task being modified). A cross-task `sched_setparam()` therefore never updated the target's sporadic parameters, and if the *caller* was itself sporadic while the target was not, it would reset a task with no sporadic state (NULL-pointer / assertion failure) and write parameters into the caller's own sporadic state.

## Impact

Bug fix only, no API change. No new feature.

## Testing

ci test
