### PR TITLE
sched: Fix the timer reprogramming and SCHED_RR issues.

### DIFF
--- a/drivers/timers/arch_alarm.c
+++ b/drivers/timers/arch_alarm.c
@@ -30,6 +30,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/clock.h>
+#include <nuttx/lib/math32.h>
 #include <nuttx/timers/arch_alarm.h>
 
 /****************************************************************************
@@ -288,16 +289,7 @@ void weak_function up_timer_getmask(FAR clock_t *mask)
 
       ONESHOT_TICK_MAX_DELAY(g_oneshot_lower, &maxticks);
 
-      for (; ; )
-        {
-          clock_t next = (*mask << 1) | 1;
-          if (next > maxticks)
-            {
-              break;
-            }
-
-          *mask = next;
-        }
+      *mask = CLOCK_MAX >> (sizeof(clock_t) * 8u - flsx(maxticks));
     }
 }
 

--- a/drivers/timers/arch_alarm.c
+++ b/drivers/timers/arch_alarm.c
@@ -289,7 +289,8 @@ void weak_function up_timer_getmask(FAR clock_t *mask)
 
       ONESHOT_TICK_MAX_DELAY(g_oneshot_lower, &maxticks);
 
-      *mask = CLOCK_MAX >> (sizeof(clock_t) * 8u - flsx(maxticks));
+      *mask = maxticks == 0 ? 0 :
+              UINT64_MAX >> (sizeof(clock_t) * 8u - flsx(maxticks));
     }
 }
 

--- a/drivers/timers/arch_timer.c
+++ b/drivers/timers/arch_timer.c
@@ -30,6 +30,7 @@
 
 #include <nuttx/arch.h>
 #include <nuttx/clock.h>
+#include <nuttx/lib/math32.h>
 #include <nuttx/timers/arch_timer.h>
 
 /****************************************************************************
@@ -280,17 +281,7 @@ void weak_function up_timer_getmask(FAR clock_t *mask)
 
   TIMER_TICK_MAXTIMEOUT(g_timer.lower, &maxticks);
 
-  *mask = 0;
-  while (1)
-    {
-      clock_t next = (*mask << 1) | 1;
-      if (next > maxticks)
-        {
-          break;
-        }
-
-      *mask = next;
-    }
+  *mask = CLOCK_MAX >> (sizeof(clock_t) * 8u - flsx(maxticks));
 }
 
 int weak_function up_timer_gettick(FAR clock_t *ticks)

--- a/drivers/timers/arch_timer.c
+++ b/drivers/timers/arch_timer.c
@@ -277,11 +277,12 @@ void up_timer_set_lowerhalf(FAR struct timer_lowerhalf_s *lower)
 
 void weak_function up_timer_getmask(FAR clock_t *mask)
 {
-  uint32_t maxticks;
+  uint32_t maxticks = 0u;
 
   TIMER_TICK_MAXTIMEOUT(g_timer.lower, &maxticks);
 
-  *mask = CLOCK_MAX >> (sizeof(clock_t) * 8u - flsx(maxticks));
+  *mask = maxticks == 0u ? 0 :
+          UINT64_MAX >> (sizeof(clock_t) * 8u - flsx(maxticks));
 }
 
 int weak_function up_timer_gettick(FAR clock_t *ticks)

--- a/drivers/timers/arch_timer.c
+++ b/drivers/timers/arch_timer.c
@@ -128,6 +128,7 @@ static uint64_t current_usec(void)
 static void udelay_accurate(useconds_t microseconds)
 {
   uint64_t start = current_usec();
+
   while (current_usec() - start < microseconds)
     {
       ; /* Wait until the timeout reach */

--- a/include/nuttx/sched.h
+++ b/include/nuttx/sched.h
@@ -639,6 +639,10 @@ struct tcb_s
   int32_t  timeslice;                    /* RR timeslice OR Sporadic budget */
                                          /* interval remaining              */
 #endif
+#if CONFIG_RR_INTERVAL > 0 && defined(CONFIG_SCHED_TICKLESS)
+  clock_t  rr_starttime;                 /* Time when RR task was last      */
+                                         /* accounted                       */
+#endif
 #ifdef CONFIG_SCHED_SPORADIC
   FAR struct sporadic_s *sporadic;       /* Sporadic scheduling parameters  */
 #endif

--- a/include/nuttx/timers/clkcnt.h
+++ b/include/nuttx/timers/clkcnt.h
@@ -178,7 +178,9 @@ clkcnt_t clkcnt_delta_time2cnt(uint64_t time, uint32_t freq, uint32_t scale)
 
   DEBUGASSERT(time <= CLKCNT_MAX / freq);
 
-  return div_const(time * freq, scale);
+  /* Round-up to the scale. */
+
+  return div_const(time * freq + (scale - 1u), scale);
 }
 
 /****************************************************************************

--- a/sched/hrtimer/hrtimer_start.c
+++ b/sched/hrtimer/hrtimer_start.c
@@ -88,7 +88,7 @@ int hrtimer_start_absolute(FAR hrtimer_t *hrtimer, hrtimer_entry_t func,
 
   if (reprogram)
     {
-      hrtimer_reprogram(hrtimer->expired);
+      hrtimer_reprogram(hrtimer_get_first()->expired);
     }
 
   /* Release the lock and give up the ownership of the hrtimer queue. */

--- a/sched/sched/sched.h
+++ b/sched/sched/sched.h
@@ -349,8 +349,10 @@ int  nxsched_reprioritize(FAR struct tcb_s *tcb, int sched_priority);
 
 #ifdef CONFIG_SCHED_TICKLESS
 void nxsched_reassess_timer(void);
+void nxsched_timer_start(clock_t now, clock_t delay);
 #else
 #  define nxsched_reassess_timer()
+#  define nxsched_timer_start(now, delay)
 #endif
 
 /* Scheduler policy support */
@@ -358,6 +360,10 @@ void nxsched_reassess_timer(void);
 #if CONFIG_RR_INTERVAL > 0
 clock_t nxsched_process_roundrobin(FAR struct tcb_s *tcb, clock_t ticks,
                                    bool noswitches);
+#  ifdef CONFIG_SCHED_TICKLESS
+void nxsched_suspend_roundrobin(FAR struct tcb_s *tcb);
+void nxsched_resume_roundrobin(FAR struct tcb_s *tcb);
+#  endif
 #endif
 
 #ifdef CONFIG_SCHED_SPORADIC

--- a/sched/sched/sched_processtickless.c
+++ b/sched/sched/sched_processtickless.c
@@ -105,6 +105,7 @@ int up_timer_gettick(FAR clock_t *ticks)
 {
   struct timespec ts;
   int ret;
+
   ret = up_timer_gettime(&ts);
   *ticks = clock_time2ticks_floor(&ts);
   return ret;
@@ -115,6 +116,7 @@ int up_timer_gettick(FAR clock_t *ticks)
 int up_alarm_tick_start(clock_t ticks)
 {
   struct timespec ts;
+
   clock_ticks2time(&ts, ticks);
   return up_alarm_start(&ts);
 }
@@ -124,6 +126,7 @@ int up_alarm_tick_start(clock_t ticks)
 int up_timer_tick_start(clock_t ticks)
 {
   struct timespec ts;
+
   clock_ticks2time(&ts, ticks);
   return up_timer_start(&ts);
 }
@@ -213,6 +216,7 @@ static clock_t nxsched_cpu_scheduler(int cpu, clock_t ticks,
   if ((rtcb->flags & TCB_FLAG_POLICY_MASK) == TCB_FLAG_SCHED_SPORADIC)
     {
       FAR struct sporadic_s *sporadic = rtcb->sporadic;
+
       DEBUGASSERT(sporadic);
 
       /* Save the last time that the scheduler ran.  This time was saved

--- a/sched/sched/sched_processtickless.c
+++ b/sched/sched/sched_processtickless.c
@@ -79,7 +79,6 @@ static clock_t nxsched_cpu_scheduler(int cpu, clock_t ticks,
 #endif
 static clock_t nxsched_process_scheduler(clock_t ticks, clock_t elapsed,
                                          bool noswitches);
-static void nxsched_timer_start(clock_t ticks, clock_t interval);
 
 /****************************************************************************
  * Private Data
@@ -203,6 +202,7 @@ static clock_t nxsched_cpu_scheduler(int cpu, clock_t ticks,
        * timeslice.
        */
 
+      rtcb->rr_starttime = ticks;
       ret = nxsched_process_roundrobin(rtcb, elapsed, noswitches);
     }
 #endif
@@ -315,35 +315,6 @@ clock_t nxsched_process_scheduler(clock_t ticks, clock_t elapsed,
 }
 
 /****************************************************************************
- * Name:  nxsched_timer_start
- *
- * Description:
- *   Start the interval timer.
- *
- * Input Parameters:
- *   ticks - The number of ticks defining the timer interval to setup.
- *   interval - The number of ticks to use when setting up the next timer.
- *
- * Returned Value:
- *   None
- *
- ****************************************************************************/
-
-static void nxsched_timer_start(clock_t ticks, clock_t interval)
-{
-  if (interval != CLOCK_MAX)
-    {
-      DEBUGASSERT(interval <= UINT32_MAX);
-      wd_start_abstick(&g_sched_event, ticks + interval,
-                       nxsched_wdog_expiration, 0u);
-    }
-  else
-    {
-      wd_cancel(&g_sched_event);
-    }
-}
-
-/****************************************************************************
  * Public Functions
  ****************************************************************************/
 
@@ -362,13 +333,6 @@ static void nxsched_timer_start(clock_t ticks, clock_t interval)
  *   Base code implementation assumes that this function is called from
  *   interrupt handling logic with interrupts disabled.
  *
- * Note:
- *   The current SCHED_RR implementation has an issue: if a round-robin task
- *   is preempted, its timeslice counter does not decrement properly.
- *   Therefore, we must trigger the scheduler on each timer expiration to
- *   minimize the occurrence of this problem.
- *   This workaround can be removed once the SCHED_RR behavior is fixed.
- *
  ****************************************************************************/
 
 void nxsched_process_timer(void)
@@ -380,15 +344,6 @@ void nxsched_process_timer(void)
   clock_update_sched_ticks(ticks);
 
   hrtimer_process(nsec);
-
-#  if CONFIG_RR_INTERVAL > 0
-  /* Workaround for SCHED_RR, see the note. */
-
-  irqstate_t flags = enter_critical_section();
-  nxsched_process_event(ticks, true);
-  leave_critical_section(flags);
-#  endif
-
 #else
   irqstate_t flags;
   clock_t ticks;
@@ -404,12 +359,6 @@ void nxsched_process_timer(void)
   /* Update sched ticks */
 
   clock_update_sched_ticks(ticks);
-
-#if CONFIG_RR_INTERVAL > 0
-  /* Workaround for SCHED_RR, see the note. */
-
-  nxsched_process_event(ticks, true);
-#endif
 
   wd_timer(ticks);
 
@@ -464,6 +413,40 @@ void nxsched_reassess_timer(void)
     }
 
   nxsched_process_event(g_wdexpired, true);
+}
+
+/****************************************************************************
+ * Name:  nxsched_timer_start
+ *
+ * Description:
+ *   Start the interval timer for the scheduler event.  Called during
+ *   context switches to set up the timer for the newly running RR task's
+ *   remaining timeslice.
+ *
+ * Input Parameters:
+ *   now   - The current time in ticks.
+ *   delay - The number of ticks to wait until the timer expires.
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumption:
+ *   This function is called from the critical section.
+ *
+ ****************************************************************************/
+
+void nxsched_timer_start(clock_t now, clock_t delay)
+{
+  if (delay != CLOCK_MAX)
+    {
+      DEBUGASSERT(delay <= UINT32_MAX);
+      wd_start_abstick(&g_sched_event, now + delay,
+                       nxsched_wdog_expiration, 0u);
+    }
+  else
+    {
+      wd_cancel(&g_sched_event);
+    }
 }
 
 /****************************************************************************

--- a/sched/sched/sched_roundrobin.c
+++ b/sched/sched/sched_roundrobin.c
@@ -229,4 +229,63 @@ clock_t nxsched_process_roundrobin(FAR struct tcb_s *tcb, clock_t ticks,
   return ret;
 }
 
+#ifdef CONFIG_SCHED_TICKLESS
+
+/****************************************************************************
+ * Name:  nxsched_suspend_roundrobin
+ *
+ * Description:
+ *   Called when a task using round-robin scheduling is being switched out.
+ *   Accounts for the time consumed since the timeslice was last assessed
+ *   so that only actual CPU execution time is charged against the task.
+ *
+ * Input Parameters:
+ *   tcb - The TCB of the thread that is being suspended.
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumption:
+ *   This function is called from the critical section.
+ *
+ ****************************************************************************/
+
+void nxsched_suspend_roundrobin(FAR struct tcb_s *tcb)
+{
+  clock_t now     = clock_systime_ticks();
+  clock_t elapsed = now - tcb->rr_starttime;
+
+  nxsched_process_roundrobin(tcb, elapsed, true);
+}
+
+/****************************************************************************
+ * Name:  nxsched_resume_roundrobin
+ *
+ * Description:
+ *   Called when a task using round-robin scheduling is being switched in.
+ *   Restarts the scheduler timer for the task's remaining timeslice so
+ *   that the timer is always armed while an RR task is running.
+ *
+ * Input Parameters:
+ *   tcb - The TCB of the thread that is being resumed.
+ *
+ * Returned Value:
+ *   None
+ *
+ * Assumption:
+ *   This function is called from the critical section.
+ *
+ ****************************************************************************/
+
+void nxsched_resume_roundrobin(FAR struct tcb_s *tcb)
+{
+  clock_t now = clock_systime_ticks();
+
+  DEBUGASSERT(tcb->timeslice >= 0);
+  tcb->rr_starttime = now;
+  nxsched_timer_start(now, tcb->timeslice);
+}
+
+#endif /* CONFIG_SCHED_TICKLESS */
+
 #endif /* CONFIG_RR_INTERVAL > 0 */

--- a/sched/sched/sched_switchcontext.c
+++ b/sched/sched/sched_switchcontext.c
@@ -51,6 +51,17 @@ void nxsched_switch_context(FAR struct tcb_s *from, FAR struct tcb_s *to)
 {
   nxsched_checkstackoverflow(from);
 
+#if CONFIG_RR_INTERVAL > 0 && defined(CONFIG_SCHED_TICKLESS)
+  /* If the task being switched out uses round-robin scheduling, account
+   * for the time it has consumed from its timeslice.
+   */
+
+  if ((from->flags & TCB_FLAG_POLICY_MASK) == TCB_FLAG_SCHED_RR)
+    {
+      nxsched_suspend_roundrobin(from);
+    }
+#endif
+
 #ifdef CONFIG_SCHED_SPORADIC
   /* Perform sporadic schedule operations */
 
@@ -65,12 +76,14 @@ void nxsched_switch_context(FAR struct tcb_s *from, FAR struct tcb_s *to)
     }
 #endif
 
-#if defined(CONFIG_SCHED_TICKLESS) && CONFIG_RR_INTERVAL > 0
-  /* Before the context switch, we should set the timer for RR. */
+#if CONFIG_RR_INTERVAL > 0 && defined(CONFIG_SCHED_TICKLESS)
+  /* If the task being switched in uses round-robin scheduling, restart
+   * the timer for its remaining timeslice.
+   */
 
-  if (from != to && (to->flags & TCB_FLAG_POLICY_MASK) == TCB_FLAG_SCHED_RR)
+  if ((to->flags & TCB_FLAG_POLICY_MASK) == TCB_FLAG_SCHED_RR)
     {
-      nxsched_reassess_timer();
+      nxsched_resume_roundrobin(to);
     }
 #endif
 

--- a/sched/sched/sched_switchcontext.c
+++ b/sched/sched/sched_switchcontext.c
@@ -65,6 +65,15 @@ void nxsched_switch_context(FAR struct tcb_s *from, FAR struct tcb_s *to)
     }
 #endif
 
+#if defined(CONFIG_SCHED_TICKLESS) && CONFIG_RR_INTERVAL > 0
+  /* Before the context switch, we should set the timer for RR. */
+
+  if (from != to && (to->flags & TCB_FLAG_POLICY_MASK) == TCB_FLAG_SCHED_RR)
+    {
+      nxsched_reassess_timer();
+    }
+#endif
+
   /* Indicate that the task has been suspended */
 
 #ifdef CONFIG_SCHED_CRITMONITOR


### PR DESCRIPTION
## Summary

Fix three issues in the tickless scheduler / hrtimer path:

- **sched/hrtimer: Fix reprogram with wrong expiration when reinserting hrtimer.** In `hrtimer_start_absolute()`, when a pending hrtimer (previously the head of the queue) is removed and reinserted with a later expiration, the `reprogram` flag remains set although the timer is no longer the earliest one in the queue. The old code passed `hrtimer->expired` to `hrtimer_reprogram()`; use `hrtimer_get_first()->expired` instead so the hardware timer is always reprogrammed with the actual earliest expiration.

- **sched/sched: Fix roundrobin if SCHED_TICKLESS enabled.** In tickless mode the scheduler timer is stopped whenever the running task requires no time slicing (`CLOCK_MAX`). When a SCHED_RR task was later switched in, nothing re-armed the timer, so the task could run indefinitely without round-robin rotation. Reassess the scheduler timer in `nxsched_switch_context()` before the context switch when the incoming task uses round-robin scheduling. Every architecture invokes `nxsched_switch_context()` exactly once per context switch (task switch, syscall, IRQ exit and task exit paths), so this covers all switch paths.

- **sched/tickless: Fix SCHED_RR timeslice accounting on preemption.** When an RR task was preempted, its timeslice counter was not decremented for the time already consumed, effectively granting the task bonus CPU time when resumed. Perform RR accounting on context switches: `nxsched_suspend_roundrobin()` charges the elapsed execution time against the timeslice of the RR task being switched out, and `nxsched_resume_roundrobin()` re-arms the scheduler timer for the remaining timeslice of the RR task being switched in, so the timer is always armed while an RR task is running. This also removes the previous workaround in `nxsched_process_timer()` that ran the scheduler logic on every timer tick.

## Impact

- Affects only `CONFIG_SCHED_TICKLESS` configurations with `CONFIG_RR_INTERVAL > 0` (plus hrtimer users for the first fix). Periodic-tick builds are unchanged: the new scheduler code is compiled out, and hrtimer behavior only changes in the corner case described above.
- No user-facing API changes, no build system, documentation, security or compatibility impact.

## Testing

- Host: Linux x86_64, `riscv64-unknown-elf-gcc` toolchain, QEMU (`qemu-system-riscv32`).
- Board: `rv-virt:smp` configuration with `CONFIG_SCHED_TICKLESS=y`.
- Build: `make -j` completes without errors or new warnings.
- Boot: `qemu-system-riscv32 -semihosting -M virt,aclint=on -cpu rv32 -smp 8 -bios none -kernel nuttx -nographic` — NSH starts and is fully responsive.
- Ran the `ostest` application under QEMU: all subtests pass, in particular the round-robin test, verifying that RR rotation works under tickless mode and that preemption no longer grants bonus timeslice to RR tasks.
