### PR TITLE
arch/sim: don't block on the wrapped RX segment of the simulated UART

### DIFF
--- a/arch/sim/src/sim/sim_uart.c
+++ b/arch/sim/src/sim/sim_uart.c
@@ -293,6 +293,7 @@ static void uart_nputs(int fd, const char *buf, size_t size)
   while (size > 0)
     {
       int ret = host_uart_puts(fd, buf, size);
+
       if (ret < 0)
         {
           continue;
@@ -805,6 +806,7 @@ void up_putc(int ch)
 {
 #ifdef USE_DEVCONSOLE
   char c = ch;
+
   up_nputs(&c, 1);
 #endif
 }

--- a/arch/sim/src/sim/sim_uart.c
+++ b/arch/sim/src/sim/sim_uart.c
@@ -622,7 +622,12 @@ static void tty_dmareceive(struct uart_dev_s *dev)
     {
       xfer->nbytes = ret;
 
-      if (ret == xfer->length && xfer->nlength > 0)
+      /* The console fd is blocking, so only continue into the wrapped
+       * part of the circular buffer if there is really more data.
+       */
+
+      if (ret == xfer->length && xfer->nlength > 0 &&
+          host_uart_checkin(priv->fd))
         {
           ret = host_uart_gets(priv->fd, xfer->nbuffer, xfer->nlength);
           if (ret > 0)


### PR DESCRIPTION
## Summary

The console fd is blocking (host_uart_start() never sets O_NONBLOCK), so when a burst of input ends exactly at the wrap boundary of the RX circular buffer, the second host_uart_gets() in tty_dmareceive() blocks inside the timer callback and freezes the whole simulator until the host sends another byte. Poll the fd first so the wrapped segment is only read when data is really available.

## Impact

we can remove workaround in NTFC for sim:

https://github.com/apache/nuttx-ntfc/blob/f68efe4e6080c0fa7018664cd284789d3314cf55/src/ntfc/device/sim.py#L38-L39

## Testing

Simulator works on NTFC without workaround from above
