### PR TITLE
arch/arm/stm32f4: fudge STM32F411VE NGPIO so GPIOH is enabled

### DIFF
--- a/arch/arm/include/stm32f4/chip.h
+++ b/arch/arm/include/stm32f4/chip.h
@@ -215,7 +215,7 @@
 #  define STM32_NSDIO                    1   /* One SDIO interface */
 #  define STM32_NLCD                     0   /* No LCD */
 #  define STM32_NUSBOTG                  1   /* USB OTG FS (only) */
-#  define STM32_NGPIO                    81  /* GPIOA-H */
+#  define STM32_NGPIO                    113 /* GPIOA-H. (N+15)>>4 is the port count; 81 yields A-F and drops H. */
 #  define STM32_NADC                     1   /* One 12-bit ADC1, 16 channels */
 #  define STM32_NDAC                     0   /* No DAC */
 #  define STM32_NCAPSENSE                0   /* No capacitive sensing channels */


### PR DESCRIPTION
Found while adding STM32F412VG in apache/nuttx#20006: the same `STM32_NGPIO 81` / "GPIOA-H" mismatch.

## Summary
Set STM32F411VE `STM32_NGPIO` to 113 so GPIO ports A–H are enabled.

## Problem
`STM32_NGPIO_PORTS` is `(N+15)>>4`. 81 is the real pin count but yields six ports A–F, so PH0/PH1 cannot be configured and GPIOH clocks/registers are never set up.

## Solution
Use 113, matching the F40x 100-pin entries (F405VG/F407VG). That gives eight ports A–H. Enabling unused F/G clocks is harmless.