### PR TITLE
cmake: fix savedefconfig semicolon decoding on wrong variable

### DIFF
--- a/cmake/savedefconfig.cmake
+++ b/cmake/savedefconfig.cmake
@@ -42,7 +42,7 @@ foreach(NameAndValue ${ConfigContents})
      OR "${NameAndValue}" MATCHES "CONFIG_ARCH_BOARD_COMMON="
      OR "${NameAndValue}" MATCHES "^CONFIG_ARCH_CUSTOM"
      OR "${NameAndValue}" MATCHES "^CONFIG_ARCH_BOARD_CUSTOM")
-    decode_semicolon(Value)
+    decode_semicolon(NameAndValue)
     file(APPEND ${TARGET_FILE} "${NameAndValue}\n")
   endif()
 endforeach()


### PR DESCRIPTION
## Summary

The arch-line filter in `cmake/savedefconfig.cmake` encodes semicolons in `NameAndValue` (to survive CMake list iteration), but then decoded a never-assigned `Value` variable before appending the line to the defconfig. As a result, any matched  CONFIG_ARCH*` value containing a semicolon was written to the generated defconfig with literal `__SEMICOLON__` placeholders instead of the real characters. Decode `NameAndValue` itself.

No in-tree defconfig currently carries a semicolon in an arch value, so this is latent; the fix changes nothing for existing configs and only makes the intended path work.

## Impact

- **Users**: None -- no in-tree defconfig is affected; only configs with semicolons in `CONFIG_ARCH*` values, which were previously corrupted, are now emitted verbatim.
- **Build**: None -- the savedefconfig helper only.
- **Hardware**: None.
- **Documentation**: None.
- **Security & Compatibility**: None.

## Testing

feeding `CONFIG_ARCH_BOARD_CUSTOM_NAME="a;b;c"`:

Before:
```
CONFIG_ARCH_BOARD_CUSTOM_NAME="a__SEMICOLON__b__SEMICOLON__c"
```
After:
```
CONFIG_ARCH_BOARD_CUSTOM_NAME="a;b;c"
```

Signed-off-by: Junbo Zheng <[zhengjunbo1@xiaomi.com](mailto:zhengjunbo1@xiaomi.com)>