### PR TITLE
sched/environ: Serialize clearenv updates.

### DIFF
--- a/sched/environ/env_clearenv.c
+++ b/sched/environ/env_clearenv.c
@@ -60,9 +60,13 @@
 int clearenv(void)
 {
   FAR struct tcb_s *tcb = this_task();
-  DEBUGASSERT(tcb->group);
+  FAR struct task_group_s *group = tcb->group;
 
-  env_release(tcb->group);
+  DEBUGASSERT(group);
+
+  nxrmutex_lock(&group->tg_mutex);
+  env_release(group);
+  nxrmutex_unlock(&group->tg_mutex);
   return OK;
 }
 


### PR DESCRIPTION
## Summary

Protect the environment release in clearenv() with the task group mutex. This prevents concurrent environment operations from racing with cleanup.

## Impact

bug fix only


## Testing

Host: macOS 26.6.2 ARM64, Apple Clang 21.0.0.
Target: sim:ostest
Build: make completes successfully with LD: nuttx.
Runtime: ran ./nuttx; all enabled OSTest subtests completed without assertions or unexpected errors.