### PR TITLE
boards/nrf5340-dk: read the button being scanned, not BTN1

### DIFF
--- a/boards/arm/nrf53/nrf5340-dk/src/nrf53_buttons.c
+++ b/boards/arm/nrf53/nrf5340-dk/src/nrf53_buttons.c
@@ -101,7 +101,7 @@ uint32_t board_buttons(void)
     {
       /* A LOW value means that the key is pressed. */
 
-      bool released = nrf53_gpio_read(g_buttons[BUTTON_BTN1]);
+      bool released = nrf53_gpio_read(g_buttons[i]);
 
       /* Accumulate the set of depressed (not released) keys */
 


### PR DESCRIPTION
board_buttons() loops over the four buttons but read the GPIO of g_buttons[BUTTON_BTN1] on every iteration, so all four bits of the returned set reflected the state of button 1 alone.

Matches the equivalent loop in nrf52840-dk's nrf52_buttons.c.


## Summary

`board_buttons()` loops over the four buttons but reads the GPIO of
`g_buttons[BUTTON_BTN1]` on every iteration:

```c
for (i = 0; i < NUM_BUTTONS; i++)
  {
    bool released = nrf53_gpio_read(g_buttons[BUTTON_BTN1]);
```

so all four bits of the returned set reflect the state of button 1
alone. The equivalent loop in nrf52840-dk's `nrf52_buttons.c` uses
`g_buttons[i]`.

## Impact

nrf5340-dk only. Buttons 2, 3 and 4 are unreadable and button 1 appears
to be pressed on all four positions.

No API, ABI or configuration change.

## Testing
What is known: carried downstream on nrf5340-dk; a build from this tree
was flashed and exercised on the DK  with all four buttons
reporting independently. 

Suggested reproduction to capture:

1. nrf5340-dk with `CONFIG_ARCH_BUTTONS=y`, plus the GPIOTE fix (see the
   companion PR) so events fire at all.
2. Before the patch, pressing any single button sets every bit in the
   set returned by `board_buttons()`, and buttons 2-4 produce no
   distinct reading. `apps/examples/buttons` shows this directly.
3. After the patch, each button reports independently.
