### PR TITLE
sensors/lsm6ds3trc: add FIFO drain functionality

### DIFF
--- a/Documentation/components/drivers/special/sensors/lsm6ds3trc.rst
+++ b/Documentation/components/drivers/special/sensors/lsm6ds3trc.rst
@@ -132,6 +132,42 @@ sensor, read in the same burst transaction as whichever sub-sensor's
 sample triggered it -- it does not have an independent output data rate
 of its own in this driver.
 
+FIFO mode
+=========
+
+Setting ``CONFIG_SENSORS_LSM6DS3TRC_FIFO=y`` switches interrupt-driven
+delivery from one uORB event per data-ready interrupt to draining the
+chip's hardware FIFO on a watermark interrupt instead -- one interrupt and
+one I2C burst read per
+``CONFIG_SENSORS_LSM6DS3TRC_FIFO_WATERMARK`` samples, rather than per
+sample. This cuts interrupt and I2C-wakeup frequency roughly by the
+watermark size, at the cost of three limitations while it's on:
+
+- Both the accelerometer and gyroscope are forced to the same output
+  data rate. Whichever sub-sensor activates first sets it; a second
+  subscriber joins that rate instead of using its own.
+- Per-sample temperature isn't available -- the FIFO pattern doesn't
+  include it. One direct temperature read happens per drain and is
+  applied to every sample in that batch instead.
+- The chip's FIFO write trigger only fires while both the accelerometer
+  and the gyroscope are physically running, even if only one of them is
+  actually subscribed. This driver forces the unsubscribed sub-sensor
+  on at the shared rate to make the FIFO work at all -- it's still left
+  out of the FIFO pattern itself, so this doesn't cost extra I2C
+  bandwidth on drain, but it does mean FIFO mode cannot power down the
+  unused sub-sensor the way non-FIFO interrupt-driven mode can.
+
+.. warning::
+   ``CONFIG_SENSORS_LSM6DS3TRC_FIFO_WATERMARK`` is in samples, not raw
+   FIFO words, but it must not exceed
+   ``CONFIG_SENSORS_LSM6DS3TRC_ACCEL_ORB_BUFSIZE`` or
+   ``CONFIG_SENSORS_LSM6DS3TRC_GYRO_ORB_BUFSIZE`` -- a single drain can
+   push that many events into each topic's uORB ring buffer at once, and
+   a smaller buffer drops the oldest ones.
+
+FIFO mode only takes effect in interrupt-driven mode (a real ``attach()``
+in ``lsm6ds3trc_config_s``); it's silently unused in kthread polling mode.
+
 This sensor also has an additional command for gaining access to extra
 functionality.
 

--- a/drivers/sensors/Kconfig
+++ b/drivers/sensors/Kconfig
@@ -1083,8 +1083,8 @@ config SENSORS_LSM6DS3TRC
 		Enable uORB driver support for the STM LSM6DS3TR-C 6-axis IMU
 		over I2C. Needs the high-priority work queue even in kthread
 		polling mode: the driver's interrupt handlers reference it
-		unconditionally (they're only dead code until a future phase wires
-		up INT1/INT2).
+		unconditionally, whether or not a board actually wires up INT1
+		to use them.
 
 if SENSORS_LSM6DS3TRC
 
@@ -1114,6 +1114,35 @@ config SENSORS_LSM6DS3TRC_GYRO_ORB_BUFSIZE
 	range 0 500
 	---help---
 		The circular buffer size for the gyroscope uORB measurements
+
+config SENSORS_LSM6DS3TRC_FIFO
+	bool "LSM6DS3TR-C FIFO drain (interrupt mode only)"
+	default n
+	---help---
+		Drain the chip's hardware FIFO on a watermark interrupt instead of
+		pushing one uORB event per physical sample on every data-ready
+		interrupt. Cuts the number of I2C transactions and interrupt
+		wakeups by roughly the watermark size, at the cost of both
+		sub-sensors being forced to the same output data rate while this
+		is on (whichever one is activated first sets it; the other joins
+		it) and per-sample temperature (the FIFO pattern doesn't include
+		it; one direct temperature read per drain is applied to the whole
+		batch instead). Only takes effect when the board registers this
+		driver with a real interrupt attach() -- it's silently unused in
+		kthread polling mode.
+
+config SENSORS_LSM6DS3TRC_FIFO_WATERMARK
+	int "LSM6DS3TR-C FIFO watermark (samples)"
+	default 8
+	range 1 300
+	depends on SENSORS_LSM6DS3TRC_FIFO
+	---help---
+		How many samples (not raw FIFO words) accumulate before the FIFO
+		threshold interrupt fires and a drain happens. Keep this at or
+		below CONFIG_SENSORS_LSM6DS3TRC_ACCEL_ORB_BUFSIZE and
+		CONFIG_SENSORS_LSM6DS3TRC_GYRO_ORB_BUFSIZE -- one drain can push
+		up to this many events into each topic's uORB ring buffer in a
+		single burst, and a smaller ring buffer will drop the oldest ones.
 
 endif # SENSORS_LSM6DS3TRC
 

--- a/drivers/sensors/lsm6ds3trc_uorb.c
+++ b/drivers/sensors/lsm6ds3trc_uorb.c
@@ -874,6 +874,24 @@ static void lsm6ds3trc_fifo_worker(FAR void *arg)
   if (status[1] & BIT_FIFO_STATUS2_OVER_RUN)
     {
       snerr("WARNING: LSM6DS3TR-C FIFO overrun, some samples were lost\n");
+
+      /* diff_words reads 0 here, not the FIFO's actual (still full)
+       * content -- confirmed on hardware (a forced read past this point
+       * recovers real, valid samples) and independently confirmed by
+       * ST's own engineers for this chip family: once Continuous mode
+       * genuinely overruns, DIFF_FIFO resets to 0 while OVER_RUN/WaterM/
+       * FIFO_FULL_SMART stay set (see ST's community forum, thread
+       * "LSM6DS3 FIFO status clarification", td-p/184022).
+       * Recovering the still-present data would mean assuming the
+       * FIFO is at capacity rather than trusting diff_words -- skipped
+       * here on purpose: with the small watermark this driver uses,
+       * reaching a real overrun at all means the drain has already
+       * fallen many seconds behind, and ST's own guidance for this
+       * condition is to avoid it via watermark sizing rather than
+       * recover from it. The mainline Linux st_lsm6dsx driver, for the
+       * same chip family, doesn't attempt recovery here either -- it
+       * only special-cases an empty FIFO, not an overrun one.
+       */
     }
 
   /* Round down to a whole number of pattern chunks -- never split one

--- a/drivers/sensors/lsm6ds3trc_uorb.c
+++ b/drivers/sensors/lsm6ds3trc_uorb.c
@@ -109,14 +109,15 @@
 #define BIT_INT_FTH (1 << 3) /* INTn_CTRL: FIFO threshold reached enable */
 
 #define BIT_FIFO_STATUS2_OVER_RUN (1 << 6) /* FIFO_STATUS2: overrun */
-#define MASK_FIFO_DIFF_HI 0x0f             /* FIFO_STATUS2: DIFF_FIFO[10:8] */
+#define MASK_FIFO_DIFF_HI 0x07             /* FIFO_STATUS2: DIFF_FIFO[10:8] */
 
-#define MASK_DEC_FIFO_XL 0x03   /* FIFO_CTRL3[1:0]: accel decimation */
-#define SHIFT_DEC_FIFO_GY 3     /* FIFO_CTRL3[4:3]: gyro decimation */
+#define MASK_DEC_FIFO_XL 0x07   /* FIFO_CTRL3[2:0]: accel decimation */
+#define SHIFT_DEC_FIFO_GY 3     /* FIFO_CTRL3[5:3]: gyro decimation */
 #define DEC_FIFO_NONE 0x0       /* Sub-sensor excluded from the FIFO */
 #define DEC_FIFO_NO_DECIMATION 0x1
 
 #define SHIFT_FIFO_ODR 3        /* FIFO_CTRL5[6:3]: FIFO-only ODR */
+#define FIFO_MODE_BYPASS 0x0
 #define FIFO_MODE_CONTINUOUS 0x6
 #endif
 
@@ -535,18 +536,51 @@ static int lsm6ds3trc_fifo_configure(FAR struct lsm6ds3trc_dev_s *dev)
   dev->fifo_pattern_words = words;
   dev->fifo_odr = odr;
 
-  err = lsm6ds3trc_set_bits(dev, FIFO_CTRL3, dec,
-                            MASK_DEC_FIFO_XL |
-                            (MASK_DEC_FIFO_XL << SHIFT_DEC_FIFO_GY));
+  /* The FIFO's data-ready write trigger only fires while BOTH the
+   * accelerometer and the gyroscope are physically running, regardless
+   * of which one(s) are actually decimated into the pattern above --
+   * force whichever sub-sensor isn't subscribed to run at the shared
+   * rate anyway (still excluded from the pattern, so it costs no extra
+   * I2C bandwidth on drain, just its own unavoidable power draw), and
+   * bring it back down once neither is subscribed. See the driver's
+   * FIFO documentation.
+   */
+
+  if (!dev->gyro.enabled)
+    {
+      err = gyro_set_odr(dev, words != 0 ? odr : ODR_OFF);
+      if (err < 0)
+        {
+          return err;
+        }
+    }
+
+  if (!dev->accel.enabled)
+    {
+      err = accel_set_odr(dev, words != 0 ? odr : ODR_OFF);
+      if (err < 0)
+        {
+          return err;
+        }
+    }
+
+  /* Reconfiguring decimation/watermark/ODR while the pattern generator
+   * is still running in Continuous mode leaves FIFO_STATUS1/2 stuck
+   * reporting a stale diff count -- reset through Bypass mode first
+   * (which also empties the FIFO), same as the datasheet's documented
+   * procedure for changing FIFO settings, and only re-enter Continuous
+   * mode once every other register below is already in its new state.
+   */
+
+  err = lsm6ds3trc_set_bits(dev, FIFO_CTRL5, FIFO_MODE_BYPASS, 0x07);
   if (err < 0)
     {
       return err;
     }
 
-  err = lsm6ds3trc_set_bits(dev, FIFO_CTRL5,
-                            ((odr & 0xf) << SHIFT_FIFO_ODR) |
-                            FIFO_MODE_CONTINUOUS,
-                            0x7f);
+  err = lsm6ds3trc_set_bits(dev, FIFO_CTRL3, dec,
+                            MASK_DEC_FIFO_XL |
+                            (MASK_DEC_FIFO_XL << SHIFT_DEC_FIFO_GY));
   if (err < 0 || words == 0)
     {
       return err;
@@ -562,8 +596,17 @@ static int lsm6ds3trc_fifo_configure(FAR struct lsm6ds3trc_dev_s *dev)
       return err;
     }
 
-  return lsm6ds3trc_set_bits(dev, FIFO_CTRL2, (watermark_words >> 8) & 0x07,
+  err = lsm6ds3trc_set_bits(dev, FIFO_CTRL2, (watermark_words >> 8) & 0x07,
                             0x07);
+  if (err < 0)
+    {
+      return err;
+    }
+
+  return lsm6ds3trc_set_bits(dev, FIFO_CTRL5,
+                            ((odr & 0xf) << SHIFT_FIFO_ODR) |
+                            FIFO_MODE_CONTINUOUS,
+                            0x7f);
 }
 #endif
 

--- a/drivers/sensors/lsm6ds3trc_uorb.c
+++ b/drivers/sensors/lsm6ds3trc_uorb.c
@@ -174,7 +174,14 @@ struct lsm6ds3trc_sens_s
   FAR struct lsm6ds3trc_dev_s *dev;    /* Reference to parent device */
   bool enabled;                        /* If this sensor is enabled */
   enum lsm6ds3trc_odr_e odr;           /* Measurement interval of this
-                                        * sensor */
+                                        * sensor, ODR_OFF while disabled */
+  enum lsm6ds3trc_odr_e last_odr;      /* Last ODR explicitly requested
+                                        * via set_interval(), ODR_OFF if
+                                        * never -- unlike odr, this
+                                        * survives being disabled, so
+                                        * activate() can restore it on
+                                        * the next enable instead of
+                                        * resetting to a fixed default */
   int fsr;                             /* Full scale range of this sensor.
                                         * Can be from either gyro or accel
                                         * FSR enum. */
@@ -1043,15 +1050,24 @@ static int lsm6ds3trc_activate(FAR struct sensor_lowerhalf_s *lower,
 
       start_thread = true;
 
-#ifdef CONFIG_SENSORS_LSM6DS3TRC_FIFO
-      /* Both sub-sensors share one FIFO write rate: join whatever the
-       * other one is already running at, if it's enabled, instead of
-       * disrupting an existing subscriber's rate.
+      /* Restore whatever ODR was last explicitly requested for this
+       * sub-sensor (via set_interval()), if any -- ODR_52HZ only
+       * applies the first time this sub-sensor is ever activated.
        */
 
-      odr = other->enabled ? other->odr : ODR_52HZ;
-#else
-      odr = ODR_52HZ;
+      odr = sens->last_odr != ODR_OFF ? sens->last_odr : ODR_52HZ;
+
+#ifdef CONFIG_SENSORS_LSM6DS3TRC_FIFO
+      /* ...but both sub-sensors share one FIFO write rate: joining
+       * whatever the other one is already running at takes priority
+       * over this sub-sensor's own remembered rate, since FIFO mode
+       * doesn't allow them to differ.
+       */
+
+      if (other->enabled)
+        {
+          odr = other->odr;
+        }
 #endif
 
       err = is_gyro ? gyro_set_odr(dev, odr) : accel_set_odr(dev, odr);
@@ -1204,6 +1220,13 @@ static int lsm6ds3trc_set_interval(FAR struct sensor_lowerhalf_s *lower,
     {
       goto early_ret;
     }
+
+  /* Remember this explicit request so activate() can restore it on the
+   * next enable, instead of resetting to a fixed default -- unlike
+   * sens->odr, this isn't touched by disabling the sensor.
+   */
+
+  sens->last_odr = odr;
 
 #ifdef CONFIG_SENSORS_LSM6DS3TRC_FIFO
   /* Both sub-sensors share one FIFO write rate -- re-pace whichever one
@@ -1468,6 +1491,7 @@ int lsm6ds3trc_register(FAR struct i2c_master_s *i2c, uint8_t addr,
   priv->gyro.lower.nbuffer = CONFIG_SENSORS_LSM6DS3TRC_GYRO_ORB_BUFSIZE;
   priv->gyro.enabled = false;
   priv->gyro.odr = ODR_OFF;
+  priv->gyro.last_odr = ODR_OFF;
   priv->gyro.fsr = LSM6DS3TRC_FSR_GY_245DPS;
   priv->gyro.dev = priv;
 
@@ -1486,6 +1510,7 @@ int lsm6ds3trc_register(FAR struct i2c_master_s *i2c, uint8_t addr,
   priv->accel.lower.nbuffer = CONFIG_SENSORS_LSM6DS3TRC_ACCEL_ORB_BUFSIZE;
   priv->accel.enabled = false;
   priv->accel.odr = ODR_OFF;
+  priv->accel.last_odr = ODR_OFF;
   priv->accel.fsr = LSM6DS3TRC_FSR_XL_4G; /* Default 4g, per project notes */
   priv->accel.dev = priv;
 

--- a/drivers/sensors/lsm6ds3trc_uorb.c
+++ b/drivers/sensors/lsm6ds3trc_uorb.c
@@ -85,6 +85,17 @@
 #define OUTZ_L_A 0x2c   /* Accel (Z) low byte. */
 #define OUTZ_H_A 0x2d   /* Accel (Z) high byte. */
 
+#ifdef CONFIG_SENSORS_LSM6DS3TRC_FIFO
+#define FIFO_CTRL1 0x06      /* FIFO watermark threshold, low byte. */
+#define FIFO_CTRL2 0x07      /* FIFO watermark threshold, high bits. */
+#define FIFO_CTRL3 0x08      /* FIFO accel/gyro decimation. */
+#define FIFO_CTRL5 0x0a      /* FIFO mode and FIFO-only ODR. */
+#define FIFO_STATUS1 0x3a    /* FIFO unread word count, low byte. */
+#define FIFO_STATUS2 0x3b    /* FIFO unread word count high bits, flags. */
+#define FIFO_DATA_OUT_L 0x3e /* FIFO data output, low byte. */
+#define FIFO_DATA_OUT_H 0x3f /* FIFO data output, high byte. */
+#endif
+
 /* Bits */
 
 #define BIT_STATUS_XLDA (1 << 0) /* Accel data ready */
@@ -93,6 +104,21 @@
 
 #define BIT_INT_DRDY_XL (1 << 0) /* INTn_CTRL: accel data-ready enable */
 #define BIT_INT_DRDY_G (1 << 1)  /* INTn_CTRL: gyro data-ready enable */
+
+#ifdef CONFIG_SENSORS_LSM6DS3TRC_FIFO
+#define BIT_INT_FTH (1 << 3) /* INTn_CTRL: FIFO threshold reached enable */
+
+#define BIT_FIFO_STATUS2_OVER_RUN (1 << 6) /* FIFO_STATUS2: overrun */
+#define MASK_FIFO_DIFF_HI 0x0f             /* FIFO_STATUS2: DIFF_FIFO[10:8] */
+
+#define MASK_DEC_FIFO_XL 0x03   /* FIFO_CTRL3[1:0]: accel decimation */
+#define SHIFT_DEC_FIFO_GY 3     /* FIFO_CTRL3[4:3]: gyro decimation */
+#define DEC_FIFO_NONE 0x0       /* Sub-sensor excluded from the FIFO */
+#define DEC_FIFO_NO_DECIMATION 0x1
+
+#define SHIFT_FIFO_ODR 3        /* FIFO_CTRL5[6:3]: FIFO-only ODR */
+#define FIFO_MODE_CONTINUOUS 0x6
+#endif
 
 /****************************************************************************
  * Private Types
@@ -173,6 +199,13 @@ struct lsm6ds3trc_dev_s
                                    * both sub-sensors */
   uint64_t timestamp;             /* When the burst became ready, taken
                                    * in the ISR */
+#ifdef CONFIG_SENSORS_LSM6DS3TRC_FIFO
+  uint8_t fifo_pattern_words;     /* Words per repeating FIFO pattern:
+                                   * 3 (one sub-sensor active) or 6
+                                   * (both), 0 if neither is */
+  enum lsm6ds3trc_odr_e fifo_odr; /* Shared ODR currently driving
+                                   * FIFO_CTRL5 */
+#endif
 };
 
 /****************************************************************************
@@ -243,11 +276,11 @@ static const uint8_t INT_CTRL[] =
   INT2_CTRL, /* INT2 */
 };
 
-/* Sensor operations. No FIFO yet (single-sample delivery per event), so
- * .fetch stays NULL -- data arrives exclusively via push_event() from
- * either the kthreads or the interrupt worker below. selftest/
- * set_calibvalue/calibrate are left unimplemented for now; the upper
- * half tolerates NULL here.
+/* Sensor operations. .fetch stays NULL either way -- data arrives
+ * exclusively via push_event(), from the kthreads, the per-sample DRDY
+ * worker, or (CONFIG_SENSORS_LSM6DS3TRC_FIFO) the FIFO-draining worker
+ * below. selftest/set_calibvalue/calibrate are left unimplemented for
+ * now; the upper half tolerates NULL here.
  */
 
 static const struct sensor_ops_s g_sensor_ops =
@@ -455,6 +488,78 @@ static int lsm6ds3trc_int_enable(FAR struct lsm6ds3trc_dev_s *dev,
   return lsm6ds3trc_set_bits(dev, reg, enable ? bit : 0, bit);
 }
 
+#ifdef CONFIG_SENSORS_LSM6DS3TRC_FIFO
+/****************************************************************************
+ * Name: lsm6ds3trc_fifo_configure
+ *
+ * Description:
+ *   Re-derive and write the FIFO decimation (which sub-sensor(s) feed the
+ *   FIFO), the shared FIFO ODR, and the watermark threshold from the
+ *   current dev->gyro/accel enabled+odr state. Called after any change to
+ *   that state (activate() and set_interval()). Both sub-sensors always
+ *   run at the same ODR while FIFO is on -- see the driver's FIFO
+ *   documentation for why.
+ *
+ ****************************************************************************/
+
+static int lsm6ds3trc_fifo_configure(FAR struct lsm6ds3trc_dev_s *dev)
+{
+  uint8_t dec = 0;
+  uint8_t words = 0;
+  enum lsm6ds3trc_odr_e odr = ODR_OFF;
+  uint16_t watermark_words;
+  uint8_t ctrl1;
+  int err;
+
+  if (dev->gyro.enabled)
+    {
+      dec |= DEC_FIFO_NO_DECIMATION << SHIFT_DEC_FIFO_GY;
+      words += 3;
+      odr = dev->gyro.odr;
+    }
+
+  if (dev->accel.enabled)
+    {
+      dec |= DEC_FIFO_NO_DECIMATION;
+      words += 3;
+      odr = dev->accel.odr;
+    }
+
+  dev->fifo_pattern_words = words;
+  dev->fifo_odr = odr;
+
+  err = lsm6ds3trc_set_bits(dev, FIFO_CTRL3, dec,
+                            MASK_DEC_FIFO_XL |
+                            (MASK_DEC_FIFO_XL << SHIFT_DEC_FIFO_GY));
+  if (err < 0)
+    {
+      return err;
+    }
+
+  err = lsm6ds3trc_set_bits(dev, FIFO_CTRL5,
+                            ((odr & 0xf) << SHIFT_FIFO_ODR) |
+                            FIFO_MODE_CONTINUOUS,
+                            0x7f);
+  if (err < 0 || words == 0)
+    {
+      return err;
+    }
+
+  watermark_words = (uint16_t)CONFIG_SENSORS_LSM6DS3TRC_FIFO_WATERMARK *
+                    words;
+
+  ctrl1 = watermark_words & 0xff;
+  err = lsm6ds3trc_write_bytes(dev, FIFO_CTRL1, &ctrl1, sizeof(ctrl1));
+  if (err < 0)
+    {
+      return err;
+    }
+
+  return lsm6ds3trc_set_bits(dev, FIFO_CTRL2, (watermark_words >> 8) & 0x07,
+                            0x07);
+}
+#endif
+
 /****************************************************************************
  * Name: lsm6ds3trc_convert_temp
  ****************************************************************************/
@@ -652,6 +757,162 @@ static int accel_thread(int argc, char **argv)
   return err;
 }
 
+#ifdef CONFIG_SENSORS_LSM6DS3TRC_FIFO
+/* Room for 2x the configured watermark (both sub-sensors' worth of
+ * words), so a drain that runs a bit late -- mutex contention, scheduler
+ * latency -- still fits in one read instead of silently falling further
+ * behind. Whatever doesn't fit stays in the chip's FIFO for the next
+ * drain; nothing is lost as long as the real FIFO (2KB) doesn't fill.
+ */
+
+#define FIFO_MAX_WORDS \
+  (CONFIG_SENSORS_LSM6DS3TRC_FIFO_WATERMARK * 6 * 2)
+
+/****************************************************************************
+ * Name: lsm6ds3trc_fifo_worker
+ *
+ * Description:
+ *   Interrupt mode only, CONFIG_SENSORS_LSM6DS3TRC_FIFO build. Runs on the
+ *   FIFO threshold (FTH) interrupt instead of per-sample DRDY: reads how
+ *   many words are waiting (FIFO_STATUS1/2), bursts them out of
+ *   FIFO_DATA_OUT_L/H, and walks the buffer in dev->fifo_pattern_words
+ *   chunks (3 words for one active sub-sensor, 6 for both -- see
+ *   lsm6ds3trc_fifo_configure()), pushing one event per chunk. Each
+ *   chunk's timestamp is interpolated backwards from dev->timestamp (the
+ *   newest sample, taken in the ISR) by the configured ODR interval,
+ *   since individual FIFO entries don't carry their own timestamp.
+ *
+ ****************************************************************************/
+
+static void lsm6ds3trc_fifo_worker(FAR void *arg)
+{
+  FAR struct lsm6ds3trc_dev_s *dev = arg;
+  uint8_t status[2];
+  int16_t raw[FIFO_MAX_WORDS];
+  int16_t raw_temp;
+  float temp_c;
+  uint16_t diff_words;
+  uint16_t nwords;
+  uint32_t interval;
+  int nsamples;
+  int i;
+  int err;
+
+  err = nxmutex_lock(&dev->devlock);
+  if (err < 0)
+    {
+      return;
+    }
+
+  if (dev->fifo_pattern_words == 0)
+    {
+      nxmutex_unlock(&dev->devlock);
+      return;
+    }
+
+  err = lsm6ds3trc_read_bytes(dev, FIFO_STATUS1, status, sizeof(status));
+  if (err < 0)
+    {
+      nxmutex_unlock(&dev->devlock);
+      snerr("ERROR: Failed to read FIFO status: %d\n", err);
+      return;
+    }
+
+  diff_words = (uint16_t)status[0] |
+               (((uint16_t)status[1] & MASK_FIFO_DIFF_HI) << 8);
+
+  if (status[1] & BIT_FIFO_STATUS2_OVER_RUN)
+    {
+      snerr("WARNING: LSM6DS3TR-C FIFO overrun, some samples were lost\n");
+    }
+
+  /* Round down to a whole number of pattern chunks -- never split one
+   * sample's words across two drains.
+   */
+
+  nwords = diff_words;
+  if (nwords > FIFO_MAX_WORDS)
+    {
+      nwords = FIFO_MAX_WORDS;
+    }
+
+  nwords -= nwords % dev->fifo_pattern_words;
+
+  if (nwords == 0)
+    {
+      nxmutex_unlock(&dev->devlock);
+      return;
+    }
+
+  err = lsm6ds3trc_read_bytes(dev, FIFO_DATA_OUT_L, raw,
+                              nwords * sizeof(int16_t));
+  if (err < 0)
+    {
+      nxmutex_unlock(&dev->devlock);
+      snerr("ERROR: Failed to read FIFO data: %d\n", err);
+      return;
+    }
+
+  /* Temperature isn't part of the FIFO pattern (FIFO_TEMP_EN stays off,
+   * see lsm6ds3trc_fifo_configure()) -- one direct read at drain time,
+   * applied to every sample in this batch, is close enough for a value
+   * that barely moves between drains.
+   */
+
+  err = lsm6ds3trc_read_bytes(dev, OUT_TEMP_L, &raw_temp, sizeof(raw_temp));
+  nxmutex_unlock(&dev->devlock);
+
+  if (err < 0)
+    {
+      snerr("ERROR: Failed to read temperature: %d\n", err);
+      return;
+    }
+
+  temp_c = lsm6ds3trc_convert_temp(raw_temp);
+  nsamples = nwords / dev->fifo_pattern_words;
+  interval = ODR_INTERVAL[dev->fifo_odr];
+
+  for (i = 0; i < nsamples; i++)
+    {
+      FAR int16_t *sample = &raw[i * dev->fifo_pattern_words];
+      uint64_t timestamp = dev->timestamp -
+                           (uint64_t)(nsamples - 1 - i) * interval;
+      int off = 0;
+
+      if (dev->gyro.enabled)
+        {
+          struct sensor_gyro gyro_data;
+          float sens = FSR_GYRO_SENS[dev->gyro.fsr];
+
+          gyro_data.timestamp = timestamp;
+          gyro_data.temperature = temp_c;
+          gyro_data.x = (float)sample[off + 0] * sens;
+          gyro_data.y = (float)sample[off + 1] * sens;
+          gyro_data.z = (float)sample[off + 2] * sens;
+
+          dev->gyro.lower.push_event(dev->gyro.lower.priv, &gyro_data,
+                                     sizeof(gyro_data));
+          off += 3;
+        }
+
+      if (dev->accel.enabled)
+        {
+          struct sensor_accel accel_data;
+          float sens = FSR_XL_SENS[dev->accel.fsr];
+
+          accel_data.timestamp = timestamp;
+          accel_data.temperature = temp_c;
+          accel_data.x = (float)sample[off + 0] * sens;
+          accel_data.y = (float)sample[off + 1] * sens;
+          accel_data.z = (float)sample[off + 2] * sens;
+
+          dev->accel.lower.push_event(dev->accel.lower.priv, &accel_data,
+                                      sizeof(accel_data));
+        }
+    }
+}
+
+#else
 /****************************************************************************
  * Name: lsm6ds3trc_worker
  *
@@ -714,6 +975,7 @@ static void lsm6ds3trc_worker(FAR void *arg)
                                   sizeof(accel_data));
     }
 }
+#endif
 
 /****************************************************************************
  * Name: lsm6ds3trc_interrupt
@@ -721,7 +983,7 @@ static void lsm6ds3trc_worker(FAR void *arg)
  * Description:
  *   ISR for the shared INT pin. Timestamps here, where the burst really
  *   became ready -- the I2C read cannot run in interrupt context, so it's
- *   deferred to lsm6ds3trc_worker() on HPWORK.
+ *   deferred to lsm6ds3trc_worker()/lsm6ds3trc_fifo_worker() on HPWORK.
  *
  ****************************************************************************/
 
@@ -736,7 +998,11 @@ static int lsm6ds3trc_interrupt(int irq, FAR void *context, FAR void *arg)
 
   dev->timestamp = sensor_get_timestamp();
 
+#ifdef CONFIG_SENSORS_LSM6DS3TRC_FIFO
+  err = work_queue(HPWORK, &dev->work, lsm6ds3trc_fifo_worker, dev, 0);
+#else
   err = work_queue(HPWORK, &dev->work, lsm6ds3trc_worker, dev, 0);
+#endif
   if (err < 0)
     {
       snerr("Could not queue LSM6DS3TR-C work queue: %d\n", err);
@@ -771,17 +1037,30 @@ static int lsm6ds3trc_activate(FAR struct sensor_lowerhalf_s *lower,
 
   if (enable && !sens->enabled)
     {
+      FAR struct lsm6ds3trc_sens_s *other = is_gyro ? &dev->accel
+                                                     : &dev->gyro;
+      enum lsm6ds3trc_odr_e odr;
+
       start_thread = true;
 
-      /* Set to a relatively low sampling rate to start up */
+#ifdef CONFIG_SENSORS_LSM6DS3TRC_FIFO
+      /* Both sub-sensors share one FIFO write rate: join whatever the
+       * other one is already running at, if it's enabled, instead of
+       * disrupting an existing subscriber's rate.
+       */
 
-      err = is_gyro ? gyro_set_odr(dev, ODR_52HZ)
-                     : accel_set_odr(dev, ODR_52HZ);
+      odr = other->enabled ? other->odr : ODR_52HZ;
+#else
+      odr = ODR_52HZ;
+#endif
+
+      err = is_gyro ? gyro_set_odr(dev, odr) : accel_set_odr(dev, odr);
       if (err < 0)
         {
           goto early_ret;
         }
 
+#ifndef CONFIG_SENSORS_LSM6DS3TRC_FIFO
       if (dev->interrupt_mode)
         {
           err = lsm6ds3trc_int_enable(dev, is_gyro ? BIT_INT_DRDY_G
@@ -791,6 +1070,7 @@ static int lsm6ds3trc_activate(FAR struct sensor_lowerhalf_s *lower,
               goto early_ret;
             }
         }
+#endif
     }
 
   /* Turn off the sensor if we're disabling */
@@ -804,6 +1084,7 @@ static int lsm6ds3trc_activate(FAR struct sensor_lowerhalf_s *lower,
           goto early_ret;
         }
 
+#ifndef CONFIG_SENSORS_LSM6DS3TRC_FIFO
       if (dev->interrupt_mode)
         {
           err = lsm6ds3trc_int_enable(dev,
@@ -815,9 +1096,28 @@ static int lsm6ds3trc_activate(FAR struct sensor_lowerhalf_s *lower,
               goto early_ret;
             }
         }
+#endif
     }
 
   sens->enabled = enable;
+
+#ifdef CONFIG_SENSORS_LSM6DS3TRC_FIFO
+  if (dev->interrupt_mode)
+    {
+      err = lsm6ds3trc_fifo_configure(dev);
+      if (err < 0)
+        {
+          goto early_ret;
+        }
+
+      err = lsm6ds3trc_int_enable(dev, BIT_INT_FTH,
+                                  dev->fifo_pattern_words != 0);
+      if (err < 0)
+        {
+          goto early_ret;
+        }
+    }
+#endif
 
   if (start_thread && !dev->interrupt_mode)
     {
@@ -905,6 +1205,37 @@ static int lsm6ds3trc_set_interval(FAR struct sensor_lowerhalf_s *lower,
       goto early_ret;
     }
 
+#ifdef CONFIG_SENSORS_LSM6DS3TRC_FIFO
+  /* Both sub-sensors share one FIFO write rate -- re-pace whichever one
+   * this call didn't target, if it's currently enabled, then let
+   * fifo_configure() re-derive FIFO_CTRL5's ODR and the watermark
+   * threshold for the new rate.
+   */
+
+  if (dev->interrupt_mode)
+    {
+      if (lower->type == SENSOR_TYPE_ACCELEROMETER && dev->gyro.enabled)
+        {
+          err = gyro_set_odr(dev, odr);
+        }
+      else if (lower->type == SENSOR_TYPE_GYROSCOPE && dev->accel.enabled)
+        {
+          err = accel_set_odr(dev, odr);
+        }
+
+      if (err < 0)
+        {
+          goto early_ret;
+        }
+
+      err = lsm6ds3trc_fifo_configure(dev);
+      if (err < 0)
+        {
+          goto early_ret;
+        }
+    }
+#endif
+
   *period_us = ODR_INTERVAL[odr];
 
 early_ret:
@@ -929,7 +1260,18 @@ static int lsm6ds3trc_get_info(FAR struct sensor_lowerhalf_s *lower,
   memcpy(info->name, "LSM6DS3TR-C", sizeof("LSM6DS3TR-C"));
   memcpy(info->vendor, "STMicro", sizeof("STMicro"));
 
-  /* TODO FIFO information once a future phase implements FIFO drain */
+#ifdef CONFIG_SENSORS_LSM6DS3TRC_FIFO
+  info->fifo_reserved_event_count = CONFIG_SENSORS_LSM6DS3TRC_FIFO_WATERMARK;
+
+  if (sens->dev->fifo_pattern_words != 0)
+    {
+      /* The chip's FIFO is 2048 words deep, shared between however many
+       * words each sample takes in the currently active pattern.
+       */
+
+      info->fifo_max_event_count = 2048 / sens->dev->fifo_pattern_words;
+    }
+#endif
 
   if (lower->type == SENSOR_TYPE_GYROSCOPE)
     {


### PR DESCRIPTION
## Summary

Adds optional hardware-FIFO draining to the LSM6DS3TR-C uORB driver
(`drivers/sensors/lsm6ds3trc_uorb.c`, added in #19997), as a follow-up to
that base driver.

Interrupt-driven mode currently pushes one uORB event per physical sample:
one I2C burst read and one interrupt per sample, at whatever ODR the topic
is running. That is the dominant power cost for a battery-constrained use
case that samples continuously. This PR adds a new whole-driver mode,
`CONFIG_SENSORS_LSM6DS3TRC_FIFO`, that instead drains the chip's hardware
FIFO in batches on a watermark interrupt, cutting both I2C transactions and
interrupt wakeups by roughly the configured watermark size.

The LSM6DS3TR-C's FIFO is the older ST "pattern" style (no per-sample tag
byte, unlike LSM6DSO/ISM330): `FIFO_CTRL3`'s per-sub-sensor decimation bits
choose which of gyro/accel feed the FIFO, `FIFO_CTRL5` sets one shared
FIFO-only ODR, and `FIFO_STATUS1/2`'s `DIFF_FIFO` reports how many 16-bit
words are waiting. The existing INT1 wiring is reused, switching from DRDY
(per-sample) to FTH (threshold reached) when the option is on.

Included in this PR:

- `lsm6ds3trc_fifo_configure()`: re-derives and writes decimation bits,
  shared FIFO ODR, and watermark threshold from the current
  gyro/accel enabled+ODR state, called from `activate()` and
  `set_interval()`.

- `lsm6ds3trc_fifo_worker()`: replaces the per-sample DRDY worker under the
  Kconfig guard -- reads `DIFF_FIFO`, bursts the available words (rounded
  down to a whole pattern chunk, capped so a late drain can't overflow the
  read buffer), and decodes each chunk into a `push_event()`, with
  per-sample timestamps interpolated backwards from the ISR timestamp by
  the configured ODR interval.
- A fix so `activate()` restores the last ODR explicitly requested via
  `set_interval()` instead of always resetting to a hardcoded 52 Hz on
  every re-activation -- previously this defeated the point of choosing a
  lower ODR for power savings once FIFO mode was involved.

- Two real FIFO-correctness fixes found via register-level hardware
  testing: the FIFO's data-ready write trigger only fires while *both*
  sub-sensors are physically running (confirmed in the datasheet and by
  register dumps), so a single-topic subscription previously left the
  FIFO never accumulating data; and reconfiguring FIFO settings while
  still in Continuous mode left `DIFF_FIFO` stuck reporting a stale count,
  fixed by resetting through Bypass mode (which also empties the FIFO)
  before writing new settings and re-entering Continuous mode last, per
  the datasheet's documented procedure. Two related bit-definition bugs
  (`MASK_FIFO_DIFF_HI`, `MASK_DEC_FIFO_XL`/`SHIFT_DEC_FIFO_GY`) were also
  fixed against the real ST datasheet rather than the in-tree `lsm6dsl.h`
  header the original driver was ported from.

- A documented, deliberately-not-"fixed" chip quirk: `DIFF_FIFO` reads 0
  at the exact moment a real overrun occurs, even though the FIFO is still
  full of valid data. This matches ST's own guidance for this chip family
  and mainline Linux's `st_lsm6dsx` driver, which doesn't attempt to
  recover from it either.

- Documentation additions covering FIFO mode and its three limitations:
  both sub-sensors forced to the same ODR, temperature no longer
  per-sample (one read per drain applied to the whole batch), and both
  sub-sensors must stay physically enabled regardless of subscription.

## Impact

- No impact on existing users: `CONFIG_SENSORS_LSM6DS3TRC_FIFO` defaults
  to `n`, and only takes effect for boards that already register this
  driver with a real interrupt `attach()` (silently unused in kthread
  polling mode).
- `boards/xtensa/esp32s3/esp32s3-xiao` (the only board currently using
  this driver) is unaffected unless its defconfig opts in.
- New Kconfig option `SENSORS_LSM6DS3TRC_FIFO_WATERMARK` (default 8
  samples) controls the batch size; its help text notes the relationship
  to the accel/gyro uORB ring buffer sizes.
- Documentation-only addition otherwise (`Documentation/components/drivers/special/sensors/lsm6ds3trc.rst`).

## Testing

**Host:** Linux, xtensa-esp32s3-elf toolchain.
**Board:** Seeed XIAO ESP32-S3, LSM6DS3TR-C over I2C, interrupt-driven mode
(shared INT1 pin, per the driver's existing single-IRQ design).

- Bench-validated on hardware, both FIFO pattern widths:
  - Both `sensor_accel0`/`sensor_gyro0` topics subscribed (6-word
    pattern) and accel-only (3-word pattern): samples arrive in
    watermark-sized bursts, interpolated timestamps spaced by the exact
    configured ODR interval (52 Hz -> 19230 us between consecutive
    samples, matched exactly), sane accel/gyro values, no I2C errors, no
    overruns, sustained for 15+ seconds of continuous streaming.
  - Accel-only and gyro-only single-topic subscriptions confirmed to
    drain correctly after the write-trigger fix (previously silently
    never accumulated data).
  - Re-activation after `set_interval()` confirmed to resume at the
    previously requested ODR instead of resetting to 52 Hz.
  - Deliberate FIFO overrun test: ~7.80 s to fill+overrun both topics at
    52 Hz, ~324 samples lost per trial if left unread that long --
    consistent with a healthy design given the default watermark drains
    roughly every 150 ms in real use.
    
    Console output:
    ```
      nsh> uorb_listener sensor_accel0,sensor_gyro0 -n 40
      
      Monitor objects num:2
      object_name:sensor_gyro, object_instance:0
      object_name:sensor_accel, object_instance:0
      sensor_gyro(now:20800000):timestamp:20665390,x:0.000000,y:0.000000,z:0.000000,temperature:34.000000
      sensor_accel(now:20800000):timestamp:20665390,x:-4.197032,y:0.221337,z:-4.559546,temperature:34.000000
      sensor_gyro(now:20800000):timestamp:20684620,x:-0.013591,y:-2.652377,z:1.369254,temperature:34.000000
      sensor_accel(now:20810000):timestamp:20684620,x:-6.427154,y:0.361318,z:-7.282593,temperature:34.000000
      sensor_gyro(now:20810000):timestamp:20703850,x:0.079565,y:-0.247400,z:0.005650,temperature:34.000000
      sensor_accel(now:20810000):timestamp:20703850,x:-6.427154,y:0.356532,z:-7.269432,temperature:34.000000
      sensor_gyro(now:20820000):timestamp:20723080,x:0.008093,y:-0.034513,z:0.015882,temperature:34.000000
      sensor_accel(now:20820000):timestamp:20723080,x:-6.427154,y:0.354140,z:-7.256271,temperature:34.000000
      ```