### PR TITLE
drivers/mtd/filemtd: open the backing file O_RDWR

### DIFF
--- a/drivers/mtd/filemtd.c
+++ b/drivers/mtd/filemtd.c
@@ -507,6 +507,7 @@ static int filemtd_ioctl(FAR struct mtd_dev_s *dev, int cmd,
         {
           FAR struct partition_info_s *info =
             (FAR struct partition_info_s *)arg;
+
           if (info != NULL)
             {
               info->numsectors  = priv->nblocks *
@@ -530,6 +531,7 @@ static int filemtd_ioctl(FAR struct mtd_dev_s *dev, int cmd,
       case MTDIOC_ERASESTATE:
         {
           FAR uint8_t *result = (FAR uint8_t *)arg;
+
           *result = CONFIG_FILEMTD_ERASESTATE;
 
           ret = OK;
@@ -580,6 +582,7 @@ static int mtd_loop_setup(FAR const char *devname, FAR const char *filename,
           /* Try to erase the entire device, before register */
 
           FAR struct file_dev_s *fdev = (FAR struct file_dev_s *)mtd;
+
           mtd->erase(mtd, offset / erasesize, fdev->nblocks);
         }
 
@@ -698,61 +701,61 @@ static int mtd_loop_ioctl(FAR struct file *filep, int cmd,
 
   switch (cmd)
     {
-    /* Command:      LOOPIOC_SETUP
-     * Description:  Setup the loop device
-     * Argument:     A pointer to a read-only instance of struct losetup_s.
-     * Dependencies: The loop device must be enabled (CONFIG_MTD_LOOP=y)
-     */
+      /* Command:      LOOPIOC_SETUP
+       * Description:  Setup the loop device
+       * Argument:     A pointer to a read-only instance of struct losetup_s.
+       * Dependencies: The loop device must be enabled (CONFIG_MTD_LOOP=y)
+       */
 
-    case MTD_LOOPIOC_SETUP:
-      {
-        FAR struct mtd_losetup_s *setup =
-          (FAR struct mtd_losetup_s *)((uintptr_t)arg);
+      case MTD_LOOPIOC_SETUP:
+        {
+          FAR struct mtd_losetup_s *setup =
+            (FAR struct mtd_losetup_s *)((uintptr_t)arg);
 
-        if (setup == NULL)
-          {
-            ret = -EINVAL;
-          }
-        else
-          {
+          if (setup == NULL)
+            {
+              ret = -EINVAL;
+            }
+          else
+            {
 #  ifndef CONFIG_MTD_CONFIG_NONE
-            ret = mtd_loop_setup(setup->devname, setup->filename,
-                                 setup->sectsize, setup->erasesize,
-                                 setup->offset, setup->configdata);
+              ret = mtd_loop_setup(setup->devname, setup->filename,
+                                   setup->sectsize, setup->erasesize,
+                                   setup->offset, setup->configdata);
 #  else
-            ret = mtd_loop_setup(setup->devname, setup->filename,
-                                 setup->sectsize, setup->erasesize,
-                                 setup->offset);
+              ret = mtd_loop_setup(setup->devname, setup->filename,
+                                   setup->sectsize, setup->erasesize,
+                                   setup->offset);
 #  endif
-          }
-      }
-      break;
+            }
+        }
+        break;
 
-    /* Command:      LOOPIOC_TEARDOWN
-     * Description:  Teardown a loop device previously setup via
-     *               LOOPIOC_SETUP
-     * Argument:     A read-able pointer to the path of the device to be
-     *               torn down
-     * Dependencies: The loop device must be enabled (CONFIG_MTD_LOOP=y)
-     */
+      /* Command:      LOOPIOC_TEARDOWN
+       * Description:  Teardown a loop device previously setup via
+       *               LOOPIOC_SETUP
+       * Argument:     A read-able pointer to the path of the device to be
+       *               torn down
+       * Dependencies: The loop device must be enabled (CONFIG_MTD_LOOP=y)
+       */
 
-    case MTD_LOOPIOC_TEARDOWN:
-      {
-        FAR const char *devname = (FAR const char *)((uintptr_t)arg);
+      case MTD_LOOPIOC_TEARDOWN:
+        {
+          FAR const char *devname = (FAR const char *)((uintptr_t)arg);
 
-        if (devname == NULL)
-          {
-            ret = -EINVAL;
-          }
-        else
-          {
-            ret = mtd_loop_teardown(devname);
-          }
-       }
-       break;
+          if (devname == NULL)
+            {
+              ret = -EINVAL;
+            }
+          else
+            {
+              ret = mtd_loop_teardown(devname);
+            }
+        }
+        break;
 
-     default:
-       ret = -ENOTTY;
+      default:
+        ret = -ENOTTY;
     }
 
   return ret;

--- a/drivers/mtd/filemtd.c
+++ b/drivers/mtd/filemtd.c
@@ -813,7 +813,7 @@ FAR struct mtd_dev_s *filemtd_initialize(FAR const char *path, off_t offset,
 
   /* Set the file open mode. */
 
-  mode = O_RDONLY | O_WRONLY | O_CLOEXEC;
+  mode = O_RDWR | O_CLOEXEC;
 
   /* Try to open the file.  NOTE that block devices will use a character
    * driver proxy.


### PR DESCRIPTION
## Summary

`filemtd_initialize()` opens its backing file with

```c
mode = O_RDONLY | O_WRONLY | O_CLOEXEC;
```

Commit 6161c73639 ("include/fcntl.h: remove O_RDOK/O_WROK aliases")
introduced this when it replaced the non-standard `O_RDOK | O_WROK`
pair, describing the change as a pure text substitution. That held while
the access mode was a genuine bitmask: `O_RDONLY` was `(1 << 0)`,
`O_WRONLY` was `(1 << 1)`, `O_RDWR` was both bits, and `O_ACCMODE` was
defined as an alias for `O_RDWR`. OR-ing the two was meaningful and
produced `O_RDWR`.

Commit 9e141acab3 ("include/fcntl.h: align open flags with Linux
values") then made the low two bits an *enumeration* — `O_RDONLY` 0,
`O_WRONLY` 1, `O_RDWR` 2 — and `O_ACCMODE` stopped being an alias for
`O_RDWR`, becoming an independent mask of 3. OR-ing two members of that
enumeration is no longer meaningful:

```
O_RDONLY | O_WRONLY  ==  0 | 1  ==  1
1 & O_ACCMODE        ==  O_WRONLY
```

The file is opened write-only, and `fs/vfs/fs_read.c:202` rejects every
read on it with `-EACCES`.

### Is this a pattern?

It looks like an isolated miss rather than a systematic one. Grepping
the tree:

* Two access-mode constants OR-ed together — this call site only.
* Bit-testing the mode instead of masking — one site,
  `fs/xipfs/xipfs_vfs.c:606`, which happens to be correct under the new
  values (and would have been wrong under the old ones, so it was
  clearly written after the change).
* Unmasked equality against an access mode — none.
* Host/guest translation — the `NUTTX_O_*` mirror in
  `include/nuttx/fs/hostfs.h` was updated in lockstep and
  `host_oflags_convert()` switches on `flags & NUTTX_O_ACCMODE`.


## Impact

Affects every user of `filemtd_initialize()` — the simulator's
file-backed MTD, `testing/fs`, and any board that layers an MTD over a
file. Reads through the device fail, so any filesystem mounted on it
fails to come up.

On the simulator it surfaces as a LittleFS mount of a filemtd-backed
partition returning `-ENOSPC`, after which nothing that lives on that
volume works: the resource pack cannot be read, fonts load with zero
metrics, and a FlashDB partition on the same device logs out-of-bound
writes. None of those point at the open mode.


## Testing

**Evidence available (captured on this tree):**

Host: Linux x86_64, GCC 15. Board: `sim`, configuration with a 4 MiB
file-backed MTD (`filemtd_initialize`) partitioned into an mtdconfig
partition, a LittleFS volume and a third raw partition.

Before, mounting the LittleFS volume on the filemtd partition:

```
sim_storage: mount /dev/rblflash -> /mnt/fs: errno 28
[E/FAL] (fal_partition_write:455) Partition write error! Partition address out of bound.
resource alloc of -1 bytes failed
GFont 0x40166fcc has line_height=0; falling back to default
```

After, same binary and same backing file, only this patch applied:

```
sim_storage: /dev/config + /dev/rblflash @/mnt/fs + /dev/rblflash_ts ready
             (fs 959 + tsdb 64 erase blks, 4096 B/erase blk)
seeded /mnt/fs/system.pbpack (147398 bytes)
pbpack table cached: 22 entries
```

The volume mounts, autoformat works, files read back, and the third
partition writes cleanly.

