### PR TITLE
arch/arm/stm32: set F412 SRAM1_END to 256KiB

### DIFF
--- a/arch/arm/src/common/stm32/stm32_allocateheap_m3m4_v1.c
+++ b/arch/arm/src/common/stm32/stm32_allocateheap_m3m4_v1.c
@@ -329,10 +329,15 @@
  *
  *   5) 64Kib of System SRAM beginning at address 0x2002:0000
  *
+ * The STM32F412 family has 256KiB of System SRAM in one bank and no CCM:
+ *
+ *   6) 256KiB of System SRAM beginning at address 0x2000:0000
+ *
  * As determined by the linker script, g_heapbase lies in the 112KiB memory
  * region and that extends to 0x2001:0000.  But the  first and second memory
  * regions are contiguous and treated as one in this logic that extends to
- * 0x2002:0000 (or 0x2003:0000 for the F427/F437/F429/F439).
+ * 0x2002:0000 (or 0x2003:0000 for the F427/F437/F429/F439, or 0x2004:0000
+ * for the F412).
  *
  * As a complication, CCM SRAM cannot be used for DMA.  So, if STM32 DMA is
  * enabled, CCM SRAM should probably be excluded from the heap or the
@@ -363,6 +368,8 @@
 #    define SRAM1_END 0x20008000
 #  elif defined(CONFIG_STM32_STM32F427) || defined(CONFIG_STM32_STM32F429)
 #    define SRAM1_END 0x20030000
+#  elif defined(CONFIG_STM32_STM32F412)
+#    define SRAM1_END 0x20040000
 #  elif defined(CONFIG_STM32_STM32F446)
 #    define SRAM1_END 0x20020000
 #  elif defined(CONFIG_STM32_STM32F469)


### PR DESCRIPTION
## Summary
The STM32F412 has 256 KiB of system SRAM at `0x20000000` and no CCM. The F2/F4 heap map never named it, so `SRAM1_END` fell through to the 128 KiB default at `0x20020000` and the upper half was left out of the heap.

## Impact
- New feature: NO
- Impact on user: YES, F412 boards get the upper 128 KiB of SRAM in the heap.
- Impact on build: NO
- Impact on hardware: NO
- Impact on documentation: NO
- Impact on security: NO
- Impact on compatibility: NO

## Testing
`nxstyle` clean on `arch/arm/src/common/stm32/stm32_allocateheap_m3m4_v1.c`. PX4 carry is PX4/NuttX (10.3) and a matching 12.12 backport; those rebuild `ark_can-flow-mr_canbootloader` / `ark_cannode_canbootloader` with `CONFIG_ARCH_CHIP_STM32F412VG` / `CG`.