### PR TITLE
arch/arm/am67: Mark the DDR MPU region Non-shareable.

### DIFF
--- a/arch/arm/src/am67/am67_mpuinit.h
+++ b/arch/arm/src/am67/am67_mpuinit.h
@@ -101,14 +101,17 @@
                                    MPU_RACR_AP_RWRW)
 
 /* DDR REGION
- *   Shareable
+ *   Non-shareable (do not add MPU_RACR_S)
  *   Cacheable
  *   Bufferable
  *   P:RW   U:RW
+ *
+ * NOTE: if DDR is marked Shareable, LDREX/STREX to it take an external data
+ * abort on this R5F; Non-shareable uses the core-local monitor instead.
+ * Observed with ldrex-based code (e.g. C++ std::atomic).
  */
 #define am67_ddr_region(base,size) \
   mpu_configure_region(base, size, MPU_RACR_TEX(1)  | \
-                                   MPU_RACR_S       | \
                                    MPU_RACR_C       | \
                                    MPU_RACR_B       | \
                                    MPU_RACR_AP_RWRW)


### PR DESCRIPTION
### Summary

  * Marking the DDR region Shareable makes `LDREX`/`STREX` to it take an
    external data abort on this Cortex-R5F: there is no external exclusive
    monitor on the path to DDR.
  * Non-shareable makes exclusives use the core-local monitor instead.
  * Every atomic on this chip compiles to inline LDREX/STREX: it selects no
    `LIBC_ATOMIC_*` backend and falls back to `LIBC_ATOMIC_TOOLCHAIN`. The abort
    therefore lands during early startup, before the console is up.
  * Drops `MPU_RACR_S` from `am67_ddr_region`.

### Impact

  * Is new feature added? Is existing feature changed? **YES** — changes the MPU
    attributes of the AM67 DDR region.
  * Impact on user? **NO** — AM67 only, and the previous setting was unusable.
  * Impact on build? **NO**.
  * Impact on hardware? **YES** — arch/arm/am67 only.
  * Impact on documentation? **NO**.
  * Impact on security? **NO**.
  * Impact on compatibility? **NO** — no external API or Kconfig change.
  * Anything else? No dependency on other PRs in this series.

### Testing

```
Build Host(s): Pardus GNU/Linux 25 (Debian 13 base), x86_64, host gcc 14
Toolchain:     arm-none-eabi-gcc 14.2.1 20241119 (15:14.2.rel1-1)
Target:        arm / TI AM67 (J722S) Cortex-R5F, board t3-gem-o1:nsh
nuttx-apps:    5a7ab4200
Loaded on the main-domain R5F by Linux remoteproc; console on UART-MAIN1.
```

Testing logs before change: the image loads and remoteproc reports the core
running, but the console stays silent — the abort happens before it comes up,
so there is no output to capture:

```
$ ssh <board> 'cat /sys/class/remoteproc/remoteprocN/state'
running
$ # UART-MAIN1: no output at all
```

The version string in the logs is from the tested build; the commits were
GPG-signed afterwards, which rewrites hashes. The code is unchanged.

Testing logs after change:

```
make distclean && ./tools/configure.sh t3-gem-o1:nsh && make -j
  -> nuttx ELF 511900 bytes, 0 compiler warnings

Console:
user_main: Exiting
ostest_main: Exiting with status 0

Test plan result:
console_alive            PASS  prompt responsive
version                  PASS  NuttX version 0.0.0 3b52393af4 Sep 10 2026 13:47:18 t3-gem-o1:nsh
procfs                   PASS  procfs readable
tasks                    PASS  2 task lines
heap_baseline            PASS  used=6672
ostest                   PASS  clean, status 0
heap_after_ostest        PASS  delta +232 bytes

PASS=7
```

### PR verification Self-Check

  * [x] This PR introduces only one functional change.
  * [x] I have updated all required description fields above.
  * [x] My PR adheres to Contributing Guidelines and Documentation.
  * [ ] My PR is still work in progress (not ready for review).
  * [x] My PR is ready for review and can be safely merged into a codebase.
