### PR TITLE
drivers/serial: qemu serial driver fixes for SMP intel64

### DIFF
--- a/drivers/serial/serial_io.c
+++ b/drivers/serial/serial_io.c
@@ -172,8 +172,16 @@ void uart_recvchars(FAR uart_dev_t *dev)
 
   while (uart_rxavailable(dev))
     {
+      /* uart_read() advances recv.tail from thread context without holding
+       * the critical section, so on SMP it can move (and wrap) while we are
+       * in here.  Sample it once per iteration and derive the free space
+       * from that snapshot: a stale value only makes us store less now,
+       * whereas reading it twice can turn the batch length negative.
+       */
+
       int nexthead = rxbuf->head + 1 < rxbuf->size ? rxbuf->head + 1 : 0;
-      bool is_full = (nexthead == rxbuf->tail);
+      sbuf_size_t tail = rxbuf->tail;
+      bool is_full = (nexthead == tail);
       FAR char *pbuf = NULL;
       char ch;
 
@@ -182,13 +190,13 @@ void uart_recvchars(FAR uart_dev_t *dev)
 
       /* How many bytes are buffered */
 
-      if (rxbuf->head >= rxbuf->tail)
+      if (rxbuf->head >= tail)
         {
-          nbuffered = rxbuf->head - rxbuf->tail;
+          nbuffered = rxbuf->head - tail;
         }
       else
         {
-          nbuffered = rxbuf->size - rxbuf->tail + rxbuf->head;
+          nbuffered = rxbuf->size - tail + rxbuf->head;
         }
 
       /* Is the level now above the watermark level that we need to report? */
@@ -231,11 +239,11 @@ void uart_recvchars(FAR uart_dev_t *dev)
 
           if (!is_full)
             {
-              if (rxbuf->tail > rxbuf->head)
+              if (tail > rxbuf->head)
                 {
-                  nbytes = rxbuf->tail - rxbuf->head - 1;
+                  nbytes = tail - rxbuf->head - 1;
                 }
-              else if (rxbuf->tail)
+              else if (tail)
                 {
                   nbytes = rxbuf->size - rxbuf->head;
                 }

--- a/drivers/serial/serial_io.c
+++ b/drivers/serial/serial_io.c
@@ -57,14 +57,22 @@
 void uart_xmitchars(FAR uart_dev_t *dev)
 {
   uint16_t nbytes = 0;
+  sbuf_size_t head;
 
 #ifdef CONFIG_SMP
   irqstate_t flags = enter_critical_section();
 #endif
 
-  /* Send while we still have data in the TX buffer & room in the fifo */
+  /* Send while we still have data in the TX buffer & room in the fifo.
+   *
+   * uart_putxmitchar() advances xmit.head from thread context without
+   * holding the critical section, so on SMP it can move (and wrap) while
+   * we are in here.  Sample it once per iteration: a stale value only
+   * makes us send less now, whereas reading it twice can turn the batch
+   * length negative and send from far beyond the buffer.
+   */
 
-  while (dev->xmit.head != dev->xmit.tail && uart_txready(dev))
+  while ((head = dev->xmit.head) != dev->xmit.tail && uart_txready(dev))
     {
       /* Send the next byte */
 
@@ -72,9 +80,9 @@ void uart_xmitchars(FAR uart_dev_t *dev)
         {
           ssize_t sent;
 
-          if (dev->xmit.tail < dev->xmit.head)
+          if (dev->xmit.tail < head)
             {
-              sent = dev->xmit.head - dev->xmit.tail;
+              sent = head - dev->xmit.tail;
             }
           else
             {


### PR DESCRIPTION

## Summary

- drivers/serial: sample xmit.head once per iteration in uart_xmitchars()
- drivers/serial: read the consumer index once in uart_recvchars()

taken from #20030

## Impact

required for SMP intel64 to pass LPT tests

## Testing

The producer is pinned to CPU1 while the 16550 TX interrupt runs on CPU0,  so every wrap of the 16-byte ring races uart_xmitchars(). The host then checks that tx.bin is exactly the first 2000000 bytes of the repeated alphabet "abcdefghijklmnopqrstuvwxyz".
  
Before (serial_io.c from parent commit):
    217615369 bytes captured, 217540918 of them NUL; first mismatch at offset 55952 ("...stuvwxyz" followed by an endless 0x00 flood).
  
After (this branch):
    2000000 bytes captured, 0 NUL, stream byte-exact.
        
Only the TX fix is exercised. The RX batch path in uart_recvchars() needs a driver with recvbuf which is not supported for qemu-intel64 serial port.

CI pass for intel64: https://github.com/apache/nuttx/actions/runs/34236734404/job/102183306099?pr=20030
