### PR TITLE
tools/Unix.mk: add nuttx.asm to manifest

### DIFF
--- a/tools/Unix.mk
+++ b/tools/Unix.mk
@@ -602,7 +602,7 @@ endif
 ifeq ($(CONFIG_RAW_DISASSEMBLY),y)
 	@echo "CP: nuttx.asm"
 	$(Q) $(OBJDUMP) -d $(BIN) > nuttx.asm
-	$(Q) echo nuttx.bin >> nuttx.asm
+	$(Q) echo nuttx.asm >> nuttx.manifest
 endif
 	$(call POSTBUILD, $(TOPDIR))
 


### PR DESCRIPTION
## Summary

Add "nuttx.asm" to nuttx.manifest when CONFIG_RAW_DISASSEMBLY is enabled

## Impact

* Erroneous "nuttx.bin" string at the end of the disassembly is removed
* "nuttx.asm" is properly added to the manifest

## Testing

Compiled for a custom target (STM32F7-based) with arm-none-eabi-gcc 13.2.1 and CONFIG_RAW_DISASSEMBLY enabled.  
I could confirm the behaviour described in the **Impact** section