### PR TITLE
Documentation/applications/system/nxinit: document the "console" option

### DIFF
--- a/Documentation/applications/system/nxinit/index.rst
+++ b/Documentation/applications/system/nxinit/index.rst
@@ -52,9 +52,45 @@ File path configured by ``CONFIG_SYSTEM_NXINIT_RC_FILE_PATH``.
   via the override option).
 - Options are modifiers for services, affecting their running mode and timing.
   Examples include class (specify service category for batch start/stop),
+  console (redirect the service's stdio to a console device; see below),
   override (override previously defined services), restart_period (interval
   for restarting exited services), and reboot_on_failure (critical services
   trigger device reboot on startup failure or abnormal exit).
+
+The ``console`` Option
+-----------------------
+
+.. code-block::
+
+    service <name> <pathname> [ <argument> ]*
+       console [ <device> ]
+
+A service does not open a console device on its own - it simply inherits
+whatever stdin/stdout/stderr NXInit itself has, which for many boards is
+never set up at all (there is no ``/dev/console`` unless
+``CONFIG_DEV_CONSOLE`` is enabled). ``console`` fixes this by opening
+``<device>`` (``CONFIG_SYSTEM_NXINIT_CONSOLE_DEV``, ``/dev/console`` by
+default, if omitted) and duplicating it onto the service's stdin, stdout
+and stderr before it is spawned.
+
+This is required for a plain shell service (e.g. ``service console sh``)
+to actually be usable as an interactive console. It is not needed for
+``nsh`` (the full NSH application, as opposed to plain ``sh``), which
+already does the equivalent internally via ``nsh_consolemain()``.
+
+For a USB gadget console (``CONFIG_CDCACM_CONSOLE``/``CONFIG_PL2303_CONSOLE``),
+the device does not exist until the gadget is actually registered with the
+USB stack - unlike a plain UART, this does not happen implicitly during
+early boot. The gadget must be brought up once, before any service using
+``console`` is started, e.g. via ``apps/system/cdcacm``'s ``sercon``:
+
+.. code-block::
+
+    on init
+        exec -- sercon
+
+    service console sh
+        console
 
 Triggers
 ========


### PR DESCRIPTION
## Summary

Documents the per-service `console [<device>]` option added to nxinit
by the companion apache/nuttx-apps#3776.

`Documentation/applications/system/nxinit/index.rst` is nxinit's only
existing doc page. This adds `console` to the option list in "Services
and Options" and a dedicated subsection explaining:

- what the option does (open the given device, or
  `CONFIG_SYSTEM_NXINIT_CONSOLE_DEV` if omitted, and dup it onto the
  service's stdin/stdout/stderr before spawning);
- why a plain shell service needs it while `nsh` does not (`nsh`
  already does the equivalent internally via `nsh_consolemain()`);
- why a USB gadget console (CDC-ACM/PL2303) additionally needs the
  gadget itself brought up first (e.g. via `exec -- sercon`), since
  the device does not exist until then, unlike a plain UART.

## Impact

Documentation only, no code change.

## Testing

```
$ tools/checkpatch.sh -g HEAD
✔️ All checks pass.
```

```
$ cd Documentation && make html
...
dumping search index in English (code: en)... done
dumping object inventory... done
build succeeded.

The HTML pages are in _build/html.
```

Confirmed the new section renders correctly in the generated output
(`_build/html/applications/system/nxinit/index.html`):

```
$ grep -o "console.\{0,80\}" _build/html/applications/system/nxinit/index.html
console-option">The <code class="docutils literal notranslate"><span class="pre">consol
console (redirect the service's stdio to a console device; see below),
console-option">
console</span></code> Option<a class="headerlink" href="#the-console-option" title="Lin
console [ &lt;device&gt; ]
```