### PR TITLE
{bp-20049} fs/procfs: fix buffer overflow in mount_sprintf

### DIFF
--- a/fs/mount/fs_procfs_mount.c
+++ b/fs/mount/fs_procfs_mount.c
@@ -182,6 +182,11 @@ static void mount_sprintf(FAR struct mount_info_s *info,
   linesize = vsnprintf(info->line, info->linelen, fmt, ap);
   va_end(ap);
 
+  if (linesize >= info->linelen)
+    {
+      linesize = info->linelen - 1;
+    }
+
   /* Copy the line buffer to the user buffer */
 
   copysize = procfs_memcpy(info->line, linesize,


### PR DESCRIPTION
## Summary

vsnprintf() returns the total formatted string length even when truncated to info->line. Passing this untruncated length to procfs_memcpy causes a read beyond the 64-byte line staging buffer.

Fixes #20011

## Impact

RELEASE

## Testing

CI