### PR TITLE
libc/misc: Add statx() via struct stat composition.

### DIFF
--- a/include/fcntl.h
+++ b/include/fcntl.h
@@ -143,6 +143,11 @@
 #define AT_SYMLINK_FOLLOW     0x0400 /* Follow symbolic links. */
 #define AT_NO_AUTOMOUNT       0x0800 /* Suppress terminal automount traversal */
 #define AT_EMPTY_PATH         0x1000 /* Allow empty relative pathname */
+#define AT_STATX_SYNC_AS_STAT 0x0000 /* Do whatever stat() does (default) */
+#define AT_STATX_FORCE_SYNC   0x2000 /* Force attributes to be sync'd */
+#define AT_STATX_DONT_SYNC    0x4000 /* Do not sync, accept stale values */
+#define AT_STATX_SYNC_TYPE    0x6000 /* Mask for the sync type values */
+#define AT_RECURSIVE          0x8000 /* Apply to the entire subtree */
 
 /* These are the notifications that can be received from F_NOTIFY (linux) */
 

--- a/include/sys/stat.h
+++ b/include/sys/stat.h
@@ -30,6 +30,7 @@
 #include <nuttx/config.h>
 
 #include <sys/types.h>
+#include <stdint.h>
 #include <time.h>
 
 /****************************************************************************
@@ -116,6 +117,33 @@
 #  define UTIME_OMIT  ((1l << 30) - 2l)
 #endif
 
+#define STATX_TYPE            0x000001u /* Want/got stx_mode & S_IFMT */
+#define STATX_MODE            0x000002u /* Want/got stx_mode & ~S_IFMT */
+#define STATX_NLINK           0x000004u /* Want/got stx_nlink */
+#define STATX_UID             0x000008u /* Want/got stx_uid */
+#define STATX_GID             0x000010u /* Want/got stx_gid */
+#define STATX_ATIME           0x000020u /* Want/got stx_atime */
+#define STATX_MTIME           0x000040u /* Want/got stx_mtime */
+#define STATX_CTIME           0x000080u /* Want/got stx_ctime */
+#define STATX_INO             0x000100u /* Want/got stx_ino */
+#define STATX_SIZE            0x000200u /* Want/got stx_size */
+#define STATX_BLOCKS          0x000400u /* Want/got stx_blocks */
+#define STATX_BASIC_STATS     0x0007ffu /* All fields common with struct stat */
+#define STATX_BTIME           0x000800u /* Want/got stx_btime */
+#define STATX_ALL             0x000fffu /* All currently supported fields */
+#define STATX_MNT_ID          0x001000u /* Want/got stx_mnt_id */
+#define STATX_DIOALIGN        0x002000u /* Want/got direct I/O alignment info */
+
+#define STATX_ATTR_COMPRESSED 0x000004u /* File is compressed by the fs */
+#define STATX_ATTR_IMMUTABLE  0x000010u /* File is marked immutable */
+#define STATX_ATTR_APPEND     0x000020u /* File is append-only */
+#define STATX_ATTR_NODUMP     0x000040u /* File is not to be dumped */
+#define STATX_ATTR_ENCRYPTED  0x000800u /* File requires key to decrypt */
+#define STATX_ATTR_AUTOMOUNT  0x001000u /* Dir: automount trigger */
+#define STATX_ATTR_MOUNT_ROOT 0x002000u /* Root of a mount point */
+#define STATX_ATTR_VERITY     0x100000u /* fs-verity protected */
+#define STATX_ATTR_DAX        0x200000u /* DAX file */
+
 /* The following macros are required by POSIX to achieve backward
  * compatibility with earlier versions of struct stat.
  */
@@ -159,6 +187,52 @@ struct stat
   blkcnt_t         st_blocks;  /* Number of blocks allocated */
 };
 
+/* Extended file status, Linux struct statx layout.  Fixed-width fields
+ * keep the ABI stable across toolchains and permit a future kernel-space
+ * statx() implementation without a user-space ABI break.
+ */
+
+struct statx_timestamp
+{
+  int64_t  tv_sec;    /* Seconds since the Epoch */
+  uint32_t tv_nsec;   /* Nanoseconds since tv_sec */
+  int32_t  reserved;
+};
+
+struct statx
+{
+  uint32_t stx_mask;                /* What results were actually filled in */
+  uint32_t stx_blksize;             /* Preferred I/O block size */
+  uint64_t stx_attributes;          /* STATX_ATTR_* flags supported+set */
+  uint32_t stx_nlink;               /* Number of hard links */
+  uint32_t stx_uid;                 /* User ID of owner */
+  uint32_t stx_gid;                 /* Group ID of owner */
+  uint16_t stx_mode;                /* File mode, S_IFMT | permissions */
+  uint16_t spare0[1];
+  uint64_t stx_ino;                 /* Inode number */
+  uint64_t stx_size;                /* File size in bytes */
+  uint64_t stx_blocks;              /* Number of 512B blocks allocated */
+  uint64_t stx_attributes_mask;     /* STATX_ATTR_* flags supported */
+
+  struct statx_timestamp stx_atime; /* Last access time */
+  struct statx_timestamp stx_btime; /* File creation time */
+  struct statx_timestamp stx_ctime; /* Last status change time */
+  struct statx_timestamp stx_mtime; /* Last data modification time */
+
+  uint32_t stx_rdev_major;          /* Device ID of special file */
+  uint32_t stx_rdev_minor;
+  uint32_t stx_dev_major;           /* ID of device containing file */
+  uint32_t stx_dev_minor;
+  uint64_t stx_mnt_id;              /* Mount ID */
+
+  /* Memory/file offset alignment for direct I/O */
+
+  uint32_t stx_dio_mem_align;
+  uint32_t stx_dio_offset_align;
+
+  uint64_t spare3[12];              /* Spare space for future expansion */
+};
+
 /****************************************************************************
  * Public Function Prototypes
  ****************************************************************************/
@@ -183,6 +257,8 @@ int lstat(FAR const char *path, FAR struct stat *buf);
 int fstat(int fd, FAR struct stat *buf);
 int fstatat(int dirfd, FAR const char *path, FAR struct stat *buf,
             int flags);
+int statx(int dirfd, FAR const char *path, int flags, unsigned int mask,
+          FAR struct statx *buf);
 int chmod(FAR const char *path, mode_t mode);
 int lchmod(FAR const char *path, mode_t mode);
 int fchmod(int fd, mode_t mode);

--- a/libs/libc/misc/CMakeLists.txt
+++ b/libs/libc/misc/CMakeLists.txt
@@ -43,6 +43,7 @@ list(
   lib_mutex.c
   lib_fchmodat.c
   lib_fstatat.c
+  lib_statx.c
   lib_getfullpath.c
   lib_openat.c
   lib_mkdirat.c

--- a/libs/libc/misc/Make.defs
+++ b/libs/libc/misc/Make.defs
@@ -25,7 +25,7 @@
 CSRCS += lib_bitmap.c lib_circbuf.c lib_creat.c lib_mknod.c lib_umask.c
 CSRCS += lib_utsname.c lib_getrandom.c lib_xorshift128.c lib_tea_encrypt.c
 CSRCS += lib_tea_decrypt.c lib_cxx_initialize.c lib_impure.c lib_memfd.c
-CSRCS += lib_mutex.c lib_fchmodat.c lib_fstatat.c lib_getfullpath.c
+CSRCS += lib_mutex.c lib_fchmodat.c lib_fstatat.c lib_statx.c lib_getfullpath.c
 CSRCS += lib_openat.c lib_mkdirat.c lib_utimensat.c lib_mallopt.c
 CSRCS += lib_idr.c lib_getnprocs.c
 

--- a/libs/libc/misc/lib_statx.c
+++ b/libs/libc/misc/lib_statx.c
@@ -1,0 +1,178 @@
+/****************************************************************************
+ * libs/libc/misc/lib_statx.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <errno.h>
+#include <fcntl.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <unistd.h>
+
+#include "libc.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: statx
+ *
+ * Description:
+ *   statx() is the Linux extended status interface.  It operates like
+ *   fstatat(), but reports the result in the Linux struct statx layout.
+ *
+ *   If the pathname given in path is relative, then it is interpreted
+ *   relative to the directory referred to by the file descriptor dirfd
+ *   (rather than relative to the current working directory of the calling
+ *   process).
+ *
+ *   If path is relative and dirfd is the special value AT_FDCWD, then
+ *   path is interpreted relative to the current working directory of the
+ *   calling process (like stat()).
+ *
+ *   If path is absolute, then dirfd is ignored.
+ *
+ *   If AT_EMPTY_PATH is set in flags and path is an empty string, then
+ *   the file referred to by dirfd itself is queried.
+ *
+ *   If AT_SYMLINK_NOFOLLOW is set in flags, then symbolic links are not
+ *   followed (like lstat()).
+ *
+ *   The AT_STATX_SYNC_TYPE values and AT_NO_AUTOMOUNT are accepted but
+ *   are no-ops: NuttX has no remote synchronization or automount
+ *   semantics.  mask is a request hint only; this implementation always
+ *   fills exactly STATX_BASIC_STATS, which Linux permits (the kernel may
+ *   return more or fewer fields than requested).
+ *
+ * Input Parameters:
+ *   dirfd - The file descriptor of the directory.
+ *   path  - A pointer to the path.
+ *   flags - AT_* flags as described above.
+ *   mask  - Requested STATX_* fields (hint, may be ignored).
+ *   buf   - The buffer to receive the extended file status.
+ *
+ * Returned Value:
+ *   Return zero on success, or -1 if an error occurred (in which case,
+ *   errno is set appropriately).
+ *
+ ****************************************************************************/
+
+int statx(int dirfd, FAR const char *path, int flags,
+          unsigned int mask, FAR struct statx *buf)
+{
+  FAR char *fullpath;
+  struct stat st;
+  int ret;
+
+  /* Sanity check the arguments (Linux reports EFAULT for NULL pointers) */
+
+  if (buf == NULL || path == NULL)
+    {
+      set_errno(EFAULT);
+      return ERROR;
+    }
+
+  if ((flags & ~(AT_SYMLINK_NOFOLLOW | AT_EMPTY_PATH | AT_NO_AUTOMOUNT |
+                 AT_STATX_SYNC_TYPE)) != 0)
+    {
+      set_errno(EINVAL);
+      return ERROR;
+    }
+
+  /* Obtain the stat data */
+
+  if (path[0] != '\0')
+    {
+      fullpath = lib_get_pathbuffer();
+      if (fullpath == NULL)
+        {
+          set_errno(ENOMEM);
+          return ERROR;
+        }
+
+      ret = lib_getfullpath(dirfd, path, fullpath, PATH_MAX);
+      if (ret < 0)
+        {
+          lib_put_pathbuffer(fullpath);
+          set_errno(-ret);
+          return ERROR;
+        }
+
+      if ((flags & AT_SYMLINK_NOFOLLOW) != 0)
+        {
+          ret = lstat(fullpath, &st);
+        }
+      else
+        {
+          ret = stat(fullpath, &st);
+        }
+
+      lib_put_pathbuffer(fullpath);
+    }
+  else if ((flags & AT_EMPTY_PATH) != 0)
+    {
+      ret = fstat(dirfd, &st);
+    }
+  else
+    {
+      set_errno(ENOENT);
+      return ERROR;
+    }
+
+  if (ret < 0)
+    {
+      return ret;
+    }
+
+  /* Translate struct stat into the Linux struct statx layout.  Fields
+   * that NuttX cannot provide (birth time, mount ID, DIO alignment,
+   * attributes) remain zero and are excluded from stx_mask.
+   */
+
+  memset(buf, 0, sizeof(*buf));
+
+  buf->stx_mask          = STATX_BASIC_STATS;
+  buf->stx_blksize       = st.st_blksize;
+  buf->stx_nlink         = st.st_nlink;
+  buf->stx_uid           = st.st_uid;
+  buf->stx_gid           = st.st_gid;
+  buf->stx_mode          = st.st_mode;
+  buf->stx_ino           = st.st_ino;
+  buf->stx_size          = st.st_size;
+  buf->stx_blocks        = st.st_blocks;
+  buf->stx_atime.tv_sec  = st.st_atim.tv_sec;
+  buf->stx_atime.tv_nsec = st.st_atim.tv_nsec;
+  buf->stx_mtime.tv_sec  = st.st_mtim.tv_sec;
+  buf->stx_mtime.tv_nsec = st.st_mtim.tv_nsec;
+  buf->stx_ctime.tv_sec  = st.st_ctim.tv_sec;
+  buf->stx_ctime.tv_nsec = st.st_ctim.tv_nsec;
+  buf->stx_rdev_major    = major(st.st_rdev);
+  buf->stx_rdev_minor    = minor(st.st_rdev);
+  buf->stx_dev_major     = major(st.st_dev);
+  buf->stx_dev_minor     = minor(st.st_dev);
+
+  return OK;
+}


### PR DESCRIPTION
## Summary

Add the Linux `statx(2)` extended-status interface to the libc as a composition of the existing `stat`/`lstat`/`fstat`/`fstatat` implementations, following the `fstatat()` pattern:

- `include/sys/stat.h`: expose the exact Linux `struct statx` / `struct statx_timestamp` ABI (fixed-width fields, so the layout is stable across toolchains and a future kernel-space implementation will not break the user-space ABI), the `STATX_*` request/result mask constants, and the `STATX_ATTR_*` attribute constants.
- `include/fcntl.h`: add the `AT_STATX_SYNC_AS_STAT` / `AT_STATX_FORCE_SYNC` / `AT_STATX_DONT_SYNC` / `AT_STATX_SYNC_TYPE` and `AT_RECURSIVE` constants.
- `libs/libc/misc/lib_statx.c`: implement `statx()` by resolving the path like `fstatat()` (via `lib_getfullpath()`) and translating the resulting `struct stat` into the `struct statx` layout.

Semantics: NuttX can only fill `STATX_BASIC_STATS`; birth time, mount ID and DIO alignment stay zero with their mask bits clear. `AT_EMPTY_PATH` is handled via `fstat()`, `AT_STATX_SYNC_*` and `AT_NO_AUTOMOUNT` are accepted as no-ops, and the `mask` argument is treated as a hint, which Linux also permits (the kernel may return more or fewer fields than requested).

Ported code that uses `statx()` (libuv, glib, libfuse, ...) now builds and runs unchanged.

## Impact

- New libc API, no existing behavior is changed. `struct stat`, `stat()`, `lstat()`, `fstat()` and `fstatat()` are untouched.
- No new Kconfig options; `statx()` is always available like the other stat family members.
- Impact on size: one new small object file in libc (`lib_statx.c`).
- Testing covered by build + boot below; the LTP statx testcases compile against this interface (they need `/proc/mounts` at runtime, so they are black-listed in the LTP port for now).

## Testing

Built and booted `sim:nsh` with this change on top of apache/master (commit `035d131b3cc`):

```
NuttShell (NSH) NuttX-10.4.0
nsh> uname -a
NuttX 10.4.0 035d131b3cc Sep  1 2026 21:37:48 sim sim
```

`ostest` passes with 0 failures:

```
ostest_main: Started user_main at PID=6
user_main: Begin argument test
...
user_main: Exiting
ostest_main: Exiting with status 0
```

`tools/checkpatch.sh -c -u -m -g apache/master..HEAD` passes.
