### PR TITLE
{bp-19854} fs/vfs/fs_read.c: Allow NULL iov_base when CONFIG_ARCH_TEXT_VBASE == 0

### DIFF
--- a/fs/vfs/fs_read.c
+++ b/fs/vfs/fs_read.c
@@ -176,6 +176,14 @@ ssize_t file_readv(FAR struct file *filep,
       return -EFAULT;
     }
 
+  /* -------------------- DO NOT REMOVE --------------------
+   * Only for kernel builds with CONFIG_ARCH_TEXT_VBASE == 0.
+   * In this case we have to allow the NULL buffer otherwise
+   * kernel builds will fail to load elf binaries found at 0.
+   */
+
+#if !defined(CONFIG_BUILD_KERNEL) || CONFIG_ARCH_TEXT_VBASE != 0
+
   /* Are all iov_base accessible? */
 
   for (ret = 0; ret < iovcnt; ret++)
@@ -185,6 +193,7 @@ ssize_t file_readv(FAR struct file *filep,
           return -EFAULT;
         }
     }
+#endif
 
   ret = -EBADF;
 


### PR DESCRIPTION
## Summary

For kernel builds where CONFIG_ARCH_TEXT_VBASE is set to 0, allow a NULL buffer in file_readv() to prevent ELF binary loading failures for binaries located at address 0.

This fix was originally introduced in #18830, but was inadvertently reverted by someone unaware that platforms with CONFIG_ARCH_TEXT_VBASE equal to 0 cannot function at all without it. This commit restores the necessary check to prevent regressions in zero-based text kernel configurations. Most platforms remain completely unaffected since only about 5 boards utilize a text virtual base of zero.

## Impact

RELEASE

## Testing

CI