### PR TITLE
{bp-19884} sched: Fix stdio initialization of standard streams when buffering is disabled

### DIFF
--- a/sched/tls/task_initinfo.c
+++ b/sched/tls/task_initinfo.c
@@ -77,6 +77,7 @@ static void task_init_stream(FAR struct streamlist *list)
       stream[i].fs_flags   |= __FS_FLAG_LBF; /* Line buffering */
 
 #  endif /* CONFIG_STDIO_LINEBUFFER */
+#endif /* !CONFIG_STDIO_DISABLE_BUFFERING && CONFIG_STDIO_BUFFER_SIZE > 0 */
 
       /* Save the file description and open flags.  Setting the
        * file descriptor locks this stream.
@@ -84,14 +85,6 @@ static void task_init_stream(FAR struct streamlist *list)
 
       stream[i].fs_cookie   = (FAR void *)(intptr_t)i;
       stream[i].fs_oflags   = i ? O_WRONLY : O_RDONLY;
-
-      /* Assign custom callbacks to NULL. */
-
-      stream[i].fs_iofunc.read  = NULL;
-      stream[i].fs_iofunc.write = NULL;
-      stream[i].fs_iofunc.seek  = NULL;
-      stream[i].fs_iofunc.close = NULL;
-#endif /* !CONFIG_STDIO_DISABLE_BUFFERING && CONFIG_STDIO_BUFFER_SIZE > 0 */
     }
 }
 #endif


### PR DESCRIPTION
## Summary

When stdio buffering is disabled, fgetc/getchar on stdin always returned EOF because fs_cookie and fs_oflags were left uninitialized and lib_fread_unlocked bails out on (fs_oflags & O_RDOK) == 0.

Fix this by moving the initialization of the fs_cookie and fs_oflags outside the CONFIG check; these fields need to be initialized regardless of CONFIG_STDIO_DISABLE_BUFFERING.

In addition, initializing stream[i].fs_iofunc pointers to NULL is redundant since the task group is allocated with kmm_zalloc/group_zalloc. Zero allocation was already assumed on fs_flags, so remove the unnecessary code.

## Impact

RELEASE

## Testing

CI