### PR TITLE
stm32g0: Add flash bank swap support

### DIFF
--- a/arch/arm/src/common/stm32/stm32_flash.h
+++ b/arch/arm/src/common/stm32/stm32_flash.h
@@ -46,6 +46,8 @@
 
 void stm32_flash_getopt(uint32_t *opt);
 int stm32_flash_optmodify(uint32_t clear, uint32_t set);
+int stm32_flash_optload(void);
+int stm32_flash_swapbanks(void);
 void stm32_flash_lock(void);
 void stm32_flash_unlock(void);
 

--- a/arch/arm/src/common/stm32/stm32_flash_m0_g0c0.c
+++ b/arch/arm/src/common/stm32/stm32_flash_m0_g0c0.c
@@ -588,6 +588,97 @@ int stm32_flash_optmodify(uint32_t clear, uint32_t set)
   return 0;
 }
 
+/****************************************************************************
+ * Name: stm32_flash_optload
+ *
+ * Description:
+ *   Reload the flash option bytes. If an option-byte change affects the
+ *   flash-bank mapping, the reload immediately resets the system.
+ *
+ * Returned Value:
+ *   Zero or a negated errno value.
+ *
+ *   -EBUSY: Timeout waiting for a previous flash operation to finish.
+ *
+ ****************************************************************************/
+
+int stm32_flash_optload(void)
+{
+  int ret;
+  bool was_locked;
+
+  ret = flash_wait_for_operation();
+  if (ret != 0)
+    {
+      return -EBUSY;
+    }
+
+  was_locked = flash_unlock_opt();
+  modifyreg32(STM32_FLASH_SR, 0, FLASH_SR_CLEAR_ERROR_FLAGS);
+
+  ret = flash_wait_for_operation();
+  if (ret != 0)
+    {
+      ret = -EBUSY;
+      goto exit;
+    }
+
+  modifyreg32(STM32_FLASH_CR, 0, FLASH_CR_OBL_LAUNCH);
+
+  while (getreg32(STM32_FLASH_CR) & FLASH_CR_OBL_LAUNCH)
+    {
+    }
+
+exit:
+  if (was_locked)
+    {
+      flash_lock_opt();
+    }
+
+  return ret;
+}
+
+/****************************************************************************
+ * Name: stm32_flash_swapbanks
+ *
+ * Description:
+ *   Toggle the flash-bank mapping in the option bytes. The new mapping takes
+ *   effect after a power-on reset or a call to stm32_flash_optload().
+ *
+ * Returned Value:
+ *   Zero or a negated errno value.
+ *
+ *   -EBUSY: Timeout waiting for a previous flash operation to finish.
+ *   -EPERM: Bank swapping is prohibited by the boot lock.
+ *
+ ****************************************************************************/
+
+int stm32_flash_swapbanks(void)
+{
+  int ret = 0;
+
+#ifdef FLASH_DUAL_BANK
+  uint32_t reg;
+
+  if (getreg32(STM32_FLASH_SECR) & FLASH_SECR_BOOT_LOCK)
+    {
+      return -EPERM;
+    }
+
+  reg = getreg32(STM32_FLASH_OPTR);
+  if (reg & FLASH_OPTR_NSWAP_BANK)
+    {
+      ret = stm32_flash_optmodify(FLASH_OPTR_NSWAP_BANK, 0);
+    }
+  else
+    {
+      ret = stm32_flash_optmodify(0, FLASH_OPTR_NSWAP_BANK);
+    }
+#endif
+
+  return ret;
+}
+
 #ifdef CONFIG_ARCH_HAVE_PROGMEM
 
 /* up_progmem_x functions defined in nuttx/include/nuttx/progmem.h


### PR DESCRIPTION
## Summary

Add STM32G0 flash APIs required to switch dual-bank memory mapping and reload
flash option bytes:

- `stm32_flash_swapbanks()` toggles `FLASH_OPTR_NSWAP_BANK`
- `stm32_flash_optload()` launches an option-byte reload
- Bank swapping returns `-EPERM` when `FLASH_SECR_BOOT_LOCK` is active
- The swap operation is a no-op on single-bank devices

Reloading option bytes after changing the bank mapping normally causes an
immediate system reset.

## Validation

- `git diff --check`: passed
- `tools/checkpatch.sh -g HEAD^..HEAD`: passed
- STM32G071 single-bank configuration with `CONFIG_STM32_PROGMEM=y`:
  - Flash driver compiled successfully
  - Both APIs exported
  - Single-bank no-op path compiled
- STM32G0B1 dual-bank configuration with `CONFIG_STM32_PROGMEM=y`:
  - Flash driver compiled successfully
  - Both APIs exported
  - Dual-bank swap path compiled

## Hardware validation

Tested the equivalent existing implementation on a 2G BMS Golgi STM32G0B1
target using two consecutive RS-485 firmware updates.

Observed option-byte states:

1. Initial USB DFU image:
   - `FLASH_OPTR=fef9feaa`
   - `nSWAP_BANK=1`
2. After the first firmware update:
   - `FLASH_OPTR=fee9feaa`
   - `nSWAP_BANK=0`
3. After the second update, initiated while the banks were swapped:
   - `FLASH_OPTR=fef9feaa`
   - `nSWAP_BANK=1`

Both updates completed successfully. After each update, the target rebooted,
mounted its filesystem, initialized its communication interfaces and BMS
hardware, and resumed normal operation.

The hardware image used the product-tree implementation from which these APIs
were ported. The submitted code was rebased and compile-validated against
current Apache NuttX master.
