### PR TITLE
include/nuttx/macro.h: Add FOREACH_IDX_ARG() and fix REVERSE_ARG()

### DIFF
--- a/Documentation/components/iterable_sections.rst
+++ b/Documentation/components/iterable_sections.rst
@@ -58,8 +58,10 @@ Available macros:
 * ``STRUCT_SECTION_ITERABLE(type, varname)`` -- define an instance inside
   the iterable section ``._<type>.static.<varname>``.  The variable name
   is part of the input section name, so the linker's ``SORT_BY_NAME()``
-  defines the iteration order (instances may encode ordering in their
-  names).
+  defines the iteration order.  A subsystem that needs a specific order
+  encodes it in the name, usually with a fixed width index:
+  ``FOREACH_ARG()`` from ``nuttx/macro.h`` hands the position of each item
+  to the definition macro as a literal that can be pasted into the name.
 * ``STRUCT_SECTION_DECLARE(type)`` -- declare the boundary symbols (file
   scope), required before iterating.
 * ``STRUCT_SECTION_FOREACH(type, iterator)`` -- for-loop over all

--- a/include/nuttx/macro.h
+++ b/include/nuttx/macro.h
@@ -112,46 +112,60 @@
 #define REVERSE_ARG(...) \
         CONCATENATE(REVERSE_, GET_ARG_COUNT(__VA_ARGS__))(__VA_ARGS__)
 
-/* Apply the macro to each argument */
+/* Apply the macro to each argument, passing the position of the argument
+ * as a literal (0, 1, 2, ...) rather than as an expression, so that the
+ * action can paste it into an identifier, for instance to build a symbol
+ * name the linker can sort.  The list is reversed before the expansion
+ * and each step emits the recursion before its own action, so both the
+ * indexes and the order of the actions follow the original list.
+ */
 
-#define FOREACH_0(action, count, param, ...)      0
-#define FOREACH_1(action, count, param, arg, ...) action(param, arg, count - 1 )
-#define FOREACH_2(action, count, param, arg, ...) action(param, arg, count - 2 ) FOREACH_1(action, count, param, __VA_ARGS__)
-#define FOREACH_3(action, count, param, arg, ...) action(param, arg, count - 3 ) FOREACH_2(action, count, param, __VA_ARGS__)
-#define FOREACH_4(action, count, param, arg, ...) action(param, arg, count - 4 ) FOREACH_3(action, count, param, __VA_ARGS__)
-#define FOREACH_5(action, count, param, arg, ...) action(param, arg, count - 5 ) FOREACH_4(action, count, param, __VA_ARGS__)
-#define FOREACH_6(action, count, param, arg, ...) action(param, arg, count - 6 ) FOREACH_5(action, count, param, __VA_ARGS__)
-#define FOREACH_7(action, count, param, arg, ...) action(param, arg, count - 7 ) FOREACH_6(action, count, param, __VA_ARGS__)
-#define FOREACH_8(action, count, param, arg, ...) action(param, arg, count - 8 ) FOREACH_7(action, count, param, __VA_ARGS__)
-#define FOREACH_9(action, count, param, arg, ...) action(param, arg, count - 9 ) FOREACH_8(action, count, param, __VA_ARGS__)
-#define FOREACH_10(action, count, param, arg, ...) action(param, arg, count - 10) FOREACH_9(action, count, param, __VA_ARGS__)
-#define FOREACH_11(action, count, param, arg, ...) action(param, arg, count - 11) FOREACH_10(action, count, param, __VA_ARGS__)
-#define FOREACH_12(action, count, param, arg, ...) action(param, arg, count - 12) FOREACH_11(action, count, param, __VA_ARGS__)
-#define FOREACH_13(action, count, param, arg, ...) action(param, arg, count - 13) FOREACH_12(action, count, param, __VA_ARGS__)
-#define FOREACH_14(action, count, param, arg, ...) action(param, arg, count - 14) FOREACH_13(action, count, param, __VA_ARGS__)
-#define FOREACH_15(action, count, param, arg, ...) action(param, arg, count - 15) FOREACH_14(action, count, param, __VA_ARGS__)
-#define FOREACH_16(action, count, param, arg, ...) action(param, arg, count - 16) FOREACH_15(action, count, param, __VA_ARGS__)
-#define FOREACH_17(action, count, param, arg, ...) action(param, arg, count - 17) FOREACH_16(action, count, param, __VA_ARGS__)
-#define FOREACH_18(action, count, param, arg, ...) action(param, arg, count - 18) FOREACH_17(action, count, param, __VA_ARGS__)
-#define FOREACH_19(action, count, param, arg, ...) action(param, arg, count - 19) FOREACH_18(action, count, param, __VA_ARGS__)
-#define FOREACH_20(action, count, param, arg, ...) action(param, arg, count - 20) FOREACH_19(action, count, param, __VA_ARGS__)
-#define FOREACH_21(action, count, param, arg, ...) action(param, arg, count - 21) FOREACH_20(action, count, param, __VA_ARGS__)
-#define FOREACH_22(action, count, param, arg, ...) action(param, arg, count - 22) FOREACH_21(action, count, param, __VA_ARGS__)
-#define FOREACH_23(action, count, param, arg, ...) action(param, arg, count - 23) FOREACH_22(action, count, param, __VA_ARGS__)
-#define FOREACH_24(action, count, param, arg, ...) action(param, arg, count - 24) FOREACH_23(action, count, param, __VA_ARGS__)
-#define FOREACH_25(action, count, param, arg, ...) action(param, arg, count - 25) FOREACH_24(action, count, param, __VA_ARGS__)
-#define FOREACH_26(action, count, param, arg, ...) action(param, arg, count - 26) FOREACH_25(action, count, param, __VA_ARGS__)
-#define FOREACH_27(action, count, param, arg, ...) action(param, arg, count - 27) FOREACH_26(action, count, param, __VA_ARGS__)
-#define FOREACH_28(action, count, param, arg, ...) action(param, arg, count - 28) FOREACH_27(action, count, param, __VA_ARGS__)
-#define FOREACH_29(action, count, param, arg, ...) action(param, arg, count - 29) FOREACH_28(action, count, param, __VA_ARGS__)
-#define FOREACH_30(action, count, param, arg, ...) action(param, arg, count - 30) FOREACH_29(action, count, param, __VA_ARGS__)
-#define FOREACH_31(action, count, param, arg, ...) action(param, arg, count - 31) FOREACH_30(action, count, param, __VA_ARGS__)
-#define FOREACH_32(action, count, param, arg, ...) action(param, arg, count - 32) FOREACH_31(action, count, param, __VA_ARGS__)
+#define FOREACH_0(action, param, ...)
+#define FOREACH_1(action, param, arg, ...) action(param, arg, 0)
+#define FOREACH_2(action, param, arg, ...) FOREACH_1(action, param, __VA_ARGS__) action(param, arg, 1)
+#define FOREACH_3(action, param, arg, ...) FOREACH_2(action, param, __VA_ARGS__) action(param, arg, 2)
+#define FOREACH_4(action, param, arg, ...) FOREACH_3(action, param, __VA_ARGS__) action(param, arg, 3)
+#define FOREACH_5(action, param, arg, ...) FOREACH_4(action, param, __VA_ARGS__) action(param, arg, 4)
+#define FOREACH_6(action, param, arg, ...) FOREACH_5(action, param, __VA_ARGS__) action(param, arg, 5)
+#define FOREACH_7(action, param, arg, ...) FOREACH_6(action, param, __VA_ARGS__) action(param, arg, 6)
+#define FOREACH_8(action, param, arg, ...) FOREACH_7(action, param, __VA_ARGS__) action(param, arg, 7)
+#define FOREACH_9(action, param, arg, ...) FOREACH_8(action, param, __VA_ARGS__) action(param, arg, 8)
+#define FOREACH_10(action, param, arg, ...) FOREACH_9(action, param, __VA_ARGS__) action(param, arg, 9)
+#define FOREACH_11(action, param, arg, ...) FOREACH_10(action, param, __VA_ARGS__) action(param, arg, 10)
+#define FOREACH_12(action, param, arg, ...) FOREACH_11(action, param, __VA_ARGS__) action(param, arg, 11)
+#define FOREACH_13(action, param, arg, ...) FOREACH_12(action, param, __VA_ARGS__) action(param, arg, 12)
+#define FOREACH_14(action, param, arg, ...) FOREACH_13(action, param, __VA_ARGS__) action(param, arg, 13)
+#define FOREACH_15(action, param, arg, ...) FOREACH_14(action, param, __VA_ARGS__) action(param, arg, 14)
+#define FOREACH_16(action, param, arg, ...) FOREACH_15(action, param, __VA_ARGS__) action(param, arg, 15)
+#define FOREACH_17(action, param, arg, ...) FOREACH_16(action, param, __VA_ARGS__) action(param, arg, 16)
+#define FOREACH_18(action, param, arg, ...) FOREACH_17(action, param, __VA_ARGS__) action(param, arg, 17)
+#define FOREACH_19(action, param, arg, ...) FOREACH_18(action, param, __VA_ARGS__) action(param, arg, 18)
+#define FOREACH_20(action, param, arg, ...) FOREACH_19(action, param, __VA_ARGS__) action(param, arg, 19)
+#define FOREACH_21(action, param, arg, ...) FOREACH_20(action, param, __VA_ARGS__) action(param, arg, 20)
+#define FOREACH_22(action, param, arg, ...) FOREACH_21(action, param, __VA_ARGS__) action(param, arg, 21)
+#define FOREACH_23(action, param, arg, ...) FOREACH_22(action, param, __VA_ARGS__) action(param, arg, 22)
+#define FOREACH_24(action, param, arg, ...) FOREACH_23(action, param, __VA_ARGS__) action(param, arg, 23)
+#define FOREACH_25(action, param, arg, ...) FOREACH_24(action, param, __VA_ARGS__) action(param, arg, 24)
+#define FOREACH_26(action, param, arg, ...) FOREACH_25(action, param, __VA_ARGS__) action(param, arg, 25)
+#define FOREACH_27(action, param, arg, ...) FOREACH_26(action, param, __VA_ARGS__) action(param, arg, 26)
+#define FOREACH_28(action, param, arg, ...) FOREACH_27(action, param, __VA_ARGS__) action(param, arg, 27)
+#define FOREACH_29(action, param, arg, ...) FOREACH_28(action, param, __VA_ARGS__) action(param, arg, 28)
+#define FOREACH_30(action, param, arg, ...) FOREACH_29(action, param, __VA_ARGS__) action(param, arg, 29)
+#define FOREACH_31(action, param, arg, ...) FOREACH_30(action, param, __VA_ARGS__) action(param, arg, 30)
+#define FOREACH_32(action, param, arg, ...) FOREACH_31(action, param, __VA_ARGS__) action(param, arg, 31)
 
-#define FOREACH_ARG_(action, count, param, ...) \
-        CONCATENATE(FOREACH_, count)(action, count, param, __VA_ARGS__)
+/* The reversed list has to be expanded before the arguments are counted,
+ * hence the extra indirection:  a macro counts the tokens it receives, not
+ * what they expand to.
+ */
+
+#define FOREACH_ARG__(action, param, ...) \
+        CONCATENATE(FOREACH_, GET_ARG_COUNT(__VA_ARGS__)) \
+        (action, param, __VA_ARGS__)
+
+#define FOREACH_ARG_(...) FOREACH_ARG__(__VA_ARGS__)
 
 #define FOREACH_ARG(action, param, ...) \
-        FOREACH_ARG_(action, GET_ARG_COUNT(__VA_ARGS__), param, __VA_ARGS__)
+        FOREACH_ARG_(action, param, REVERSE_ARG(__VA_ARGS__))
 
 #endif /* __INCLUDE_NUTTX_MACRO_H */

--- a/include/nuttx/sched_note.h
+++ b/include/nuttx/sched_note.h
@@ -169,7 +169,7 @@
 /* Set the type of each parameter */
 
 #define NOTE_PRINTF_TYPE(_, arg, index) + ((NOTE_PRINTF_ARG_TYPE(arg) << (index) * 2))
-#define NOTE_PRINTF_TYPES(...)          FOREACH_ARG(NOTE_PRINTF_TYPE, _, ##__VA_ARGS__)
+#define NOTE_PRINTF_TYPES(...)        0 FOREACH_ARG(NOTE_PRINTF_TYPE, _, ##__VA_ARGS__)
 
 /* Using macro expansion to calculate the expression of tag, tag will
  * be a constant at compile time, which will reduce the number of


### PR DESCRIPTION

## Summary

`FOREACH_ARG()` hands the action the position of the argument as an
expression (`count - N`), which cannot be pasted into an identifier. This
adds a companion that passes it as a two digit literal (`00`, `01`, ...),
so the position can become part of a symbol name and, through
`SORT_BY_NAME()`, part of the order the linker gives to the objects a
subsystem registers with the link time iterable sections.

The dispatch uses `CONCATENATE()` and `GET_ARG_COUNT()`, each arity emits
its own literal, and the list is reversed first with `REVERSE_ARG()`, so
no increment tables are needed. An empty list expands to nothing.

Using `REVERSE_ARG()` required fixing it first:

`REVERSE_ARG()` expanded to `REVERSE_ARG_(##__VA_ARGS__)`. The token
before the `##` is an opening parenthesis, not a comma, so the GNU
extension that swallows an empty variable argument list does not apply:
the preprocessor pastes `(` with the first argument and the build fails
with

```
error: pasting "(" and "x" does not give a valid preprocessing token
```

The macro therefore only ever worked with an empty argument list, which
is why the problem went unnoticed since the file was added in
3271142b87. Dropping the `##` makes the arguments expand; the empty case
is unaffected.

**And fix `REVERSE_ARG()`, which it needs**

## Impact

**Nothing existing is affected.** `FOREACH_IDX_ARG()` is entirely new, and
`REVERSE_ARG()` has no user in either repository: with arguments it did
not compile, so no code could depend on it, and with an empty list it
expands exactly as before. No macro already in the header changes
behaviour.

The documentation of the iterable sections already said that an instance
may encode its order in its name but not how; it now points at the new
macro (four lines in
`Documentation/components/iterable_sections.rst`).

The first user of the new macro is the zbus port
(apache/nuttx-apps#3743), which names one object per channel/observer
pair after the position of the observer in the channel definition.

## Testing

Host: Ubuntu 24.04.4 x86_64, arm-none-eabi-gcc 13.2.1.

Expansion checked for 0, 1, 3, 8 and 32 arguments with

```c
#define SHOW(p, x, i) [p:x:i]
FOREACH_IDX_ARG(SHOW, P, a, b, c)   /* [P:c:02] [P:b:01] [P:a:00] */
FOREACH_IDX_ARG(SHOW, P)            /* expands to nothing */
```

and the 32 argument case yields `[a1:00] ... [d8:31]`. Without the
`REVERSE_ARG()` fix the same expansions fail with the pasting error
quoted above.

Built and run on linum-stm32h753bi together with apache/nuttx-apps#3743:
the observations of every channel come out of the linker grouped per
channel and ordered by the position in the definition, and the zbus test
suite passes 17/17 twice in the same boot, including a test that asserts
the notification order.

`tools/checkpatch.sh -c -u -m -g` on the commit: all checks pass, and
`sphinx-build -W` builds the documentation clean.
