### PR TITLE
ci: apply Depends-On dependencies to the memory report

### DIFF
--- a/.github/scripts/depends_on.py
+++ b/.github/scripts/depends_on.py
@@ -23,8 +23,12 @@ Markdown code blocks. Repositories are restricted to ``NUTTX_REPO`` and
 
 CLI:
     python3 depends_on.py                 # print result JSON
-    python3 depends_on.py --print-state   # print state used by the edit gate
+    python3 depends_on.py --print-state   # status line, then one ref per line
     python3 depends_on.py --github-output # write workflow outputs and report
+
+The --print-state output is a contract rather than a debugging aid: the first
+line is the status and every remaining line is a reference in declaration
+order. It is parsed by membrowse-report.yml and pinned by test_depends_on.py.
 """
 
 from __future__ import annotations

--- a/.github/workflows/membrowse-report.yml
+++ b/.github/workflows/membrowse-report.yml
@@ -7,8 +7,10 @@ on:
       - master
       - "releases/*"
 
+# pull-requests read: needed to re-read edited Depends-On declarations on re-runs.
 permissions:
   contents: read
+  pull-requests: read
 
 # Per-PR group so superseded PR pushes cancel; per-SHA on push so master
 # commits never share a group. A shared refs/heads/master group lets a burst
@@ -186,6 +188,152 @@ jobs:
 
       - name: After CLEAN-UP Disk Space
         run: df -h
+
+      # Apply declared nuttx/apps dependencies before measuring, matching
+      # build.yml's checkout mapping and cherry-pick order. API or parser
+      # failures and parsed dependencies that cannot be applied are fatal, so a
+      # report is never taken from the wrong source set. Keep this after the
+      # disk cleanup: applying a dependency deepens a checkout.
+      - name: Apply depends-on PRs
+        if: ${{ github.event_name == 'pull_request' && github.base_ref == 'master' }}
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -uo pipefail
+
+          # Re-read the current body so a re-run picks up an edited Depends-On
+          # line. Do not fall back to the event payload: unlike build.yml, which
+          # resolves this once for every target, each matrix leg resolves
+          # independently and could otherwise use a different declaration.
+          if ! PR_BODY="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.body // ""')"; then
+            echo "::error::Could not read the PR description."
+            exit 1
+          fi
+
+          # A missing parser, a crash, or an unknown status all leave the
+          # declaration unevaluated.
+          PARSER=sources/nuttx/.github/scripts/depends_on.py
+          if [ ! -f "$PARSER" ]; then
+            echo "::error::${PARSER} not found."
+            exit 1
+          fi
+
+          STATE="${RUNNER_TEMP:-/tmp}/depends-on-state.txt"
+          if ! python3 "$PARSER" --print-state > "$STATE"; then
+            echo "::error::Could not parse the depends-on declarations."
+            exit 1
+          fi
+
+          # --print-state omits warnings. Run --github-output again with its
+          # outputs and report discarded so dropped entries remain visible as
+          # workflow annotations.
+          if ! WARNINGS="$(GITHUB_OUTPUT=/dev/null REPORT_PATH= python3 "$PARSER" --github-output)"; then
+            echo "::error::Could not re-read the depends-on warnings."
+            exit 1
+          fi
+          printf '%s\n' "$WARNINGS" | grep '^::warning::' || true
+
+          STATUS=$(head -n 1 "$STATE")
+          case "$STATUS" in
+            ok) ;;
+            none)
+              echo "No Depends-On declaration; building against the default sources."
+              exit 0 ;;
+            invalid)
+              # The parser warning forwarded above already explains this.
+              echo "No valid dependency parsed; building against the default sources."
+              exit 0 ;;
+            *)
+              echo "::error::Unexpected depends-on parser status: ${STATUS}"
+              exit 1 ;;
+          esac
+
+          git config --global user.email "actions@github.com"
+          git config --global user.name "github-actions"
+
+          # ok must carry at least one reference; an unreadable or empty list
+          # would skip the loop and report the default sources as though the
+          # declaration had been applied. Keep the loop in this shell, not a
+          # pipeline, so a dependency failure exits the step.
+          if ! tail -n +2 "$STATE" > "${STATE}.refs" || [ ! -s "${STATE}.refs" ]; then
+            echo "::error::Could not read the parsed dependency list."
+            exit 1
+          fi
+          # The report is keyed by the pull request head SHA, which names
+          # neither checkout: nuttx is the pull request merged into its base,
+          # and apps is an unpinned default branch the event never mentions.
+          # Record both in the summary, before anything is applied, so the
+          # source set is visible where the report is read.
+          NUTTX_CHECKOUT_SHA=$(git -C sources/nuttx rev-parse HEAD)
+          APPS_CHECKOUT_SHA=$(git -C sources/apps rev-parse HEAD)
+          {
+            echo "### Depends-On source set"
+            echo
+            echo "Measured under this pull request's head SHA, together with:"
+            echo "- \`apache/nuttx\` checkout @ \`${NUTTX_CHECKOUT_SHA}\`"
+            echo "- \`apache/nuttx-apps\` checkout @ \`${APPS_CHECKOUT_SHA}\`"
+          } >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+
+          while read -r DEP; do
+            [ -n "$DEP" ] || continue
+            DEP_REPO=${DEP%/pull/*}
+            DEP_NUM=${DEP##*/}
+
+            # Keep the repository mapping aligned with build.yml.
+            case "$DEP_REPO" in
+              "apache/nuttx")       REPO_PATH=sources/nuttx ;;
+              "apache/nuttx-apps")  REPO_PATH=sources/apps ;;
+              *)
+                echo "::error::Unsupported dependency repository: ${DEP_REPO}"
+                exit 1 ;;
+            esac
+
+            echo "Applying dependency ${DEP}"
+            # Deepening is best effort; the common-base and rev-list checks
+            # below still fail closed. Say it happened, so a missing common
+            # base is not mistaken for an unrelated dependency.
+            if [ -f "${REPO_PATH}/.git/shallow" ] \
+               && ! git -C "$REPO_PATH" fetch --unshallow origin; then
+              echo "::warning::Could not deepen ${REPO_PATH}; a missing common base below may follow from that rather than from ${DEP}."
+            fi
+            if ! git -C "$REPO_PATH" fetch origin "pull/${DEP_NUM}/head:dep-${DEP_NUM}"; then
+              echo "::error::Could not fetch ${DEP} (the PR may not exist)."
+              exit 1
+            fi
+
+            # Reject unrelated histories before computing HEAD..dep, which
+            # would otherwise list every dependency commit.
+            if [ -z "$(git -C "$REPO_PATH" merge-base "dep-${DEP_NUM}" HEAD || true)" ]; then
+              echo "::error::Could not find a common base with ${DEP}."
+              exit 1
+            fi
+            if ! COMMITS=$(git -C "$REPO_PATH" rev-list --reverse "HEAD..dep-${DEP_NUM}"); then
+              echo "::error::Could not list the commits of ${DEP}."
+              exit 1
+            fi
+
+            DEP_SHA=$(git -C "$REPO_PATH" rev-parse "dep-${DEP_NUM}")
+            if [ -z "$COMMITS" ]; then
+              echo "Dependency ${DEP} is already included."
+              echo "- \`${DEP}\` @ \`${DEP_SHA}\` (already in the checkout)" \
+                >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+              continue
+            fi
+
+            # shellcheck disable=SC2086
+            if ! git -C "$REPO_PATH" cherry-pick $COMMITS; then
+              echo "::error::Could not cherry-pick ${DEP}."
+              echo "::error::If your pull request contains merge commits, rebase instead of merging."
+              git -C "$REPO_PATH" cherry-pick --abort || true
+              exit 1
+            fi
+            echo "Applied ${DEP} @ ${DEP_SHA}"
+            echo "- \`${DEP}\` @ \`${DEP_SHA}\`" \
+              >> "${GITHUB_STEP_SUMMARY:-/dev/null}"
+          done < "${STATE}.refs"
 
       - name: Docker Login
         uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f  # v4.6.0

--- a/Documentation/testing/nuttx-ci.rst
+++ b/Documentation/testing/nuttx-ci.rst
@@ -154,6 +154,9 @@ commit list cannot be determined, or it causes a cherry-pick conflict,
 ``Fetch-Source`` fails instead of silently testing without the requested
 dependency.
 
+The memory footprint workflow applies the same declarations independently,
+using the same parser and apply sequence (see `Memory Footprint Tracking`_).
+
 When a valid dependency report is available, the follow-up comment reports one
 of three outcomes:
 
@@ -249,3 +252,9 @@ The integration consists of:
 
 * the set of tracked targets, configured in ``.github/membrowse-targets.json``
 * the ``membrowse-*.yml`` workflows under ``.github/workflows/`` that drive it
+
+The memory report applies the same ``Depends-On:`` declarations as the Build
+workflow (see `Pull Request Dependencies`_), so a pull request that only builds
+on top of another one is measured against a tree that compiles. The declaration
+rules and the ``master``-only gate are the same. A dependency that cannot be
+fetched or applied fails the job in both workflows.


### PR DESCRIPTION
## Summary

Teaches the MemBrowse memory report to honour the `Depends-On:` declarations
that `build.yml` already understands, so a pull request that builds only with
another one can produce a report from the declared combined source set.

Requested in #19867.

For pull requests targeting `master`, the workflow re-reads the current
description, parses dependencies with the existing
`.github/scripts/depends_on.py`, and applies accepted `apache/nuttx` and
`apache/nuttx-apps` dependencies to the matching checkout in declaration order.
A dependency already reachable from the checkout is recorded without being
cherry-picked again. Unsupported references are dropped with a warning; a
declaration with no valid references retains the default sources.

Failures that leave the declaration unevaluated, or a parsed dependency
unapplied, stop the job rather than produce a report for the wrong source set.
Checkout deepening is best effort, but the subsequent common-base and
commit-list checks remain fail-closed.

### Changes

- `.github/workflows/membrowse-report.yml` — add an `Apply depends-on PRs` step
  and grant `pull-requests: read` so it can re-read the pull request
  description.
- `.github/scripts/depends_on.py` — document that `--print-state` is a parsed
  output contract with a second consumer.
- `Documentation/testing/nuttx-ci.rst` — cross-reference the dependency and
  memory-footprint sections.

## Impact

The functional change affects only MemBrowse reports for pull requests
targeting `master`. Pull requests without a declaration retain the normal source
selection, but the step still re-reads the description and invokes the parser;
a failure in either operation fails the job. Push runs and release-branch pull
requests do not run the dependency step.

The workflow's `GITHUB_TOKEN` gains `pull-requests: read`. Its GitHub
permissions remain read-only, and it does not post pull request comments;
commenting stays in the separate privileged `membrowse-comment.yml`.

Declared dependency code shares the upload job's trust boundary, so
secret-bearing same-repository runs must reference trusted dependency heads;
details are documented below.

No NuttX runtime, board, hardware, or `build.yml` behaviour changes.
`.github/scripts/depends_on.py` changes only its module docstring, and the CI
documentation is updated in `Documentation/testing/nuttx-ci.rst`.

## Known limitations

**The source set is not sampled atomically across the matrix.** Each matrix leg
independently checks out the unpinned nuttx-apps default branch, re-reads the
live pull request body, and resolves dependencies from mutable
`refs/pull/N/head` refs. The apps baseline was already a mutable input; the live
body read and the mutable dependency refs are the two this change adds. Run
`33403284777` observed the same checkout and dependency SHAs in both legs, but
that does not guarantee atomicity. Eliminating the race would require resolving
the complete source set once and distributing immutable SHAs or a shared source
artifact to every leg.

**A stale or mixed downstream comment is a conditional risk.** The comment
workflow was not exercised by the staging runs. It runs after every
non-cancelled report conclusion, including failures, and queries MemBrowse by
`workflow_run.head_sha` without an originating run ID or target manifest. A
re-run after editing `Depends-On:` reuses the same head SHA, so MemBrowse's
overwrite and retention behaviour could expose stale targets or a mixture from
different runs. This was not observed: the staging upload identity and
`workflow_run.head_sha` matched.

**Provenance is per-leg.** Each job summary records the pre-apply
`apache/nuttx` and `apache/nuttx-apps` checkout SHAs and every dependency head
SHA in declaration order, including already-contained dependencies. These
values can reconstruct the source set while the Git objects remain available,
but there is no combined post-apply tree SHA or matrix-wide manifest.

**Dependency inclusion uses commit reachability, not patch equivalence.** Like
`build.yml`, the step cherry-picks `HEAD..dep` and treats a dependency as
included only when its commits are reachable by identity. If equivalent changes
land under rewritten SHAs, or overlapping stack members are declared
separately, replay may stop as empty, conflict, or apply cleanly and reach the
same tree. Declare only the unlanded stack tip, rebase or update it after an
ancestor lands under rewritten SHAs, and remove declarations once their
dependencies land.

**Declared dependencies share the upload job's trust boundary.** Unlike the
limitations above, this one is introduced here: before this change the report
workflow built only its own checkouts. Dependency code is built in the same job
before the final upload step receives `MEMBROWSE_API_KEY`. The key is scoped to
that step, and fork-triggered runs do not receive repository secrets, but
earlier code can still affect the shared workspace and runner environment files.
Secret-bearing same-repository runs must therefore declare only trusted
dependency heads. Full isolation would require separate build and upload jobs
connected by an artifact.

## Testing

The staging runs used GitHub-hosted `ubuntu-latest` runners and the NuttX CI
container. They ran in the `zhn-test` mirror, so logs show
`zhn-test/nuttx-apps` where upstream uses `apache/nuttx-apps`. The staging
revisions also carried mirror mapping and a two-target matrix; neither change is
part of this pull request.

**Base-ref gate.** Two runs used identical source trees and declarations but
targeted different branches:

| Run | Base ref | `Apply depends-on PRs` | Build |
| --- | --- | --- | --- |
| [`33255928602`](https://github.com/zhn-test/nuttx/actions/runs/33255928602) | `membrowse-base-20260824` (master-equivalent) | applied both legs | success |
| [`33373845058`](https://github.com/zhn-test/nuttx/actions/runs/33373845058) | `releases/membrowse-e2e` | skipped both legs | success |

The corresponding merge commits (`7879d12b72`, `e3e9e6228d`) had identical
parents, trees, and workflow content. Staging replaced the literal `master` with
its master-equivalent branch, so this verifies the gating mechanism rather than
the literal branch name.

**Dependency application.** Run `33255928602` applied both a same-repository
NuttX dependency (`pull/33` @ `995cd8dde0…`) and a companion nuttx-apps
dependency (`pull/18` @ `d826dcfc8a…`) in both the ARM
`stm32-nucleo-f103rb` and RISC-V `hifive1-revb` legs, then built successfully.

**Order, already-included handling, and provenance.** Run
[`33403284777`](https://github.com/zhn-test/nuttx/actions/runs/33403284777)
applied two dependencies in declaration order, recognised a third as already
included, recorded full checkout and dependency SHAs, and built both targets.
The submitted workflow and the tested candidate `4a77864b…` are byte-identical
after comments are removed, so the commands and parser behaviour exercised by
the run are unchanged.

The mirror had no MemBrowse API key, so its tokenless uploads returned HTTP 404
and were tolerated by a staging-only `continue-on-error`. The run therefore
verifies dependency handling, provenance, and builds, but not a successful
MemBrowse upload or the downstream comment workflow. The upload identity still
matched the pull request head SHA.

**Local checks.** The submitted commit passed 40 parser tests, `py_compile`,
YAML parsing, `bash -n` over all 14 shell blocks, and `git diff --check`.
Extracted-step tests confirmed that body/parser, fetch/history, commit-list, and
cherry-pick failures stop the job. `none` and `invalid` retain the default
sources; invalid declarations emit one warning, and unsupported repositories
warn without preventing supported entries in the same declaration from being
applied. The recorded summary contains full source SHAs in declaration order,
including already-contained dependencies.

The RST section references were also checked, and parsing introduced no new
diagnostics.