### PR TITLE
arch/arm/stm32h5: Add PM stop and standby support

### DIFF
--- a/arch/arm/src/stm32h5/Make.defs
+++ b/arch/arm/src/stm32h5/Make.defs
@@ -116,6 +116,13 @@ ifeq ($(CONFIG_STM32_PWM),y)
 CHIP_CSRCS += stm32_pwm.c
 endif
 
+ifeq ($(CONFIG_PM),y)
+CHIP_CSRCS += stm32_pmstandby.c stm32_pmstop.c
+ifneq ($(CONFIG_ARCH_CUSTOM_PMINIT),y)
+CHIP_CSRCS += stm32_pminitialize.c
+endif
+endif
+
 ifeq ($(CONFIG_STM32_IWDG),y)
 CHIP_CSRCS += stm32_iwdg.c
 endif

--- a/arch/arm/src/stm32h5/stm32_pm.h
+++ b/arch/arm/src/stm32h5/stm32_pm.h
@@ -1,0 +1,91 @@
+/****************************************************************************
+ * arch/arm/src/stm32h5/stm32_pm.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_STM32H5_STM32_PM_H
+#define __ARCH_ARM_SRC_STM32H5_STM32_PM_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdbool.h>
+
+#include "chip.h"
+#include "arm_internal.h"
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+#ifndef __ASSEMBLY__
+#ifdef __cplusplus
+#define EXTERN extern "C"
+extern "C"
+{
+#else
+#define EXTERN extern
+#endif
+
+/****************************************************************************
+ * Name: stm32_pmstop
+ *
+ * Description:
+ *   Enter STOP mode.
+ *
+ * Input Parameters:
+ *   svos5 - true: To further reduce power consumption in Stop mode, put the
+ *           internal voltage regulator in "stop mode voltage scaling"
+ *           scale 5 which is the lowest-power stop mode.
+ *           false: Use SVOS3 which is the default voltage scaling value.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void stm32_pmstop(bool svos5);
+
+/****************************************************************************
+ * Name: stm32_pmstandby
+ *
+ * Description:
+ *   Enter STANDBY mode.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void stm32_pmstandby(void);
+
+#undef EXTERN
+#ifdef __cplusplus
+}
+#endif
+#endif /* __ASSEMBLY__ */
+
+#endif /* __ARCH_ARM_SRC_STM32H5_STM32_PM_H */

--- a/arch/arm/src/stm32h5/stm32_pminitialize.c
+++ b/arch/arm/src/stm32h5/stm32_pminitialize.c
@@ -1,0 +1,64 @@
+/****************************************************************************
+ * arch/arm/src/stm32h5/stm32_pminitialize.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+#include <nuttx/power/pm.h>
+
+#include "arm_internal.h"
+#include "stm32_pm.h"
+
+#ifdef CONFIG_PM
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: arm_pminitialize
+ *
+ * Description:
+ *   This function is called by MCU-specific logic at power-on reset in
+ *   order to provide one-time initialization the power management subsystem.
+ *   This function must be called *very* early in the initialization sequence
+ *   *before* any other device drivers are initialized (since they may
+ *   attempt to register with the power management subsystem).
+ *
+ * Input Parameters:
+ *   None.
+ *
+ * Returned Value:
+ *   None.
+ *
+ ****************************************************************************/
+
+void arm_pminitialize(void)
+{
+  /* Initialize the NuttX power management subsystem proper */
+
+  pm_initialize();
+}
+
+#endif /* CONFIG_PM */

--- a/arch/arm/src/stm32h5/stm32_pmstandby.c
+++ b/arch/arm/src/stm32h5/stm32_pmstandby.c
@@ -1,0 +1,88 @@
+/****************************************************************************
+ * arch/arm/src/stm32h5/stm32_pmstandby.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdbool.h>
+
+#include "arm_internal.h"
+#include "nvic.h"
+#include "stm32_rcc.h"
+#include "stm32_pwr.h"
+#include "stm32_pm.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: stm32_pmstandby
+ *
+ * Description:
+ *   Enter STANDBY mode.
+ *
+ * Input Parameters:
+ *   None
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void stm32_pmstandby(void)
+{
+  uint32_t regval;
+
+  /* Clear the wake-up flags before resetting. */
+
+  modifyreg32(STM32_PWR_PMCR, 0, PWR_PMCR_CSSF);
+  modifyreg32(STM32_PWR_WUSCR, 0, PWR_WUSCR_CWUF1 | PWR_WUSCR_CWUF2 |
+                                  PWR_WUSCR_CWUF3 | PWR_WUSCR_CWUF4 |
+                                  PWR_WUSCR_CWUF5 | PWR_WUSCR_CWUF6 |
+                                  PWR_WUSCR_CWUF7 | PWR_WUSCR_CWUF8);
+
+  /* Clear reset flags. */
+
+  modifyreg32(STM32_RCC_RSR, 0, RCC_RSR_RMVF);
+
+  /* Set the Low Power Mode to Standby in the Power Mode Control Register.
+   * Unlike H7 which has multiple power domains (D1, D2, D3), H5 uses a
+   * single bit in PMCR to select between Stop and Standby modes.
+   * Setting LPMS bit to 1 selects Standby mode.
+   */
+
+  modifyreg32(STM32_PWR_PMCR, 0, PWR_PMCR_LPMS);
+
+  /* Set SLEEPDEEP bit of Cortex System Control Register */
+
+  regval  = getreg32(NVIC_SYSCON);
+  regval |= NVIC_SYSCON_SLEEPDEEP;
+  putreg32(regval, NVIC_SYSCON);
+
+  /* Sleep until the wakeup reset occurs */
+
+  asm("wfi");
+}

--- a/arch/arm/src/stm32h5/stm32_pmstop.c
+++ b/arch/arm/src/stm32h5/stm32_pmstop.c
@@ -1,0 +1,110 @@
+/****************************************************************************
+ * arch/arm/src/stm32h5/stm32_pmstop.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdbool.h>
+
+#include "arm_internal.h"
+#include "nvic.h"
+#include "stm32_pwr.h"
+#include "stm32_pm.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: stm32_pmstop
+ *
+ * Description:
+ *   Enter STOP mode.
+ *
+ * Input Parameters:
+ *   svos5 - true: To further reduce power consumption in Stop mode, put the
+ *           internal voltage regulator in "stop mode voltage scaling"
+ *           scale 5 which is the lowest-power stop mode.
+ *           false: Use SVOS3 which is the default voltage scaling value.
+ *
+ * Returned Value:
+ *   None
+ *
+ ****************************************************************************/
+
+void stm32_pmstop(bool svos5)
+{
+  uint32_t regval;
+
+  /* Clear the Low Power Mode Selection (LPMS) bit in the power mode control
+   * register to specify Stop mode when entering DeepSleep.
+   */
+
+  regval  = getreg32(STM32_PWR_PMCR);
+  regval &= ~(PWR_PMCR_LPMS | PWR_PMCR_SVOS_MASK);
+
+  /* Set low-power voltage scaling.  */
+
+  if (svos5)
+    {
+      regval |= PWR_PMCR_SVOS_SVOS5;
+    }
+  else
+    {
+      /* Set regulator to normal (S3) mode */
+
+      regval |= PWR_PMCR_SVOS_SVOS3;
+    }
+
+  putreg32(regval, STM32_PWR_PMCR);
+
+  /* Set SLEEPDEEP bit of Cortex System Control Register */
+
+  regval  = getreg32(NVIC_SYSCON);
+  regval |= NVIC_SYSCON_SLEEPDEEP;
+  putreg32(regval, NVIC_SYSCON);
+
+  /* Sleep until the wakeup interrupt or event occurs */
+
+#ifdef CONFIG_PM_WFE
+  /* Mode: SLEEP + Entry with WFE */
+
+  asm volatile ("wfe");
+#else
+  /* Mode: SLEEP + Entry with WFI */
+
+  asm volatile ("wfi");
+#endif
+
+  /* Clear deep sleep bits, so that MCU does not go into deep sleep in
+   * idle.
+   */
+
+  /* Clear SLEEPDEEP bit of Cortex System Control Register */
+
+  regval  = getreg32(NVIC_SYSCON);
+  regval &= ~NVIC_SYSCON_SLEEPDEEP;
+  putreg32(regval, NVIC_SYSCON);
+}


### PR DESCRIPTION
## Summary

**Implement PM STOP.** When waking from stop, execution resumes. stm32h7's `stm32_pmstop` has a `bool lpds` parameter. There is no LPDS on stm32h5 but there is the same lower-power voltage scaling value (SVOS5) that H7 uses in conjunction with LPDS, so keep the parameter for stm32h5 but rename it to svos5 which uses SVOS5 without LPDS present. It allows chosing between SVOS3 and SVOS5.

**Implement PM STANDBY.** When waking from standby, it's always a reset. It's similar to STM32H7 except that it has a slightly simpler power control register.

Add arm_pminitialize implementation with default pm subsystem initialization.

Don't update the docs to say PM supported since PM SLEEP is not added yet. Maybe I should still update the docs to say PM is supported anyways? I see that most idle loops (e.g. stm32l4/stm32l4_idle.c) don't use stm32_pmsleep despite supporting it.

## Impact

It's additive. It's missing stm32_pmsleep.

stm32_pmstop has a parameter like stm32h7, but the semantics are slightly different.

## Testing

`nucleo-h563zi:nsh` with the following enabled:

```
CONFIG_PM=y
CONFIG_ARCH_IRQBUTTONS=y
CONFIG_ARCH_IRQPRIO=y
```

### nucleo-h563zi current consumption measurements

Normal baseline: 165.2 mA
`stm32_pmstop(false)` (SVOS3): 132.2 mA
`stm32_pmstop(true)` (SVOS5): 132.0 mA
`stm32_pmstandby()`: 131.6 mA

### STOP

Make button trigger interrupt, not event.

```diff
diff --git a/boards/arm/stm32h5/nucleo-h563zi/src/stm32_buttons.c b/boards/arm/stm32h5/nucleo-h563zi/src/stm32_buttons.c
index d0899271aa..2a1b29cb6b 100644
--- a/boards/arm/stm32h5/nucleo-h563zi/src/stm32_buttons.c
+++ b/boards/arm/stm32h5/nucleo-h563zi/src/stm32_buttons.c
@@ -105,7 +105,7 @@ int board_button_irq(int id, xcpt_t irqhandler, void *arg)
 
   if (id == BUTTON_USER)
     {
-      ret = stm32_gpiosetevent(GPIO_BTN_USER, true, true, true,
+      ret = stm32_gpiosetevent(GPIO_BTN_USER, true, true, false,
                                irqhandler, arg);
     }

```

Setup the button to trigger a high-enough priority interrupt to wake from stop. Both `stm32_pmstop(false)` (SVOS3) and `stm32_pmstop(true)` (SVOS5) were tested.

```c
static int xcpt(int irq, FAR void *context, FAR void *arg)
{
  return 0;
}

static void up_idlepm(void)
{
  irqstate_t flags;

  board_button_initialize();
  board_button_irq(0, xcpt, NULL);
  up_prioritize_irq(STM32_IRQ_EXTI13, NVIC_SYSH_HIGH_PRIORITY);

  flags = enter_critical_section();

  stm32_pmstop(false);

  stm32_clockenable();

  leave_critical_section(flags);

  syslog(LOG_DEBUG, "woke up");
  up_mdelay(100);
}
```

It triggers on both edges.

```
ABCG

NuttShel(Nwoke up
SH) NuttX-13.0.1-RC0
nsh> woke up
woke up
woke up
woke up
woke up
woke up
woke up
```

### STANDBY

Standby is deeper than stop. Use a WKUP pin to cause a reset from standby mode.

```c
static void up_idlepm(void)
{
  irqstate_t flags;

  flags = enter_critical_section();

  /* Enable WKUP1 to trigger reset from standby
   * by PA0 going high. Specify pullup.
   */
  modifyreg32(STM32_PWR_WUCR,
              PWR_WUCR_MASK_WUPPUPD(1),
              PWR_WUCR_PU_WUPPUPD(1) | PWR_WUCR_WUPEN(1));
  up_mdelay(1);

  stm32_pmstandby();

  /* unreachable because standby can only be left by reset. */
}
```

It enters standby before all startup UART data can be sent. Disconnecting PA0 from ground causes reset.

```
ABCG

NuttShellABCG

NuttShellABCG

NuttShellABCG

NuttShell
```