### PR TITLE
arm/stm32: Preserve ICACHE state when reading STM32H5 UID.

### DIFF
--- a/arch/arm/src/common/stm32/stm32_uid.c
+++ b/arch/arm/src/common/stm32/stm32_uid.c
@@ -46,6 +46,10 @@
 #include "chip.h"
 #include "stm32_uid.h"
 
+#ifdef CONFIG_STM32_ICACHE
+#  include "stm32_icache.h"
+#endif
+
 #ifdef STM32_SYSMEM_UID /* Not defined for some STM32 parts */
 
 /****************************************************************************
@@ -56,6 +60,19 @@ void stm32_get_uniqueid(uint8_t uniqueid[12])
 {
   uint32_t uid[3];
   int i;
+#ifdef CONFIG_STM32_ICACHE
+  bool icache_enabled;
+
+  /* The UID on STM32 Cortex-M33 parts cannot be read while the instruction
+   * cache is enabled.  Preserve the cache state across the UID access.
+   */
+
+  icache_enabled = stm32_icache_enabled();
+  if (icache_enabled)
+    {
+      stm32_disable_icache();
+    }
+#endif
 
   /* Read the UID with 32-bit accesses. Some parts (STM32H5) store the UID
    * in flash memory that does not support 8-bit reads.
@@ -65,6 +82,13 @@ void stm32_get_uniqueid(uint8_t uniqueid[12])
     {
       uid[i] = getreg32(STM32_SYSMEM_UID + 4 * i);
     }
+
+#ifdef CONFIG_STM32_ICACHE
+  if (icache_enabled)
+    {
+      stm32_enable_icache();
+    }
+#endif
 
   memcpy(uniqueid, uid, 12);
 }

--- a/arch/arm/src/stm32h5/stm32_icache.c
+++ b/arch/arm/src/stm32h5/stm32_icache.c
@@ -180,6 +180,7 @@ static inline void stm32_icache_set_ier(uint32_t ier)
 static inline void stm32_icache_reset_hmon(void)
 {
   uint32_t regval;
+
   regval = getreg32(STM32_ICACHE_CR);
   regval |= ICACHE_CR_HITMRST;
   putreg32(regval, STM32_ICACHE_CR);
@@ -190,6 +191,7 @@ static inline void stm32_icache_reset_hmon(void)
 static inline void stm32_icache_reset_mmon(void)
 {
   uint32_t regval;
+
   regval = getreg32(STM32_ICACHE_CR);
   regval |= ICACHE_CR_MISSMRST;
   putreg32(regval, STM32_ICACHE_CR);
@@ -200,6 +202,7 @@ static inline void stm32_icache_reset_mmon(void)
 static inline void stm32_icache_enable_monitors(void)
 {
   uint32_t regval;
+
   regval = getreg32(STM32_ICACHE_CR);
   regval |= (ICACHE_CR_MISSMEN | ICACHE_CR_HITMEN);
   putreg32(regval, STM32_ICACHE_CR);
@@ -208,6 +211,7 @@ static inline void stm32_icache_enable_monitors(void)
 static inline void stm32_icache_disable_monitors(void)
 {
   uint32_t regval;
+
   regval = getreg32(STM32_ICACHE_CR);
   regval &= ~(ICACHE_CR_MISSMEN | ICACHE_CR_HITMEN);
   putreg32(regval, STM32_ICACHE_CR);
@@ -298,6 +302,7 @@ void stm32_icache_initialize(void)
 void stm32_icache_reset_monitors(void)
 {
   uint32_t regval;
+
   regval = getreg32(STM32_ICACHE_CR);
   regval |= (ICACHE_CR_MISSMRST | ICACHE_CR_HITMRST);
   putreg32(regval, STM32_ICACHE_CR);
@@ -318,9 +323,15 @@ size_t stm32_get_icache_size(void)
 void stm32_disable_icache(void)
 {
   uint32_t regval;
+
   regval = getreg32(STM32_ICACHE_CR);
   regval &= ~(ICACHE_CR_EN);
   putreg32(regval, STM32_ICACHE_CR);
+}
+
+bool stm32_icache_enabled(void)
+{
+  return (getreg32(STM32_ICACHE_CR) & ICACHE_CR_EN) != 0;
 }
 
 void stm32_enable_icache(void)

--- a/arch/arm/src/stm32h5/stm32_icache.h
+++ b/arch/arm/src/stm32h5/stm32_icache.h
@@ -118,6 +118,22 @@ void stm32_enable_icache(void);
 void stm32_disable_icache(void);
 
 /****************************************************************************
+ * Name: stm32_icache_enabled
+ *
+ * Description:
+ *   Returns whether the STM32H5 ICACHE is enabled.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   true if the ICACHE is enabled; false otherwise.
+ *
+ ****************************************************************************/
+
+bool stm32_icache_enabled(void);
+
+/****************************************************************************
  * Name: stm32_reset_monitors
  *
  * Description:


### PR DESCRIPTION
Summary
The STM32H5 unique ID is stored in flash information memory, which cannot be accessed while the instruction cache is enabled. Attempting to read it with ICACHE enabled causes a bus fault.
Temporarily disable the instruction cache while reading the UID using 32-bit accesses, then restore it only when it was originally enabled. This preserves the caller's cache state and prevents the fault during UID access.
Impact
This change affects STM32H5 targets that enable CONFIG_STM32_ICACHE and call stm32_get_uniqueid().
The existing cache state is preserved:
- If ICACHE is enabled, it is disabled for the UID read and then re-enabled.
- If ICACHE is already disabled, it remains disabled.
Other STM32 families and STM32H5 configurations without ICACHE are unaffected. There are no configuration, API, documentation, or build-system changes.
Testing
Host:
WSL2 Ubuntu 24.04
STM32 GNU Toolchain 13.2.1
Apache NuttX CI container
Clang 17.0.1
Target:
STM32H563ZI
ST-LINK/V2
STMicroelectronics OpenOCD
Static checks
The full commit-aware NuttX check passed:
$ ./tools/checkpatch.sh -c -u -m -g apache/master..HEAD
Used config files:
    1: .codespellrc
✔️ All checks pass.
git diff --check also passed.
GNU build
Built nucleo-h563zi:nsh with CONFIG_STM32_ICACHE=y using the GNU EABI toolchain:
CONFIG_ARM_TOOLCHAIN_GNU_EABI=y
CONFIG_ARCH_CHIP_STM32H5=y
CONFIG_STM32_ICACHE=y

Memory region         Used Size  Region Size  %age Used
           flash:      226256 B         2 MB     10.79%
            sram:        9832 B       256 KB      3.75%
Clang build
Built nucleo-h563zi:nsh in the Apache NuttX CI container with Clang and ICACHE enabled.
The board's GNU-specific software stack-check option was disabled and LIBM_NONE selected for this cross-toolchain build:
CONFIG_ARM_TOOLCHAIN_CLANG=y
CONFIG_ARCH_TOOLCHAIN_CLANG=y
CONFIG_ARMV8M_STACKCHECK_NONE=y
CONFIG_LIBM_NONE=y
CONFIG_STM32_ICACHE=y

Memory region         Used Size  Region Size  %age Used
           flash:      187804 B         2 MB      8.96%
            sram:        9800 B       256 KB      3.74%
The generated stm32_uid.o was inspected to confirm that it was compiled by Clang 17.0.1.
Hardware validation
Before the change, calling stm32_get_uniqueid() with ICACHE enabled produced a precise bus fault while accessing the UID address:
CFSR: 0x00008200
HFSR: 0x40000000
BFAR: 0x08fff800
After applying the change:
- The firmware reached its application entry point without a hard fault or assertion.
- The UID was read successfully:
003A004D 31335107 36323839
- CFSR and HFSR remained clear.
- ICACHE_CR was 0x00000005 after the read, confirming that the previously enabled instruction cache was restored.
Assisted-by: Codex:gpt-5