### PR TITLE
cmake: fix undefined function name in parse args error messages

### DIFF
--- a/cmake/nuttx_parse_function_args.cmake
+++ b/cmake/nuttx_parse_function_args.cmake
@@ -73,14 +73,14 @@ function(nuttx_parse_function_args)
                         "${IN_MULTI_VALUE}" "${IN_ARGN}")
 
   if(OUT_UNPARSED_ARGUMENTS)
-    message(FATAL_ERROR "${IN_NAME}: unparsed ${OUT_UNPARSED_ARGUMENTS}")
+    message(FATAL_ERROR "${IN_FUNC}: unparsed ${OUT_UNPARSED_ARGUMENTS}")
   endif()
 
   foreach(arg ${IN_REQUIRED})
     if(NOT OUT_${arg})
       if(NOT "${OUT_${arg}}" STREQUAL "0")
         message(
-          FATAL_ERROR "${IN_NAME} requires argument ${arg}\nARGN: ${IN_ARGN}")
+          FATAL_ERROR "${IN_FUNC} requires argument ${arg}\nARGN: ${IN_ARGN}")
       endif()
     endif()
   endforeach()


### PR DESCRIPTION
## Summary

`nuttx_parse_function_args()` declares `FUNC` as its one-value keyword, so the parsed variable is `IN_FUNC`. However, both `FATAL_ERROR` messages referenced a never-defined `${IN_NAME}`, which always expands to an empty string. As a result, every argument-misuse diagnostic of every wrapper built on this parser printed an empty function name, and the user had no way to tell which function rejected the arguments. Reference `IN_FUNC` instead.

## Impact

- **Users**: None -- error-message-only change; no behavior change on any successful configure path.
- **Build**: None -- the parse logic itself is untouched.
- **Hardware**: None.
- **Documentation**: None.
- **Security & Compatibility**: None.

## Testing

Called a wrapper of `nuttx_parse_function_args()` with a bad keyword and with a missing required argument via `cmake -P` on Ubuntu 22.04:

Before:
CMake Error at cmake/nuttx_parse_function_args.cmake:76 (message):
```
  : unparsed WRONG;x
```
After:
CMake Error at cmake/nuttx_parse_function_args.cmake:76 (message):
```
  myfunc: unparsed WRONG;x
```
CMake Error at cmake/nuttx_parse_function_args.cmake:82 (message):
```
  myfunc requires argument MODE
```
Both error paths now identify the calling function.

Signed-off-by: Junbo Zheng <[zhengjunbo1@xiaomi.com](mailto:zhengjunbo1@xiaomi.com)>