### PR TITLE
tools/export: prefix each linker script in toolchain.cmake

### DIFF
--- a/tools/toolchain.cmake.export
+++ b/tools/toolchain.cmake.export
@@ -4,10 +4,17 @@ set(NUTTX 1)
 
 set(CMAKE_TRY_COMPILE_TARGET_TYPE STATIC_LIBRARY)
 
-set(NUTTX_PATH ${CMAKE_CURRENT_LIST_DIR}/..)
+set(NUTTX_PATH "${CMAKE_CURRENT_LIST_DIR}/..")
+get_filename_component(NUTTX_PATH "${NUTTX_PATH}" ABSOLUTE)
 include(${NUTTX_PATH}/scripts/target.cmake)
 
-set(LINKER_SCRIPT ${NUTTX_PATH}/scripts/${LDNAME})
+# LDNAME may list several space-separated linker scripts. Prefix each one.
+separate_arguments(_ldname_list UNIX_COMMAND "${LDNAME}")
+set(_ldscripts)
+foreach(_ld IN LISTS _ldname_list)
+  list(APPEND _ldscripts "-T${NUTTX_PATH}/scripts/${_ld}")
+endforeach()
+string(REPLACE ";" " " LINKER_SCRIPT "${_ldscripts}")
 
 set(CMAKE_C_FLAGS "${ARCHCPUFLAGS} ${ARCHCFLAGS} -D__NuttX__")
 set(CMAKE_CXX_FLAGS "${ARCHCPUFLAGS} ${ARCHCXXFLAGS} -D__NuttX__")
@@ -27,10 +34,10 @@ add_compile_options(-ffunction-sections -fdata-sections)
 set(ENTRY_NAME "_start")
 
 set(CMAKE_C_LINK_EXECUTABLE
-    "<CMAKE_LINKER> ${LDFLAGS} --entry=${ENTRY_NAME} -T${LINKER_SCRIPT} <OBJECTS> -o <TARGET> <LINK_LIBRARIES> -L${NUTTX_PATH}/libs --start-group ${LDLIBS} ${EXTRA_LIBS} --end-group"
+    "<CMAKE_LINKER> ${LDFLAGS} --entry=${ENTRY_NAME} ${LINKER_SCRIPT} <OBJECTS> -o <TARGET> <LINK_LIBRARIES> -L${NUTTX_PATH}/libs --start-group ${LDLIBS} ${EXTRA_LIBS} --end-group"
 )
 set(CMAKE_CXX_LINK_EXECUTABLE
-    "<CMAKE_LINKER> ${LDFLAGS} --entry=${ENTRY_NAME} -T${LINKER_SCRIPT} <OBJECTS> -o <TARGET> <LINK_LIBRARIES> -L${NUTTX_PATH}/libs --start-group ${LDLIBS} ${EXTRA_LIBS} --end-group"
+    "<CMAKE_LINKER> ${LDFLAGS} --entry=${ENTRY_NAME} ${LINKER_SCRIPT} <OBJECTS> -o <TARGET> <LINK_LIBRARIES> -L${NUTTX_PATH}/libs --start-group ${LDLIBS} ${EXTRA_LIBS} --end-group"
 )
 
 set(CMAKE_FIND_ROOT_PATH_MODE_PROGRAM NEVER)


### PR DESCRIPTION
tools/export: prefix each linker script in toolchain.cmake.

## Summary

  * Why change is necessary: make export writes several names into LDNAME, but the exported toolchain.cmake only prefixes the first file with the scripts directory.
  * What functional part of the code is being changed: tools/toolchain.cmake.export linker-script path generation.
  * How: split LDNAME, prefix every script with the normalized export scripts path, and pass each as its own -T argument.
  * Related NuttX Issue: https://github.com/apache/nuttx/issues/19820

## Impact

  * Is new feature added? Is existing feature changed? NO. Fixes exported CMake toolchain files for boards with more than one linker script.
  * Impact on user (will user need to adapt to change)? NO
  * Impact on build (will build process change)? YES. Out-of-tree CMake apps that consume make export now receive a -T path for every LDNAME script.
  * Impact on hardware (will arch(s) / board(s) / driver(s) change)? NO
  * Impact on documentation (is update required / provided)? NO
  * Impact on security (any sort of implications)? NO
  * Impact on compatibility (backward/forward/interoperability)? NO. Single-script LDNAME still produces one -T argument.

## Testing

  I confirm that changes are verified on local setup and works as intended:
  * Build Host(s): Windows 11, CMake 3.29.2
  * Target(s): cmake -P reconstruction of the reported ESP32-S3 LDNAME list from #19820, plus the single-script gnu-elf.ld case

  Testing logs before change:

  `
  OLD_RULE=-T/tmp/nuttx-export-13.0.0/scripts/../scripts/esp32s3_peripherals.ld esp32s3_rom_aliases.ld flat_memory.ld esp32s3_sections.ld
  `

  Testing logs after change:

  `
  NUTTX_PATH=/tmp/nuttx-export-13.0.0
  NEW_RULE=-T/tmp/nuttx-export-13.0.0/scripts/esp32s3_peripherals.ld -T/tmp/nuttx-export-13.0.0/scripts/esp32s3_rom_aliases.ld -T/tmp/nuttx-export-13.0.0/scripts/flat_memory.ld -T/tmp/nuttx-export-13.0.0/scripts/esp32s3_sections.ld
  EXPORT_LDNAME_OK
  `

## PR verification Self-Check

  * [x] This PR introduces only one functional change.
  * [x] I have updated all required description fields above.
  * [x] My PR adheres to Contributing Guidelines and Documentation (git commit title and message, coding standard, etc).
  * [ ] My PR is still work in progress (not ready for review).
  * [x] My PR is ready for review and can be safely merged into a codebase.
