### PR TITLE
{bp-19872} net/arp: fix cross-interface resolution and a device-lock leak

### DIFF
--- a/net/arp/arp_send.c
+++ b/net/arp/arp_send.c
@@ -328,8 +328,13 @@ int arp_send(in_addr_t ipaddr)
         {
           /* ARP request for the same destination is in progress, directly
            * wait arp response notify.
+           *
+           * Drop the device lock: this path skips the netdev_unlock()
+           * below, and the receive path needs that same lock to deliver
+           * the reply.  The waiter above is already installed.
            */
 
+          netdev_unlock(dev);
           goto wait;
         }
 

--- a/net/arp/arp_table.c
+++ b/net/arp/arp_table.c
@@ -81,8 +81,9 @@
 
 struct arp_table_info_s
 {
-  in_addr_t    ai_ipaddr;   /* IP address for lookup */
-  FAR uint8_t *ai_ethaddr;  /* Location to return the MAC address */
+  in_addr_t    ai_ipaddr;           /* IP address for lookup */
+  FAR uint8_t *ai_ethaddr;          /* Location to return the MAC address */
+  FAR struct net_driver_s *ai_dev;  /* The device the frame will be sent on */
 };
 
 /****************************************************************************
@@ -116,6 +117,16 @@ static const struct ether_addr g_zero_ethaddr =
 static int arp_match(FAR struct net_driver_s *dev, FAR void *arg)
 {
   FAR struct arp_table_info_s *info = arg;
+
+  /* Only the egress device may answer for its own address.  Otherwise a
+   * frame sent on one interface takes the MAC of another that happens to
+   * hold the address, which breaks setups sharing a subnet.
+   */
+
+  if (info->ai_dev != NULL && dev != info->ai_dev)
+    {
+      return 0;
+    }
 
   /* Make sure that this is an Ethernet device (or an IEEE 802.11 device
    * which is also Ethernet)
@@ -529,6 +540,7 @@ int arp_find(in_addr_t ipaddr, FAR uint8_t *ethaddr,
 
   info.ai_ipaddr  = ipaddr;
   info.ai_ethaddr = ethaddr;
+  info.ai_dev     = dev;
 
   if (netdev_foreach(arp_match, &info) != 0)
     {


### PR DESCRIPTION
## Summary

Two independent defects in net/arp that together make a peer periodically
unreachable when two network interfaces share an IPv4 subnet. Both are needed:
fixing either one alone produces a worse result than the bug, which is why they
are submitted together as separate commits.

1. arp_find() can answer with another interface's MAC.
The ARP table itself is keyed by (device, address), but on a cache miss
arp_find() falls back to netdev_foreach(arp_match, ...), and arp_match()
compares only the IP address. Any interface holding that address wins and its
MAC is returned, regardless of the device the frame is going out on. A frame
transmitted on interface A can therefore be addressed to the MAC of interface B.
Note the asymmetry with route selection, which already filters on
IFF_IS_RUNNING (netdev_prefixlen_findby_lipv4addr()).

2. arp_send() leaks dev->d_lock.
The -EINPROGRESS branch does goto wait, jumping over the netdev_unlock(dev)
further down, and arp_wait() does not release the lock either. The caller
therefore sleeps holding d_lock, while netdev_upper_rxpoll_work() needs that
same lock to dispatch incoming frames — so the ARP reply being waited for can
never reach arp_input(). Because d_lock is recursive, retries re-acquire it
and the recursion depth is never unwound, so the interface stays blocked.

Defect 2 is normally invisible: the wrong-MAC shortcut of defect 1 keeps the code
from ever reaching real ARP resolution. Remove the shortcut without fixing the
lock and a self-healing outage becomes a permanent loss of connectivity.

## Impact

RELEASE

## Testing

CI