### PR TITLE
boards/esp32s3-xiao: wire up Wi-Fi, guarding PM light sleep during ra…

### DIFF
--- a/boards/xtensa/esp32s3/esp32s3-xiao/src/esp32s3_bringup.c
+++ b/boards/xtensa/esp32s3/esp32s3-xiao/src/esp32s3_bringup.c
@@ -38,6 +38,7 @@
 #include <errno.h>
 #include <nuttx/fs/fs.h>
 #include <nuttx/himem/himem.h>
+#include <nuttx/power/pm.h>
 #include <arch/board/board.h>
 
 #include "espressif/esp_gpio.h"
@@ -45,6 +46,10 @@
 
 #ifdef CONFIG_ESPRESSIF_HR_TIMER
 #  include "espressif/esp_hr_timer.h"
+#endif
+
+#ifdef CONFIG_ESPRESSIF_WIFI
+#  include "esp32s3_board_wlan.h"
 #endif
 
 #ifdef CONFIG_ESP32S3_I2C
@@ -155,6 +160,25 @@ int esp32s3_bringup(void)
              "Failed to initialize LSM6DS3TR-C driver for I2C0: %d\n",
              ret);
     }
+#endif
+
+#ifdef CONFIG_ESPRESSIF_WIFI
+#  ifdef CONFIG_PM
+  /* Wi-Fi radio calibration can't tolerate PM_STANDBY light sleep. */
+
+  pm_stay(PM_IDLE_DOMAIN, PM_IDLE);
+#  endif
+
+  ret = board_wlan_init();
+  if (ret < 0)
+    {
+      syslog(LOG_ERR, "ERROR: Failed to initialize wlan subsystem=%d\n",
+             ret);
+    }
+
+#  ifdef CONFIG_PM
+  pm_relax(PM_IDLE_DOMAIN, PM_IDLE);
+#  endif
 #endif
 
   /* If we got here then perhaps not all initialization was successful, but


### PR DESCRIPTION
## Summary

`esp32s3-xiao`'s board bringup never wires up Wi-Fi at all: unlike
`esp32s3-devkit`/`esp32s3-eye`, it has no `#ifdef CONFIG_ESPRESSIF_WIFI`
include of `esp32s3_board_wlan.h` and no call to `board_wlan_init()`.
This PR adds both, mirroring those boards' pattern exactly.

Wiring it up on its own isn't enough for a board that also uses
`CONFIG_PM`, though: Wi-Fi's PHY/RF calibration inside
`board_wlan_init()` cannot tolerate the clock gating of `PM_STANDBY`
(light sleep). If the idle task enters light sleep while `phy_init`'s
calibration is still running -- which the greedy governor is free to
do the moment the CPU goes idle during driver init -- the calibration
hangs forever waiting on a clock that just stopped. This PR also adds
a `pm_stay(PM_IDLE_DOMAIN, PM_IDLE)` / `pm_relax()` guard around
`board_wlan_init()` to prevent that race.

`esp32c3-devkit` and `esp32c6-devkit` also combine `CONFIG_PM` with
Wi-Fi, but don't hit this today: both call `board_wlan_init()` well
before `esp_pmconfigure()` (which is what actually arms the PM
governor) runs, near the very end of bringup -- so PM isn't active yet
during their Wi-Fi init. `esp32s3-xiao`'s PM handling begins earlier in
bringup, which is why the two can race here.

## Impact

- Affects only `esp32s3-xiao`.
- No impact on boards that don't enable `CONFIG_ESPRESSIF_WIFI`, or
  that enable it without `CONFIG_PM` -- the new code is compiled out
  entirely in both cases.
- No impact on existing behavior for boards that enable both
  `CONFIG_PM` and `CONFIG_ESPRESSIF_WIFI` today (none currently do, on
  this board -- Wi-Fi wasn't wired up before this PR).

## Testing

Tested on real Seeed XIAO ESP32-S3 hardware (WROOM1-N8R8, 8MB octal
PSRAM), against this branch's `apache/nuttx:master` base, using a
config with `CONFIG_ESPRESSIF_WIFI` + `CONFIG_PM` both enabled (no
tickless scheduling involved -- this race is independent of it).

Without the PM guard (Wi-Fi wired up, `board_wlan_init()` called with
no lock around it): boot hangs 100% of the time, reproducible across
repeated flashes with 50s+ waits, right after the `net80211 rom
version` log line and before `phy_init` ever prints -- never reaches
NSH, and doesn't respond to a UART wakeup keypress either (a genuine
hang, not the board just being asleep).

With the fix in this PR, boot log:


```
I (951) pp: pp rom version: e7ae62f
I (952) net80211: net80211 rom version: e7ae62f
I (980) wifi_init: rx ba win: 6
I (981) wifi_init: LWIP disabled
I (985) phy_init: phy_version 711,97bcf0a2,Aug 25 2025,19:04:10

NuttShell (NSH) NuttX-13.0.1-RC1
nsh>
```


`ps` shows the `wifi` and `netdev-wlan0` kernel threads running
normally alongside the rest of the system:


```
    5     0     0 253 RR       Kthread   - Waiting  MQ empty  0000000000000000 0006608 wifi
    7     0     0 100 RR       Kthread   - Waiting  Semaphore 0000000000000000 0001960 netdev-wlan0 0x3fcb7168 0
```
`ifup wlan0` and `wapi scan wlan0` both work normally, finding real
access points:

```
nsh> ifup wlan0
ifup wlan0...OK
nsh> wapi scan wlan0
bssid / frequency / signal level / encode / ssid
e8:45:8b:44:a1:90	2437	-68	0800	VIVOFIBRA-WIFI6-A190
00:49:75:a3:55:83	2437	-50	0800	VIVOFIBRA-WIFI6-A190_EXT
94:37:98:2e:f8:fc	2437	-38	0800	repetidor-wifi
```