### PR TITLE
fix/esp32s3-tickless-timeout-overflow

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_tickless.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_tickless.c
@@ -76,9 +76,9 @@
 #define CTICK_PER_SEC         (ESP32S3_SYSTIMER_TICKS_PER_SEC)
 #define CTICK_PER_USEC        (CTICK_PER_SEC / USEC_PER_SEC)
 
-#define SEC_2_CTICK(s)        ((s) * CTICK_PER_SEC)
-#define USEC_2_CTICK(us)      ((us) * CTICK_PER_USEC)
-#define NSEC_2_CTICK(nsec)    (((nsec) * CTICK_PER_USEC) / NSEC_PER_USEC)
+#define SEC_2_CTICK(s)        ((uint64_t)(s) * CTICK_PER_SEC)
+#define USEC_2_CTICK(us)      ((uint64_t)(us) * CTICK_PER_USEC)
+#define NSEC_2_CTICK(nsec)    (((uint64_t)(nsec) * CTICK_PER_USEC) / NSEC_PER_USEC)
 
 #define CTICK_2_SEC(tick)     ((tick) / CTICK_PER_SEC)
 #define CTICK_2_USEC(tick)    ((tick) / CTICK_PER_USEC)
@@ -246,6 +246,7 @@ static int IRAM_ATTR tickless_isr(int irq, void *context, void *arg)
 
   uint64_t unit_ticks = tickless_getcounter();
   uint64_t alarm_ticks = tickless_getalarmvalue();
+
   if (unit_ticks < alarm_ticks)
     {
       modifyreg32(SYSTIMER_CONF_REG, 0, SYSTIMER_TARGET0_WORK_EN);


### PR DESCRIPTION
## Summary

`CONFIG_ESP32S3_TICKLESS` hangs forever the first time a task sleeps
with a fractional-second timeout of ~134ms or more (e.g.
`usleep(500000)`) while another task also has a pending timeout —
e.g. `apps/testing/ostest` hangs immediately, since that's exactly
what `user_main()`'s first statement does.

## Root cause

```c
#define NSEC_2_CTICK(nsec)    (((nsec) * CTICK_PER_USEC) / NSEC_PER_USEC)
```

`nsec` is a 32-bit `long` and `CTICK_PER_USEC` is 16 (16MHz systimer),
so `nsec * 16` overflows a 32-bit signed int for `tv_nsec >= ~134ms`.
The overflowed (negative) result gets added into `up_timer_start()`'s
`uint64_t cpu_ticks`, wrapping to a value near `UINT64_MAX`. The
systimer alarm then gets programmed that many ticks in the future —
effectively never — so the sleeping task never wakes up.

`SEC_2_CTICK`/`USEC_2_CTICK` have the same class of bug at higher
thresholds.

## Fix

Cast to `uint64_t` before multiplying in all three macros, forcing
64-bit arithmetic (matching the already-safe `CTICK_2_*` macros).

Also fixed a pre-existing nxstyle nit (missing blank line) in
`tickless_isr()`, next to the changed code.

## Testing

Board: Seeed XIAO ESP32-S3, built on current `master`.

- Reproduced: instrumented `up_timer_start()` and confirmed the exact
  overflow (`cpu_ticks=18446744073709121682` for a ~500-700ms sleep).
- Before: `ostest` (`CONFIG_ESP32S3_TICKLESS=y`) hangs right after
  `Started user_main`, reproducible every time from a clean flash.
- After: full `ostest` suite runs past that point and completes.
- Plain single-task sleeps (`sleep 3` from NSH) keep correct timing
  before and after (3.06s measured).