### PR TITLE
cmake: parse EXTRAFLAGS with separate_arguments

### DIFF
--- a/cmake/nuttx_add_library.cmake
+++ b/cmake/nuttx_add_library.cmake
@@ -55,8 +55,8 @@ function(nuttx_add_library_internal target)
   # add extra flags into command line
 
   if(DEFINED EXTRAFLAGS)
-    string(REPLACE " " ";" eflags "${EXTRAFLAGS}")
-    target_compile_options(${target} PRIVATE ${eflags})
+    separate_arguments(EXTRAFLAGS_LIST UNIX_COMMAND "${EXTRAFLAGS}")
+    target_compile_options(${target} PRIVATE ${EXTRAFLAGS_LIST})
   endif()
 
   # Set install config for all library


### PR DESCRIPTION
cmake: parse EXTRAFLAGS with separate_arguments.

## Summary

  * Why change is necessary: leftover EXTRAFLAGS handling after #18194 still splits flags on every space.
  * What functional part of the code is being changed: cmake/nuttx_add_library.cmake extra-flag parsing.
  * How: use separate_arguments(UNIX_COMMAND) so quoted flags such as -I"/path with spaces" stay one compile option, matching EXTRA_FLAGS.
  * Related NuttX Issue: none opened (same class as merged #18194).

## Impact

  * Is new feature added? Is existing feature changed? NO
  * Impact on user (will user need to adapt to change)? NO
  * Impact on build (will build process change)? YES. EXTRAFLAGS is parsed with shell quoting instead of a naive space split.
  * Impact on hardware (will arch(s) / board(s) / driver(s) change)? NO
  * Impact on documentation (is update required / provided)? NO
  * Impact on security (any sort of implications)? NO
  * Impact on compatibility (backward/forward/interoperability)? NO. Unquoted space-separated flags still become one option each.

## Testing

  I confirm that changes are verified on local setup and works as intended:
  * Build Host(s): Windows 11, CMake 3.29.2
  * Target(s): cmake -P parse check of EXTRAFLAGS (host CMake, no board image)

  Testing logs before change:

  `
  EXTRAFLAGS=-Wno-cpp -Werror -I"/tmp/path with spaces/include"
  string(REPLACE " " ";")
  OLD_LEN=5
  OLD_ITEM=[-Wno-cpp]
  OLD_ITEM=[-Werror]
  OLD_ITEM=[-I"/tmp/path]
  OLD_ITEM=[with]
  OLD_ITEM=[spaces/include"]
  `

  Testing logs after change:

  `
  separate_arguments(UNIX_COMMAND)
  NEW_LEN=3
  NEW_ITEM=[-Wno-cpp]
  NEW_ITEM=[-Werror]
  NEW_ITEM=[-I/tmp/path with spaces/include]
  EXTRAFLAGS_PARSE_OK
  `

## PR verification Self-Check

  * [x] This PR introduces only one functional change.
  * [x] I have updated all required description fields above.
  * [x] My PR adheres to Contributing Guidelines and Documentation (git commit title and message, coding standard, etc).
  * [ ] My PR is still work in progress (not ready for review).
  * [x] My PR is ready for review and can be safely merged into a codebase.
