### PR TITLE
Documentation: Fix incorrect timer initialization API names

### DIFF
--- a/Documentation/implementation/tickless_os.rst
+++ b/Documentation/implementation/tickless_os.rst
@@ -160,8 +160,8 @@ Imported Intefaces
 The interfaces that must be provided by the platform specified code
 are defined in ``include/nuttx/arch.h`` and summarized below.
 
-``up_timer_intialize()``
-^^^^^^^^^^^^^^^^^^^^^^^^
+``up_timer_initialize()``
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code:: c
 
@@ -169,7 +169,7 @@ are defined in ``include/nuttx/arch.h`` and summarized below.
 
 * **Description:** Initializes all platform-specific timer facilities.
   This function is called early in the initialization sequence by
-  ``up_intialize()``. On return, the current up-time should be available
+  ``up_initialize()``. On return, the current up-time should be available
   from ``up_timer_gettime()`` and the interval timer is ready for use
   (but not actively timing).
 * **Input Parameters:** None.


### PR DESCRIPTION
*Note: Please adhere to [Contributing Guidelines](https://github.com/apache/nuttx/blob/master/CONTRIBUTING.md).*

## Summary

*The tickless OS documentation contains incorrect names for the
platform timer initialization APIs.

This change corrects `up_timer_intialize()` to
`up_timer_initialize()` and `up_intialize()` to `up_initialize()`,
matching the API declarations in `include/nuttx/arch.h`.*

## Impact

*Documentation-only change.*

## Testing

*make html*

*Please provide information about your host machine, the board(s) you
tested your changes on, and how you tested. Logs should be included.*

*For example, when changing something in the core OS functions, you
may want to run the OSTest application to verify that there are no
regressions. Changes to ADC code may warrant running the `adc`
example. Adding a new uORB driver may require that you run
`uorb_listener` to verify correct operation.*

*Pure documentation changes can just be tested with `make html`
(see docs) and verification of the correct format in your
browser.*

**_PRs without testing information will not be accepted. We will
request test logs._**
