### PR TITLE
Documentation, tools/ci: Say where the NXFLAT tools actually come from

### DIFF
--- a/Documentation/components/nxflat.rst
+++ b/Documentation/components/nxflat.rst
@@ -147,18 +147,22 @@ which links the module into the NXFLAT binary format.
 ``tools/mknxflat`` whenever ``CONFIG_NXFLAT`` is selected, so there is
 nothing to install.
 
-``ldnxflat`` is not part of NuttX and has to be built from the buildroot
-package, which can be downloaded from
-`Bitbucket.org <https://bitbucket.org/nuttx/buildroot/downloads>`__.  You
-will need version 0.1.7 or later:
+``ldnxflat`` is not part of NuttX and cannot be: it is GPL and derives from
+elf2flt.  It lives in the NuttX buildroot toolchain, at
+`patacongo/buildroot <https://github.com/patacongo/buildroot>`__, under
+``toolchain/nxflat``.
 
--  Unpack the package and ``cd`` into the resulting directory.
--  Copy a configuration file into the top buildroot directory:
-   ``cp boards/abc-defconfig-x.y.z .config``.
--  Run ``make menuconfig`` and select the NXFLAT toolchain.  Building GCC
-   can be omitted if you already have a toolchain of your own.
--  Run ``make``.  The tool binaries are left under
-   ``build_abc/staging_dir/bin``; put that directory on your ``PATH``.
+Only that one tool is needed.  The rest of the buildroot toolchain is not:
+an ordinary ``arm-none-eabi`` GCC compiles and links NXFLAT modules, so a
+board does not have to select ``CONFIG_ARM_TOOLCHAIN_BUILDROOT`` to use
+them.
+
+``ldnxflat`` reads its input through libbfd, so it is built against a
+binutils source tree and a binutils build of the same version.
+``toolchain/nxflat/Makefile`` takes those as ``BINUTILS_DIR`` and
+``BINUTILS_DIR1``, and expects an ``arch`` symbolic link naming the target,
+``thumb2`` or ``arm``.  Where the binutils build leaves ``libbfd.a`` varies,
+so the library path may need adjusting.  Put the result on your ``PATH``.
 
 On ARM, ``arch/arm/src/common/Toolchain.defs`` provides both ``MKNXFLAT``
 (with the ``-a`` option following ``CONFIG_ARM_THUMB``) and ``LDNXFLAT``, so

--- a/Documentation/introduction/about.rst
+++ b/Documentation/introduction/about.rst
@@ -38,7 +38,7 @@ NuttX is a real time embedded operating system (RTOS). Its goals are:
   Non-restrictive Apache license.
 
 * **GNU Toolchains**
-  Compatible GNU toolchains based on `buildroot <http://buildroot.uclibc.org/>`__ available for `download <https://bitbucket.org/nuttx/buildroot/downloads/>`__
+  Compatible GNU toolchains based on `buildroot <http://buildroot.uclibc.org/>`__ available for `download <https://github.com/patacongo/buildroot>`__
   to provide a complete development environment for many architectures.
 
 Feature Set

--- a/Documentation/introduction/development_environments.rst
+++ b/Documentation/introduction/development_environments.rst
@@ -11,11 +11,11 @@ The is the most natural development environment for NuttX. Any version
 of the GCC/binutils toolchain may be used. There is a highly modified
 `buildroot <http://buildroot.uclibc.org/>`__ available for download from
 the `NuttX
-Bitbucket.org <https://bitbucket.org/nuttx/buildroot/downloads/>`__
-page. This download may be used to build a NuttX-compatible ELF
+buildroot <https://github.com/patacongo/buildroot>`__
+repository. This download may be used to build a NuttX-compatible ELF
 toolchain under Linux or Cygwin. That toolchain will support ARM, m68k,
 m68hc11, m68hc12, and SuperH ports. The buildroot GIT may be accessed in
-the NuttX `buildroot GIT <https://bitbucket.org/nuttx/buildroot>`__.
+the NuttX `buildroot repository <https://github.com/patacongo/buildroot>`__.
 
 Linux + GNU ``make`` + SDCC for Linux
 =====================================
@@ -33,7 +33,7 @@ Windows with Cygwin + GNU ``make`` + GCC/binutils (custom built under Cygwin)
 This combination works well too. It works just as well as the native
 Linux environment except that compilation and build times are a little
 longer. The custom NuttX
-`buildroot <https://bitbucket.org/nuttx/buildroot/downloads/>`__
+`buildroot <https://github.com/patacongo/buildroot>`__
 referenced above may be build in the Cygwin environment as well.
 
 Windows with Cygwin + GNU ``make`` + SDCC (custom built under Cygwin)

--- a/Documentation/legacy_README.md
+++ b/Documentation/legacy_README.md
@@ -707,7 +707,7 @@ These are standalone repositories:
     originates from <http://cxx.uclibc.org/> and has been adapted for NuttX by the
     RGMP team (<http://rgmp.sourceforge.net/wiki/index.php/Main_Page>).
 
-  * <https://bitbucket.org/nuttx/buildroot>
+  * <https://github.com/patacongo/buildroot>
 
     A environment that you can to use to build a custom, NuttX GNU toolchain.
 
@@ -1841,7 +1841,7 @@ then you may encounter these:
      for NXFLAT.  NXFLAT is a binary format described in
      Documentation/NuttXNxFlat.html.  It may be possible to build
      standalone versions of the NXFLAT tools; there are a few examples
-     of this in the buildroot repository at <https://bitbucket.org/nuttx/buildroot>
+     of this in the buildroot repository at <https://github.com/patacongo/buildroot>
      However, it is possible that there could be interoperability issues
      with your toolchain since they will be using different versions of
      binutils and possibly different ABIs.

--- a/Documentation/platforms/arm/c5471/boards/c5471evm/README.txt
+++ b/Documentation/platforms/arm/c5471/boards/c5471evm/README.txt
@@ -9,7 +9,7 @@ Toolchain
   different from the default).
 
   If you have no ARM toolchain, one can be downloaded from the NuttX
-  Bitbucket download site (https://bitbucket.org/nuttx/buildroot/downloads/).
+  buildroot repository (https://github.com/patacongo/buildroot).
 
   1. You must have already configured NuttX in <some-dir>nuttx.
 

--- a/Documentation/platforms/arm/dm320/boards/ntosd-dm320/README.txt
+++ b/Documentation/platforms/arm/dm320/boards/ntosd-dm320/README.txt
@@ -112,7 +112,7 @@ NuttX buildroot Toolchain
   different from the default).
 
   If you have no ARM toolchain, one can be downloaded from the NuttX
-  Bitbucket download site (https://bitbucket.org/nuttx/buildroot/downloads/).
+  buildroot repository (https://github.com/patacongo/buildroot).
 
   1. You must have already configured NuttX in <some-dir>nuttx.
 

--- a/Documentation/platforms/arm/kl/boards/freedom-kl25z/README.txt
+++ b/Documentation/platforms/arm/kl/boards/freedom-kl25z/README.txt
@@ -39,7 +39,7 @@ NuttX Buildroot Toolchain
   different from the default in your PATH variable).
 
   If you have no Cortex-M0 toolchain, one can be downloaded from the NuttX
-  Bitbucket download site (https://bitbucket.org/nuttx/buildroot/downloads/).
+  buildroot repository (https://github.com/patacongo/buildroot).
   This GNU toolchain builds and executes in the Linux or Cygwin environment.
 
   1. You must have already configured NuttX in <some-dir>/nuttx.

--- a/Documentation/platforms/arm/kl/boards/freedom-kl26z/README.txt
+++ b/Documentation/platforms/arm/kl/boards/freedom-kl26z/README.txt
@@ -39,7 +39,7 @@ NuttX Buildroot Toolchain
   different from the default in your PATH variable).
 
   If you have no Cortex-M0 toolchain, one can be downloaded from the NuttX
-  Bitbucket download site (https://bitbucket.org/nuttx/buildroot/downloads/).
+  buildroot repository (https://github.com/patacongo/buildroot).
   This GNU toolchain builds and executes in the Linux or Cygwin environment.
 
   1. You must have already configured NuttX in <some-dir>/nuttx.

--- a/Documentation/platforms/arm/lpc17xx/index.rst
+++ b/Documentation/platforms/arm/lpc17xx/index.rst
@@ -156,7 +156,7 @@ boards.
 2) Cygwin/MSYS with Cygwin GNU toolchain, 3) Cygwin/MSYS with Windows
 native toolchain (CodeSourcery devkitARM or Code Red), or 4) Native
 Windows. A DIY toolchain for Linux or Cygwin is provided by the NuttX
-`buildroot <https://bitbucket.org/nuttx/buildroot/downloads/>`__
+`buildroot <https://github.com/patacongo/buildroot>`__
 package.
 
 NXP LPC178x

--- a/Documentation/platforms/arm/lpc214x/boards/mcu123-lpc214x/README.txt
+++ b/Documentation/platforms/arm/lpc214x/boards/mcu123-lpc214x/README.txt
@@ -54,7 +54,7 @@ NuttX buildroot Toolchain
   different from the default in your PATH variable).
 
   If you have no Cortex-M3 toolchain, one can be downloaded from the NuttX
-  Bitbucket download site (https://bitbucket.org/nuttx/buildroot/downloads/).
+  buildroot repository (https://github.com/patacongo/buildroot).
   This GNU toolchain builds and executes in the Linux or Cygwin environment.
 
   1. You must have already configured NuttX in <some-dir>/nuttx.

--- a/Documentation/platforms/arm/lpc31xx/boards/ea3131/index.rst
+++ b/Documentation/platforms/arm/lpc31xx/boards/ea3131/index.rst
@@ -81,7 +81,7 @@ be modified to point to the correct path to the Cortex-M3 GCC toolchain (if
 different from the default in your PATH variable).
 
 If you have no Cortex-M3 toolchain, one can be downloaded from the NuttX
-Bitbucket download site (https://bitbucket.org/nuttx/buildroot/downloads/).
+buildroot repository (https://github.com/patacongo/buildroot).
 This GNU toolchain builds and executes in the Linux or Cygwin environment.
 
 1. You must have already configured NuttX in ``<some-dir>/nuttx``.

--- a/Documentation/platforms/arm/lpc31xx/boards/ea3152/index.rst
+++ b/Documentation/platforms/arm/lpc31xx/boards/ea3152/index.rst
@@ -81,7 +81,7 @@ be modified to point to the correct path to the Cortex-M3 GCC toolchain (if
 different from the default in your ``PATH`` variable).
 
 If you have no Cortex-M3 toolchain, one can be downloaded from the NuttX
-Bitbucket download site (https://bitbucket.org/nuttx/buildroot/downloads/).
+buildroot repository (https://github.com/patacongo/buildroot).
 This GNU toolchain builds and executes in the Linux or Cygwin environment.
 
 1. You must have already configured NuttX in ``<some-dir>/nuttx``.

--- a/Documentation/platforms/arm/lpc31xx/boards/olimex-lpc-h3131/index.rst
+++ b/Documentation/platforms/arm/lpc31xx/boards/olimex-lpc-h3131/index.rst
@@ -89,7 +89,7 @@ be modified to point to the correct path to the Cortex-M3 GCC toolchain (if
 different from the default in your ``PATH`` variable).
 
 If you have no Cortex-M3 toolchain, one can be downloaded from the NuttX
-Bitbucket download site (https://bitbucket.org/nuttx/buildroot/downloads/).
+buildroot repository (https://github.com/patacongo/buildroot).
 This GNU toolchain builds and executes in the Linux or Cygwin environment.
 
 1. You must have already configured NuttX in ``<some-dir>/nuttx``.

--- a/Documentation/platforms/arm/nuc1xx/boards/nutiny-nuc120/README.txt
+++ b/Documentation/platforms/arm/nuc1xx/boards/nutiny-nuc120/README.txt
@@ -40,7 +40,7 @@ NuttX Buildroot Toolchain
   different from the default in your PATH variable).
 
   If you have no Cortex-M0 toolchain, one can be downloaded from the NuttX
-  Bitbucket download site (https://bitbucket.org/nuttx/buildroot/downloads/).
+  buildroot repository (https://github.com/patacongo/buildroot).
   This GNU toolchain builds and executes in the Linux or Cygwin environment.
 
   1. You must have already configured NuttX in <some-dir>/nuttx.

--- a/Documentation/platforms/arm/nuc1xx/index.rst
+++ b/Documentation/platforms/arm/nuc1xx/index.rst
@@ -36,7 +36,7 @@ development.
 2) Cygwin/MSYS with Cygwin GNU toolchain, 3) Cygwin/MSYS with Windows
 native toolchain, or 4) Native Windows. A DIY toolchain for Linux or
 Cygwin is provided by the NuttX
-`buildroot <https://bitbucket.org/nuttx/buildroot/downloads/>`__
+`buildroot <https://github.com/patacongo/buildroot>`__
 package.
 
 

--- a/Documentation/platforms/arm/sam34/index.rst
+++ b/Documentation/platforms/arm/sam34/index.rst
@@ -14,7 +14,7 @@ Cygwin (with native Windows GNU tools or Cygwin-based GNU tools).
 2) Cygwin/MSYS with Cygwin GNU toolchain, 3) Cygwin/MSYS with Windows
 native toolchain (CodeSourcery or devkitARM), or 4) Native Windows. A
 DIY toolchain for inux or Cygwin is provided by the NuttX
-`buildroot <https://bitbucket.org/nuttx/buildroot/downloads/>`__
+`buildroot <https://github.com/patacongo/buildroot>`__
 package.
 
 Microchip SAM3X
@@ -139,7 +139,7 @@ FLASH file system.
 with Windows native GNU Cortex-M3 or M4 toolchain (CodeSourcery or
 devkitARM), or 4) Native Windows. A DIY toolchain for Linux or Cygwin is
 provided by the NuttX
-`buildroot <https://bitbucket.org/nuttx/buildroot/downloads/>`__
+`buildroot <https://github.com/patacongo/buildroot>`__
 package.
 
 Supported Boards

--- a/Documentation/platforms/arm/sama5/boards/sama5d3-xplained/README.txt
+++ b/Documentation/platforms/arm/sama5/boards/sama5d3-xplained/README.txt
@@ -175,7 +175,7 @@ NuttX EABI "buildroot" Toolchain
   different from the default in your PATH variable).
 
   If you have no Cortex-M3 toolchain, one can be downloaded from the NuttX
-  Bitbucket download site (https://bitbucket.org/nuttx/buildroot/downloads/).
+  buildroot repository (https://github.com/patacongo/buildroot).
   This GNU toolchain builds and executes in the Linux or Cygwin environment.
 
   1.  You must have already configured NuttX in <some-dir>/nuttx.

--- a/Documentation/platforms/arm/sama5/boards/sama5d3x-ek/README.txt
+++ b/Documentation/platforms/arm/sama5/boards/sama5d3x-ek/README.txt
@@ -173,7 +173,7 @@ NuttX EABI "buildroot" Toolchain
   different from the default in your PATH variable).
 
   If you have no Cortex-M3 toolchain, one can be downloaded from the NuttX
-  Bitbucket download site (https://bitbucket.org/nuttx/buildroot/downloads/).
+  buildroot repository (https://github.com/patacongo/buildroot).
   This GNU toolchain builds and executes in the Linux or Cygwin environment.
 
   1. You must have already configured NuttX in <some-dir>/nuttx.

--- a/Documentation/platforms/arm/sama5/boards/sama5d4-ek/README.txt
+++ b/Documentation/platforms/arm/sama5/boards/sama5d4-ek/README.txt
@@ -167,7 +167,7 @@ NuttX EABI "buildroot" Toolchain
   different from the default in your PATH variable).
 
   If you have no Cortex-M3 toolchain, one can be downloaded from the NuttX
-  Bitbucket download site (https://bitbucket.org/nuttx/buildroot/downloads/).
+  buildroot repository (https://github.com/patacongo/buildroot).
   This GNU toolchain builds and executes in the Linux or Cygwin environment.
 
   1.  You must have already configured NuttX in <some-dir>/nuttx.

--- a/Documentation/platforms/arm/samd2l2/boards/samd20-xplained/README.txt
+++ b/Documentation/platforms/arm/samd2l2/boards/samd20-xplained/README.txt
@@ -355,7 +355,7 @@ NuttX EABI "buildroot" Toolchain
   different from the default in your PATH variable).
 
   If you have no Cortex-M0 toolchain, one can be downloaded from the NuttX
-  Bitbucket download site (https://bitbucket.org/nuttx/buildroot/downloads/).
+  buildroot repository (https://github.com/patacongo/buildroot).
   This GNU toolchain builds and executes in the Linux or Cygwin environment.
 
   1. You must have already configured NuttX in <some-dir>/nuttx.

--- a/Documentation/platforms/arm/samd2l2/boards/saml21-xplained/README.txt
+++ b/Documentation/platforms/arm/samd2l2/boards/saml21-xplained/README.txt
@@ -338,7 +338,7 @@ NuttX EABI "buildroot" Toolchain
   different from the default in your PATH variable).
 
   If you have no Cortex-M0 toolchain, one can be downloaded from the NuttX
-  Bitbucket download site (https://bitbucket.org/nuttx/buildroot/downloads/).
+  buildroot repository (https://github.com/patacongo/buildroot).
   This GNU toolchain builds and executes in the Linux or Cygwin environment.
 
   1. You must have already configured NuttX in <some-dir>/nuttx.

--- a/Documentation/platforms/arm/stm32f4/index.rst
+++ b/Documentation/platforms/arm/stm32f4/index.rst
@@ -401,7 +401,7 @@ be modified to point to the correct path to the Cortex-M3 GCC toolchain (if
 different from the default in your PATH variable).
 
 If you have no Cortex-M3 toolchain, one can be downloaded from the NuttX
-Bitbucket download site (https://bitbucket.org/nuttx/buildroot/downloads/).
+buildroot repository (https://github.com/patacongo/buildroot).
 This GNU toolchain builds and executes in the Linux or Cygwin environment.
 
 NXFLAT Toolchain

--- a/Documentation/platforms/arm/stm32l4/boards/nucleo-l432kc/index.rst
+++ b/Documentation/platforms/arm/stm32l4/boards/nucleo-l432kc/index.rst
@@ -118,7 +118,7 @@ be modified to point to the correct path to the Cortex-M3 GCC toolchain (if
 different from the default in your PATH variable).
 
 If you have no Cortex-M3 toolchain, one can be downloaded from the NuttX
-Bitbucket download site (https://bitbucket.org/nuttx/buildroot/downloads/).
+buildroot repository (https://github.com/patacongo/buildroot).
 This GNU toolchain builds and executes in the Linux or Cygwin environment.
 
 1. You must have already configured NuttX in <some-dir>/nuttx.::

--- a/Documentation/platforms/arm/stm32l4/boards/nucleo-l476rg/index.rst
+++ b/Documentation/platforms/arm/stm32l4/boards/nucleo-l476rg/index.rst
@@ -119,7 +119,7 @@ be modified to point to the correct path to the Cortex-M3 GCC toolchain (if
 different from the default in your PATH variable).
 
 If you have no Cortex-M3 toolchain, one can be downloaded from the NuttX
-Bitbucket download site (https://bitbucket.org/nuttx/buildroot/downloads/).
+buildroot repository (https://github.com/patacongo/buildroot).
 This GNU toolchain builds and executes in the Linux or Cygwin environment.
 
 1. You must have already configured NuttX in <some-dir>/nuttx.::

--- a/Documentation/platforms/arm/str71x/boards/olimex-strp711/README.txt
+++ b/Documentation/platforms/arm/str71x/boards/olimex-strp711/README.txt
@@ -169,7 +169,7 @@ NuttX buildroot Toolchain
   different from the default).
 
   If you have no ARM toolchain, one can be downloaded from the NuttX
-  Bitbucket download site (https://bitbucket.org/nuttx/buildroot/downloads/).
+  buildroot repository (https://github.com/patacongo/buildroot).
 
   1. You must have already configured NuttX in <some-dir>nuttx.
 

--- a/Documentation/platforms/arm/tiva/index.rst
+++ b/Documentation/platforms/arm/tiva/index.rst
@@ -30,7 +30,7 @@ with a GNU arm-nuttx-elf toolchain\* under either Linux or Cygwin.
 2) Cygwin/MSYS with Cygwin GNU toolchain, 3) Cygwin/MSYS with Windows
 native toolchain (CodeSourcery or devkitARM), or 4) Native Windows. A
 DIY toolchain for Linux or Cygwin is provided by the NuttX
-`buildroot <https://bitbucket.org/nuttx/buildroot/downloads/>`__
+`buildroot <https://github.com/patacongo/buildroot>`__
 package.
 
 TI/Stellaris LM3S6965

--- a/Documentation/platforms/avr/at90usb/index.rst
+++ b/Documentation/platforms/avr/at90usb/index.rst
@@ -42,7 +42,7 @@ done:
 native toolchain, or 4) Native Windows. All testing, however, has been
 performed using the NuttX DIY toolchain for Linux or Cygwin is provided
 by the NuttX
-`buildroot <https://bitbucket.org/nuttx/buildroot/downloads/>`__
+`buildroot <https://github.com/patacongo/buildroot>`__
 package. As a result, that toolchain is recommended.
 
 Toolchains
@@ -64,7 +64,7 @@ Buildroot
 ---------
 
 There is a DIY buildroot version for the AVR boards here:
-http://bitbucket.org/nuttx/buildroot/downloads/. See the following section for
+https://github.com/patacongo/buildroot. See the following section for
 details on building this toolchain.
 
 Before building, make sure that the path to the new toolchain is included in

--- a/Documentation/platforms/avr/atmega/atmega128/boards/amber/index.rst
+++ b/Documentation/platforms/avr/atmega/atmega128/boards/amber/index.rst
@@ -214,7 +214,7 @@ Buildroot
 ---------
 
 There is a DIY buildroot version for the AVR boards here:
-http://bitbucket.org/nuttx/buildroot/downloads/. See the following section for
+https://github.com/patacongo/buildroot. See the following section for
 details on building this toolchain.
 
 You may also have to modify the PATH environment variable if your make cannot

--- a/Documentation/platforms/hc/m9s12/boards/demo9s12ne64/index.rst
+++ b/Documentation/platforms/hc/m9s12/boards/demo9s12ne64/index.rst
@@ -24,7 +24,7 @@ modified to point to the correct path to the HC12 GCC toolchain (if different
 from the default in your PATH variable).
 
 If you have no HC12 toolchain, one can be downloaded from the NuttX
-Bitbucket download site (https://bitbucket.org/nuttx/buildroot/downloads/).
+buildroot repository (https://github.com/patacongo/buildroot).
 This GNU toolchain builds and executes in the Linux or Cygwin
 environments.
 

--- a/Documentation/platforms/hc/m9s12/boards/ne64badge/index.rst
+++ b/Documentation/platforms/hc/m9s12/boards/ne64badge/index.rst
@@ -115,7 +115,7 @@ modified to point to the correct path to the HC12 GCC toolchain (if different
 from the default in your PATH variable).
 
 If you have no HC12 toolchain, one can be downloaded from the NuttX
-Bitbucket download site (https://bitbucket.org/nuttx/buildroot/downloads/).
+buildroot repository (https://github.com/patacongo/buildroot).
 This GNU toolchain builds and executes in the Linux or Cygwin
 environments.
 

--- a/Documentation/platforms/hc/m9s12/index.rst
+++ b/Documentation/platforms/hc/m9s12/index.rst
@@ -14,7 +14,7 @@ included:
 -  The Future Electronics Group NE64 /PoE Badge board.
 
 Both use a GNU arm-nuttx-elf toolchain\* under Linux or Cygwin. The
-NuttX `buildroot <https://bitbucket.org/nuttx/buildroot/downloads/>`__
+NuttX `buildroot <https://github.com/patacongo/buildroot>`__
 provides a properly patched GCC 3.4.4 toolchain that is highly optimized
 for the m9s12x family.
 

--- a/Documentation/platforms/misco/lm32/boards/misoc/index.rst
+++ b/Documentation/platforms/misco/lm32/boards/misoc/index.rst
@@ -15,8 +15,8 @@ A GNU GCC-based toolchain is assumed. The ``PATH`` environment variable should
 be modified to point to the correct path to the LM32 GCC toolchain (if different
 from the default in your ``PATH`` variable).
 
-If you have no LM32 toolchain, one can be cloned from the NuttX Bitbucket GIT
-repository (https://bitbucket.org/nuttx/buildroot). This GNU toolchain builds
+If you have no LM32 toolchain, one can be cloned from the NuttX buildroot GIT
+repository (https://github.com/patacongo/buildroot). This GNU toolchain builds
 and executes in the Linux or Cygwin environment.
 
 1. You must have already configured NuttX in ``<some-dir>/nuttx``.
@@ -30,13 +30,13 @@ and executes in the Linux or Cygwin environment.
 
 .. code:: console
 
-   $ git clone git@bitbucket.org:nuttx/buildroot.git <some-dir>/buildroot
+   $ git clone git@github.com:patacongo/buildroot.git <some-dir>/buildroot
 
 or
 
 .. code:: console
 
-   $ git clone https://patacongo@bitbucket.org/nuttx/buildroot.git <some-dir>/buildroot
+   $ git clone https://github.com/patacongo/buildroot.git <some-dir>/buildroot
 
 3. 
 

--- a/Documentation/platforms/renesas/m16c/boards/skp16c26/index.rst
+++ b/Documentation/platforms/renesas/m16c/boards/skp16c26/index.rst
@@ -70,7 +70,7 @@ Building the R8C/M16C/M32C GNU Toolchain Using Buildroot
 
      .. code:: console
 
-        $ git clone https://patacongo@bitbucket.org/nuttx/buildroot.git buildroot
+        $ git clone https://github.com/patacongo/buildroot.git buildroot
 
      Make the archive directory:
 

--- a/Documentation/platforms/renesas/sh1/boards/us7032evb1/index.rst
+++ b/Documentation/platforms/renesas/sh1/boards/us7032evb1/index.rst
@@ -23,7 +23,7 @@ modified to point to the correct path to the SH toolchain (if different from the
 default).
 
 If you have no SH toolchain, one can be downloaded from the NuttX Bitbucket
-download site (https://bitbucket.org/nuttx/buildroot/downloads/).
+repository (https://github.com/patacongo/buildroot).
 
 1. You must have already configured NuttX in <some-dir>nuttx.
 

--- a/tools/ci/testlist/arm-06.dat
+++ b/tools/ci/testlist/arm-06.dat
@@ -1,5 +1,5 @@
 /arm/r*,CONFIG_ARM_TOOLCHAIN_GNU_EABI
-# NXFLAT tools (mknxflat) are not available in the CI container
+# ldnxflat is not available in the CI container.  mknxflat is in tree.
 -pimoroni-pico-2-plus:xipfs-nxflat
 
 # Boards build by CMake


### PR DESCRIPTION
## Summary

Two things in the NXFLAT documentation are no longer true.

The download link is dead. `bitbucket.org/nuttx/buildroot` returns 404; the buildroot that still carries `ldnxflat` is [patacongo/buildroot](https://github.com/patacongo/buildroot).

The instructions also ask for more than is needed. `mknxflat` came in tree with #19600, so only `ldnxflat` has to be built, and an ordinary `arm-none-eabi` GCC compiles and links NXFLAT modules — a board does not have to select `CONFIG_ARM_TOOLCHAIN_BUILDROOT` to use them. The page still described building the whole buildroot toolchain through `make menuconfig`.

What `ldnxflat` does need, and what the page did not say, is a binutils source tree and a binutils build of the same version, because it reads its input through libbfd.

The CI test list carried the same stale claim: `tools/ci/testlist/arm-06.dat` says the container lacks `mknxflat`. It lacks `ldnxflat`; `mknxflat` is built from `tools/nxflat` whenever `CONFIG_NXFLAT` is set.

## Impact

Documentation and one comment. No code, no configuration.

## Testing

Verified by doing it: `ldnxflat` built from `patacongo/buildroot` against binutils 2.43 libbfd, and `lm3s6965-ek:qemu-nxflat` built with the stock `arm-none-eabi` GCC 15.3 rather than the buildroot toolchain, with `CONFIG_ARM_TOOLCHAIN_GNU_EABI` in place of `CONFIG_ARM_TOOLCHAIN_BUILDROOT`. It runs under `qemu-system-arm -M lm3s6965evb`: the `errno` and `hello` NXFLAT tests pass.

`tools/checkpatch.sh -c -u -m -g` passes.

## The rest of the dead links

The second commit takes the same dead address out of the other 33 files that carried it, mostly as a "Bitbucket download site" for some board's toolchain. There are no downloads to offer, so those now name the repository and the prose around them says so.

Every repository under the old Bitbucket organisation is gone, not just buildroot:

| address | status |
| --- | --- |
| `bitbucket.org/nuttx/buildroot` | 404 |
| `bitbucket.org/nuttx/nuttx` | 404 |
| `bitbucket.org/nuttx/tools` | 404 |
| `bitbucket.org/nuttx/uclibc` | 404 |
| `bitbucket.org/nuttx/nxwidgets` | 404 |
| `bitbucket.org/patacongo/obsoleted` | 200, left alone |

Only the buildroot ones are changed here, because `patacongo/buildroot` is a verified replacement. The others each need a decision about what replaces them, which is not this patch.

