### PR TITLE
stm32h7: Fix Protected user SRAM placement and attributes.

### DIFF
--- a/arch/arm/src/stm32h7/stm32_allocateheap.c
+++ b/arch/arm/src/stm32h7/stm32_allocateheap.c
@@ -253,15 +253,15 @@ void up_allocate_heap(void **heap_start, size_t *heap_size)
   DEBUGASSERT(ubase < (uintptr_t)SRAM_END);
 
   /* Adjust that size to account for MPU alignment requirements.
-   * NOTE that there is an implicit assumption that the SRAM123_END
-   * is aligned to the MPU requirement.
+   * NOTE that there is an implicit assumption that SRAM_END is aligned
+   * to the MPU requirement.
    */
 
   log2  = (int)mpu_log2regionfloor(usize);
   DEBUGASSERT((SRAM_END & ((1 << log2) - 1)) == 0);
 
   usize = (1 << log2);
-  ubase = SRAM123_END - usize;
+  ubase = SRAM_END - usize;
 
   /* Return the user-space heap settings */
 
@@ -320,8 +320,8 @@ void up_allocate_kheap(void **heap_start, size_t *heap_size)
   DEBUGASSERT(ubase < (uintptr_t)SRAM_END);
 
   /* Adjust that size to account for MPU alignment requirements.
-   * NOTE that there is an implicit assumption that the SRAM123_END
-   * is aligned to the MPU requirement.
+   * NOTE that there is an implicit assumption that SRAM_END is aligned
+   * to the MPU requirement.
    */
 
   log2  = (int)mpu_log2regionfloor(usize);

--- a/arch/arm/src/stm32h7/stm32_mpuinit.c
+++ b/arch/arm/src/stm32h7/stm32_mpuinit.c
@@ -53,6 +53,26 @@
 #endif
 
 /****************************************************************************
+ * Private Functions
+ ****************************************************************************/
+
+#ifdef CONFIG_BUILD_PROTECTED
+static void stm32_mpu_user_intsram(uintptr_t start, size_t size)
+{
+  /* STM32H7 protected user memory can span AXI and D2 SRAM.  Keep it
+   * Normal and non-shareable so that LDREX/STREX use the CPU-local
+   * exclusive monitor.  Dual-core RPTUN shared memory is mapped separately
+   * below with shareable attributes.
+   */
+
+  mpu_configure_region(start, size,
+                       MPU_RASR_TEX_SO |
+                       MPU_RASR_C |
+                       MPU_RASR_AP_RWRW);
+}
+#endif
+
+/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -94,7 +114,7 @@ void stm32_mpuinitialize(void)
   mpu_user_flash(USERSPACE->us_textstart,
                  USERSPACE->us_textend - USERSPACE->us_textstart);
 
-  mpu_user_intsram(datastart, dataend - datastart);
+  stm32_mpu_user_intsram(datastart, dataend - datastart);
 #endif
 
 #ifdef CONFIG_RPTUN
@@ -121,7 +141,7 @@ void stm32_mpuinitialize(void)
 
 void stm32_mpu_uheap(uintptr_t start, size_t size)
 {
-  mpu_user_intsram(start, size);
+  stm32_mpu_user_intsram(start, size);
 }
 #endif
 


### PR DESCRIPTION
## Summary

* Make STM32H7 Protected user heap placement consistently use `SRAM_END`,
  which represents the primary SRAM selected for the active M7/M4 chip
  configuration.
* Remove the fixed `SRAM123_END` placement that is inconsistent with heap
  sizing and is undefined for dual-core M7 and M4 configurations.
* Map Protected user data and heap SRAM as Normal, cacheable, and
  non-shareable so LDREX/STREX synchronization uses the CPU-local exclusive
  monitor on STM32H7.
* Keep dual-core RPTUN SRAM unaffected: its shared region is mapped separately
  with explicit shareable attributes.

## Impact

* New feature: **NO**. This fixes STM32H7 Protected memory placement and MPU
  attributes.
* User adaptation: **NO**.
* Build process: **NO**.
* Hardware: **YES**. Only STM32H7 Protected builds are affected. Flat builds
  are unchanged. Dual-core shared RPTUN SRAM keeps its existing mapping.
* Documentation: Public API documentation is not affected; source comments
  document the mapping and dual-core exception.
* Security: **NO** reduction in privilege separation. User access permissions
  remain `P:RW/U:RW`; only the SRAM memory attributes change.
* Compatibility: The Protected user heap now resides in the SRAM region
  selected by the board/chip configuration instead of a fixed D2 boundary.

## Testing

Build host:

* Linux 6.8.0-60-generic, x86_64
* GNU Arm Embedded Toolchain 10.3.1 20210824

Target:

* ARM Cortex-M7, STM32H7, PX4 FMUv6C
* Apache NuttX master `850805d70c88b0d63d4364d7110ce5363d2448ee`
* Protected user heap in AXI SRAM, write-through data cache enabled
* Runtime stress used an integration image containing apache/nuttx#19982 and
  apache/nuttx-apps#3759 as the workload. Those PRs are test dependencies,
  not code dependencies of this change.

Build output:

```text
Protected kernel:
  kflash  877528 B / 896 KB (95.64%)
  ksram    54320 B / 128 KB (41.44%)

Protected user:
  uflash  751000 B / 1 MB   (71.62%)
  usram     8192 B / 384 KB (2.08%)
```

Runtime stress results:

```text
Protected libc user WQ: 15.6540 / 15.6540 / 15.6540 s
Protected kernel WQ:    30.1490 / 30.1480 / 30.1480 s

Steady current memory after initial run:
  Kmem used/free: 10104 / 243848 B
  Umem used/free:  9232 / 416752 B
```

The tests repeatedly exercised pthread creation, mutex/semaphore atomics,
multi-worker queues, synchronous cancellation, and queue teardown. All runs
completed without assertion, fault, residual worker, or cumulative Kmem/Umem
growth. The board cold-booted into NSH and remained stable.

Validation:

```text
tools/checkpatch.sh -m -g upstream/master..fix/stm32h7-protected-memory: pass
tools/checkpatch.sh -g upstream/master..fix/stm32h7-protected-memory: pass
git diff --check upstream/master..fix/stm32h7-protected-memory: pass
```

## PR verification Self-Check

* [x] This PR introduces only one functional change.
* [x] I have updated all required description fields above.
* [x] My PR adheres to the contributing guidelines and coding standard.
* [ ] My PR is still work in progress.
* [x] My PR is ready for review and can be safely merged.
