### PR TITLE
fs/procfs: fix potential out-of-bounds read in mount_sprintf()

### DIFF
--- a/fs/mount/fs_procfs_mount.c
+++ b/fs/mount/fs_procfs_mount.c
@@ -182,6 +182,11 @@ static void mount_sprintf(FAR struct mount_info_s *info,
   linesize = vsnprintf(info->line, info->linelen, fmt, ap);
   va_end(ap);
 
+  if (linesize >= info->linelen)
+    {
+      linesize = info->linelen - 1;
+    }
+
   /* Copy the line buffer to the user buffer */
 
   copysize = procfs_memcpy(info->line, linesize,


### PR DESCRIPTION
## Summary
When formatting entries for `/proc/fs/mount`, `vsnprintf()` returns the full string length even if output is truncated to fit the 64-byte `info->line` staging buffer. `mount_sprintf()` was passing this untruncated length to `procfs_memcpy()`, causing an out-of-bounds read past `info->line` when a mountpoint path was long enough (e.g. >= 50 characters).

This PR clamps `linesize` to `info->linelen - 1` before calling `procfs_memcpy()`, limiting the copy to the actual bytes stored in the buffer.

Fixes #20011

## Impact
- **Is new feature needed?** No
- **Impact on user?** Prevents procfs buffer overflow reads when long mount paths are present.
- **Impact on build?** None
- **Impact on hardware?** None

## Testing
- Verified `mount_sprintf()` bounds logic when formatting long mount point paths (> 50 chars).
- Confirmed output string truncation functions properly without reading past the end of `info->line`.
