### PR TITLE
boards/xtensa/esp32s3/esp32s3-xiao: add SD card support over SPI2

### DIFF
--- a/boards/xtensa/esp32s3/esp32s3-xiao/src/Make.defs
+++ b/boards/xtensa/esp32s3/esp32s3-xiao/src/Make.defs
@@ -36,6 +36,10 @@ ifeq ($(CONFIG_DEV_GPIO),y)
 CSRCS += esp32s3_gpio.c
 endif
 
+ifeq ($(CONFIG_ESP32S3_SPI),y)
+CSRCS += esp32s3_board_spi.c
+endif
+
 DEPPATH += --dep-path board
 VPATH += :board
 CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)board$(DELIM)board

--- a/boards/xtensa/esp32s3/esp32s3-xiao/src/esp32s3_board_spi.c
+++ b/boards/xtensa/esp32s3/esp32s3-xiao/src/esp32s3_board_spi.c
@@ -1,0 +1,57 @@
+/****************************************************************************
+ * boards/xtensa/esp32s3/esp32s3-xiao/src/esp32s3_board_spi.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <stdint.h>
+#include <stdbool.h>
+#include <nuttx/debug.h>
+
+#include <nuttx/spi/spi.h>
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: esp32s3_spi2_status
+ ****************************************************************************/
+
+#ifdef CONFIG_ESP32S3_SPI2
+
+uint8_t esp32s3_spi2_status(struct spi_dev_s *dev, uint32_t devid)
+{
+  uint8_t status = 0;
+
+  if (devid == SPIDEV_MMCSD(0))
+    {
+      return SPI_STATUS_PRESENT;
+    }
+
+  return status;
+}
+
+#endif

--- a/boards/xtensa/esp32s3/esp32s3-xiao/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/esp32s3-xiao/src/esp32s3_bringup.c
@@ -51,6 +51,10 @@
 #  include "esp32s3_i2c.h"
 #endif
 
+#if defined(CONFIG_ESP32S3_SDMMC) || defined(CONFIG_MMCSD_SPI)
+#  include "esp32s3_board_sdmmc.h"
+#endif
+
 #include "esp32s3-xiao.h"
 
 #ifdef CONFIG_USERLED
@@ -120,6 +124,14 @@ int esp32s3_bringup(void)
   if (ret < 0)
     {
       syslog(LOG_ERR, "ERROR: userled_lower_initialize() failed: %d\n", ret);
+    }
+#endif
+
+#ifdef CONFIG_MMCSD_SPI
+  ret = board_sdmmc_spi_initialize();
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to initialize SDMMC: %d\n", ret);
     }
 #endif
 


### PR DESCRIPTION
The XIAO ESP32-S3 Sense's onboard microSD slot (Seeed XIAOML Kit) is wired to SPI2 through the GPIO matrix: SCK=GPIO7, MOSI=GPIO9, MISO=GPIO8 (confirmed against espressif/arduino-esp32's XIAO_ESP32S3/pins_arduino.h) and CS=GPIO21 (confirmed against this project's own working xiaoml_bench_logger.ino, which tries CS candidates {21, 3} in that order -- GPIO3 is a documented fallback, not the real pin; a Seeed wiki page that names GPIO3 as CS turned out to be wrong and was the initial, unsuccessful attempt here).

Wires up board_sdmmc_spi_initialize() (common esp32s3 board code, CONFIG_MMCSD_SPI) into this board's bringup, and adds the esp32s3_spi2_status() callback (SPI_STATUS_PRESENT for SPIDEV_MMCSD(0)) that esp32s3-devkit and other in-tree boards already provide -- the esp32s3-xiao board had no SPI board file at all before this.

Validated on the bench: CMD0/CMD41/CMD58 handshake succeeds, SD ver2 card identified (SanDisk 32GB, 62333952 sectors), mounts as vfat, survives umount+remount with a written file intact.

Needed board defconfig additions (not included in this NuttX-tree commit; see the 61680_FW project repo for the board config that turns this on):
```
  CONFIG_ESP32S3_SPI2=y
  CONFIG_ESP32S3_SPI2_CSPIN=21
  CONFIG_ESP32S3_SPI2_CLKPIN=7
  CONFIG_ESP32S3_SPI2_MOSIPIN=9
  CONFIG_ESP32S3_SPI2_MISOPIN=8
  CONFIG_MMCSD=y
  CONFIG_NSH_MMCSDSPIPORTNO=2
  CONFIG_FS_FAT=y
  CONFIG_FAT_LFN=y
  CONFIG_FAT_LCNAMES=y
```

- Real Testing
```
nsh> mount -t vfat /dev/mmcsd0 /mnt
fat_checkbootrecord: WARNING: Signature: aa55 FS sectorsize: 0 HW sectorsize: 512
nsh> mount
  /etc type romfs
  /mnt type vfat
  /proc type procfs
nsh> echo "hello sd card MY_FW" > /mnt/test.txt
nsh> ls -l /mnt
/mnt:
 drw-rw-rw-           0 RUN00001/
 drw-rw-rw-           0 RUN00002/
 drw-rw-rw-           0 RUN00003/
 -rw-rw-rw-          23 test.txt
 drw-rw-rw-           0 System Volume Information/
nsh> cat /mnt/test.txt
hello sd card MY_FW
nsh> umount /mnt
nsh> mount -t vfat /dev/mmcsd0 /mnt
fat_checkbootrecord: WARNING: Signature: aa55 FS sectorsize: 0 HW sectorsize: 512
nsh> cat /mnt/test.txt
hello sd card MY_FW
```