### PR TITLE
arch/risc-v: assign per-cpu data by logical cpu

### DIFF
--- a/arch/risc-v/src/common/riscv_percpu.c
+++ b/arch/risc-v/src/common/riscv_percpu.c
@@ -26,7 +26,6 @@
 
 #include <nuttx/config.h>
 #include <nuttx/irq.h>
-#include <nuttx/queue.h>
 #include <nuttx/spinlock.h>
 
 #include <arch/barriers.h>
@@ -60,7 +59,6 @@ static_assert(RISCV_PERCPU_KSP == offsetof(riscv_percpu_t, ksp),
  ****************************************************************************/
 
 static riscv_percpu_t   g_percpu[HART_CNT];
-static sq_queue_t       g_freelist;
 static uintptr_t        g_initialized;
 static spinlock_t       g_percpu_spin;
 
@@ -96,8 +94,6 @@ static void riscv_percpu_init(void)
       goto out_with_lock;
     }
 
-  sq_init(&g_freelist);
-
   for (i = 0; i < HART_CNT; i++)
     {
       /* Set interrupt stack (if any) */
@@ -105,8 +101,6 @@ static void riscv_percpu_init(void)
 #if CONFIG_ARCH_INTERRUPTSTACK > 15
       g_percpu[i].irq_stack = (uintptr_t)g_intstacktop - i * INT_STACK_SIZE;
 #endif
-
-      sq_addlast((struct sq_entry_s *) &g_percpu[i], &g_freelist);
     }
 
 out_with_lock:
@@ -131,18 +125,22 @@ out_with_lock:
 void riscv_percpu_add_hart(uintptr_t hartid)
 {
   riscv_percpu_t *percpu;
-  irqstate_t      flags;
+  int             cpu;
 
   /* Make sure we are initialized */
 
   riscv_percpu_init();
 
-  /* Get free entry for this hart, this must not fail */
+  /* Get the per CPU entry corresponding to this hart. */
 
-  flags = spin_lock_irqsave(&g_percpu_spin);
-  percpu = (riscv_percpu_t *)sq_remfirst(&g_freelist);
-  spin_unlock_irqrestore(&g_percpu_spin, flags);
-  DEBUGASSERT(percpu);
+  cpu = riscv_hartid_to_cpuid(hartid);
+
+  if (cpu < 0 || cpu >= HART_CNT)
+    {
+      PANIC();
+    }
+
+  percpu = &g_percpu[cpu];
 
   /* Assign hartid, stack has already been assigned */
 

--- a/arch/risc-v/src/common/riscv_percpu.h
+++ b/arch/risc-v/src/common/riscv_percpu.h
@@ -67,20 +67,16 @@
  * will set up [m/s]scratch to point to the CPUs own area
  */
 
-union riscv_percpu_s
+struct riscv_percpu_s
 {
-  union riscv_percpu_s *next;      /* For sl list linkage */
-  struct
-  {
-    struct tcb_s       *tcb;       /* Current thread TCB */
-    uintreg_t           hartid;    /* Hart ID */
-    uintreg_t           irq_stack; /* Interrupt stack */
-    uintreg_t           usp;       /* Area to store user sp */
-    uintreg_t           ksp;       /* Area to load kernel sp */
-  };
+  struct tcb_s *tcb;       /* Current thread TCB */
+  uintreg_t     hartid;    /* Hart ID */
+  uintreg_t     irq_stack; /* Interrupt stack */
+  uintreg_t     usp;       /* Area to store user sp */
+  uintreg_t     ksp;       /* Area to load kernel sp */
 };
 
-typedef union riscv_percpu_s riscv_percpu_t;
+typedef struct riscv_percpu_s riscv_percpu_t;
 
 /****************************************************************************
  * Public Function Prototypes


### PR DESCRIPTION
## Summary

Fix the assignment of RISC-V per-CPU data so that each HART is assigned
the `g_percpu` entry corresponding to its logical CPU ID.

Previously, `riscv_percpu_init()` initialized interrupt stacks according
to the `g_percpu[]` array index and placed the entries in a FIFO freelist.
`riscv_percpu_add_hart()` then assigned entries according to the order in
which HARTs registered. When HART boot order differs from logical CPU
order, a HART can therefore be associated with the wrong per-CPU
interrupt stack.

This change uses `riscv_hartid_to_cpuid()` to select the corresponding
`g_percpu[]` entry directly and removes the now-unused freelist.

## Impact

- Impact on user: NO, no user-facing API changes.
- Impact on build: NO, no build-system changes are introduced.
- Impact on hardware: YES, this affects RISC-V SMP platforms using
  scratch-based per-CPU storage by making per-CPU interrupt-stack
  assignment deterministic with respect to logical CPU ID.
- Impact on API: NO.
- Impact on security: NO.
- Impact on compatibility: NO.

## Testing

Built and boot-tested with `rv-virt:ksmp64` using
`riscv-none-elf-gcc 13.2.0` on Linux with QEMU 10.2.1.

### Build Log

```text
Memory region         Used Size  Region Size  %age Used
          kflash:      125604 B         2 MB      5.99%
           ksram:       47232 B         2 MB      2.25%
           pgram:           0 GB         4 MB      0.00%
CP: nuttx.hex
BUILD EXIT CODE: 0
```
### Runtime Log:
```
CPU0  ... 0x80408800  2048
CPU1  ... 0x80408000  2048
CPU2  ... 0x80407800  2048
CPU3  ... 0x80407000  2048

CPU0 IDLE
CPU1 IDLE
CPU2 IDLE
CPU3 IDLE
```
All four CPUs booted successfully, and the interrupt-stack bases were
spaced by 2048 bytes in the expected CPU-index order.

The rv-virt:ksmp64 SMP exception entry does not read
RISCV_PERCPU_IRQSTACK, so this runtime test verifies normal SMP boot
and the expected per-CPU stack layout but does not exercise the specific
interrupt-stack path affected by this change.

MPFS uses the RISCV_PERCPU_IRQSTACK path, but no in-tree MPFS SMP
configuration is available for runtime validation in this environment.

Fixes: #19875