### PR TITLE
arch/risc-v/src/eic7700x/Kconfig: fix broken kconfig-frontends parsing

### DIFF
--- a/arch/risc-v/src/eic7700x/Kconfig
+++ b/arch/risc-v/src/eic7700x/Kconfig
@@ -47,4 +47,4 @@ config EIC7700X_CPU_FREQ_MHZ
 		cores at 1400, so the default changes nothing and merely says
 		so in the log.
 
-endif 
+endif


### PR DESCRIPTION
## Summary
`kconfig-frontends` package needs newline at the end of Kconfig file, otherwise the parsing fails.

## Impact
Fixes broken NuttX build for any board if `kconfig-frontends` is used introduced in 1686bb6

## Testing
`./tools/configure.sh samv71-xult:nsh` results with prior to the change:

```
arch/risc-v/src/eic7700x/Kconfig:50: 'endif' in different file than 'if'
arch/risc-v/src/eic7700x/Kconfig:39: location of the 'if'
arch/risc-v/Kconfig:956: 'endif' in different file than 'if'
arch/risc-v/src/eic7700x/Kconfig:39: location of the 'if'
arch/risc-v/Kconfig:961: 'endif' in different file than 'if'
arch/risc-v/src/eic7700x/Kconfig:39: location of the 'if'
arch/Kconfig:257: 'endif' in different file than 'if'
arch/risc-v/src/eic7700x/Kconfig:39: location of the 'if'
Kconfig:2996: 'endmenu' in different file than 'menu'
arch/risc-v/src/eic7700x/Kconfig:39: location of the 'menu'
make: *** [tools/Unix.mk:756: olddefconfig] Error 1
ERROR: failed to refresh
```

It configures and builds fine after the fix.