### PR TITLE
arch/arm/src/common/stm32: accept interface-recipient GET/SET_DESCRIPTOR

### DIFF
--- a/arch/arm/src/common/stm32/stm32_otgfsdev_m3m4_v1.c
+++ b/arch/arm/src/common/stm32/stm32_otgfsdev_m3m4_v1.c
@@ -2447,7 +2447,9 @@ static inline void stm32_ep0out_stdrequest(struct stm32_usbdev_s *priv,
         {
           usbtrace(TRACE_INTDECODE(STM32_TRACEINTID_GETSETDESC), 0);
           if ((ctrlreq->type & USB_REQ_RECIPIENT_MASK) ==
-              USB_REQ_RECIPIENT_DEVICE)
+              USB_REQ_RECIPIENT_DEVICE ||
+              (ctrlreq->type & USB_REQ_RECIPIENT_MASK) ==
+              USB_REQ_RECIPIENT_INTERFACE)
             {
               stm32_req_dispatch(priv, &priv->ctrlreq);
             }


### PR DESCRIPTION
## Summary

HID class devices fetch their HID Report Descriptor with a
`GET_DESCRIPTOR` setup packet whose recipient is an interface
(bmRequestType = 0x81, wValue = 0x2200).

`stm32_ep0out_stdrequest()` only dispatches GET/SET_DESCRIPTOR when the
recipient is the device and stalls every other recipient.  As a result,
HID class devices cannot enumerate on the STM32 OTG FS.

This change also dispatches interface-recipient descriptor requests to
the class driver, following the existing device-recipient path.

## Impact

- Bug fix only; no new configuration options, interfaces or data
  structures.
- Behavior change is limited to interface-recipient GET/SET_DESCRIPTOR
  requests, which previously were always stalled.
- No impact on in-tree classes (CDC/ACM, MSC, RNDIS, ...) that only use
  device-recipient descriptor requests.

## Testing

Tested on an STM32F407VET6 board with a custom HID class device
(interrupt IN endpoint) under NuttX releases/13.0, which contains the
same code path as master:

- Before the change: USB enumeration fails, host cannot obtain the HID
  Report Descriptor (STALL on GET_DESCRIPTOR, wValue = 0x2200).
- After the change: device enumerates, HID report transfers succeed.

Host: Windows 11 Pro 25H2 (build 26200.9168)
Windows Device Manager shows the device as HID-compliant under USB Input Device.