### PR TITLE
tools/nxstyle: whitelist S2OPC identifiers

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -303,6 +303,11 @@ static const char *g_white_prefix[] =
   "SystemCoreClock",  /* SystemCoreClock, SystemCoreClockUpdate */
   "cmse_",            /* ARM CMSE TrustZone intrinsics (arm_cmse.h) */
   "MQTTErrors",       /* apps/tools/netutils/mqttc/MQTT-C/include/mqtt.h */
+
+  /* Ref:  apps/netutils/s2opc, apps/examples/s2opc */
+
+  "SOPC_",
+  "OpcUa_",
   NULL
 };
 
@@ -764,6 +769,14 @@ static const char *g_white_content_list[] =
   "xedgeInitDiskIo",
   "xedgeOpenAUX",
   "baParseDate",
+
+  /* Ref:  apps/netutils/s2opc, apps/examples/s2opc */
+
+  "buildBuildDate",
+  "buildDockerId",
+  "buildSrcCommit",
+  "buildVersion",
+  "logSystem",
 
   NULL
 };


### PR DESCRIPTION

## Summary

Whitelist the S2OPC and OPC UA prefixes plus the mixed-case structure fields used by the NuttX port and server example.

## Impact

nxstyle

## Testing

CI
