### PR TITLE
arch/arm/nrf53: fix inverted GPIOTE per-instance channel index

### DIFF
--- a/arch/arm/src/nrf53/nrf53_gpiote.c
+++ b/arch/arm/src/nrf53/nrf53_gpiote.c
@@ -182,6 +182,7 @@ static int nrf53_gpiote_isr(int irq, void *context, void *arg)
 
               xcpt_t callback = g_gpiote_ch_callbacks[off].callback;
               void *cbarg = g_gpiote_ch_callbacks[off].arg;
+
               ret = callback(irq, context, cbarg);
 
               /* Clear event */
@@ -210,10 +211,11 @@ static int nrf53_gpiote_isr(int irq, void *context, void *arg)
             {
               case 0:
                 addr = NRF53_GPIO_P0_BASE + NRF53_GPIO_LATCH_OFFSET;
-              break;
+                break;
+
               case 1:
                 addr = NRF53_GPIO_P1_BASE + NRF53_GPIO_LATCH_OFFSET;
-              break;
+                break;
             }
 
           /* Retrieve LATCH register */
@@ -256,7 +258,7 @@ static int nrf53_gpiote_isr(int irq, void *context, void *arg)
               ret = callback(irq, context, cbarg);
             }
 #endif
-       }
+        }
     }
 
   return ret;

--- a/arch/arm/src/nrf53/nrf53_gpiote.c
+++ b/arch/arm/src/nrf53/nrf53_gpiote.c
@@ -405,7 +405,7 @@ void nrf53_gpiote_set_ch_event(uint32_t pinset, int channel,
   inst = 0;
 #endif
 
-  rchan = (inst == 1) ? channel : (channel - GPIOTE_PER_CHANNEL);
+  rchan = (inst == 1) ? (channel - GPIOTE_PER_CHANNEL) : channel;
 
   /* NOTE: GPIOTE module has priority over GPIO module
    *       so GPIO configuration will be ignored
@@ -567,7 +567,7 @@ void nrf53_gpiote_set_task(uint32_t pinset, int channel,
   inst = 0;
 #endif
 
-  rchan = (inst == 1) ? channel : (channel - GPIOTE_PER_CHANNEL);
+  rchan = (inst == 1) ? (channel - GPIOTE_PER_CHANNEL) : channel;
 
   /* Select GPIOTE pin */
 


### PR DESCRIPTION
## Summary

The driver presents a single channel space of `GPIOTE_CHANNELS` entries
across the application core's two GPIOTE peripherals, and splits it:

```c
inst  = (channel < GPIOTE_PER_CHANNEL) ? 0 : 1;
rchan = (inst == 1) ? channel : (channel - GPIOTE_PER_CHANNEL);
```

`rchan` is the channel index *within* the selected instance, used to
build the per-channel register offsets, so it must be

```c
rchan = channel - GPIOTE_PER_CHANNEL * inst
```

The ternary has the two arms the other way round: a channel on instance
0 gets `rchan = channel - GPIOTE_PER_CHANNEL`, which is negative, and a
channel on instance 1 gets an index still offset by a full instance.

### Corroboration

The interrupt handler in this same file already applies that mapping in
the opposite direction, converting a per-instance channel back to the
global one:

```c
off = i + GPIOTE_PER_CHANNEL * inst;    /* nrf53_gpiote.c, nrf53_gpiote_isr() */
```

The two were inconsistent, and it is the `rchan` sites that disagreed
with the rest of the driver.

Per the nRF5340 Product Specification, *GPIOTE - GPIO tasks and events*,
the application core has two GPIOTE instances:

| instance | base | channels | CONFIG |
|---|---|---|---|
| GPIOTE0 (secure) | `0x5000D000` | 8 | `CONFIG[n]`, n = 0..7 |
| GPIOTE1 (non-secure) | `0x4002F000` | 8 | `CONFIG[n]`, n = 0..7 |

`CONFIG[n]` sits at offset `0x510 + 4n`. That matches
`GPIOTE_PER_CHANNEL == 8` in the driver, the two base addresses in
`hardware/nrf53_memorymap_cpuapp.h`, and `NRF53_GPIOTE_CONFIG_OFFSET()`
in `hardware/nrf53_gpiote.h` - so `rchan` is required to be in 0..7 and
a negative value cannot address a CONFIG register.

Both call sites are corrected.

## Impact

Any nRF5340 board using GPIOTE. For a channel on instance 0 the CONFIG
register write lands at a computed-negative offset and the GPIOTE
interrupt is never enabled, so the event never fires - on nrf5340-dk
this makes the board buttons dead.

## Testing

Suggested reproduction to capture:

1. nrf5340-dk with `CONFIG_ARCH_BUTTONS=y` and `CONFIG_INPUT_BUTTONS`,
   registering the board button lower-half as `/dev/buttons`.
2. Before the patch, `poll(POLLIN)` on `/dev/buttons` never returns and
   no press is observed - the GPIOTE interrupt is never enabled for
   channels on instance 0.
3. After the patch, presses and releases arrive.
