### PR TITLE
sched/sporadic: clear policy flag when stopping sporadic scheduling

### DIFF
--- a/sched/sched/sched_sporadic.c
+++ b/sched/sched/sched_sporadic.c
@@ -731,6 +731,7 @@ FAR struct replenishment_s *
       for (i = 0; i < sporadic->max_repl; i++)
         {
           FAR struct replenishment_s *tmp = &sporadic->replenishments[i];
+
           if ((tmp->flags & SPORADIC_FLAG_ALLOCED) == 0)
             {
               repl        = tmp;
@@ -889,6 +890,12 @@ int nxsched_stop_sporadic(FAR struct tcb_s *tcb)
 
   kmm_free(tcb->sporadic);
   tcb->sporadic = NULL;
+
+  /* The policy flag must not outlive the freed sporadic state: the final
+   * context switch on thread exit would dereference it.
+   */
+
+  tcb->flags &= ~TCB_FLAG_POLICY_MASK;
   return OK;
 }
 


### PR DESCRIPTION
## Summary

nxsched_stop_sporadic() freed tcb->sporadic but left TCB_FLAG_SCHED_SPORADIC set in tcb->flags.  On thread exit, nxtask_recover() calls nxsched_stop_sporadic() and the final context switch in up_exit() then sees the stale SPORADIC policy flag and calls nxsched_suspend_sporadic() on a TCB whose sporadic state is already freed, tripping DEBUGASSERT(tcb->sporadic) and hanging the system (reproduced by ostest sporadic_test on sim, present on master).

Clear the policy bits inside nxsched_stop_sporadic() so every caller leaves the TCB in a consistent state.

## Impact

Bug fix only; no new feature, no api change.

## Testing


Built and ran `sim:ostest` with `CONFIG_SCHED_SPORADIC=y`, `CONFIG_SCHED_SPORADIC_MAXREPL=8`, `CONFIG_TESTING_OSTEST_LOOPS=1`.
Host: macOS 15, arm64 

1. Before the fix 

`sporadic_test()` reliably crashes ~37s in, right after
`pthread_cancel(sporadic_thread)`:

```
user_main: sporadic scheduler test
sporadic_test: Starting sporadic thread at priority 192 (hi) 64 (lo)
   0 SPORADIC: 0->192
   ... priority alternates 192 <-> 64 for the full 37s ...
  37 SPORADIC: 192->192
dump_assert_info: Current Version: NuttX 13.0.1 87db6b21f8-dirty sim
dump_assert_info: Assertion failed : at file: /sched/sched/sched_sporadic.c:1131 task: Idle_Task
dump_tasks:    PID GROUP PRI POLICY   TYPE    NPX STATE   EVENT
dump_task:       0     0   0 FIFO     Kthread -   Ready             Idle_Task
dump_task:       4     4 100 FIFO     Task    -   Waiting Signal     ostest_main
dump_task:       5     5 194 FIFO     Task    -   Waiting Mutex:281  ostest
dump_task:     281    -1 194 SPORADIC pthread P Inactive            ostest
```

Note PID 281 is already Inactive but still carries the SPORADIC
policy: `tcb->sporadic` was freed by `nxsched_stop_sporadic()` via
`nxtask_recover()` while `TCB_FLAG_SCHED_SPORADIC` remained set.

2. After the fix

Same test, same configuration: no assertion. The sporadic thread
exits cleanly, priority scheduling is unaffected (identical 192 <-> 64
alternation across the whole test window), and the former crash site
is gone.

