### PR TITLE
cmake: reconfigure when .config changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -413,6 +413,15 @@ if(NOT EXISTS ${NUTTX_BINARY_DIR}/.config OR NOT "${NUTTX_DEFCONFIG}" STREQUAL
   message(STATUS "  Appdir: ${NUTTX_APPS_DIR}")
 endif()
 
+# config.h and CONFIG_* are generated at configure time. Watch .config so an
+# out-of-band edit (kconfig-tweak) reruns CMake instead of leaving a stale
+# header. .config is only rewritten when missing or the defconfig path changes,
+# so this does not loop.
+set_property(
+  DIRECTORY
+  APPEND
+  PROPERTY CMAKE_CONFIGURE_DEPENDS ${NUTTX_BINARY_DIR}/.config)
+
 # declare global custom targets at very beginning `nuttx_global` is used to hold
 # global target properties to solve that cmake GLOBAL property can not use
 # generator expression this is needed to make sure added before project() create


### PR DESCRIPTION
cmake: reconfigure when .config changes.

## Summary

  * Why change is necessary: `config.h` and `CONFIG_*` are generated at configure time. `kconfig-tweak` (and other out-of-band `.config` edits) do not go through the `menuconfig` target, so Ninja left a stale `include/nuttx/config.h`.
  * What functional part of the code is being changed: CMakeLists.txt configure-depends for `${NUTTX_BINARY_DIR}/.config`.
  * How: `CMAKE_CONFIGURE_DEPENDS` on `.config`. That file is only rewritten when it is missing or the board defconfig path changes, so watching it does not loop.
  * Related NuttX Issue: https://github.com/apache/nuttx/issues/12322

## Impact

  * Is new feature added? Is existing feature changed? NO
  * Impact on user (will user need to adapt to change)? NO
  * Impact on build (will build process change)? YES. Ninja re-runs CMake after an out-of-band `.config` edit, which is what the reporter expected (`Re-running CMake...`).
  * Impact on hardware (will arch(s) / board(s) / driver(s) change)? NO
  * Impact on documentation (is update required / provided)? NO
  * Impact on security (any sort of implications)? NO
  * Impact on compatibility (backward/forward/interoperability)? NO. Unchanged `.config` still does not reconfigure.

## Testing

  I confirm that changes are verified on local setup and works as intended:
  * Build Host(s): Windows 11, CMake 3.29.2, Ninja
  * Target(s): cmake -P lock that CMakeLists.txt watches `.config`; a Ninja mini-project with the same `CMAKE_CONFIGURE_DEPENDS` one-liner

  Testing logs before change:

  ```
  gh search code repo:apache/nuttx CMAKE_CONFIGURE_DEPENDS
  []
  ```

  Testing logs after change:

  ```
  cmake -P _tmp_test_cfgdep.cmake
  -- CMAKELISTS_WATCHES_DOTCONFIG

  cmake --build mini/b   # after editing watched.txt
  [0/1] Re-running CMake...
  -- Configuring done (0.0s)
  -- Generating done (0.0s)
  ```

## PR verification Self-Check

  * [x] This PR introduces only one functional change.
  * [x] I have updated all required description fields above.
  * [x] My PR adheres to Contributing Guidelines and Documentation (git commit title and message, coding standard, etc).
  * [ ] My PR is still work in progress (not ready for review).
  * [x] My PR is ready for review and can be safely merged into a codebase.
