### PR TITLE
fs: POSIX filesystem bug fixes (rename/canonicalize/LINK_MAX)

### DIFF
--- a/fs/hostfs/hostfs.c
+++ b/fs/hostfs/hostfs.c
@@ -184,54 +184,14 @@ static void hostfs_mkpath(FAR struct hostfs_mountpt_s  *fs,
                           FAR const char *relpath,
                           FAR char *path, int pathlen)
 {
-  int depth = 0;
-  int first;
-  int x;
-
-  /* Copy base host path to output */
-
-  strlcpy(path, fs->fs_root, pathlen);
-
-  /* Be sure we aren't trying to use ".." to display outside of our
-   * mounted path.
+  /* Copy base host path to output and append relative path directly.
+   * Note: Both ".." segments and leading slashes are already resolved
+   * by the VFS layer (_inode_canonicalize + inode_nextname) before
+   * relpath reaches here.
    */
 
-  x = 0;
-  while (relpath[x] == '/')
-    {
-      x++;
-    }
-
-  first = x;
-
-  while (relpath[x] != '\0')
-    {
-      /* Test for ".." occurrence */
-
-      if (strncmp(&relpath[x], "..", 2) == 0)
-        {
-          /* Reduce depth by 1 */
-
-          depth--;
-          x += 2;
-        }
-
-      else if (relpath[x] == '/' && relpath[x + 1] != '/' &&
-               relpath[x + 1] != '\0')
-        {
-          depth++;
-          x++;
-        }
-      else
-        {
-          x++;
-        }
-    }
-
-  if (depth >= 0)
-    {
-      strlcat(path, &relpath[first], pathlen);
-    }
+  strlcpy(path, fs->fs_root, pathlen);
+  strlcat(path, relpath, pathlen);
 }
 
 /****************************************************************************

--- a/fs/hostfs/hostfs.c
+++ b/fs/hostfs/hostfs.c
@@ -573,6 +573,7 @@ static int hostfs_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
           case FIOC_FILEPATH:
             {
               FAR char *path = (FAR char *)(uintptr_t)arg;
+
               ret = inode_getpath(filep->f_inode, path, PATH_MAX);
               if (ret >= 0)
                 {

--- a/fs/inode/fs_inodesearch.c
+++ b/fs/inode/fs_inodesearch.c
@@ -398,25 +398,50 @@ static int _inode_search(FAR struct inode_search_s *desc)
 
   if (desc->buffer == NULL)
     {
-      desc->buffer = lib_get_tempbuffer(PATH_MAX);
+      FAR const char *cwd = NULL;
+      size_t buflen;
+
+      /* For a relative path the absolute form is "<cwd>/<path>".  That
+       * concatenation can exceed PATH_MAX even when the relative path
+       * itself is within PATH_MAX: a relative path of PATH_MAX-1 bytes
+       * is legal per pathconf(_PC_PATH_MAX), but the prefix added by the
+       * cwd pushes the uncanonicalized form past the limit.  Size the
+       * buffer to hold the full absolute form so that ".." segments are
+       * collapsed against the correct suffix; truncating first could
+       * drop the trailing component and let ".." collapse the path onto
+       * a directory (yielding the wrong errno, e.g. EISDIR, instead of
+       * resolving the file).  _inode_canonicalize() still rejects any
+       * result whose canonicalized length reaches PATH_MAX.
+       */
+
+      if (*desc->path != '/')
+        {
+          cwd = _inode_getcwd();
+          buflen = strlen(cwd) + 1 + strlen(desc->path) + 1;
+        }
+      else
+        {
+          buflen = strlen(desc->path) + 1;
+        }
+
+      if (buflen < PATH_MAX)
+        {
+          buflen = PATH_MAX;
+        }
+
+      desc->buffer = lib_get_tempbuffer(buflen);
       if (desc->buffer == NULL)
         {
           return -ENOMEM;
         }
 
-      /* Convert relative path to absolute, or just copy absolute path.
-       * Use desc->path directly (points to caller's string) as source
-       * to avoid overlap with desc->buffer.
-       */
-
-      if (*desc->path != '/')
+      if (cwd != NULL)
         {
-          snprintf(desc->buffer, PATH_MAX, "%s/%s",
-                   _inode_getcwd(), desc->path);
+          snprintf(desc->buffer, buflen, "%s/%s", cwd, desc->path);
         }
       else
         {
-          strlcpy(desc->buffer, desc->path, PATH_MAX);
+          strlcpy(desc->buffer, desc->path, buflen);
         }
 
       desc->path = desc->buffer;

--- a/fs/inode/fs_inodesearch.c
+++ b/fs/inode/fs_inodesearch.c
@@ -48,6 +48,7 @@ static int _inode_linktarget(FAR struct inode *inode,
 #endif
 static int _inode_search(FAR struct inode_search_s *desc);
 static FAR const char *_inode_getcwd(void);
+static int _inode_canonicalize(FAR char *path);
 
 /****************************************************************************
  * Public Data
@@ -241,6 +242,103 @@ static int _compute_path_depth(FAR const char *path)
 }
 
 /****************************************************************************
+ * Name: _inode_canonicalize
+ *
+ * Description:
+ *   Remove "." and ".." segments from an absolute path in-place.
+ *   The path MUST start with '/'.  Returns -EINVAL if ".." attempts
+ *   to ascend beyond the root directory, or -ENAMETOOLONG if the
+ *   canonicalized result is >= PATH_MAX bytes.
+ *
+ ****************************************************************************/
+
+static int _inode_canonicalize(FAR char *path)
+{
+  /* Skip the initial '/' -- caller guarantees absolute path */
+
+  FAR char *src = path + 1;
+  FAR char *dst = path + 1;
+
+  while (*src != '\0')
+    {
+      /* Skip duplicate slashes */
+
+      if (*src == '/')
+        {
+          src++;
+          continue;
+        }
+
+      /* Check for "." (current directory) */
+
+      if (src[0] == '.' && (src[1] == '/' || src[1] == '\0'))
+        {
+          src += (src[1] == '/') ? 2 : 1;
+          continue;
+        }
+
+      /* Check for ".." (parent directory) */
+
+      if (src[0] == '.' && src[1] == '.' &&
+          (src[2] == '/' || src[2] == '\0'))
+        {
+          /* Cannot go above root */
+
+          if (dst <= path + 1)
+            {
+              return -EINVAL;
+            }
+
+          /* Remove trailing slash first */
+
+          dst--;
+
+          /* Scan backward to find the previous '/' */
+
+          while (dst > path + 1 && *(dst - 1) != '/')
+            {
+              dst--;
+            }
+
+          src += (src[2] == '/') ? 3 : 2;
+          continue;
+        }
+
+      /* Regular path component: copy until end of segment (including '/') */
+
+      do
+        {
+          if (dst != src)
+            {
+              *dst = *src;
+            }
+
+          dst++;
+          src++;
+        }
+      while (*src != '\0' && *(src - 1) != '/');
+    }
+
+  /* Remove trailing slash (unless root "/") */
+
+  if (dst > path + 1 && *(dst - 1) == '/')
+    {
+      dst--;
+    }
+
+  *dst = '\0';
+
+  /* After canonicalization, check if the resolved path exceeds PATH_MAX */
+
+  if ((dst - path) >= PATH_MAX)
+    {
+      return -ENAMETOOLONG;
+    }
+
+  return 0;
+}
+
+/****************************************************************************
  * Name: _inode_checkpath
  ****************************************************************************/
 
@@ -313,9 +411,9 @@ static int _inode_search(FAR struct inode_search_s *desc)
       return ret;
     }
 
-  /* Convert the relative path to the absolute path */
+  /* Ensure we have a writable buffer for path manipulation */
 
-  if (*desc->path != '/')
+  if (desc->buffer == NULL)
     {
       desc->buffer = lib_get_tempbuffer(PATH_MAX);
       if (desc->buffer == NULL)
@@ -323,8 +421,33 @@ static int _inode_search(FAR struct inode_search_s *desc)
           return -ENOMEM;
         }
 
-      snprintf(desc->buffer, PATH_MAX, "%s/%s", _inode_getcwd(), desc->path);
+      /* Convert relative path to absolute, or just copy absolute path.
+       * Use desc->path directly (points to caller's string) as source
+       * to avoid overlap with desc->buffer.
+       */
+
+      if (*desc->path != '/')
+        {
+          snprintf(desc->buffer, PATH_MAX, "%s/%s",
+                   _inode_getcwd(), desc->path);
+        }
+      else
+        {
+          strlcpy(desc->buffer, desc->path, PATH_MAX);
+        }
+
       desc->path = desc->buffer;
+    }
+
+  /* Canonicalize the path to remove "." and ".." segments.  This ensures
+   * that mountpoint relpath never contains ".." which most filesystems
+   * (tmpfs, romfs, etc.) cannot resolve.
+   */
+
+  ret = _inode_canonicalize(desc->buffer);
+  if (ret < 0)
+    {
+      return ret;
     }
 
   name = desc->path;

--- a/fs/inode/fs_inodesearch.c
+++ b/fs/inode/fs_inodesearch.c
@@ -256,7 +256,7 @@ static int _inode_checkpath(const char *path)
 
   /* Check each segment of the path */
 
-  while (*path != '\0' && namelen <= NAME_MAX && pathlen < PATH_MAX)
+  while (*path != '\0' && pathlen < PATH_MAX)
     {
       if (*path == '/')
         {
@@ -264,14 +264,17 @@ static int _inode_checkpath(const char *path)
         }
       else
         {
-          namelen++;
+          if (++namelen > NAME_MAX)
+            {
+              return -ENAMETOOLONG;
+            }
         }
 
       path++;
       pathlen++;
     }
 
-  return *path != '\0' ? -ENAMETOOLONG : OK;
+  return pathlen >= PATH_MAX ? -ENAMETOOLONG : OK;
 }
 
 /****************************************************************************

--- a/fs/inode/fs_inodesearch.c
+++ b/fs/inode/fs_inodesearch.c
@@ -61,16 +61,6 @@ FAR struct inode *g_root_inode = NULL;
  ****************************************************************************/
 
 /****************************************************************************
- * Name: _inode_isdotdot
- ****************************************************************************/
-
-static inline bool _inode_isdotdot(FAR const char *name)
-{
-  return name[0] == '.' && name[1] == '.' &&
-         (name[2] == '\0' || name[2] == '/');
-}
-
-/****************************************************************************
  * Name: _inode_isdot
  ****************************************************************************/
 
@@ -221,20 +211,13 @@ static int _compute_path_depth(FAR const char *path)
   FAR const char *name = path;
   int depth = 0;
 
+  /* After _inode_canonicalize(), path never contains ".." segments,
+   * so we only need to count path components.
+   */
+
   while (*name != '\0')
     {
-      if (_inode_isdotdot(name))
-        {
-          if (--depth < 0)
-            {
-              break;
-            }
-        }
-      else
-        {
-          depth++;
-        }
-
+      depth++;
       name = inode_nextname(name);
     }
 
@@ -511,31 +494,6 @@ static int _inode_search(FAR struct inode_search_s *desc)
               relpath = name;
               ret = OK;
               break;
-            }
-          else if (_inode_isdotdot(name))
-            {
-              do
-                {
-                  if (above != NULL)
-                    {
-                      inode = above;
-                      above = above->i_parent;
-                    }
-
-                  name = inode_nextname(name);
-                }
-              while (_inode_isdotdot(name));
-
-              if (*name == '\0')
-                {
-                  relpath = name;
-                  ret = OK;
-                  break;
-                }
-
-              above = inode;
-              left  = NULL;
-              inode = inode->i_child;
             }
           else
             {

--- a/fs/rpmsgfs/rpmsgfs.c
+++ b/fs/rpmsgfs/rpmsgfs.c
@@ -207,54 +207,14 @@ static void rpmsgfs_mkpath(FAR struct rpmsgfs_mountpt_s *fs,
                            FAR const char *relpath,
                            FAR char *path, int pathlen)
 {
-  int depth = 0;
-  int first;
-  int x;
-
-  /* Copy base host path to output */
-
-  strlcpy(path, fs->fs_root, pathlen);
-
-  /* Be sure we aren't trying to use ".." to display outside of our
-   * mounted path.
+  /* Copy base host path to output and append relative path directly.
+   * Note: Both ".." segments and leading slashes are already resolved
+   * by the VFS layer (_inode_canonicalize + inode_nextname) before
+   * relpath reaches here.
    */
 
-  x = 0;
-  while (relpath[x] == '/')
-    {
-      x++;
-    }
-
-  first = x;
-
-  while (relpath[x] != '\0')
-    {
-      /* Test for ".." occurrence */
-
-      if (strncmp(&relpath[x], "..", 2) == 0)
-        {
-          /* Reduce depth by 1 */
-
-          depth--;
-          x += 2;
-        }
-
-      else if (relpath[x] == '/' && relpath[x + 1] != '/' &&
-               relpath[x + 1] != '\0')
-        {
-          depth++;
-          x++;
-        }
-      else
-        {
-          x++;
-        }
-    }
-
-  if (depth >= 0)
-    {
-      strlcat(path, &relpath[first], pathlen - strlen(path));
-    }
+  strlcpy(path, fs->fs_root, pathlen);
+  strlcat(path, relpath, pathlen);
 
   while (fs->timeout > 0)
     {

--- a/fs/smartfs/smartfs_utils.c
+++ b/fs/smartfs/smartfs_utils.c
@@ -331,7 +331,9 @@ int smartfs_unmount(FAR struct smartfs_mountpt_s *fs)
       /* Test if this FS's blkdriver matches ours (it could be us) */
 
       if (nextfs->fs_blkdriver == fs->fs_blkdriver)
-        count++;
+        {
+          count++;
+        }
 
       /* Test if this entry is our's */
 
@@ -411,7 +413,7 @@ int smartfs_unmount(FAR struct smartfs_mountpt_s *fs)
 #else
   if (fs->fs_blkdriver)
     {
-     inode = fs->fs_blkdriver;
+      inode = fs->fs_blkdriver;
       if (inode)
         {
           if (inode->u.i_bops && inode->u.i_bops->close)
@@ -1528,20 +1530,20 @@ off_t smartfs_seek_internal(FAR struct smartfs_mountpt_s *fs,
   /* Calculate the file position to seek to based on current position */
 
   switch (whence)
-  {
-    case SEEK_SET:
-    default:
-      newpos = offset;
-      break;
+    {
+      case SEEK_SET:
+      default:
+        newpos = offset;
+        break;
 
-    case SEEK_CUR:
-      newpos = sf->filepos + offset;
-      break;
+      case SEEK_CUR:
+        newpos = sf->filepos + offset;
+        break;
 
-    case SEEK_END:
-      newpos = sf->entry.datlen + offset;
-      break;
-  }
+      case SEEK_END:
+        newpos = sf->entry.datlen + offset;
+        break;
+    }
 
   /* Ensure newpos is in range */
 

--- a/fs/smartfs/smartfs_utils.c
+++ b/fs/smartfs/smartfs_utils.c
@@ -518,293 +518,257 @@ int smartfs_finddirentry(FAR struct smartfs_mountpt_s *fs,
 
       strlcpy(fs->fs_workbuffer, segment, seglen + 1);
 
-      /* Search for "." and ".." as segment names */
+      /* Search for the entry in the current directory.
+       * Note: "." and ".." segments are already resolved by the VFS layer
+       * (_inode_canonicalize) before relpath reaches here.
+       */
 
-      if (strcmp(fs->fs_workbuffer, ".") == 0)
+      dirsector = dirstack[depth];
+
+      /* Read the directory */
+
+      offset = 0xffff;
+
+#if CONFIG_SMARTFS_ERASEDSTATE == 0xff
+      while (dirsector != 0xffff)
+#else
+      while (dirsector != 0)
+#endif
         {
-          /* Just ignore this segment.  Advance ptr if not on NULL */
+          /* Read the next directory in the chain */
 
-          if (*ptr == '/')
+          readwrite.logsector = dirsector;
+          readwrite.count = fs->fs_llformat.availbytes;
+          readwrite.buffer = (uint8_t *)fs->fs_rwbuffer;
+          readwrite.offset = 0;
+          ret = FS_IOCTL(fs, BIOC_READSECT, (unsigned long) &readwrite);
+          if (ret < 0)
             {
-              ptr++;
-            }
-
-          segment = ptr;
-          continue;
-        }
-      else if (strcmp(fs->fs_workbuffer, "..") == 0)
-        {
-          /* Up one level */
-
-          if (depth == 0)
-            {
-              /* We went up one level past our mount point! */
-
               goto errout;
             }
 
-          /* "Pop" to the previous directory level */
+          /* Point to next sector in chain */
 
-          depth--;
-          if (*ptr == '/')
+          header = (FAR struct smartfs_chain_header_s *) fs->fs_rwbuffer;
+          dirsector = SMARTFS_NEXTSECTOR(header);
+
+          /* Search for the entry */
+
+          offset = sizeof(struct smartfs_chain_header_s);
+          entry = (struct smartfs_entry_header_s *)
+            &fs->fs_rwbuffer[offset];
+          while (offset < readwrite.count)
             {
-              ptr++;
-            }
+              /* Test if this entry is valid and active */
 
-          segment = ptr;
-          continue;
-        }
-      else
-        {
-          /* Search for the entry in the current directory */
-
-          dirsector = dirstack[depth];
-
-          /* Read the directory */
-
-          offset = 0xffff;
-
-#if CONFIG_SMARTFS_ERASEDSTATE == 0xff
-          while (dirsector != 0xffff)
+#ifdef CONFIG_SMARTFS_ALIGNED_ACCESS
+              if (((smartfs_rdle16(&entry->flags) &
+                    SMARTFS_DIRENT_EMPTY) ==
+                  (SMARTFS_ERASEDSTATE_16BIT & SMARTFS_DIRENT_EMPTY)) ||
+                  ((smartfs_rdle16(&entry->flags)
+                    & SMARTFS_DIRENT_ACTIVE) !=
+                  (SMARTFS_ERASEDSTATE_16BIT & SMARTFS_DIRENT_ACTIVE)))
 #else
-          while (dirsector != 0)
+              if (((entry->flags & SMARTFS_DIRENT_EMPTY) ==
+                  (SMARTFS_ERASEDSTATE_16BIT & SMARTFS_DIRENT_EMPTY)) ||
+                  ((entry->flags & SMARTFS_DIRENT_ACTIVE) !=
+                  (SMARTFS_ERASEDSTATE_16BIT & SMARTFS_DIRENT_ACTIVE)))
 #endif
-            {
-              /* Read the next directory in the chain */
-
-              readwrite.logsector = dirsector;
-              readwrite.count = fs->fs_llformat.availbytes;
-              readwrite.buffer = (uint8_t *)fs->fs_rwbuffer;
-              readwrite.offset = 0;
-              ret = FS_IOCTL(fs, BIOC_READSECT, (unsigned long) &readwrite);
-              if (ret < 0)
                 {
-                  goto errout;
-                }
-
-              /* Point to next sector in chain */
-
-              header = (FAR struct smartfs_chain_header_s *) fs->fs_rwbuffer;
-              dirsector = SMARTFS_NEXTSECTOR(header);
-
-              /* Search for the entry */
-
-              offset = sizeof(struct smartfs_chain_header_s);
-              entry = (struct smartfs_entry_header_s *)
-                &fs->fs_rwbuffer[offset];
-              while (offset < readwrite.count)
-                {
-                  /* Test if this entry is valid and active */
-
-#ifdef CONFIG_SMARTFS_ALIGNED_ACCESS
-                  if (((smartfs_rdle16(&entry->flags) &
-                        SMARTFS_DIRENT_EMPTY) ==
-                      (SMARTFS_ERASEDSTATE_16BIT & SMARTFS_DIRENT_EMPTY)) ||
-                      ((smartfs_rdle16(&entry->flags)
-                        & SMARTFS_DIRENT_ACTIVE) !=
-                      (SMARTFS_ERASEDSTATE_16BIT & SMARTFS_DIRENT_ACTIVE)))
-#else
-                  if (((entry->flags & SMARTFS_DIRENT_EMPTY) ==
-                      (SMARTFS_ERASEDSTATE_16BIT & SMARTFS_DIRENT_EMPTY)) ||
-                      ((entry->flags & SMARTFS_DIRENT_ACTIVE) !=
-                      (SMARTFS_ERASEDSTATE_16BIT & SMARTFS_DIRENT_ACTIVE)))
-#endif
-                    {
-                      /* This entry isn't valid, skip it */
-
-                      offset += entrysize;
-                      entry = (struct smartfs_entry_header_s *)
-                        &fs->fs_rwbuffer[offset];
-
-                      continue;
-                    }
-
-                  /* Test if the name matches */
-
-                  if (strncmp(entry->name, fs->fs_workbuffer,
-                      fs->fs_llformat.namesize) == 0)
-                    {
-                      /* We found it!  If this is the last segment entry,
-                       * then report the entry.  If it isn't the last
-                       * entry, then validate it is a directory entry and
-                       * open it and continue searching.
-                       */
-
-                      if (*ptr == '\0')
-                        {
-                          /* We are at the last segment.  Report the entry */
-
-                          /* Fill in the entry */
-
-#ifdef CONFIG_SMARTFS_ALIGNED_ACCESS
-                          direntry->firstsector =
-                            smartfs_rdle16(&entry->firstsector);
-                          direntry->flags = smartfs_rdle16(&entry->flags);
-                          direntry->utc = smartfs_rdle32(&entry->utc);
-#else
-                          direntry->firstsector = entry->firstsector;
-                          direntry->flags = entry->flags;
-                          direntry->utc = entry->utc;
-#endif
-                          direntry->dsector = readwrite.logsector;
-                          direntry->doffset = offset;
-                          direntry->dfirst = dirstack[depth];
-                          if (direntry->name == NULL)
-                            {
-                              direntry->name = (FAR char *)
-                                fs_heap_malloc(fs->fs_llformat.namesize + 1);
-                            }
-
-                          strlcpy(direntry->name, entry->name,
-                                  fs->fs_llformat.namesize + 1);
-                          direntry->datlen = 0;
-
-                          /* Scan the file's sectors to calculate the length
-                           * and perform a rudimentary check.
-                           */
-
-#ifdef CONFIG_SMARTFS_ALIGNED_ACCESS
-                          if ((smartfs_rdle16(&entry->flags) &
-                                SMARTFS_DIRENT_TYPE) ==
-                              SMARTFS_DIRENT_TYPE_FILE)
-#else
-                          if ((entry->flags & SMARTFS_DIRENT_TYPE) ==
-                              SMARTFS_DIRENT_TYPE_FILE)
-#endif
-                            {
-#ifdef CONFIG_SMARTFS_ALIGNED_ACCESS
-                              dirsector =
-                                smartfs_rdle16(&entry->firstsector);
-#else
-                              dirsector = entry->firstsector;
-#endif
-                              readwrite.count =
-                                sizeof(struct smartfs_chain_header_s);
-                              readwrite.buffer = (uint8_t *)fs->fs_rwbuffer;
-                              readwrite.offset = 0;
-
-                              while (dirsector != SMARTFS_ERASEDSTATE_16BIT)
-                                {
-                                  /* Read the next sector of the file */
-
-                                  readwrite.logsector = dirsector;
-                                  ret = FS_IOCTL(fs, BIOC_READSECT,
-                                                 (unsigned long) &readwrite);
-                                  if (ret < 0)
-                                    {
-                                      ferr("ERROR: Error in sector"
-                                           " chain at %d!\n", dirsector);
-                                      break;
-                                    }
-
-                                  /* Add used bytes to the total and point
-                                   * to next sector
-                                   */
-
-                                  if (SMARTFS_USED(header) !=
-                                      SMARTFS_ERASEDSTATE_16BIT)
-                                    {
-                                      direntry->datlen +=
-                                        SMARTFS_USED(header);
-                                    }
-
-                                  dirsector = SMARTFS_NEXTSECTOR(header);
-                                }
-                            }
-
-                          *parentdirsector = dirstack[depth];
-                          *filename = segment;
-                          ret = OK;
-                          goto errout;
-                        }
-                      else
-                        {
-                          /* Validate it's a directory */
-
-#ifdef CONFIG_SMARTFS_ALIGNED_ACCESS
-                          if ((smartfs_rdle16(&entry->flags) &
-                               SMARTFS_DIRENT_TYPE) !=
-                              SMARTFS_DIRENT_TYPE_DIR)
-#else
-                          if ((entry->flags & SMARTFS_DIRENT_TYPE) !=
-                              SMARTFS_DIRENT_TYPE_DIR)
-#endif
-                            {
-                              /* Not a directory!  Report the error */
-
-                              ret = -ENOTDIR;
-                              goto errout;
-                            }
-
-                          /* "Push" the directory and continue searching */
-
-                          if (depth >= CONFIG_SMARTFS_DIRDEPTH - 1)
-                            {
-                              /* Directory depth too big */
-
-                              ret = -ENAMETOOLONG;
-                              goto errout;
-                            }
-
-#ifdef CONFIG_SMARTFS_ALIGNED_ACCESS
-                          dirstack[++depth] =
-                            smartfs_rdle16(&entry->firstsector);
-#else
-                          dirstack[++depth] = entry->firstsector;
-#endif
-                          segment = ptr + 1;
-                          break;
-                        }
-                    }
-
-                  /* Not this entry.  Skip to the next one */
+                  /* This entry isn't valid, skip it */
 
                   offset += entrysize;
                   entry = (struct smartfs_entry_header_s *)
                     &fs->fs_rwbuffer[offset];
+
+                  continue;
                 }
 
-              /* Test if a directory entry was found and break if it was */
+              /* Test if the name matches */
 
-              if (offset < readwrite.count)
+              if (strncmp(entry->name, fs->fs_workbuffer,
+                  fs->fs_llformat.namesize) == 0)
                 {
-                  break;
+                  /* We found it!  If this is the last segment entry,
+                   * then report the entry.  If it isn't the last
+                   * entry, then validate it is a directory entry and
+                   * open it and continue searching.
+                   */
+
+                  if (*ptr == '\0')
+                    {
+                      /* We are at the last segment.  Report the entry */
+
+                      /* Fill in the entry */
+
+#ifdef CONFIG_SMARTFS_ALIGNED_ACCESS
+                      direntry->firstsector =
+                        smartfs_rdle16(&entry->firstsector);
+                      direntry->flags = smartfs_rdle16(&entry->flags);
+                      direntry->utc = smartfs_rdle32(&entry->utc);
+#else
+                      direntry->firstsector = entry->firstsector;
+                      direntry->flags = entry->flags;
+                      direntry->utc = entry->utc;
+#endif
+                      direntry->dsector = readwrite.logsector;
+                      direntry->doffset = offset;
+                      direntry->dfirst = dirstack[depth];
+                      if (direntry->name == NULL)
+                        {
+                          direntry->name = (FAR char *)
+                            fs_heap_malloc(fs->fs_llformat.namesize + 1);
+                        }
+
+                      strlcpy(direntry->name, entry->name,
+                              fs->fs_llformat.namesize + 1);
+                      direntry->datlen = 0;
+
+                      /* Scan the file's sectors to calculate the length
+                       * and perform a rudimentary check.
+                       */
+
+#ifdef CONFIG_SMARTFS_ALIGNED_ACCESS
+                      if ((smartfs_rdle16(&entry->flags) &
+                            SMARTFS_DIRENT_TYPE) ==
+                          SMARTFS_DIRENT_TYPE_FILE)
+#else
+                      if ((entry->flags & SMARTFS_DIRENT_TYPE) ==
+                          SMARTFS_DIRENT_TYPE_FILE)
+#endif
+                        {
+#ifdef CONFIG_SMARTFS_ALIGNED_ACCESS
+                          dirsector =
+                            smartfs_rdle16(&entry->firstsector);
+#else
+                          dirsector = entry->firstsector;
+#endif
+                          readwrite.count =
+                            sizeof(struct smartfs_chain_header_s);
+                          readwrite.buffer = (uint8_t *)fs->fs_rwbuffer;
+                          readwrite.offset = 0;
+
+                          while (dirsector != SMARTFS_ERASEDSTATE_16BIT)
+                            {
+                              /* Read the next sector of the file */
+
+                              readwrite.logsector = dirsector;
+                              ret = FS_IOCTL(fs, BIOC_READSECT,
+                                             (unsigned long) &readwrite);
+                              if (ret < 0)
+                                {
+                                  ferr("ERROR: Error in sector"
+                                       " chain at %d!\n", dirsector);
+                                  break;
+                                }
+
+                              /* Add used bytes to the total and point
+                               * to next sector
+                               */
+
+                              if (SMARTFS_USED(header) !=
+                                  SMARTFS_ERASEDSTATE_16BIT)
+                                {
+                                  direntry->datlen +=
+                                    SMARTFS_USED(header);
+                                }
+
+                              dirsector = SMARTFS_NEXTSECTOR(header);
+                            }
+                        }
+
+                      *parentdirsector = dirstack[depth];
+                      *filename = segment;
+                      ret = OK;
+                      goto errout;
+                    }
+                  else
+                    {
+                      /* Validate it's a directory */
+
+#ifdef CONFIG_SMARTFS_ALIGNED_ACCESS
+                      if ((smartfs_rdle16(&entry->flags) &
+                           SMARTFS_DIRENT_TYPE) !=
+                          SMARTFS_DIRENT_TYPE_DIR)
+#else
+                      if ((entry->flags & SMARTFS_DIRENT_TYPE) !=
+                          SMARTFS_DIRENT_TYPE_DIR)
+#endif
+                        {
+                          /* Not a directory!  Report the error */
+
+                          ret = -ENOTDIR;
+                          goto errout;
+                        }
+
+                      /* "Push" the directory and continue searching */
+
+                      if (depth >= CONFIG_SMARTFS_DIRDEPTH - 1)
+                        {
+                          /* Directory depth too big */
+
+                          ret = -ENAMETOOLONG;
+                          goto errout;
+                        }
+
+#ifdef CONFIG_SMARTFS_ALIGNED_ACCESS
+                      dirstack[++depth] =
+                        smartfs_rdle16(&entry->firstsector);
+#else
+                      dirstack[++depth] = entry->firstsector;
+#endif
+                      segment = ptr + 1;
+                      break;
+                    }
                 }
+
+              /* Not this entry.  Skip to the next one */
+
+              offset += entrysize;
+              entry = (struct smartfs_entry_header_s *)
+                &fs->fs_rwbuffer[offset];
             }
 
-          /* If we found a dir entry, then continue searching */
+          /* Test if a directory entry was found and break if it was */
 
           if (offset < readwrite.count)
             {
-              /* Update the segment pointer */
-
-              if (*ptr != '\0')
-                {
-                  ptr++;
-                }
-
-              segment = ptr;
-              continue;
+              break;
             }
-
-          /* Entry not found!  Report the error.  Also, if this is the last
-           * segment, then report the parent directory sector.
-           */
-
-          if (*ptr == '\0')
-            {
-              *parentdirsector = dirstack[depth];
-              *filename = segment;
-            }
-          else
-            {
-              *parentdirsector = 0xffff;
-              *filename = NULL;
-            }
-
-          ret = -ENOENT;
-          goto errout;
         }
+
+      /* If we found a dir entry, then continue searching */
+
+      if (offset < readwrite.count)
+        {
+          /* Update the segment pointer */
+
+          if (*ptr != '\0')
+            {
+              ptr++;
+            }
+
+          segment = ptr;
+          continue;
+        }
+
+      /* Entry not found!  Report the error.  Also, if this is the last
+       * segment, then report the parent directory sector.
+       */
+
+      if (*ptr == '\0')
+        {
+          *parentdirsector = dirstack[depth];
+          *filename = segment;
+        }
+      else
+        {
+          *parentdirsector = 0xffff;
+          *filename = NULL;
+        }
+
+      ret = -ENOENT;
+      goto errout;
     }
 
 errout:

--- a/fs/smartfs/smartfs_utils.c
+++ b/fs/smartfs/smartfs_utils.c
@@ -1918,7 +1918,7 @@ int smartfs_extendfile(FAR struct smartfs_mountpt_s *fs,
    * will, unfortunately, need to allocate one.
    */
 
-  buffer = fs_heap_malloc(SMARTFS_TRUNCBUFFER_SIZE);
+  buffer = (FAR uint8_t *)lib_get_tempbuffer(SMARTFS_TRUNCBUFFER_SIZE);
   if (buffer == NULL)
     {
       return -ENOMEM;
@@ -2115,7 +2115,7 @@ errout_with_buffer:
 #ifndef CONFIG_SMARTFS_USE_SECTOR_BUFFER
   /* Release the allocated buffer */
 
-  fs_heap_free(buffer);
+  lib_put_tempbuffer((FAR char *)buffer);
 #endif
   /* Restore the original file position */
 

--- a/fs/vfs/fs_link.c
+++ b/fs/vfs/fs_link.c
@@ -180,12 +180,23 @@ int link(FAR const char *path1, FAR const char *path2)
 
   else
     {
+      /* If inode_find for path2 failed for a reason other than "path does
+       * not exist" (e.g. ENAMETOOLONG, ELOOP), propagate that error
+       * directly instead of falling through to the EXDEV check.
+       */
+
+      if (ret != -ENOENT && ret != -ENOTDIR)
+        {
+          errcode = -ret;
+          goto errout_with_newinode;
+        }
+
       /* Cannot link between pseudofs and other mountpoints */
 
       if (INODE_IS_MOUNTPT(target))
         {
           errcode = EXDEV;
-          goto errout_with_target;
+          goto errout_with_newinode;
         }
 
       /* Create an inode in the pseudo-filesystem at this path. */

--- a/fs/vfs/fs_rename.c
+++ b/fs/vfs/fs_rename.c
@@ -405,17 +405,50 @@ static int mountptrename(FAR const char *oldpath, FAR struct inode *oldinode,
 
       if (ret >= 0)
         {
+          /* If old and new refer to the same file (same st_dev and
+           * st_ino), POSIX requires rename() to return success without
+           * doing anything.  Both names must remain intact.
+           *
+           * Guard: only trust st_ino when it is non-zero.  Several
+           * filesystems (tmpfs, littlefs, fat) do not populate st_ino,
+           * leaving it 0 for every file.  Without this guard, any two
+           * distinct files would be mistaken for hard links to the same
+           * inode, causing rename() to skip the actual operation.
+           */
+
+          if (oldbuf.st_ino != 0 &&
+              oldbuf.st_dev == newbuf.st_dev &&
+              oldbuf.st_ino == newbuf.st_ino)
+            {
+              ret = OK;
+              goto errout_with_newinode;
+            }
+
           newisdir = S_ISDIR(newbuf.st_mode);
 
           /* Is the new path a directory? */
 
           if (newisdir)
             {
+              size_t oldlen;
+
               /* It is an error to rename a file to a directory */
 
               if (!oldisdir)
                 {
                   ret = -EISDIR;
+                  goto errout_with_newinode;
+                }
+
+              /* It is an error to rename a directory into one of its
+               * own subdirectories (new is below old).
+               */
+
+              oldlen = strlen(oldrelpath);
+              if (strncmp(newrelpath, oldrelpath, oldlen) == 0 &&
+                  newrelpath[oldlen] == '/')
+                {
+                  ret = -EINVAL;
                   goto errout_with_newinode;
                 }
 

--- a/include/limits.h
+++ b/include/limits.h
@@ -208,7 +208,7 @@
 #define ARG_MAX        _POSIX_ARG_MAX
 #define CHILD_MAX      _POSIX_CHILD_MAX
 #define LINE_MAX       _POSIX2_LINE_MAX
-#define LINK_MAX       _POSIX_LINK_MAX
+#define LINK_MAX       128
 #define MAX_CANON      _POSIX_MAX_CANON
 #define MAX_INPUT      _POSIX_MAX_INPUT
 #define NAME_MAX       _POSIX_NAME_MAX

--- a/libs/libc/unistd/lib_pathconf.c
+++ b/libs/libc/unistd/lib_pathconf.c
@@ -122,7 +122,7 @@ long fpathconf(int fildes, int name)
         return PATH_MAX;
 
       case _PC_LINK_MAX:
-        return _POSIX_LINK_MAX;
+        return LINK_MAX;
 
       case _PC_NAME_MAX:
         return _POSIX_NAME_MAX;


### PR DESCRIPTION
## Summary

This PR contains 8 bug-fix commits for the NuttX POSIX filesystem layer:

1. **fs/smartfs**: change fs_heap to lib_tempbuffer (prerequisite for #5)
2. **fs/inode**: fix off-by-one in `_inode_checkpath` NAME_MAX check
3. **fs/vfs/rename**: fix rename to same file and rename to subdirectory
4. **fs/inode**: canonicalize path before inode search to fix `..` resolution
5. **fs**: remove redundant `..` handling in FS layers after VFS canonicalization
6. **fs/inode**: fix relative-path truncation causing wrong EISDIR
7. **fs/vfs**: fix `link()` returning EXDEV instead of ENAMETOOLONG
8. **libc/limits**: increase LINK_MAX to 128 and fix `pathconf`

## Dependencies

This PR depends on:
- PR #19949 (fs: add hardlink and mountpt link/lstat infrastructure) — **merged**
- PR #19950 (fs/inode: add POSIX path-resolution infrastructure) — **merged**
- PR #19990 (fs: add hostfs/rpmsgfs link/symlink/readlink/lstat backends) — **in review**

Depends-On: https://github.com/apache/nuttx/pull/19990

## Testing

- Build verified: `sim:nsh` with `FS_HOSTFS + FS_LINKS + FS_SMARTFS`, zero errors/warnings
- Integration tested on top of PR#1 + PR#2 + PR#3 combined baseline

## Impact

- Fixes POSIX rename semantics (same-file via hardlink, subdirectory detection)
- Fixes path canonicalization for `..` resolution across mount boundaries
- Fixes `link()` error code confusion (EXDEV vs ENAMETOOLONG)
- Removes ~360 lines of redundant `..` handling now handled by VFS layer
- Raises LINK_MAX from 8 to 128 to match modern POSIX expectations
