### PR TITLE
fs/inode: propagate inode search errors

### DIFF
--- a/fs/inode/fs_inodereserve.c
+++ b/fs/inode/fs_inodereserve.c
@@ -53,6 +53,7 @@ static ino_t g_ino;
 static int inode_namelen(FAR const char *name)
 {
   FAR const char *tmp = name;
+
   while (*tmp && *tmp != '/')
     {
       tmp++;
@@ -210,13 +211,17 @@ int inode_reserve(FAR const char *path,
   SETUP_SEARCH(&desc, path, false);
 
   ret = inode_search(&desc);
-  if (ret >= 0)
+  if (ret != -ENOENT)
     {
       /* It is an error if the node already exists in the tree (or if it
        * lies within a mountpoint, we don't distinguish here).
        */
 
-      ret = -EEXIST;
+      if (ret >= 0)
+        {
+          ret = -EEXIST;
+        }
+
       goto errout_with_search;
     }
 
@@ -249,6 +254,7 @@ int inode_reserve(FAR const char *path,
        */
 
       FAR const char *nextname = inode_nextname(name);
+
       if (*nextname != '\0')
         {
           /* Insert an operationless node */


### PR DESCRIPTION
## Summary

Fix `inode_reserve()` to propagate inode search errors instead of continuing
inode creation for every negative return from `inode_search()`.

`inode_search()` returns `-ENOENT` when the path is valid but the target inode
does not exist yet. Other negative returns indicate an actual lookup or path
error, such as `-ENAMETOOLONG`.

Previously, `inode_reserve()` continued processing any negative return. For an
overlong pathname, this could leave the insertion metadata invalid and reach
`inode_insert()` with a `NULL` parent, triggering an assertion.

This change allows inode creation to continue only when `inode_search()` returns
`-ENOENT`. All other errors are propagated through the existing cleanup path.

## Testing

Tested on the NuttX simulator with ProcFS, TMPFS, and ASan enabled.
No ASan error was reported during the tests.

### 1. Regression test: overlong pathname

#### Before the fix

Running an overlong mount path:

```text
nsh> mount -t tmpfs tmpfs /tmp/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
````

triggered:

```text
dump_assert_info: Assertion failed parent != ((void*)0):
at file: inode/fs_inodereserve.c:140
task: nsh_main
```

The simulator therefore hit the `NULL` parent assertion in `inode_reserve()`.

#### After the fix

The same command returned:

```text
nsh> mount -t tmpfs tmpfs /tmp/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
nsh: mount: mount failed: 36
```

where `36` is `ENAMETOOLONG`.

No assertion or crash occurred.

### 2. Valid pathname / normal inode creation

A valid mount was verified:

```text
nsh> mount -t tmpfs tmpfs /a
nsh>
```

The mount was then confirmed with:

```text
nsh> mount
  /a type tmpfs
  /bin type binfs
  /data type hostfs
  /etc type romfs
  /proc type procfs
  /tmp type tmpfs
```

This confirms that valid inode creation and mounting still work after the change.

### 3. Existing inode handling

Created `/a/b` and then attempted to create it again:

```text
nsh> mkdir /a/b
nsh>
nsh> mkdir /a/b
nsh: /a/b: mkdir failed: 17
```

where `17` is `EEXIST`.

This confirms that an existing inode is still handled as an existing target
rather than being treated as a missing inode.

### 4. Build

The NuttX simulator build completed successfully with `CONFIG_SIM_ASAN=y`:

```text
Create version.h
LD: nuttx
...
SIM elf with dynamic libs archive in nuttx.tgz
BUILD EXIT CODE: 0
```

### 5. Static checks

The following checks passed:

```text
git diff --check
tools/checkpatch.sh -g HEAD
```

### 6. PATH_MAX-specific case

A separate runtime test targeting the `PATH_MAX` limit was attempted, but the
long NSH input could not be delivered reliably in the simulator environment.
Therefore, no `PATH_MAX` runtime result is claimed here.
