### PR TITLE
arch/tricore: fpu: drop iLLD dependency and fix Makefile

### DIFF
--- a/arch/tricore/include/irq.h
+++ b/arch/tricore/include/irq.h
@@ -147,14 +147,14 @@
 /* FPU registers */
 
 #ifdef CONFIG_ARCH_TC1V6
-#  define FPU_SYNC_TRAP_REG  CPU_FPU_TRAP_CON
-#  define FPU_ASYNC_TRAP_REG CPU_FPU_TRAP_CON
+#  define FPU_SYNC_TRAP_REG   0xA000
+#  define FPU_ASYNC_TRAP_REG  0xA000
 #else
-#  define FPU_SYNC_TRAP_REG  CPU_FPU_SYNC_TRAP_CON
-#  define FPU_ASYNC_TRAP_REG CPU_FPU_TRAP_CON
+#  define FPU_SYNC_TRAP_REG   0xA030
+#  define FPU_ASYNC_TRAP_REG  0xA000
 #endif
-#define FPU_TRAP_FZE_SHIFT   20
-#define FPU_TRAP_TCL_SHIFT   1
+#define FPU_TRAP_FZE_SHIFT    20
+#define FPU_TRAP_TCL_SHIFT    1
 
 #ifndef __ASSEMBLY__
 

--- a/arch/tricore/src/Makefile
+++ b/arch/tricore/src/Makefile
@@ -239,7 +239,7 @@ distclean:: clean
 ifeq ($(BOARDMAKE),y)
 	$(Q) $(MAKE) -C board distclean
 endif
-	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds)
+	$(call DELFILE, $(CSRCS:.c=.ddc) $(ASRCS:.S=.dds))
 	$(call DELFILE, Make.dep)
 	$(call DELFILE, .depend)
 

--- a/arch/tricore/src/common/tricore_fpu.c
+++ b/arch/tricore/src/common/tricore_fpu.c
@@ -28,7 +28,7 @@
 
 #include <string.h>
 
-#include "tricore_internal.h"
+#include <arch/irq.h>
 
 /****************************************************************************
  * Public Functions
@@ -42,8 +42,8 @@ void tricore_fpuinit(void)
 {
   /* FPU zero-divide trap enable */
 
-  __mtcr(FPU_SYNC_TRAP_REG,
-         __mfcr(FPU_SYNC_TRAP_REG) | (1U << FPU_TRAP_FZE_SHIFT));
+  tricore_mtcr(FPU_SYNC_TRAP_REG, tricore_mfcr(FPU_SYNC_TRAP_REG) |
+                                  (1U << FPU_TRAP_FZE_SHIFT));
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Drop iLLD dependency from TriCore FPU code and fix a missing closing paren in the arch/tricore/src Makefile.

- Replace `__mfcr`/`__mtcr` intrinsics and iLD-provided register symbols with `tricore_mfcr`/`tricore_mtcr` and hardcoded register values, so FPU code no longer depends on `IfxCpu_Intrinsics.h`.
- Add the missing `)` in `$(call DELFILE, ...)` at `arch/tricore/src/Makefile:241`, which caused `unterminated call to function "call"` build error.

## Impact

- Files: `arch/tricore/include/irq.h`, `arch/tricore/src/common/tricore_fpu.c`, `arch/tricore/src/Makefile`.
- No behavioral change to FPU initialization or context compare logic.
- Fixes a Makefile syntax error that blocks the build.

## Testing

- Local nxstyle check (`tools/checkpatch.sh -f`) passes on both source files.
- Build verified locally on TC4xx board config.