### PR TITLE
tools/nxstyle: whitelist Micro XRCE-DDS type names

### DIFF
--- a/tools/nxstyle.c
+++ b/tools/nxstyle.c
@@ -261,6 +261,17 @@ static const char *g_white_prefix[] =
 
   "uxrCustom",           /* uxrCustomTransport */
 
+  /* Ref:  apps/examples/xrcedds
+   * Public type names from the eProsima Micro XRCE-DDS Client and
+   * Micro-CDR APIs.
+   */
+
+  "uxrUDPTransport",     /* uxrUDPTransport */
+  "uxrSession",          /* uxrSession */
+  "uxrStreamId",         /* uxrStreamId */
+  "uxrObjectId",         /* uxrObjectId */
+  "ucdrBuffer",          /* ucdrBuffer */
+
   /* Ref:  arch/arm/src/common/ameba, arch/arm/src/rtl8721dx,
    * arch/arm/src/rtl8720f, arch/arm/src/rtl8721f and the matching boards.
    * Realtek Ameba SDK ROM/HAL symbols and ARM CMSE intrinsics referenced


### PR DESCRIPTION
Allow public eProsima Micro XRCE-DDS Client and Micro-CDR type names
used by the XRCE-DDS example.

## Summary

The XRCE-DDS example uses public type names from the eProsima
Micro XRCE-DDS Client and Micro-CDR APIs. Some of these identifiers
use mixed-case naming and cannot be renamed locally without changing
the upstream API names.

Add these identifiers to the nxstyle whitelist so that the XRCE-DDS
example can pass the NuttX style checks while preserving the upstream
API names.

Related to [apache/nuttx-apps#3777](https://github.com/apache/nuttx-apps/pull/3777).

## Impact

This change only extends the nxstyle identifier whitelist.

There is no runtime, ABI, hardware, or functional impact.

## Testing

Verified the XRCE-DDS source files with NuttX style checks after
adding the required public API identifiers to the whitelist.

The previous `Mixed case identifier found` errors for these
Micro XRCE-DDS / Micro-CDR identifiers are no longer reported.

```sh
~/nuttxspace/nuttx$ ./tools/checkpatch.sh -c -m -g upstream/master..HEAD
Used config files:
    1: .codespellrc
✔️ All checks pass.
```