### PR TITLE
arch/risc-v: initialize qemu-rv mmu pagetable data to zero

### DIFF
--- a/arch/risc-v/src/qemu-rv/qemu_rv_mm_init.c
+++ b/arch/risc-v/src/qemu-rv/qemu_rv_mm_init.c
@@ -29,6 +29,7 @@
 #include <nuttx/nuttx.h>
 
 #include <stdint.h>
+#include <string.h>
 #include <assert.h>
 #include <nuttx/debug.h>
 
@@ -173,6 +174,7 @@ static void slab_init(uintptr_t start)
 static uintptr_t slab_alloc(void)
 {
   pgalloc_slab_t *slab = (pgalloc_slab_t *)sq_remfirst(&g_free_slabs);
+
   return slab ? (uintptr_t)slab->memory : 0;
 }
 
@@ -245,6 +247,14 @@ static void map_region(uintptr_t paddr, uintptr_t vaddr, size_t size,
 
 void qemu_rv_kernel_mappings(void)
 {
+  /* Clear page tables */
+
+  memset(m_l1_pgtable, 0, sizeof(m_l1_pgtable));
+  memset(m_l2_pgtable, 0, sizeof(m_l2_pgtable));
+#ifdef CONFIG_ARCH_MMU_TYPE_SV39
+  memset(m_l3_pgtable, 0, sizeof(m_l3_pgtable));
+#endif
+
   /* Initialize slab allocator for the L2/L3 page tables */
 
   slab_init(KMM_PBASE);


### PR DESCRIPTION
Fixes  #19874 

  Note: Please adhere to Contributing Guidelines https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md.
  ## Summary
  When running QEMU with a backend file to simulate RAM with randomized or uninitialized data, the MMU page tables
  contain garbage values. This occurs because the m_l1_pgtable, m_l2_pgtable, and m_l3_pgtable structures are placed
  in the .pgtables section, which is marked as NONLOAD in the linker script.

  Because they aren't zeroed out alongside .bss during initialization, qemu_rv_kernel_mappings() incorrectly uses this
  uninitialized memory when configuring the MMU, causing mmu_ln_getentry to fetch invalid mappings and fail.

  This PR fixes the issue by explicitly calling memset() to zero-initialize the L1/L2/L3 page tables at the beginning
  of qemu_rv_kernel_mappings() prior to setting up the slab allocator.

  ## Impact

  • Users: Resolves boot failures for users running qemu-rv boards on QEMU with simulated/randomized RAM backend files.
  • Architecture: Changes are strictly confined to the qemu-rv RISC-V architecture memory initialization logic. No
  impact on other targets.
  • Build/Hardware: No build or hardware compatibility impact.

  ## Testing

  • Host machine: Ubuntu 24.04 (Host QEMU 10.0.0)
  • Target: qemu-rv (rv32 / rv64)
  • Testing procedure:
      1. Configured NuttX for the qemu-rv target.
      2. Booted the resulting image using QEMU with a backend file simulating randomly initialized RAM.
      3. Verified that the map_region MMU logic correctly allocates from the zero-initialized page tables, and the
      kernel boots smoothly without faults.