### PR TITLE
arch/sim: set stdin/stdout nonblocking in host_uart_start()

### DIFF
--- a/arch/sim/src/sim/posix/sim_hostuart.c
+++ b/arch/sim/src/sim/posix/sim_hostuart.c
@@ -111,6 +111,16 @@ void host_uart_start(void)
       host_uninterruptible_no_return(fcntl, 0, F_SETFL, flags | O_NONBLOCK);
     }
 
+  /* Set stdout to non-blocking to prevent write(1, ...) from blocking
+   * the entire sim process when the host pipe buffer is full.
+   */
+
+  flags = host_uninterruptible(fcntl, 1, F_GETFL, 0);
+  if (flags > 0)
+    {
+      host_uninterruptible_no_return(fcntl, 1, F_SETFL, flags | O_NONBLOCK);
+    }
+
   /* Restore the original terminal mode before exit */
 
   atexit(restoremode);

--- a/arch/sim/src/sim/posix/sim_hostuart.c
+++ b/arch/sim/src/sim/posix/sim_hostuart.c
@@ -95,6 +95,8 @@ static void restoremode(void)
 
 void host_uart_start(void)
 {
+  int flags;
+
   /* Get the current stdin terminal mode */
 
   tcgetattr(0, &g_cooked);
@@ -102,6 +104,12 @@ void host_uart_start(void)
   /* Put stdin into raw mode */
 
   setrawmode(0);
+
+  flags = host_uninterruptible(fcntl, 0, F_GETFL, 0);
+  if (flags > 0)
+    {
+      host_uninterruptible_no_return(fcntl, 0, F_SETFL, flags | O_NONBLOCK);
+    }
 
   /* Restore the original terminal mode before exit */
 

--- a/arch/sim/src/sim/posix/sim_hostuart.c
+++ b/arch/sim/src/sim/posix/sim_hostuart.c
@@ -95,7 +95,7 @@ static void restoremode(void)
 
 void host_uart_start(void)
 {
-  int flags;
+  int nonblock = 1;
 
   /* Get the current stdin terminal mode */
 
@@ -105,21 +105,13 @@ void host_uart_start(void)
 
   setrawmode(0);
 
-  flags = host_uninterruptible(fcntl, 0, F_GETFL, 0);
-  if (flags > 0)
-    {
-      host_uninterruptible_no_return(fcntl, 0, F_SETFL, flags | O_NONBLOCK);
-    }
+  host_uninterruptible_no_return(ioctl, 0, FIONBIO, &nonblock);
 
   /* Set stdout to non-blocking to prevent write(1, ...) from blocking
    * the entire sim process when the host pipe buffer is full.
    */
 
-  flags = host_uninterruptible(fcntl, 1, F_GETFL, 0);
-  if (flags > 0)
-    {
-      host_uninterruptible_no_return(fcntl, 1, F_SETFL, flags | O_NONBLOCK);
-    }
+  host_uninterruptible_no_return(ioctl, 1, FIONBIO, &nonblock);
 
   /* Restore the original terminal mode before exit */
 


### PR DESCRIPTION
## Summary
- Set both stdin (fd 0) and stdout (fd 1) to nonblocking via `ioctl(FIONBIO)` in `host_uart_start()`.
- When the sim is connected via pipe (e.g. by an automation tool) and the host side does not read stdout in time, the pipe buffer fills up and `write(1, ...)` blocks the entire sim process. This happens inside `host_uninterruptible` (irq disabled), so the NuttX scheduler is completely frozen and all threads stop.
- With nonblocking I/O, `write()` returns `EAGAIN` instead; the TX data stays in the NuttX xmit buffer and `sim_tty_work` retries every 1ms until the pipe has space.

## Impact
- Only affects the sim platform host UART setup (`arch/sim/src/sim/posix/sim_hostuart.c`), no functional change for interactive terminal usage.

## Testing
Built and booted `sim:nsh` on Linux, console I/O works as before; verified the sim no longer freezes when stdout is a pipe that is not drained by the reader.