### PR TITLE
{bp-19873} arch/risc-v/espressif: fix SoftAP-only build of the Wi-Fi event handler

### DIFF
--- a/arch/risc-v/src/common/espressif/esp_wifi_event_handler.c
+++ b/arch/risc-v/src/common/espressif/esp_wifi_event_handler.c
@@ -100,6 +100,7 @@ static bool g_wifi_handler_registered;
  *
  ****************************************************************************/
 
+#ifdef ESP_WLAN_HAS_STA
 static void esp_reconnect_work_cb(void *arg)
 {
   UNUSED(arg);
@@ -119,6 +120,7 @@ static void esp_reconnect_work_cb(void *arg)
       wlerr("Failed to reconnect to Wi-Fi on callback\n");
     }
 }
+#endif /* ESP_WLAN_HAS_STA */
 
 /****************************************************************************
  * Name: esp_wifi_event_handler


### PR DESCRIPTION
## Summary

esp_reconnect_work_cb() dereferences g_sta_reconnect, which is only declared under ESP_WLAN_HAS_STA, so CONFIG_ESPRESSIF_WIFI_SOFTAP alone fails to compile.  Guard the callback as the Xtensa counterpart does.

## Impact

RELEASE

## Testing

CI