### PR TITLE
stm32g0: Fix erase bank selection after bank swap

### DIFF
--- a/arch/arm/src/common/stm32/stm32_flash_m0_g0c0.c
+++ b/arch/arm/src/common/stm32/stm32_flash_m0_g0c0.c
@@ -373,6 +373,7 @@ static void flash_lock_cr(void)
 static bool flash_unlock_opt(void)
 {
   bool was_locked = false;
+
   flash_unlock_cr();
 
   if (getreg32(STM32_FLASH_CR) & FLASH_CR_OPTLOCK)
@@ -688,6 +689,9 @@ ssize_t up_progmem_eraseblock(size_t block)
 {
   int ret;
   size_t block_address;
+#ifdef FLASH_DUAL_BANK
+  bool bank2;
+#endif
 
   ret = flash_verify_blocknum(block);
   if (ret < 0)
@@ -729,7 +733,17 @@ ssize_t up_progmem_eraseblock(size_t block)
    * match the correct bank.
    */
 
-  if (block >= flash_bank2_priv.stblock)
+  /* BKER selects a physical bank, while block numbers follow the memory map.
+   * Reverse the bank selection when the banks are swapped in the memory map.
+   */
+
+  bank2 = block >= flash_bank2_priv.stblock;
+  if ((getreg32(STM32_FLASH_OPTR) & FLASH_OPTR_NSWAP_BANK) == 0)
+    {
+      bank2 = !bank2;
+    }
+
+  if (bank2)
     {
       modifyreg32(STM32_FLASH_CR, 0, FLASH_CR_BKER);
     }


### PR DESCRIPTION
## Summary

Fix STM32G0 flash erase-bank selection when the flash banks are swapped.

Flash page numbers follow the logical memory mapping, while the FLASH_CR
BKER bit selects a physical flash bank. When nSWAP_BANK is cleared, the
physical banks are reversed in the memory map, so BKER must also be
reversed when erasing a logical address.

## Validation

- `git diff --check`: passed
- `tools/checkpatch.sh -g HEAD^..HEAD`: passed
- Built `stm32_flash_m0_g0c0.c` for STM32G0B1 with
  `CONFIG_STM32_PROGMEM=y`
- Hardware tested on a 2G BMS Golgi board using two consecutive
  RS-485 firmware updates:
  - Initial state: `FLASH_OPTR=fef9feaa`, nSWAP_BANK set
  - After update 1: `FLASH_OPTR=fee9feaa`, nSWAP_BANK cleared
  - Update 2 was initiated while the banks were swapped
  - After update 2: `FLASH_OPTR=fef9feaa`, nSWAP_BANK set
- Both updates completed, rebooted into the programmed image, mounted
  the filesystem, initialized communications and BMS hardware, and
  operated normally

The hardware image used the existing product-tree version of the same
bank-selection correction. The submitted implementation ports that
logic to the current common STM32 flash driver.
