### PR TITLE
tools/ci: add qemu-system-x86 to the linux CI image

### DIFF
--- a/tools/ci/docker/linux/Dockerfile
+++ b/tools/ci/docker/linux/Dockerfile
@@ -405,6 +405,7 @@ RUN apt-get update -qq && DEBIAN_FRONTEND="noninteractive" TZ=Etc/UTC apt-get in
   npm \
   qemu-system-arm \
   qemu-system-misc \
+  qemu-system-x86 \
   python3 \
   python3-pip \
   python-is-python3 \


### PR DESCRIPTION

## Summary

tools/ci: add qemu-system-x86 to the linux CI image

Required to run the qemu-intel64 citest/NTFC configuration on CI; the image only shipped qemu-system-arm and qemu-system-misc.

## Impact

It will take an additional ~40MB of space

## Testing

CI