### PR TITLE
xtensa/esp32s3: Fix CONSOLE_DEV clobbered by USBSERIAL macro.

### DIFF
--- a/arch/xtensa/src/esp32s3/esp32s3_serial.c
+++ b/arch/xtensa/src/esp32s3/esp32s3_serial.c
@@ -101,8 +101,11 @@
 #  endif
 #endif /* CONSOLE_UART */
 
-#ifdef CONFIG_ESP32S3_USBSERIAL
+#if defined(CONFIG_ESP32S3_USBSERIAL) && !defined(CONSOLE_DEV)
 #  define CONSOLE_DEV           g_uart_usbserial
+#endif
+
+#ifdef CONFIG_ESP32S3_USBSERIAL
 #  define TTYACM0_DEV           g_uart_usbserial
 #endif
 
@@ -855,194 +858,196 @@ static int esp32s3_ioctl(struct file *filep, int cmd, unsigned long arg)
     {
 #ifdef CONFIG_SERIAL_TIOCSERGSTRUCT
 
-    /* Get the internal driver data structure for debug purposes. */
+      /* Get the internal driver data structure for debug purposes. */
 
-    case TIOCSERGSTRUCT:
-      {
-         struct esp32s3_uart_s *user = (struct esp32s3_uart_s *)arg;
-         if (user == NULL)
-           {
-             ret = -EINVAL;
-           }
-         else
-           {
-             memcpy(user, dev->priv, sizeof(struct esp32s3_uart_s));
-           }
-       }
-       break;
+      case TIOCSERGSTRUCT:
+        {
+          struct esp32s3_uart_s *user = (struct esp32s3_uart_s *)arg;
+
+          if (user == NULL)
+            {
+              ret = -EINVAL;
+            }
+          else
+            {
+              memcpy(user, dev->priv, sizeof(struct esp32s3_uart_s));
+            }
+        }
+        break;
 #endif
 
 #ifdef CONFIG_SERIAL_TERMIOS
 
-    /* Fill a termios structure with the required information. */
+      /* Fill a termios structure with the required information. */
 
-    case TCGETS:
-      {
-        struct termios  *termiosp   = (struct termios *)arg;
-        struct esp32s3_uart_s *priv = (struct esp32s3_uart_s *)dev->priv;
-        if (termiosp == NULL)
-          {
-            ret = -EINVAL;
-            break;
-          }
+      case TCGETS:
+        {
+          struct termios  *termiosp   = (struct termios *)arg;
+          struct esp32s3_uart_s *priv = (struct esp32s3_uart_s *)dev->priv;
 
-        /* Return parity (0 = no parity, 1 = odd parity, 2 = even parity). */
+          if (termiosp == NULL)
+            {
+              ret = -EINVAL;
+              break;
+            }
 
-        termiosp->c_cflag = (priv->parity != 0 ? PARENB : 0) |
-                            (priv->parity == 1 ? PARODD : 0);
+          /* Return parity (0 = no, 1 = odd, 2 = even). */
 
-        /* Return stop bits */
+          termiosp->c_cflag = (priv->parity != 0 ? PARENB : 0) |
+                              (priv->parity == 1 ? PARODD : 0);
 
-        termiosp->c_cflag |= priv->stop_b2 != 0 ? CSTOPB : 0;
+          /* Return stop bits */
+
+          termiosp->c_cflag |= priv->stop_b2 != 0 ? CSTOPB : 0;
 
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
-        termiosp->c_cflag |=  priv->oflow != 0 ? CCTS_OFLOW : 0;
+          termiosp->c_cflag |=  priv->oflow != 0 ? CCTS_OFLOW : 0;
 #endif
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
-        termiosp->c_cflag |=  priv->iflow != 0 ? CRTS_IFLOW : 0;
+          termiosp->c_cflag |=  priv->iflow != 0 ? CRTS_IFLOW : 0;
 #endif
 
-        /* Set the baud rate in the termiosp using the
-         * cfsetispeed interface.
-         */
+          /* Set the baud rate in the termiosp using the
+           * cfsetispeed interface.
+           */
 
-        cfsetispeed(termiosp, priv->baud);
+          cfsetispeed(termiosp, priv->baud);
 
-        /* Return number of bits. */
+          /* Return number of bits. */
 
-        switch (priv->bits)
-          {
-          case 5:
-            termiosp->c_cflag |= CS5;
-            break;
+          switch (priv->bits)
+            {
+              case 5:
+                termiosp->c_cflag |= CS5;
+                break;
 
-          case 6:
-            termiosp->c_cflag |= CS6;
-            break;
+              case 6:
+                termiosp->c_cflag |= CS6;
+                break;
 
-          case 7:
-            termiosp->c_cflag |= CS7;
-            break;
+              case 7:
+                termiosp->c_cflag |= CS7;
+                break;
 
-          default:
-          case 8:
-            termiosp->c_cflag |= CS8;
-            break;
-          }
-      }
-      break;
+              default:
+              case 8:
+                termiosp->c_cflag |= CS8;
+                break;
+            }
+        }
+        break;
 
-    case TCSETS:
-      {
-        struct termios  *termiosp   = (struct termios *)arg;
-        struct esp32s3_uart_s *priv = (struct esp32s3_uart_s *)dev->priv;
-        uint32_t baud;
-        uint32_t current_int_sts;
-        uint8_t  parity;
-        uint8_t  bits;
-        uint8_t  stop2;
+      case TCSETS:
+        {
+          struct termios  *termiosp   = (struct termios *)arg;
+          struct esp32s3_uart_s *priv = (struct esp32s3_uart_s *)dev->priv;
+          uint32_t baud;
+          uint32_t current_int_sts;
+          uint8_t  parity;
+          uint8_t  bits;
+          uint8_t  stop2;
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
-        bool iflow;
+          bool iflow;
 #endif
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
-        bool oflow;
+          bool oflow;
 #endif
 
-        if (termiosp == NULL)
-          {
-            ret = -EINVAL;
-            break;
-          }
+          if (termiosp == NULL)
+            {
+              ret = -EINVAL;
+              break;
+            }
 
-        /* Get the target baud rate to change. */
+          /* Get the target baud rate to change. */
 
-        baud = cfgetispeed(termiosp);
+          baud = cfgetispeed(termiosp);
 
-        /* Decode number of bits. */
+          /* Decode number of bits. */
 
-        switch (termiosp->c_cflag & CSIZE)
-          {
-          case CS5:
-            bits = 5;
-            break;
+          switch (termiosp->c_cflag & CSIZE)
+            {
+              case CS5:
+                bits = 5;
+                break;
 
-          case CS6:
-            bits = 6;
-            break;
+              case CS6:
+                bits = 6;
+                break;
 
-          case CS7:
-            bits = 7;
-            break;
+              case CS7:
+                bits = 7;
+                break;
 
-          case CS8:
-            bits = 8;
-            break;
+              case CS8:
+                bits = 8;
+                break;
 
-          default:
-            ret = -EINVAL;
-            break;
-          }
+              default:
+                ret = -EINVAL;
+                break;
+            }
 
-        /* Decode parity. */
+          /* Decode parity. */
 
-        if ((termiosp->c_cflag & PARENB) != 0)
-          {
-            parity = (termiosp->c_cflag & PARODD) != 0 ? 1 : 2;
-          }
-        else
-          {
-            parity = 0;
-          }
+          if ((termiosp->c_cflag & PARENB) != 0)
+            {
+              parity = (termiosp->c_cflag & PARODD) != 0 ? 1 : 2;
+            }
+          else
+            {
+              parity = 0;
+            }
 
-        /* Decode stop bits. */
+          /* Decode stop bits. */
 
-        stop2 = (termiosp->c_cflag & CSTOPB) != 0 ? 1 : 0;
+          stop2 = (termiosp->c_cflag & CSTOPB) != 0 ? 1 : 0;
 
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
-        iflow = (termiosp->c_cflag & CRTS_IFLOW) != 0;
+          iflow = (termiosp->c_cflag & CRTS_IFLOW) != 0;
 #endif
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
-        oflow = (termiosp->c_cflag & CCTS_OFLOW) != 0;
+          oflow = (termiosp->c_cflag & CCTS_OFLOW) != 0;
 #endif
 
-        /* Verify that all settings are valid before
-         * performing the changes.
-         */
+          /* Verify that all settings are valid before
+           * performing the changes.
+           */
 
-        if (ret == OK)
-          {
-            /* Fill the private struct fields. */
+          if (ret == OK)
+            {
+              /* Fill the private struct fields. */
 
-            priv->baud      = baud;
-            priv->parity    = parity;
-            priv->bits      = bits;
-            priv->stop_b2   = stop2;
+              priv->baud      = baud;
+              priv->parity    = parity;
+              priv->bits      = bits;
+              priv->stop_b2   = stop2;
 #ifdef CONFIG_SERIAL_IFLOWCONTROL
-            priv->iflow     = iflow;
+              priv->iflow     = iflow;
 #endif
 #ifdef CONFIG_SERIAL_OFLOWCONTROL
-            priv->oflow     = oflow;
+              priv->oflow     = oflow;
 #endif
 
-            /* Effect the changes immediately - note that we do not
-             * implement TCSADRAIN or TCSAFLUSH, only TCSANOW option.
-             * See nuttx/libs/libc/termios/lib_tcsetattr.c
-             */
+              /* Effect the changes immediately - note that we do not
+               * implement TCSADRAIN or TCSAFLUSH, only TCSANOW option.
+               * See nuttx/libs/libc/termios/lib_tcsetattr.c
+               */
 
-            esp32s3_lowputc_disable_all_uart_int(priv, &current_int_sts);
-            ret = esp32s3_setup(dev);
+              esp32s3_lowputc_disable_all_uart_int(priv, &current_int_sts);
+              ret = esp32s3_setup(dev);
 
-            /* Restore the interrupt state */
+              /* Restore the interrupt state */
 
-            esp32s3_lowputc_restore_all_uart_int(priv, &current_int_sts);
-          }
-      }
-      break;
+              esp32s3_lowputc_restore_all_uart_int(priv, &current_int_sts);
+            }
+        }
+        break;
 #endif /* CONFIG_SERIAL_TERMIOS */
 
-    default:
-      ret = -ENOTTY;
-      break;
+      default:
+        ret = -ENOTTY;
+        break;
     }
 
   return ret;
@@ -1086,6 +1091,7 @@ static bool esp32s3_rxflowcontrol(struct uart_dev_s *dev,
 {
   bool ret = false;
   struct esp32s3_uart_s *priv = dev->priv;
+
   if (priv->iflow)
     {
       if (nbuffered == 0 || upper == false)


### PR DESCRIPTION
## Summary

  * Why change is necessary (fix, update, new feature)? Fix — a boot-time
    hang/reset-loop bug.
  * What functional part of the code is being changed?
    `arch/xtensa/src/esp32s3/esp32s3_serial.c`, the `CONSOLE_DEV` macro
    selection logic used by the ESP32-S3 serial driver.
  * How does the change exactly work (what will change and how)?
    When `CONFIG_ESP32S3_USBSERIAL` is enabled at the same time as a real
    UART is selected as the system console (`CONFIG_UARTx_SERIAL_CONSOLE`),
    an unconditional `#define CONSOLE_DEV g_uart_usbserial` silently
    overrides the correct earlier definition that pointed `CONSOLE_DEV` at
    the chosen UART device. `xtensa_earlyserialinit()` then calls
    `esp32s3_setup(&CONSOLE_DEV)` — a function only valid for a
    `struct esp32s3_uart_s` — on what is actually `g_uart_usbserial`, whose
    `priv` points to an unrelated `struct esp32s3_usbserial_s`. Reading
    `priv->id` off the wrong struct returns garbage, which is then used to
    compute a UART register address; the resulting access to invalid IO
    hangs the CPU until the RTC watchdog resets the board, in a loop,
    before NSH ever starts. The fix guards the USBSERIAL assignment with
    `!defined(CONSOLE_DEV)`, mirroring the pattern already used a few lines
    below in the same file for `TTYS1_DEV`/`TTYS2_DEV`.
  * Related NuttX Issue: none filed yet.

## Impact

  * **Is new feature added?** 
  Is existing feature changed? NO — pure bug fix,
    no behavior change for any config that was working correctly before
    (the only configs affected are ones where `CONSOLE_DEV` was silently
    wrong, i.e. already broken).

## Testing

  I confirm that changes are verified on local setup and works as intended:
  * Build Host(s): Linux (x86_64), GCC via the `xtensa-esp32s3-elf`
    toolchain (esp-elf 14.2.0).
  * Target(s): xtensa, Seeed XIAO ESP32-S3 (esp32s3-xiao), custom
    out-of-tree defconfig with `CONFIG_ESP32S3_UART0=y`,
    `CONFIG_UART0_SERIAL_CONSOLE=y`, `CONFIG_ESP32S3_USBSERIAL=y`.
  * Reproduction: flash a config with a UART selected as
    `SERIAL_CONSOLE` while `CONFIG_ESP32S3_USBSERIAL` is also enabled, and
    watch the UART console — it boot-loops instead of reaching NSH.

  Testing logs before change:

  ```
  ESP-ROM:esp32s3-20210327
  Build:Mar 27 2021
  rst:0x10 (RTCWDT_RTC_RST),boot:0x9 (SPI_FAST_FLASH_BOOT)
  ...
  *** Booting NuttX ***
  dram: lma 0x00000020 vma 0x3fc8e7e0 len 0x184c   (6220)
  iram: lma 0x00001874 vma 0x40374000 len 0x8494   (33940)
  ...
  total segments stored 7
  <hang here -- nothing else is ever printed>

  <~8s later, resets and repeats identically, forever>
  ```

  Testing logs after change:

  ```
  nsh> uname -a
  NuttX 13.0.1-RC0 734c06c4f3-dirty Sep  3 2026 11:50:28 xtensa esp32s3-xiao
  nsh> ls /dev
  /dev:
   console
   i2c0
   mmcsd0
   null
   ttyACM0
   ttyS0
   uorb/
   usensor
   zero
  nsh>
  ```
