### PR TITLE
sched/critmonitor: Fix context switch state tracking

### DIFF
--- a/sched/sched/sched_critmonitor.c
+++ b/sched/sched/sched_critmonitor.c
@@ -377,12 +377,11 @@ void nxsched_switch_critmon(FAR struct tcb_s *from, FAR struct tcb_s *to)
   clock_t tick = elapsed * CLOCKS_PER_SEC / perf_getfreq();
 
   nxsched_critmon_cpuload(from, current, tick);
-  to->run_start = current;
 #endif
 
 #if CONFIG_SCHED_CRITMONITOR_MAXTIME_THREAD >= 0
   from->run_time += elapsed;
-  to->run_time = current;
+  to->run_start = current;
   if (elapsed > from->run_max)
     {
       from->run_max = elapsed;

--- a/sched/sched/sched_critmonitor.c
+++ b/sched/sched/sched_critmonitor.c
@@ -154,6 +154,7 @@ static void nxsched_critmon_cpuload(FAR struct tcb_s *tcb, clock_t current,
                                     clock_t tick)
 {
   int i;
+
   UNUSED(i);
 
   /* Update the cpuload of the thread ready to be suspended */
@@ -374,6 +375,7 @@ void nxsched_switch_critmon(FAR struct tcb_s *from, FAR struct tcb_s *to)
 
 #ifdef CONFIG_SCHED_CPULOAD_CRITMONITOR
   clock_t tick = elapsed * CLOCKS_PER_SEC / perf_getfreq();
+
   nxsched_critmon_cpuload(from, current, tick);
   to->run_start = current;
 #endif
@@ -465,6 +467,7 @@ void nxsched_update_critmon(FAR struct tcb_s *tcb)
     {
 #ifdef CONFIG_SCHED_CPULOAD_CRITMONITOR
       clock_t tick = elapsed * CLOCKS_PER_SEC / perf_getfreq();
+
       nxsched_process_taskload_ticks(tcb, tick);
 #endif
 

--- a/sched/sched/sched_critmonitor.c
+++ b/sched/sched/sched_critmonitor.c
@@ -420,7 +420,7 @@ void nxsched_switch_critmon(FAR struct tcb_s *from, FAR struct tcb_s *to)
 
   if (to->lockcount > 0)
     {
-      to->premp_start = current;
+      to->preemp_start = current;
     }
 #endif /* CONFIG_SCHED_CRITMONITOR_MAXTIME_PREEMPTION */
 

--- a/tools/pynuttx/nxgdb/protocols/thread.py
+++ b/tools/pynuttx/nxgdb/protocols/thread.py
@@ -101,10 +101,10 @@ class Tcb(Value):
     run_start: Value
     run_max: Value
     run_time: Value
-    premp_start: Value
-    premp_max: Value
-    premp_caller: Value
-    premp_max_caller: Value
+    preemp_start: Value
+    preemp_max: Value
+    preemp_caller: Value
+    preemp_max_caller: Value
     crit_start: Value
     crit_max: Value
     crit_caller: Value


### PR DESCRIPTION
## Summary
  Commit b2a69ba781 merged the critical monitor suspend and resume paths into `nxsched_switch_critmon()`, but introduced two state tracking problems:

  * It reintroduced the obsolete `premp_start` field name. The field was previously renamed to `preemp_start`, causing configurations with preemption monitoring enabled to fail to build.
  * It assigned the current timestamp to `to->run_time` instead of `to->run_start`. This overwrote the accumulated runtime and left a stale start timestamp for the next context-switch calculation when `CONFIG_SCHED_CPULOAD_CRITMONITOR` was disabled.

  This PR corrects the preemption field reference, restores the target thread's `run_start` timestamp, and updates the GDB TCB protocol annotations to match the current `struct tcb_s` fields.

## Impact

Bug fix only; no new features.


## Testing

Host: macOS 25.6 (arm64), Apple clang version 21.0.0
Target: sim:ostest

Build: clean, no warnings/errors introduced by this change.

ostest run (5 loops, CONFIG_TESTING_OSTEST_LOOPS=5, auto poweroff):

    $ ./nuttx
    stdio_test: write fd=1
    stdio_test: Standard I/O Check: printf
    stdio_test: write fd=2
    stdio_test: Standard I/O Check: fprintf to stderr
    ostest_main: putenv(Variable1=BadValue3)
    ostest_main: setenv(Variable1, GoodValue1, TRUE)
    ostest_main: setenv(Variable2, BadValue1, FALSE)
    ostest_main: setenv(Variable2, GoodValue2, TRUE)
    ostest_main: setenv(Variable3, GoodValue3, FALSE)
    ostest_main: setenv(Variable3, BadValue2, FALSE)
    show_variable: Variable=Variable1 has value=GoodValue1
    show_variable: Variable=Variable2 has value=GoodValue2
    show_variable: Variable=Variable3 has value=GoodValue3
    ostest_main: Started user_main at PID=5
    ...
    Final memory usage:
    VARIABLE  BEFORE   AFTER
    ======== ======== ========
    arena     4000000  4000000
    ordblks         2        7
    mxordblk  3faaaa0  3faaaa0
    uordblks    452e0    457c0
    fordblks  3fbad20  3fba840
    user_main: Exiting
    ostest_main: Exiting with status 0

Full log: 52364 lines, no FAILED / ASSERT / PANIC; final heap statistics
match the baseline (no leaks introduced).


