### PR TITLE
boards/arm/am67/t3-gem-o1: Load .data at its run address.

### DIFF
--- a/boards/arm/am67/t3-gem-o1/scripts/sdram.ld
+++ b/boards/arm/am67/t3-gem-o1/scripts/sdram.ld
@@ -101,7 +101,6 @@ SECTIONS
     } > ddr
 
     _etext = ABSOLUTE(.); /* End of code/read-only sections */
-    _sidata = _etext;    /* Start of initial values for .data (LMA) */
 
     .init_section :
     {
@@ -111,7 +110,7 @@ SECTIONS
         _einit = ABSOLUTE(.);
     } > ddr
 
-    .data : AT ( _sidata )
+    .data :
     {
         _sdata = ABSOLUTE(.);
         *(.data .data.*)


### PR DESCRIPTION
### Summary

  * The linker script gave `.data` a separate load address
    (`.data : AT (_sidata)`, `_sidata = _etext`), but this is a RAM/remoteproc
    image (`CONFIG_BOOT_RUNFROMISRAM=y`) whose `arm_data_initialize` only zeros
    `.bss` — the LMA→VMA copy is compiled out under `CONFIG_BOOT_RUNFROMFLASH`.
  * `_sidata` was taken before `.init_section`, so `.data`'s load address sat
    `sizeof(.init_section)` below its run address, and remoteproc loads segments
    by `p_paddr`.
  * That section is empty in both in-tree configurations, so the two addresses
    coincide today and the fault is **latent**: `LMA == VMA` already, and this
    change is a no-op for the shipped `nsh` and `netnsh` builds.
  * It becomes real as soon as anything lands in `.init_array` — a C++ static
    constructor, for instance — which is how it was first seen: initialised
    globals read shifted and the console pinmux table took a data abort in
    `arm_boot` before the console came up.
  * Dropping the `AT()` makes `.data` load at its run address (LMA == VMA),
    which is what is required when nothing copies `.data` at boot.

### Impact

  * Is new feature added? Is existing feature changed? **NO** — bug fix.
  * Impact on user? **NO**.
  * Impact on build? **NO** (link layout of one board only).
  * Impact on hardware? **YES** — t3-gem-o1 only.
  * Impact on documentation? **NO**.
  * Impact on security? **NO**.
  * Impact on compatibility? **NO**.
  * Anything else? No dependency on other PRs in this series.

### Testing

```
Build Host(s): Pardus GNU/Linux 25 (Debian 13 base), x86_64, host gcc 14
Toolchain:     arm-none-eabi-gcc 14.2.1 20241119 (15:14.2.rel1-1)
Target:        arm / TI AM67 (J722S) Cortex-R5F, board t3-gem-o1:nsh
nuttx-apps:    5a7ab4200
Loaded on the main-domain R5F by Linux remoteproc; console on UART-MAIN1.
```

Testing logs before change: not reproducible in the in-tree configurations --
`.init_section` is empty there, so `_sidata` already equals `_sdata` and the
pre-change image links with `LMA == VMA`. The fault was originally observed in
a build with C++ static constructors. Verified by inspection instead:

```
$ arm-none-eabi-nm nuttx | grep -E ' _etext| _sinit| _einit| _sdata'
a2235168 A _einit
a2235168 A _etext
a2235168 A _sdata
a2235168 A _sinit
```

Because the fault is latent, the pre-change image boots too. The log below
therefore shows only that this change does no harm -- it is not evidence of a
failure being fixed.

The version string in the logs is from the tested build; the commits were
GPG-signed afterwards, which rewrites hashes. The code is unchanged.

Testing logs after change:

```
make distclean && ./tools/configure.sh t3-gem-o1:nsh && make -j
  -> nuttx ELF 511876 bytes, 0 compiler warnings

Console:
nsh> echo hwtest-alive
nsh> cat /proc/version
NuttX version 0.0.0 8ec1e42bf0 Sep 10 2026 13:47:37 t3-gem-o1:nsh
nsh> ls /proc
nsh> cat /proc/meminfo
nsh> ps

Test plan result:
console_alive            PASS  prompt responsive
version                  PASS  NuttX version 0.0.0 8ec1e42bf0 Sep 10 2026 13:47:37 t3-gem-o1:nsh
procfs                   PASS  procfs readable
tasks                    PASS  2 task lines

PASS=4
```

### PR verification Self-Check

  * [x] This PR introduces only one functional change.
  * [x] I have updated all required description fields above.
  * [x] My PR adheres to Contributing Guidelines and Documentation.
  * [ ] My PR is still work in progress (not ready for review).
  * [x] My PR is ready for review and can be safely merged into a codebase.
