### PR TITLE
sched/wqueue: Fix work_cancel() to return -ENOENT when no such work is queued

### DIFF
--- a/sched/wqueue/kwork_cancel.c
+++ b/sched/wqueue/kwork_cancel.c
@@ -45,8 +45,9 @@
 static int work_qcancel(FAR struct kwork_wqueue_s *wqueue, bool sync,
                         FAR struct work_s *work)
 {
-  irqstate_t flags;
   FAR sem_t *sync_wait = NULL;
+  irqstate_t flags;
+  int ret = 0;
 
   if (wqueue == NULL || work == NULL)
     {
@@ -70,6 +71,10 @@ static int work_qcancel(FAR struct kwork_wqueue_s *wqueue, bool sync,
         {
           work_timer_reset(wqueue);
         }
+    }
+  else
+    {
+      ret = -ENOENT;
     }
 
   /* Note that cancel_sync can not be called in the interrupt
@@ -102,7 +107,7 @@ static int work_qcancel(FAR struct kwork_wqueue_s *wqueue, bool sync,
       nxsem_wait_uninterruptible(sync_wait);
     }
 
-  return 0;
+  return ret;
 }
 
 /****************************************************************************


### PR DESCRIPTION
## Summary

Fix work_cancel() to return -ENOENT when no such work is queued

## Impact

required to pass intel64 LTP tests

## Testing

NTFC