### PR TITLE
boards: fix mtd_partition() argument units in flash partition loops

### DIFF
--- a/boards/arm/at32/at32f437-mini/src/at32_w25.c
+++ b/boards/arm/at32/at32f437-mini/src/at32_w25.c
@@ -129,6 +129,7 @@ int at32_w25initialize(int minor)
   /* Register the MTD driver */
 
   char path[32];
+
   snprintf(path, sizeof(path), "/dev/mtdblock%d", minor);
   ret = register_mtddriver(path, mtd, 0755, NULL);
   if (ret < 0)
@@ -141,136 +142,149 @@ int at32_w25initialize(int minor)
   /* Initialize to provide SMARTFS on the MTD interface */
 
 #ifdef FLASH_PART
-{
-  int partno;
-  int partsize;
-  int partoffset;
-  int partszbytes;
-  int erasesize;
-  const char *partstring = FLASH_PART_LIST;
-  const char *ptr;
-  struct mtd_dev_s *mtd_part;
-  char partref[16];
-  struct mtd_geometry_s geo;
-
-  /* Now create a partition on the FLASH device */
-
-  partno = 0;
-  ptr = partstring;
-  partoffset = 0;
-
-  /* Get the geometry of the FLASH device */
-
-  ret = mtd->ioctl(mtd, MTDIOC_GEOMETRY, (unsigned long)((uintptr_t)&geo));
-  if (ret < 0)
+  do
     {
-      syslog(LOG_ERR, "ERROR: mtd->ioctl failed: %d\n", ret);
-      return ret;
-    }
+      int partno;
+      int partsize;
+      int partoffset;
+      int partszbytes;
+      int erasesize;
+      int blkpererase;
+      const char *partstring = FLASH_PART_LIST;
+      const char *ptr;
+      struct mtd_dev_s *mtd_part;
+      char partref[16];
+      struct mtd_geometry_s geo;
 
-  /* Get the Flash erase size */
+      /* Now create a partition on the FLASH device */
 
-  erasesize = geo.erasesize;
+      partno = 0;
+      ptr = partstring;
+      partoffset = 0;
 
-  while (*ptr != '\0')
-    {
-      /* Get the partition size */
+      /* Get the geometry of the FLASH device */
 
-      partsize = atoi(ptr);
-      partszbytes = (partsize << 10); /* partsize is defined in KB */
-
-      /* Check if partition size is bigger then erase block */
-
-      if (partszbytes < erasesize)
+      ret = mtd->ioctl(mtd, MTDIOC_GEOMETRY,
+                       (unsigned long)((uintptr_t)&geo));
+      if (ret < 0)
         {
-          syslog(LOG_ERR,
-                "ERROR: Partition size is lesser than erasesize!\n");
-          return -1;
+          syslog(LOG_ERR, "ERROR: mtd->ioctl failed: %d\n", ret);
+          return ret;
         }
 
-      /* Check if partition size is multiple of erase block */
+      /* Get the Flash erase size */
 
-      if ((partszbytes % erasesize) != 0)
+      erasesize = geo.erasesize;
+
+      while (*ptr != '\0')
         {
-          syslog(LOG_ERR,
-                "ERROR: Partition size isn't multiple of erasesize!\n");
-          return -1;
-        }
+          /* Get the partition size */
 
-      mtd_part = mtd_partition(mtd, partoffset, partszbytes / erasesize);
-      partoffset += partszbytes / erasesize;
+          partsize = atoi(ptr);
+          partszbytes = (partsize << 10); /* partsize is defined in KB */
 
-#ifdef FLASH_CONFIG_PART
-      /* Test if this is the config partition */
+          /* Check if partition size is bigger then erase block */
 
-      if (FLASH_CONFIG_PART_NUMBER == partno)
-        {
-          /* Register the partition as the config device */
+          if (partszbytes < erasesize)
+            {
+              syslog(LOG_ERR,
+                    "ERROR: Partition size is lesser than erasesize!\n");
+              return -1;
+            }
 
-          mtdconfig_register(mtd_part);
-        }
-      else
-#endif
-        {
-          /* Now initialize a SMART Flash block device and bind it
-           * to the MTD device.
+          /* Check if partition size is multiple of erase block */
+
+          if ((partszbytes % erasesize) != 0)
+            {
+              syslog(LOG_ERR,
+                    "ERROR: Partition size isn't multiple of erasesize!\n");
+              return -1;
+            }
+
+          /* mtd_partition() expects the offset and size in units of the
+           * underlying device "blocks" (geo.blocksize, 256B for the W25),
+           * not erase blocks.  partoffset is tracked in erase blocks, so
+           * convert.  Without this, partitions are erasesize/blocksize
+           * (16x for the W25) too small and misaligned.
            */
 
-  #if defined(CONFIG_MTD_SMART) && defined(CONFIG_FS_SMARTFS)
-          snprintf(partref, sizeof(partref), "p%d", partno);
-          smart_initialize(W25QXX_FLASH_MINOR,
-                          mtd_part, partref);
-  #endif
-        }
+          blkpererase = geo.blocksize > 0 ? erasesize / geo.blocksize : 1;
+          mtd_part = mtd_partition(mtd, partoffset * blkpererase,
+                                   partszbytes / geo.blocksize);
+          partoffset += partszbytes / erasesize;
 
-      /* Set the partition name */
+#ifdef FLASH_CONFIG_PART
+          /* Test if this is the config partition */
+
+          if (FLASH_CONFIG_PART_NUMBER == partno)
+            {
+              /* Register the partition as the config device */
+
+              mtdconfig_register(mtd_part);
+            }
+          else
+#endif
+            {
+              /* Now initialize a SMART Flash block device and bind it
+               * to the MTD device.
+               */
+
+  #if defined(CONFIG_MTD_SMART) && defined(CONFIG_FS_SMARTFS)
+              snprintf(partref, sizeof(partref), "p%d", partno);
+              smart_initialize(W25QXX_FLASH_MINOR,
+                              mtd_part, partref);
+  #endif
+            }
+
+          /* Set the partition name */
 
 #if defined(CONFIG_MTD_PARTITION_NAMES)
-      if (!mtd_part)
-        {
-          syslog(LOG_ERR, "Error: failed to create partition %s\n",
-                partname);
-          return -1;
-        }
+          if (!mtd_part)
+            {
+              syslog(LOG_ERR, "Error: failed to create partition %s\n",
+                    partname);
+              return -1;
+            }
 
-      mtd_setpartitionname(mtd_part, partname);
+          mtd_setpartitionname(mtd_part, partname);
 
-      /* Now skip to next name.  We don't need to split the string here
-       * because the MTD partition logic will only display names up to
-       * the comma, thus allowing us to use a single static name
-       * in the code.
-       */
+          /* Now skip to next name.  We don't need to split the string here
+           * because the MTD partition logic will only display names up to
+           * the comma, thus allowing us to use a single static name
+           * in the code.
+           */
 
-      while (*partname != ',' && *partname != '\0')
-        {
-          /* Skip to next ',' */
+          while (*partname != ',' && *partname != '\0')
+            {
+              /* Skip to next ',' */
 
-          partname++;
-        }
+              partname++;
+            }
 
-      if (*partname == ',')
-        {
-          partname++;
-        }
+          if (*partname == ',')
+            {
+              partname++;
+            }
 #endif
 
-      /* Update the pointer to point to the next size in the list */
+          /* Update the pointer to point to the next size in the list */
 
-      while ((*ptr >= '0') && (*ptr <= '9'))
-        {
-          ptr++;
+          while ((*ptr >= '0') && (*ptr <= '9'))
+            {
+              ptr++;
+            }
+
+          if (*ptr == ',')
+            {
+              ptr++;
+            }
+
+          /* Increment the part number */
+
+          partno++;
         }
-
-      if (*ptr == ',')
-        {
-          ptr++;
-        }
-
-      /* Increment the part number */
-
-      partno++;
     }
-}
+  while (0);
 
 #else /* CONFIG_FLASH_PART */
 

--- a/boards/arm/samd5e5/metro-m4/src/sam_smartfs.c
+++ b/boards/arm/samd5e5/metro-m4/src/sam_smartfs.c
@@ -93,13 +93,15 @@ int sam_smartfs_initialize(void)
       return ret;
     }
 
-  #ifdef CONFIG_MTD_PARTITION
+#ifdef CONFIG_MTD_PARTITION
+  do
     {
       int partno;
       int partsize;
       int partoffset;
       int partszbytes;
       int erasesize;
+      int blkpererase;
       const char *partstring = "256";
       const char *ptr;
       struct mtd_dev_s *mtd_part;
@@ -111,95 +113,105 @@ int sam_smartfs_initialize(void)
       ptr = partstring;
       partoffset = 0;
 
-          /* Get the Flash erase size */
+      /* Get the Flash erase size */
 
-          erasesize = geo.erasesize;
+      erasesize = geo.erasesize;
 
-          while (*ptr != '\0')
+      while (*ptr != '\0')
+        {
+          /* Get the partition size */
+
+          partsize = atoi(ptr);
+          partszbytes = (partsize << 10); /* partsize is defined in KB */
+          printf("partsize %d partszbytes %d\n", partsize, partszbytes);
+
+          /* Check if partition size is bigger then erase block */
+
+          if (partszbytes < erasesize)
             {
-              /* Get the partition size */
-
-              partsize = atoi(ptr);
-              partszbytes = (partsize << 10); /* partsize is defined in KB */
-              printf("partsize %d partszbytes %d\n", partsize, partszbytes);
-
-              /* Check if partition size is bigger then erase block */
-
-              if (partszbytes < erasesize)
-                {
-                  syslog(LOG_ERR,
+              syslog(LOG_ERR,
                     "ERROR: Partition size is lesser than erasesize!\n");
-                  return -1;
-                }
+              return -1;
+            }
 
-              /* Check if partition size is multiple of erase block */
+          /* Check if partition size is multiple of erase block */
 
-              if ((partszbytes % erasesize) != 0)
-                {
-                  syslog(LOG_ERR,
+          if ((partszbytes % erasesize) != 0)
+            {
+              syslog(LOG_ERR,
                     "ERROR: Partition size is not multiple of erasesize!\n");
-                  return -1;
-                }
+              return -1;
+            }
 
-              mtd_part = mtd_partition(mtd, partoffset,
-                                       partszbytes / erasesize);
-              partoffset += partszbytes / erasesize;
+          /* mtd_partition() expects the offset and size in units of
+           * the underlying device "blocks" (geo.blocksize, 512B for
+           * the SAMD5E5 progmem), not erase blocks.  partoffset is
+           * tracked in erase blocks, so convert.  Without this,
+           * partitions are erasesize/blocksize (16x) too small and
+           * misaligned.
+           */
 
-              /* Test if this is the config partition */
+          blkpererase = geo.blocksize > 0 ?
+                        erasesize / geo.blocksize : 1;
+          mtd_part = mtd_partition(mtd, partoffset * blkpererase,
+                                   partszbytes / geo.blocksize);
+          partoffset += partszbytes / erasesize;
 
-            #ifndef  CONFIG_MTD_CONFIG_NONE
-              if (partno == 0)
-                {
-                  /* Register the partition as the config device */
+          /* Test if this is the config partition */
 
-                  mtdconfig_register(mtd_part);
-                }
-                else
-            #endif
-                {
-                  /* Now initialize a SMART Flash block device
-                   * and bind it to the MTD device.
-                   */
+#ifndef CONFIG_MTD_CONFIG_NONE
+          if (partno == 0)
+            {
+              /* Register the partition as the config device */
 
-            #if defined(CONFIG_MTD_SMART) && defined(CONFIG_FS_SMARTFS)
-                      snprintf(partref, sizeof(partref), "p%d", partno);
-                      smart_initialize(0, mtd_part, partref);
-            #endif
-                }
+              mtdconfig_register(mtd_part);
+            }
+          else
+#endif
+            {
+              /* Now initialize a SMART Flash block device
+               * and bind it to the MTD device.
+               */
 
-                  /* Set the partition name */
+#if defined(CONFIG_MTD_SMART) && defined(CONFIG_FS_SMARTFS)
+              snprintf(partref, sizeof(partref), "p%d", partno);
+              smart_initialize(0, mtd_part, partref);
+#endif
+            }
 
-            #ifdef CONFIG_MTD_PARTITION_NAMES
-                  if (!mtd_part)
-                    {
-                      syslog(LOG_ERR,
-                            "Error: failed to create partition %s\n",
-                            partname);
-                      return -1;
-                    }
+          /* Set the partition name */
 
-                  mtd_setpartitionname(mtd_part, partname);
+#ifdef CONFIG_MTD_PARTITION_NAMES
+          if (!mtd_part)
+            {
+              syslog(LOG_ERR,
+                    "Error: failed to create partition %s\n",
+                    partname);
+              return -1;
+            }
 
-                  /* Now skip to next name.
-                   * We don't need to split the string here
-                   * because the MTD partition logic will only
-                   * display names up to the comma,
-                   * thus allowing us to use a single static name
-                   * in the code.
-                   */
+          mtd_setpartitionname(mtd_part, partname);
 
-                  while (*partname != ',' && *partname != '\0')
-                    {
-                      /* Skip to next ',' */
+          /* Now skip to next name.
+           * We don't need to split the string here
+           * because the MTD partition logic will only
+           * display names up to the comma,
+           * thus allowing us to use a single static name
+           * in the code.
+           */
 
-                      partname++;
-                    }
+          while (*partname != ',' && *partname != '\0')
+            {
+              /* Skip to next ',' */
 
-                  if (*partname == ',')
-                    {
-                      partname++;
-                    }
-            #endif
+              partname++;
+            }
+
+          if (*partname == ',')
+            {
+              partname++;
+            }
+#endif
 
           /* Update the pointer to point to the next size in the list */
 
@@ -218,7 +230,8 @@ int sam_smartfs_initialize(void)
           partno++;
         }
     }
-  #else /* CONFIG_MTD_PARTITION */
+  while (0);
+#else /* CONFIG_MTD_PARTITION */
 
   /* Configure the device with no partition support */
 
@@ -229,7 +242,7 @@ int sam_smartfs_initialize(void)
       return ret;
     }
 
-    #endif
+#endif
 
   return OK;
 }

--- a/boards/arm/stm32f1/stm32f103-minimum/src/stm32_w25.c
+++ b/boards/arm/stm32f1/stm32f103-minimum/src/stm32_w25.c
@@ -123,6 +123,7 @@ int stm32_w25initialize(int minor)
   /* Register the MTD driver */
 
   char path[32];
+
   snprintf(path, sizeof(path), "/dev/mtdblock%d", minor);
   ret = register_mtddriver(path, mtd, 0755, NULL);
   if (ret < 0)
@@ -145,12 +146,14 @@ int stm32_w25initialize(int minor)
     }
 
 #ifdef CONFIG_STM32F103MINIMUM_FLASH_PART
+  do
     {
       int partno;
       int partsize;
       int partoffset;
       int partszbytes;
       int erasesize;
+      int blkpererase;
       const char *partstring = CONFIG_STM32F103MINIMUM_FLASH_PART_LIST;
       const char *ptr;
       struct mtd_dev_s *mtd_part;
@@ -191,7 +194,16 @@ int stm32_w25initialize(int minor)
               return -1;
             }
 
-          mtd_part = mtd_partition(mtd, partoffset, partszbytes / erasesize);
+          /* mtd_partition() expects the offset and size in units of the
+           * underlying device "blocks" (geo.blocksize, 256B for the W25),
+           * not erase blocks.  partoffset is tracked in erase blocks, so
+           * convert.  Without this, partitions are erasesize/blocksize
+           * (16x for the W25) too small and misaligned.
+           */
+
+          blkpererase = geo.blocksize > 0 ? erasesize / geo.blocksize : 1;
+          mtd_part = mtd_partition(mtd, partoffset * blkpererase,
+                                   partszbytes / geo.blocksize);
           partoffset += partszbytes / erasesize;
 
 #ifdef CONFIG_STM32F103MINIMUM_FLASH_CONFIG_PART
@@ -265,6 +277,7 @@ int stm32_w25initialize(int minor)
           partno++;
         }
     }
+  while (0);
 #else /* CONFIG_STM32F103MINIMUM_FLASH_PART */
 
   /* Configure the device with no partition support */

--- a/boards/arm/stm32f4/stm32f429i-disco/src/stm32_bringup.c
+++ b/boards/arm/stm32f4/stm32f429i-disco/src/stm32_bringup.c
@@ -180,12 +180,14 @@ int stm32_bringup(void)
         }
 
 #ifdef CONFIG_STM32F429I_DISCO_FLASH_PART
+      do
         {
           int partno;
           int partsize;
           int partoffset;
           int partszbytes;
           int erasesize;
+          int blkpererase;
           const char *partstring = CONFIG_STM32F429I_DISCO_FLASH_PART_LIST;
           const char *ptr;
           struct mtd_dev_s *mtd_part;
@@ -225,8 +227,18 @@ int stm32_bringup(void)
                   return -1;
                 }
 
-              mtd_part    = mtd_partition(mtd, partoffset,
-                                          partszbytes / erasesize);
+              /* mtd_partition() expects the offset and size in units of
+               * the underlying device "blocks" (geo.blocksize, 256B for
+               * the SST25), not erase blocks.  partoffset is tracked in
+               * erase blocks, so convert.  Without this, partitions are
+               * erasesize/blocksize (16x for the SST25) too small and
+               * misaligned.
+               */
+
+              blkpererase = geo.blocksize > 0 ?
+                            erasesize / geo.blocksize : 1;
+              mtd_part    = mtd_partition(mtd, partoffset * blkpererase,
+                                          partszbytes / geo.blocksize);
               partoffset += partszbytes / erasesize;
 
 #ifdef CONFIG_STM32F429I_DISCO_FLASH_CONFIG_PART
@@ -299,6 +311,7 @@ int stm32_bringup(void)
               partno++;
             }
         }
+      while (0);
 #else /* CONFIG_STM32F429I_DISCO_FLASH_PART */
 
       /* Configure the device with no partition support */
@@ -324,9 +337,11 @@ int stm32_bringup(void)
 #if defined(CONFIG_RAMMTD) && defined(CONFIG_STM32F429I_DISCO_RAMMTD)
   /* Create a RAM MTD device if configured */
 
+  do
     {
       uint8_t *start =
           kmm_malloc(CONFIG_STM32F429I_DISCO_RAMMTD_SIZE * 1024);
+
       mtd = rammtd_initialize(start,
                               CONFIG_STM32F429I_DISCO_RAMMTD_SIZE * 1024);
       mtd->ioctl(mtd, MTDIOC_BULKERASE, 0);
@@ -339,7 +354,7 @@ int stm32_bringup(void)
       smart_initialize(CONFIG_STM32F429I_DISCO_RAMMTD_MINOR, mtd, NULL);
 #endif
     }
-
+  while (0);
 #endif /* CONFIG_RAMMTD && CONFIG_STM32F429I_DISCO_RAMMTD */
 
 #ifdef HAVE_USBHOST


### PR DESCRIPTION
## Summary

`mtd_partition(mtd, firstblock, nblocks)` takes the partition offset and size in units of the **underlying device "blocks"** (`geo.blocksize`), not erase blocks. The implementation is authoritative:

- `drivers/mtd/mtd_partition.c:875` computes `blkpererase = erasesize / blocksize`;
- `drivers/mtd/mtd_partition.c:885-886` divides the incoming `firstblock`/`nblocks` by `blkpererase` to derive erase-block boundaries (`erasestart`/`eraseend`), i.e. the inputs are treated as `blocksize` units;
- `part_bread`/`part_bwrite` (`drivers/mtd/mtd_partition.c:274`/`:296`) use `priv->firstblock` directly as a block index into the parent device;
- the doc comment at `include/nuttx/mtd/mtd.h:286` ("The offset in bytes to the first block") is stale — the implementation is what callers must match.

Four board drivers instead accumulated `partoffset` and computed the partition size in **erase-block** units and passed them straight to `mtd_partition()`. On devices where `blocksize != erasesize` — W25/SST25 SPI NOR (256B vs 4KB) and SAMD5E5 program memory (512B vs 8KB cluster) — every partition came out `erasesize/blocksize` (16x) too small, and partitions after the first were misaligned/overlapping. On the W25 this is hardware-confirmed: a 512KB partition is reported as 32KB (see Testing).

This change converts `partoffset` and `partszbytes` to `geo.blocksize` units at the `mtd_partition()` call site while keeping the loop's erase-block accumulation:

```c
blkpererase = geo.blocksize > 0 ? erasesize / geo.blocksize : 1;
mtd_part = mtd_partition(mtd, partoffset * blkpererase,
                         partszbytes / geo.blocksize);
partoffset += partszbytes / erasesize;
```

Affected boards:
- `stm32f103-minimum` (W25Q32FV on SPI1)
- `at32f437-mini` (W25, same code as upstream `stm32f103-minimum`)
- `stm32f429i-disco` (SST25F064; the buggy path is enabled in the shipped `extflash` defconfig)
- `metro-m4` (SAMD5E5 program memory via `mtd_progmem`)

The remaining `mtd_partition()` call sites were audited and are correct: `b-l475e-iot01a`/`stm32l476vg-disco` already use `geo.blocksize`; `mikroe-stm32f4` hardcodes the 256B conversion; the progmem OTA boards (imxrt/nrf5x/samv7/stm32h7) pass page units that equal `geo.blocksize`; the ESP32/ESP32C3/ESP32S3, BL602, TLSR82, RTL8720C and `fs/partition` paths are internally consistent.

## Impact

- **Users**: partition sizes on the affected boards are now correct. With the buggy code, a 512KB partition was reported (and usable) as 32KB only; partitions already formatted with the buggy code occupy only `blocksize/erasesize` of the intended region and should be re-created/reformatted after this change.
- **Build**: no new configuration options, no new dependencies, no API/ABI change (`mtd_partition()` signature untouched). Pure board-level code change.
- **Hardware**: only boards that enable the affected partition paths and have `blocksize != erasesize` are affected; devices with `blocksize == erasesize` (e.g. `CONFIG_W25_SECT512`) behave unchanged.
- **Documentation**: none (the stale comment at `include/nuttx/mtd/mtd.h:286` could be fixed separately; out of scope here).
- **Security**: none.

## Testing

**Hardware (bug reproduction, before fix)** — environment:

| Item | Value |
| --- | --- |
| NuttX baseline | master @ `15678acf` |
| Board | `stm32f103-minimum` code, reproduced on its derived board `stm32f103-mini-v2` (STM32F103RCT6) |
| External FLASH | W25Q16 (2MB, SPI1, CS=PA2) |
| Config | `CONFIG_STM32F103MINIMUM_FLASH=y`, `CONFIG_STM32F103MINIMUM_FLASH_PART=y`, `CONFIG_MTD_SMART=y`, `CONFIG_FS_SMARTFS=y`; partition list `512,512,512,512` (4×512KB) |
| Toolchain / build | arm-none-eabi-gcc 10.3-2021.10; `./tools/configure.sh -l stm32f103-minimum:xxx && make` |

Test steps and result:
1. Flash the build, boot, then `mksmartfs /dev/smart0p1` and mount it.
2. The partition reports **32KB instead of the expected 512KB** (512KB ÷ 16 = 32KB; 16 = erasesize/blocksize = 4096/256). Partitions after the first are also misaligned.
3. 32KB happens to be a multiple of the 4KB erase block, so the partition is created without error — it is simply the wrong size.

**After the fix (this workspace, compile-level):**

- Host: Linux; toolchain arm-none-eabi-gcc 10.3-2021.10; NuttX master @ `15678acf` + this change.
- `stm32f103-minimum/src/stm32_w25.c` and `at32f437-mini/src/at32_w25.c`: `-fsyntax-only` with the partition path emulated (`CONFIG_STM32_SPI1`/`CONFIG_AT32_SPI1`, `CONFIG_MTD_W25`, `CONFIG_*_FLASH_PART`, `CONFIG_FS_SMARTFS`, `CONFIG_MTD_SMART`, ...) → **exit 0, no errors**.
- `stm32f429i-disco/src/stm32_bringup.c` and `samd5e5/metro-m4/src/sam_smartfs.c`: full-file syntax check is not possible in this workspace (generated `include/nuttx/config.h`/`include/arch/chip` point at a stale, different board build); the exact edited statements were extracted from disk into a type-stub harness reproducing the real signatures and compiled with `-Wall -Wextra` → **exit 0, no errors**.
- Tree-wide grep confirms no remaining `mtd_partition(..., partszbytes / erasesize)` call sites.

**Expected post-fix hardware result (to be confirmed on board):** repeating the same steps above, `/dev/smart0p1` should report **512KB**, and `/dev/mtd0p*` offsets should be contiguous and non-overlapping.
