### PR TITLE
arch/arm/stm32h7: poll MDIO completion in microseconds, not 5 ms steps

### DIFF
--- a/arch/arm/src/stm32h7/stm32_mdio.c
+++ b/arch/arm/src/stm32h7/stm32_mdio.c
@@ -63,7 +63,7 @@ struct stm32_mdio_lowerhalf_s
 {
   struct mdio_lowerhalf_s base;
 
-  /* MDIO bus timeout in milliseconds */
+  /* MDIO bus timeout in microseconds */
 
   int timeout;
 };
@@ -95,7 +95,7 @@ struct stm32_mdio_lowerhalf_s g_stm32_mdio_lowerhalf =
     {
       .ops = &g_stm32_mdio_ops
     },
-  .timeout = 10
+  .timeout = 10000
 };
 
 /****************************************************************************
@@ -131,9 +131,14 @@ static int stm32_c22_read(struct mdio_lowerhalf_s *dev, uint8_t phydev,
 
   stm32_putreg(regval, STM32_ETH_MACMDIOAR);
 
-  /* Wait for the transfer to complete */
+  /* Wait for the transfer to complete.  A Clause 22 frame is 64 MDC
+   * cycles, about 30 us at a 2.5 MHz MDC, so poll at a fraction of that.
+   * A millisecond delay here turns every PHY register access into a
+   * busy-wait far longer than the transfer, and the autonegotiation link
+   * wait in stm32_phyinit() issues thousands of them.
+   */
 
-  for (to = priv->timeout; to >= 0; to--)
+  for (to = priv->timeout; to > 0; to -= 10)
     {
       if ((stm32_getreg(STM32_ETH_MACMDIOAR) & ETH_MACMDIOAR_MB) == 0)
         {
@@ -142,10 +147,10 @@ static int stm32_c22_read(struct mdio_lowerhalf_s *dev, uint8_t phydev,
           break;
         }
 
-      up_mdelay(5);
+      up_udelay(10);
     }
 
-  if (to <= 0)
+  if (retval < 0)
     {
       ninfo("MII transfer timed out: phydev: %04x regaddr: %04x\n",
             phydev, regaddr);
@@ -192,7 +197,7 @@ static int stm32_c22_write(struct mdio_lowerhalf_s *dev, uint8_t phydev,
 
   /* Wait for the transfer to complete */
 
-  for (to = priv->timeout; to >= 0; to--)
+  for (to = priv->timeout; to > 0; to -= 10)
     {
       if ((stm32_getreg(STM32_ETH_MACMDIOAR) & ETH_MACMDIOAR_MB) == 0)
         {
@@ -200,10 +205,10 @@ static int stm32_c22_write(struct mdio_lowerhalf_s *dev, uint8_t phydev,
           break;
         }
 
-      up_mdelay(5);
+      up_udelay(10);
     }
 
-  if (to <= 0)
+  if (retval < 0)
     {
       ninfo("MII transfer timed out: phydevaddr: %04x phyregaddr: %04x"
             "value: %04x\n", phydev, regaddr, value);


### PR DESCRIPTION
## Summary

`stm32_c22_read()` / `stm32_c22_write()` in `arch/arm/src/stm32h7/stm32_mdio.c` wait for the MACMDIOAR busy bit with `up_mdelay(5)` between checks. A Clause 22 frame is ~30 us at a 2.5 MHz MDC, so the first check always sees the bus busy and every PHY register access costs a 5 ms busy-wait. Before the MDIO bus refactor (95efa6f7cf) `stm32_phyread()` polled the busy bit in a tight loop.

The cost shows up in `stm32_phyinit()`, which waits for link-up with `PHY_RETRY_TIMEOUT` (6552) MSR reads when `STM32H7_AUTONEG` is set. With no cable attached, `ifup` spends ~33 s of CPU in `up_mdelay()` with the network lock held. On an STM32H753 running PX4 the `netinit` monitor thread pinned the core at 44% for the first 65 s after boot (priority-inherited to 100 because a UDP sender was blocked on the net lock), and every socket operation on other threads stalled until the link wait timed out.

This polls every 10 us instead, with the timeout expressed in microseconds so the total bound stays at 10 ms, and reports a timeout from the result rather than the loop counter so a transfer completing on the last iteration is not logged as timed out.

## Impact

STM32H7 boards with `STM32H7_ETHMAC`. PHY register access goes from a fixed 5 ms to ~30 us; the autonegotiation link wait with no cable drops from ~33 s of CPU to under a second of mostly sleeping. No functional change when the PHY responds.

## Testing

Host: Linux, GCC 13.2.1. Board: ARK FMU-V6X (STM32H753, LAN8742A PHY, `CONFIG_STM32H7_AUTONEG=y`, `CONFIG_STM32H7_PHY_POLLING=y`, `CONFIG_NETINIT_MONITOR=y`), no ethernet cable, running PX4 on NuttX 12.12.0 with this change cherry-picked. `top once` sampled every 2 s from power-on over the debug console.

Before (netinit at 44% until ~65 s uptime, priority 100 inherited from a blocked UDP sender, then 0.44% = one 5 ms MDIO read per 2 s poll):

```
[ 23.0]    6 netinit                       537 44.715   704/ 2032 100 ( 49)  READY  4
[ 49.0]    6 netinit                       538 44.770   704/ 2032 100 ( 49)  READY  4
[ 75.1]    6 netinit                       529 44.076   704/ 2032 100 ( 49)  READY  4
[ 77.1]    6 netinit                       157 13.072   704/ 2032  49 ( 49)  w:sem  4 | WARN  [mavlink] no broadcasting address found
[ 79.1]    6 netinit                         5  0.431   704/ 2032  49 ( 49)  w:sem  4
[ 99.1]    6 netinit                         5  0.440   704/ 2032  49 ( 49)  w:sem  4
```

After:

```
[ 13.0]    6 netinit                        19  1.654   704/ 2032 100 ( 49)  w:sig  4
[ 15.0]    6 netinit                        11  0.940   704/ 2032  49 ( 49)  w:sem  4 | WARN  [mavlink] no broadcasting address found
[ 17.0]    6 netinit                         0  0.004   704/ 2032  49 ( 49)  w:sem  4
[ 69.1]    6 netinit                         0  0.005   704/ 2032  49 ( 49)  w:sem  4
```

Timestamps are seconds since power-on; the board reaches the shell at ~12 s. The UDP MAVLink instance that was blocked on the net lock for 65 s now proceeds at ~2 s. `tools/checkpatch.sh -c -u -m -g origin/master..HEAD` passes.
