### PR TITLE
arch/arm/ameba: fix rtl8721f CMake build and flash chain

### DIFF
--- a/arch/arm/src/common/ameba/cmake/ameba_board.cmake
+++ b/arch/arm/src/common/ameba/cmake/ameba_board.cmake
@@ -208,16 +208,28 @@ list(APPEND AMEBA_EXTRA_LIBS ${_crtbegin} ${_crtend} -lm -lstdc++)
 
 set(AMEBA_KM4_LD ${AMEBA_KM4_PROJ}/ld)
 set(AMEBA_IMG2_LD ${AMEBA_KM4_LD}/ameba_img2_all.ld)
-set(AMEBA_ROM_LD ${AMEBA_KM4_LD}/ameba_rom_symbol_acut_s.ld)
 set(GENLDSCRIPT ${AMEBA_PREBUILT}/ld.script.gen)
+
+# ROM symbol linker script(s), appended after the preprocessed image2 script.
+# Most ICs (rtl8721dx / rtl8720f) use a single script; rtl8721f overrides
+# AMEBA_ROM_LDS in its arch CMakeLists with four scripts (secure + wifi + os +
+# NS) so the ROM BSS (__rom_bss_*_ns__) and WiFi ROM (rtw_*) symbols resolve --
+# mirroring that IC's ameba_board.mk cat order.
+if(NOT DEFINED AMEBA_ROM_LDS)
+  set(AMEBA_ROM_LDS ameba_rom_symbol_acut_s.ld)
+endif()
+set(AMEBA_ROM_LD_PATHS "")
+foreach(_ld ${AMEBA_ROM_LDS})
+  list(APPEND AMEBA_ROM_LD_PATHS ${AMEBA_KM4_LD}/${_ld})
+endforeach()
 
 message(
   STATUS "ameba: generating ld.script.gen (AP ${AMEBA_AP_PROJECT} image2)")
 execute_process(
   COMMAND
     sh ${AMEBA_TOOLS_DIR}/ameba_gen_ldscript.sh ${CMAKE_C_COMPILER}
-    ${AMEBA_IMG2_LD} ${AMEBA_ROM_LD} ${AMEBA_AUTOCONF} ${AMEBA_PREBUILT}
-    ${AMEBA_AP_PROJECT} ${GENLDSCRIPT}
+    ${AMEBA_IMG2_LD} ${AMEBA_AUTOCONF} ${AMEBA_PREBUILT} ${AMEBA_AP_PROJECT}
+    ${GENLDSCRIPT} ${AMEBA_ROM_LD_PATHS}
   RESULT_VARIABLE _rc)
 if(NOT _rc EQUAL 0)
   message(FATAL_ERROR "ameba_gen_ldscript.sh failed (rc=${_rc})")

--- a/arch/arm/src/common/ameba/tools/ameba_gen_ldscript.sh
+++ b/arch/arm/src/common/ameba/tools/ameba_gen_ldscript.sh
@@ -10,15 +10,17 @@
 #   1. C-preprocess ameba_img2_all.ld (it #includes ameba_layout.ld and the
 #      config-derived platform_autoconf.h, staged as
 #      project_<proj>/platform_autoconf.h on the include path).
-#   2. Append ameba_rom_symbol_acut_s.ld (ROM symbol addresses).
+#   2. Append the ROM symbol linker script(s) (ROM symbol addresses).  Most
+#      ICs pass a single script; rtl8721f passes four scripts (secure + wifi +
+#      os + NS), matching the make build's cat.
 #   3. Fold NuttX's .vectors orphan section into the loadable SRAM data region
 #      so the large power-of-two aligned vector table does not land in and
 #      overflow the tiny fixed KM4_IMG2_ENTRY region.
 #
 # This reproduces the SDK-generated rlx8721d.ld; the SDK tree stays read-only.
 #
-# Usage: ameba_gen_ldscript.sh <cc> <img2_ld> <rom_ld> <autoconf> \
-#                              <prebuilt_dir> <ap_project> <out>
+# Usage: ameba_gen_ldscript.sh <cc> <img2_ld> <autoconf> <prebuilt_dir> \
+#                              <ap_project> <out> <rom_ld>...
 #
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -43,16 +45,17 @@ set -e
 
 CC="$1"
 IMG2_LD="$2"
-ROM_LD="$3"
-AUTOCONF="$4"
-PREBUILT="$5"
-AP_PROJECT="$6"
-OUT="$7"
+AUTOCONF="$3"
+PREBUILT="$4"
+AP_PROJECT="$5"
+OUT="$6"
+shift 6
+ROM_LDS="$@"
 
-if [ -z "$CC" ] || [ -z "$IMG2_LD" ] || [ -z "$ROM_LD" ] || [ -z "$AUTOCONF" ] \
-   || [ -z "$PREBUILT" ] || [ -z "$AP_PROJECT" ] || [ -z "$OUT" ]; then
-  echo "usage: ameba_gen_ldscript.sh <cc> <img2_ld> <rom_ld> <autoconf>" \
-       "<prebuilt_dir> <ap_project> <out>" >&2
+if [ -z "$CC" ] || [ -z "$IMG2_LD" ] || [ -z "$AUTOCONF" ] || [ -z "$PREBUILT" ] \
+   || [ -z "$AP_PROJECT" ] || [ -z "$OUT" ] || [ -z "$ROM_LDS" ]; then
+  echo "usage: ameba_gen_ldscript.sh <cc> <img2_ld> <autoconf> <prebuilt_dir>" \
+       "<ap_project> <out> <rom_ld>..." >&2
   exit 1
 fi
 
@@ -61,9 +64,9 @@ fi
 mkdir -p "$PREBUILT/project_$AP_PROJECT"
 cp "$AUTOCONF" "$PREBUILT/project_$AP_PROJECT/platform_autoconf.h"
 
-# 1) preprocess, 2) append ROM symbols
+# 1) preprocess, 2) append ROM symbol script(s), in the given order
 "$CC" -E -P -xc -c "$IMG2_LD" -o "$OUT" -I "$PREBUILT"
-cat "$ROM_LD" >> "$OUT"
+cat $ROM_LDS >> "$OUT"
 
 # 3) fold NuttX .vectors into the loadable SRAM data region
 sed -i 's|^\([[:space:]]*\)\*(\.data\*)|\1*(.vectors*)\n\1*(.data*)|' "$OUT"

--- a/arch/arm/src/common/ameba/tools/ameba_setup_env.sh
+++ b/arch/arm/src/common/ameba/tools/ameba_setup_env.sh
@@ -71,13 +71,30 @@ resolve_bindir() {
 
   # 2. system python3 -- expose it via a non-venv shim dir so a bare `python`
   #    exists and the system site-packages (with the deps) stay visible.
-  if command -v python3 >/dev/null 2>&1 && py_has_deps python3; then
-    sp=$(command -v python3)
-    mkdir -p "$SHIMBIN"
-    ln -sf "$sp" "$SHIMBIN/python"
-    ln -sf "$sp" "$SHIMBIN/python3"
-    printf '%s\n' "$SHIMBIN"
-    return 0
+  #
+  #    Resolve the REAL system interpreter, never our own shim: a previous run
+  #    put $SHIMBIN on PATH ahead of the system python3, so `command -v python3`
+  #    would return $SHIMBIN/python3 and `ln -sf shim shim` would create a
+  #    self-referential symlink loop ("Too many levels of symbolic links").
+  #    Scan PATH for the first python3 that is not inside $SHIMBIN, then
+  #    canonicalise it so the shim always points at a real interpreter.
+  sp=""
+  _oldifs=$IFS
+  IFS=:
+  for _d in $PATH; do
+    case "$_d" in "$SHIMBIN" | "$SHIMBIN"/) continue ;; esac
+    if [ -x "$_d/python3" ]; then sp="$_d/python3"; break; fi
+  done
+  IFS=$_oldifs
+  if [ -n "$sp" ]; then
+    sp=$(readlink -f "$sp" 2>/dev/null || printf '%s' "$sp")
+    if py_has_deps "$sp"; then
+      mkdir -p "$SHIMBIN"
+      ln -sf "$sp" "$SHIMBIN/python"
+      ln -sf "$sp" "$SHIMBIN/python3"
+      printf '%s\n' "$SHIMBIN"
+      return 0
+    fi
   fi
 
   return 1

--- a/arch/arm/src/rtl8721f/CMakeLists.txt
+++ b/arch/arm/src/rtl8721f/CMakeLists.txt
@@ -90,6 +90,13 @@ set(AMEBA_NP_TARGET km4ns)
 set(AMEBA_CFG_WIFI ${CONFIG_RTL8721F_WIFI})
 set(AMEBA_CFG_FLASHFS ${CONFIG_RTL8721F_FLASH_FS})
 
+# rtl8721f's combined image2 linker script must append four ROM symbol scripts
+# (secure + wifi + os + NS), in this order, to match
+# arch/arm/src/rtl8721f/ameba_board.mk.  ameba_board.cmake consumes this; the
+# other ICs leave it unset and default to the single script.
+set(AMEBA_ROM_LDS ameba_rom_symbol_bcut_s.ld ameba_rom_symbol_bcut_wifi.ld
+                  ameba_rom_symbol_bcut_os.ld ameba_rom_symbol_bcut.ld)
+
 # Resolve AMEBA_SDK / asdk toolchain (provisioned by `. tools/ameba/env.sh`)
 # before the SDK-relative source lists below reference it.
 include(${AMEBA_COMMON}/cmake/ameba_sdk.cmake)

--- a/arch/arm/src/rtl8721f/CMakeLists.txt
+++ b/arch/arm/src/rtl8721f/CMakeLists.txt
@@ -97,6 +97,13 @@ set(AMEBA_CFG_FLASHFS ${CONFIG_RTL8721F_FLASH_FS})
 set(AMEBA_ROM_LDS ameba_rom_symbol_bcut_s.ld ameba_rom_symbol_bcut_wifi.ld
                   ameba_rom_symbol_bcut_os.ld ameba_rom_symbol_bcut.ld)
 
+# The SDK ships no bare RTL8721F.rdev flash profile (unlike RTL8721Dx /
+# RTL8720F); it splits by flash type into RTL8721F_NOR.rdev /
+# RTL8721F_NAND.rdev.  The EVB is NOR, so override the default (AMEBA_PY_SOC =
+# RTL8721F) accordingly -- matching
+# boards/arm/rtl8721f/rtl8721f_evb/scripts/Make.defs.
+set(AMEBA_FLASH_PROFILE RTL8721F_NOR)
+
 # Resolve AMEBA_SDK / asdk toolchain (provisioned by `. tools/ameba/env.sh`)
 # before the SDK-relative source lists below reference it.
 include(${AMEBA_COMMON}/cmake/ameba_sdk.cmake)


### PR DESCRIPTION
## Summary

  The rtl8721f  port is already merged, but its CMake build+flash
  path was broken end to end. This fixes the three independent breakages so a
  CMake build of rtl8721f links, reconfigures, and flashes cleanly. Each is a
  bug in already-merged code; none change behaviour for rtl8721dx / rtl8720f.

  1. **Per-IC ROM symbol linker scripts.** The shared CMake build hardcoded a
     single ROM symbol script (`ameba_rom_symbol_acut_s.ld`), so linking
     rtl8721f left `__rom_bss_*_ns__` and the `rtw_*` WiFi ROM symbols
     undefined. `AMEBA_ROM_LDS` is now a per-IC list (keeping the previous
     single-script default); rtl8721f overrides it with its four ROM symbol
     scripts, matching its `ameba_board.mk` cat order. rtl8721dx / rtl8720f keep
     the single default script.

  2. **Self-referential python shim symlink loop.** `ameba_setup_env.sh`
     resolved the system interpreter via `command -v python3`. Once a prior run
     put the shim dir at the front of `PATH`, that lookup returned the shim
     itself and `ln -sf shim shim` created a self-referential symlink, breaking
     every subsequent CMake reconfigure with "Too many levels of symbolic
     links". It now scans `PATH` skipping the shim dir and canonicalises with
     `readlink -f`. Affects all Ameba ICs; first-build behaviour is unchanged.

  3. **Flash profile for rtl8721f.** The SDK ships no bare `RTL8721F.rdev`
     (unlike RTL8721Dx / RTL8720F); it splits by flash type into
     `RTL8721F_NOR.rdev` / `RTL8721F_NAND.rdev`, so the default flash target
     failed with "profile not found: RTL8721F.rdev". rtl8721f now overrides
     `AMEBA_FLASH_PROFILE` to `RTL8721F_NOR`, matching its EVB and Make.defs.

  ## Impact

  - No change to rtl8721dx / rtl8720f: they keep the single default ROM script
    and the bare `RTL8721Dx` / `RTL8720F` flash profile. Only shared defaults
    were made overridable.

  ## Testing

  - **rtl8721f:** CMake configure → ninja → nuttx.bin; flashed boot.bin +
    nuttx.bin over UART, booted to NSH on the EVB.
  - **rtl8721dx:** regression smoke of all board configs (nsh, adc, gpio, i2c,
    pwm, spi, uart) — every one configures and links cleanly with CMake; ROM
    script and flash profile resolve exactly as before.