### PR TITLE
libs/libxx/libcxx: fix string constexpr destructor build error on ARM

### DIFF
--- a/libs/libxx/libcxx/0001-libcxx-fix-string-constexpr-dtor-build-error.patch
+++ b/libs/libxx/libcxx/0001-libcxx-fix-string-constexpr-dtor-build-error.patch
@@ -1,0 +1,14 @@
+--- libcxx/include/string
++++ libcxx/include/string
+@@ -1091,7 +1091,11 @@
+   }
+ #endif // _LIBCPP_CXX03_LANG
+
++#if defined(__arm__) && !defined(__clang__)
++  inline ~basic_string() {
++#else
+   inline _LIBCPP_CONSTEXPR_SINCE_CXX20 ~basic_string() {
++#endif
+     if (__is_long())
+       __alloc_traits::deallocate(__alloc(), __get_long_pointer(), __get_long_cap());
+   }

--- a/libs/libxx/libcxx/CMakeLists.txt
+++ b/libs/libxx/libcxx/CMakeLists.txt
@@ -55,6 +55,8 @@ if(CONFIG_LIBCXX)
         ${CMAKE_CURRENT_LIST_DIR}/0001-Fix-build-error-about-__GLIBC__.patch &&
         patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/libcxx <
         ${CMAKE_CURRENT_LIST_DIR}/0001-libc-Fix-failures-with-GCC-14-92663.patch
+        && patch -p1 -d ${CMAKE_CURRENT_LIST_DIR}/libcxx <
+        ${CMAKE_CURRENT_LIST_DIR}/0001-libcxx-fix-string-constexpr-dtor-build-error.patch
       DOWNLOAD_NO_PROGRESS true
       TIMEOUT 30)
 

--- a/libs/libxx/libcxx/Make.defs
+++ b/libs/libxx/libcxx/Make.defs
@@ -37,6 +37,7 @@ libcxx/libcxx: libcxx-$(LIBCXX_VERSION).src.tar.xz
 	$(Q) patch -p0 < libcxx/0001-libcxx-fix-ld-errors.patch -d libcxx
 	$(Q) patch -p0 < libcxx/0001-Fix-build-error-about-__GLIBC__.patch -d libcxx
 	$(Q) patch -p0 < libcxx/0001-libc-Fix-failures-with-GCC-14-92663.patch -d libcxx
+	$(Q) patch -p0 < libcxx/0001-libcxx-fix-string-constexpr-dtor-build-error.patch -d libcxx
 
 endif
 


### PR DESCRIPTION
## Summary

Building libcxx with GCC for ARM fails on the `operator""s` string
literal operators: `basic_string` is treated as a non-literal type
because its constexpr destructor is rejected by the ARM GCC toolchain.

include/libcxx/string:4410:24: error: invalid return type
'std::__1::basic_string<char>' of 'constexpr' function ...
note: 'std::__1::basic_string<char>' does not have 'constexpr'
destructor

The same error is reported for the `wchar_t` / `char8_t` / `char16_t`
overloads of `operator""s`. This looks like an ARM GCC toolchain issue.
As a workaround, add a patch that drops the constexpr qualifier from
`~basic_string()` for the `(__arm__ && !__clang__)` case, and wire it
into both the Make.defs and CMakeLists.txt build flows.

## Impact

libcxx compilation for ARM + GCC only. No functional or behavioral
change for other architectures or the Clang toolchain.

## Testing

CI (ARM + libcxx boards).

Locally verified that the new patch applies cleanly on top of the
existing libcxx 17.0.6 patch chain for both the Make (`patch -p0`) and
CMake (`patch -p1`) build flows, and that the resulting `include/string`
is byte-identical to the intended change.