### PR TITLE
net: preserve checksum state for empty fragments

### DIFF
--- a/net/utils/net_chksum.c
+++ b/net/utils/net_chksum.c
@@ -61,6 +61,11 @@ uint16_t checksum(uint16_t sum, FAR const uint8_t *data,
   FAR const uint8_t *last_byte;
   uint16_t t;
 
+  if (len == 0)
+    {
+      return sum;
+    }
+
   dataptr = data;
   last_byte = data + len - 1;
 


### PR DESCRIPTION
checksum() accesses data[0] and calculates an invalid last_byte pointer when processing an empty fragment with odd state set.

Return early when len is zero to preserve the checksum state and avoid accessing data from an empty fragment.

Assisted by: GitHub Copilot

## Summary

`checksum()` in `net/utils/net_chksum.c` mishandles a zero-length fragment
when an odd byte is still pending from a previous fragment (`*odd == true`).

Before this fix, the function unconditionally computed:

    last_byte = data + len - 1;

and, when `*odd == true`, unconditionally read `dataptr[0]` to consume the
pending byte, regardless of whether the current fragment contained any bytes.

With `len == 0`, this could form an invalid pointer from the zero-length
fragment and read `data[0]` even though the current fragment contained no
valid bytes. The code also cleared `*odd`, discarding the pending-byte state
needed by the next fragment.

This can corrupt the checksum when a byte stream is split such that an
empty I/O buffer fragment follows an odd-length fragment.

The fix adds an early return for `len == 0`, before any pointer arithmetic or
dereference. `sum` and `*odd` are left unchanged, so a zero-length fragment
does not affect the running checksum state.

Fixes #20010

## Impact

This prevents an invalid read and checksum corruption when an empty fragment
is encountered while an odd byte is pending.

No API or ABI changes are introduced.

## Validation
The corresponding regression test is provided in
apache/nuttx-apps PR https://github.com/apache/nuttx-apps/pull/3771


### Regression test with the buggy implementation

The corresponding regression test was verified against the implementation
without the zero-length guard and failed as expected:

```text
[ RUN      ] test_others_chksum
[ ERROR    ] --- 30617 != 30396
[ LINE     ] --- others/test_others_chksum.c:52
[  FAILED  ] test_others_chksum
````

### Regression test with the fix applied

With the `len == 0` handling fix restored, the test passed:

```text
nsh: mount: mount failed: 20
nsh> cmocka_net_others
[==========] others_tests: Running 2 test(s).
[ RUN      ] test_others_bufpool
[       OK ] test_others_bufpool
[ RUN      ] test_others_chksum
[       OK ] test_others_chksum
[==========] others_tests: 2 test(s) run.
[  PASSED  ] 2 test(s).
```

The `mount failed: 20` message occurs during simulator startup and did not
prevent `cmocka_net_others` from running successfully.

`git diff --check` completed with no output.

`./tools/checkpatch.sh -g HEAD` completed successfully with all checks passing.
```text
✔️ All checks pass.
````
### Checkpatch

The exact CI-style check was run:

```text
Used config files:
    1: .codespellrc
✔️ All checks pass.
````
