### PR TITLE
arch/sim: make nuttx link target depend on staging libraries

### DIFF
--- a/arch/sim/src/Makefile
+++ b/arch/sim/src/Makefile
@@ -485,7 +485,7 @@ endef
 # stuff doesn't work there as we expect.
 # Note: _stext stuff is for CONFIG_CXX_INITIALIZE_SINIT, which in not
 # necessary for macOS.
-nuttx$(EXEEXT): libarch$(LIBEXT) board/libboard$(LIBEXT) $(HEADOBJ) $(LINKOBJS) $(HOSTOBJS) nuttx-names.dat $(EXTRA_LIB_DEPS)
+nuttx$(EXEEXT): libarch$(LIBEXT) board/libboard$(LIBEXT) $(HEADOBJ) $(LINKOBJS) $(HOSTOBJS) nuttx-names.dat $(EXTRA_LIB_DEPS) $(addprefix $(TOPDIR)$(DELIM)staging$(DELIM),$(LINKLIBS))
 	$(Q) echo "LD:  nuttx$(EXEEXT)"
 	$(Q) $(LD) -r $(LDLINKFLAGS) $(RELPATHS) $(EXTRA_LIBPATHS) $(EXTRALINKCMDS) \
 	     -o nuttx.rel $(REQUIREDOBJS) $(LDSTARTGROUP) $(RELLIBS) $(EXTRA_LIBS) $(LDENDGROUP)


### PR DESCRIPTION
## Summary

The `nuttx` link target in `arch/sim/src/Makefile` did not list the
libraries it links as prerequisites. Its dependency list only covered
`libarch.a`, `board/libboard.a`, the arch objects and `nuttx-names.dat`,
so when a library changed without touching any of those — e.g. editing an
application such as `apps/examples/hello/hello_main.c` — the app was
recompiled and `staging/libapps.a` was refreshed, but make still judged
`nuttx` up to date and skipped the relink. The change therefore never
reached the final binary (only a full rebuild such as `make distclean`
would relink).

Fix: add the staging libraries to the `nuttx` target's prerequisite list
via `$(addprefix $(TOPDIR)$(DELIM)staging$(DELIM),$(LINKLIBS))`, matching
the pattern already used by `arch/arm/src/Makefile`. `NUTTXLIBS`
(`tools/FlatLibs.mk`) is entirely composed of `staging/lib*.a` entries,
so `LINKLIBS` (with the `staging/` prefix stripped) round-trips back to
the actual `$(TOPDIR)/staging/lib*.a` files, which `pass2` has already
refreshed before the arch link is invoked, so no ordering or circular
dependency is introduced.

## Impact

- Build process: the sim build now relinks `nuttx` whenever any linked
  library (kernel or app) changes, and still skips the link when nothing
  changed. No more manual `rm nuttx` / `make distclean` needed after app
  edits.
- Other architectures: unaffected — this only extends the prerequisite
  list of the sim `nuttx` target; ARM and others already use the same
  pattern.
- Hardware: none (simulator build only). Documentation: none.
- Compatibility: none — change is additive and does not alter the link
  command or the produced binary layout.

## Testing

Host: x86_64 Linux, NuttX sim build (`CONFIG_ARCH_SIM=y`,
`CONFIG_EXAMPLES_HELLO=y`, `CONFIG_COVERAGE_TOOLCHAIN=y`, flat build).

- **Before the fix**: edited `apps/examples/hello/hello_main.c` and ran
  `make`. Verified the object was recompiled (`hello_main.c` 18:18:41 <
  `.o` 18:18:45) and `staging/libapps.a` refreshed (18:18:45), but
  `make -n nuttx` printed no `LD:` line and the `nuttx` binary mtime
  stayed unchanged (17:31:52) — link skipped.
- **Control**: `touch arch/sim/src/libarch.a` then `make -n nuttx`
  printed `echo "LD:  nuttx"`, confirming the skipped link was caused by
  the missing library prerequisites.
- **After the fix**: `make -n nuttx` prints `LD: nuttx` with the stale
  binary + fresh `staging/libapps.a`; a full `make` ran the link
  (`LD: nuttx`), updated the binary mtime (17:31:52 -> 18:30:56), and
  `strings nuttx/nuttx` shows the updated `Hello, World!! count=%d`
  format string from the modified `hello_main.c`.