### PR TITLE
sched/waitid: fix parent check and WNOWAIT handling

### DIFF
--- a/sched/sched/sched_cpuload_oneshot.c
+++ b/sched/sched/sched_cpuload_oneshot.c
@@ -194,7 +194,7 @@ static void nxsched_oneshot_start(void)
   /* Then re-start the oneshot timer */
 
   secs       = USEC2SEC(usecs);
-  usecs     -= 100000 * secs;
+  usecs     -= USEC_PER_SEC * secs;
 
   ts.tv_sec  = secs;
   ts.tv_nsec = 1000 * usecs;

--- a/sched/sched/sched_setscheduler.c
+++ b/sched/sched/sched_setscheduler.c
@@ -172,6 +172,11 @@ int nxsched_set_scheduler(pid_t pid, int policy,
   irqstate_t flags;
   int ret = -EINVAL;
 
+  if (param == NULL)
+    {
+      return -EINVAL;
+    }
+
   /* Check if the task to modify the calling task */
 
   if (pid == 0)

--- a/sched/sched/sched_waitid.c
+++ b/sched/sched/sched_waitid.c
@@ -56,7 +56,7 @@
 #ifdef CONFIG_SCHED_CHILD_STATUS
 static void exited_child(FAR struct tcb_s *rtcb,
                          FAR struct child_status_s *child,
-                         FAR siginfo_t *info)
+                         FAR siginfo_t *info, int options)
 {
   /* The child has exited. Return the saved exit status (and some fudged
    * information).
@@ -72,10 +72,15 @@ static void exited_child(FAR struct tcb_s *rtcb,
       info->si_status          = child->ch_status;
     }
 
-  /* Discard the child entry */
+  /* Discard the child entry unless WNOWAIT is set (the caller wants the
+   * child to remain in a waitable state).
+   */
 
-  group_remove_child(rtcb->group, child->ch_pid);
-  group_free_child(child);
+  if ((options & WNOWAIT) == 0)
+    {
+      group_remove_child(rtcb->group, child->ch_pid);
+      group_free_child(child);
+    }
 }
 #endif
 
@@ -117,7 +122,7 @@ int waittcb(FAR struct tcb_s *rtcb, idtype_t idtype, int options,
                * Return the exit status and break out of the loop.
                */
 
-              exited_child(rtcb, child, info);
+              exited_child(rtcb, child, info, options);
               break;
             }
         }
@@ -141,7 +146,7 @@ int waittcb(FAR struct tcb_s *rtcb, idtype_t idtype, int options,
                * of the loop.
                */
 
-              exited_child(rtcb, child, info);
+              exited_child(rtcb, child, info, options);
               break;
             }
         }
@@ -232,7 +237,7 @@ int waittcb(FAR struct tcb_s *rtcb, idtype_t idtype, int options,
 
                       if ((child->ch_flags & CHILD_FLAG_EXITED) != 0)
                         {
-                          exited_child(rtcb, child, NULL);
+                          exited_child(rtcb, child, NULL, options);
                         }
                     }
 #endif
@@ -255,7 +260,7 @@ int waittcb(FAR struct tcb_s *rtcb, idtype_t idtype, int options,
                   if (child &&
                       (child->ch_flags & CHILD_FLAG_EXITED) != 0)
                     {
-                      exited_child(rtcb, child, NULL);
+                      exited_child(rtcb, child, NULL, options);
                     }
                 }
 #endif
@@ -369,7 +374,7 @@ int waitid(idtype_t idtype, id_t id, FAR siginfo_t *info, int options)
 
   if ((idtype == P_PID || idtype == P_ALL) &&
       (options & WEXITED) != 0 &&
-      (options & ~(WEXITED | WNOHANG)) == 0)
+      (options & ~(WEXITED | WNOHANG | WNOWAIT)) == 0)
 #endif
     {
       errcode = OK;

--- a/sched/sched/sched_waitid.c
+++ b/sched/sched/sched_waitid.c
@@ -400,7 +400,7 @@ int waitid(idtype_t idtype, id_t id, FAR siginfo_t *info, int options)
             {
               /* Make sure that the thread it is our child. */
 
-              if (ctcb->group->tg_ppid != rtcb->pid)
+              if (ctcb->group->tg_ppid != rtcb->group->tg_pid)
                 {
                   errcode = ECHILD;
                 }
@@ -437,7 +437,8 @@ int waitid(idtype_t idtype, id_t id, FAR siginfo_t *info, int options)
 
           ctcb = nxsched_get_tcb((pid_t)id);
 
-          if (!ctcb || !ctcb->group || ctcb->group->tg_ppid != rtcb->pid)
+          if (!ctcb || !ctcb->group ||
+              ctcb->group->tg_ppid != rtcb->group->tg_pid)
             {
               errcode = ECHILD;
             }

--- a/sched/sched/sched_waitpid.c
+++ b/sched/sched/sched_waitpid.c
@@ -373,7 +373,8 @@ pid_t nxsched_waitpid(pid_t pid, FAR int *stat_loc, int options)
        */
 
       ctcb = nxsched_get_tcb(pid);
-      if (!ctcb || !ctcb->group || ctcb->group->tg_ppid != rtcb->pid ||
+      if (!ctcb || !ctcb->group ||
+          ctcb->group->tg_ppid != rtcb->group->tg_pid ||
           (ctcb->flags & TCB_FLAG_EXIT_PROCESSING) != 0)
         {
           ret = -ECHILD;


### PR DESCRIPTION
## Summary

Fix two waitid() bugs found during a code review of sched/sched:

* Parent/child verification compared the child's tg_ppid against the calling thread's pid (rtcb->pid) instead of its group pid, so any non-leader thread waiting for a child of its own group always got ECHILD (sched_waitid.c x2; same bug also fixed in sched_waitpid.c).
* waitid() documented WNOWAIT as supported but always discarded the child status entry, so WNOWAIT|WEXITED consumed the status and a subsequent real wait failed with ECHILD. Now the entry is kept when WNOWAIT is set, matching waitpid() behavior.

Also includes two small one-line fixes in the same area: sched_setscheduler() now rejects a NULL param with -EINVAL instead of dereferencing it, and cpuload_oneshot.c uses USEC_PER_SEC instead of a hardcoded 100000.

## Impact

bug fixes only

## Testing

   Host: macOS 26.6.2 ARM64, Apple Clang 21.0.0.
   Target: sim:ostest .
    Build: cmake + ninja complete successfully with "Linking C executable nuttx".
    Runtime: ran ./nuttx and executed ostest; all enabled OSTest subtests (5 loops) completed without assertions or unexpected errors, exiting with status 0.
    Static checks: nxstyle, checkpatch, and commit-message checks pass.
