### PR TITLE
libc: add paths.h, sys/ttydefaults.h and termios IUTF8

### DIFF
--- a/include/paths.h
+++ b/include/paths.h
@@ -1,0 +1,73 @@
+/****************************************************************************
+ * include/paths.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_PATHS_H
+#define __INCLUDE_PATHS_H
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* Default search path. */
+
+#define _PATH_DEFPATH "/usr/bin:/bin"
+
+/* All standard utilities path. */
+
+#define _PATH_STDPATH "/usr/bin:/bin:/usr/sbin:/sbin"
+
+#define _PATH_BSHELL    "/bin/sh"
+#define _PATH_CONSOLE   "/dev/console"
+#define _PATH_CSHELL    "/bin/csh"
+#define _PATH_DEVDB     "/var/run/dev.db"
+#define _PATH_DEVNULL   "/dev/null"
+#define _PATH_DRUM      "/dev/drum"
+#define _PATH_GSHADOW   "/etc/gshadow"
+#define _PATH_KLOG      "/proc/kmsg"
+#define _PATH_KMEM      "/dev/kmem"
+#define _PATH_LASTLOG   "/var/log/lastlog"
+#define _PATH_MAILDIR   "/var/mail"
+#define _PATH_MAN       "/usr/share/man"
+#define _PATH_MEM       "/dev/mem"
+#define _PATH_MNTTAB    "/etc/fstab"
+#define _PATH_MOUNTED   "/etc/mtab"
+#define _PATH_NOLOGIN   "/etc/nologin"
+#define _PATH_PRESERVE  "/var/lib"
+#define _PATH_RWHODIR   "/var/spool/rwho"
+#define _PATH_SENDMAIL  "/usr/sbin/sendmail"
+#define _PATH_SHADOW    "/etc/shadow"
+#define _PATH_SHELLS    "/etc/shells"
+#define _PATH_TTY       "/dev/tty"
+#define _PATH_UNIX      "/boot/vmlinux"
+#define _PATH_UTMP      "/var/run/utmp"
+#define _PATH_VI        "/usr/bin/vi"
+#define _PATH_WTMP      "/var/log/wtmp"
+
+/* Provide trailing slash, since mostly used for building pathnames. */
+
+#define _PATH_DEV       "/dev/"
+#define _PATH_TMP       "/tmp/"
+#define _PATH_VARDB     "/var/lib/misc/"
+#define _PATH_VARRUN    "/var/run/"
+#define _PATH_VARTMP    "/var/tmp/"
+
+#endif /* __INCLUDE_PATHS_H */

--- a/include/sys/ttydefaults.h
+++ b/include/sys/ttydefaults.h
@@ -1,0 +1,102 @@
+/****************************************************************************
+ * include/sys/ttydefaults.h
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-FileCopyrightText: 1982, 1986, 1993 The Regents of the University of
+ *   California.  All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ * 3. Neither the name of the University nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+#ifndef __INCLUDE_SYS_TTYDEFAULTS_H
+#define __INCLUDE_SYS_TTYDEFAULTS_H
+
+/****************************************************************************
+ * Pre-processor Definitions
+ ****************************************************************************/
+
+/* System wide defaults for terminal state.  Compatible with the historical
+ * 4.4BSD <sys/ttydefaults.h> used by portable command line utilities.
+ */
+
+/* Control Character Defaults */
+
+#define CTRL(x)  ((x) & 037)
+
+#define CEOF     CTRL('d')
+#ifdef _POSIX_VDISABLE
+#  define CEOL   _POSIX_VDISABLE
+#else
+#  define CEOL   '\0'          /* XXX avoid _POSIX_VDISABLE requirement */
+#endif
+#define CERASE   0177
+#define CINTR    CTRL('c')
+#define CSTATUS  CTRL('t')
+#define CKILL    CTRL('u')
+#define CMIN     1
+#define CQUIT    034           /* FS, ^\ */
+#define CSUSP    CTRL('z')
+#define CTIME    0
+#define CDSUSP   CTRL('y')
+#define CSTART   CTRL('q')
+#define CSTOP    CTRL('s')
+#define CLNEXT   CTRL('v')
+#define CDISCARD CTRL('o')
+#define CWERASE  CTRL('w')
+#define CREPRINT CTRL('r')
+#define CEOT     CEOF
+
+/* Compat */
+
+#define CBRK     CEOL
+#define CRPRNT   CREPRINT
+#define CFLUSH   CDISCARD
+
+/* PROTECTED INCLUSION ENDS HERE */
+
+/* #define TTYDEFCHARS to include an array of default control characters. */
+
+#ifdef TTYDEFCHARS
+
+static const cc_t ttydefchars[] =
+{
+  CEOF, CEOL, CEOL, CERASE, CWERASE, CKILL, CREPRINT, CERASE, CINTR,
+  CQUIT, CSUSP, CDSUSP, CSTART, CSTOP, CLNEXT, CDISCARD, CMIN, CTIME,
+  CSTATUS, _POSIX_VDISABLE
+};
+
+#undef TTYDEFCHARS
+#endif /* TTYDEFCHARS */
+
+/* Default terminal flag values (only used if referenced). */
+
+#define TTYDEF_IFLAG (BRKINT | ISTRIP | ICRNL | IMAXBEL | IXON | IXANY)
+#define TTYDEF_OFLAG (OPOST | ONLCR)
+#define TTYDEF_LFLAG (ECHO | ICANON | ISIG | IEXTEN | ECHOE | ECHOKE | ECHOCTL)
+#define TTYDEF_CFLAG (CREAD | CS7 | PARENB | HUPCL)
+#define TTYDEF_SPEED (B9600)
+
+#endif /* __INCLUDE_SYS_TTYDEFAULTS_H */

--- a/include/termios.h
+++ b/include/termios.h
@@ -51,6 +51,7 @@
 #define IXANY     (1 << 11) /* Bit 11: Enable any character to restart output */
 #define IXOFF     (1 << 12) /* Bit 12: Enable start/stop input control */
 #define IMAXBEL   (1 << 13) /* Bit 13: Ring bell when input queue is full */
+#define IUTF8     (1 << 14) /* Bit 14: Input is UTF8 (for canonical erase) */
 
 /* Terminal output modes (c_oflag in the termios structure) */
 


### PR DESCRIPTION
## Summary
Add commonly required POSIX/BSD interfaces that portable command-line utilities expect but that were missing from the C library:

- `include/paths.h`: `_PATH_DEFPATH` and the other standard default paths.
- `include/sys/ttydefaults.h`: BSD default control-character and terminal flag definitions.
- `include/termios.h`: define the `IUTF8` input flag.

## Impact
New header files only, no existing code is modified. Required by portable command-line utilities (e.g. toybox) that include these headers unconditionally.

## Testing
Built and booted `sim:nsh` successfully with the new headers in place.