### PR TITLE
arch/risc-v/src/common: fix wrong vregs access in up_initial_state

### DIFF
--- a/arch/risc-v/src/common/riscv_initialstate.c
+++ b/arch/risc-v/src/common/riscv_initialstate.c
@@ -60,7 +60,7 @@ void up_initial_state(struct tcb_s *tcb)
 {
   struct xcptcontext *xcp = &tcb->xcp;
 #if defined(CONFIG_ARCH_RV_ISA_V) && (CONFIG_ARCH_RV_VECTOR_BYTE_LENGTH == 0)
-  uintptr_t *vregs = tcb->vregs;
+  uintreg_t *vregs = xcp->vregs;
 #endif
   uintptr_t regval;
   uintptr_t topstack;


### PR DESCRIPTION
## Summary

Fix a build failure when `CONFIG_ARCH_RV_ISA_V=y` and
`CONFIG_ARCH_RV_VECTOR_BYTE_LENGTH=0`. 
`vregs` belongs to `struct xcptcontext`, not `struct tcb_s`.

## Impact

Cause a build failure.

## Testing

ostest passed on QEMU 8.2.10.

- Host: Ubuntu 20.04.6 LTS, x86_64
- Toolchain: xPack RISC-V Embedded GCC 15.2.0
- Board configuration: `rv-virt:smp64`
- Emulator: QEMU 8.2.10

Configuration:

```text
CONFIG_ARCH_RV_ISA_V=y
CONFIG_ARCH_RV_VECTOR_BYTE_LENGTH=0
CONFIG_SMP_NCPUS=8
```

Test results:

```text
NuttShell (NSH) NuttX-13.0.1-RC1
nsh>uname -a
NuttX 13.0.1-RC1 0d41cda84d Sep 11 2026 14:40:04 risc-v rv-virt
nsh>
nsh> ostest
(...)
wdog_test end...

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fcfbe0  1fcfbe0
ordblks        11       11
mxordblk  1fb2468  1fb2468
uordblks     b818     b818
fordblks  1fc43c8  1fc43c8

user_main: round-robin scheduler test
rr_test: Set thread priority to 1
rr_test: Set thread policy to SCHED_RR
rr_test: Starting first get_primes_thread
         First get_primes_thread: 655
rr_test: Starting second get_primes_thread
         Second get_primes_thread: 656
rr_test: Waiting for threads to complete -- this should take awhile
         If RR scheduling is working, they should start and complete at
         about the same time
get_primes_thread id=1 started, looking for primes < 30000, doing 10 run(s)
get_primes_thread id=2 started, looking for primes < 30000, doing 10 run(s)
get_primes_thread id=1 finished, found 3246 primes, last one was 29989
get_primes_thread id=2 finished, found 3246 primes, last one was 29989
rr_test: Done

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fcfbe0  1fcfbe0
ordblks        11       11
mxordblk  1fb2468  1fb2468
uordblks     b818     b818
fordblks  1fc43c8  1fc43c8

user_main: barrier test
barrier_test: Initializing barrier
barrier_test: Thread 0 created
barrier_test: Thread 1 created
barrier_test: Thread 2 created
barrier_test: Thread 3 created
barrier_test: Thread 4 created
barrier_test: Thread 5 created
barrier_test: Thread 6 created
barrier_test: Thread 7 created
barrier_func: Thread 0 started
barrier_func: Thread 1 started
barrier_func: Thread 2 started
barrier_func: Thread 3 started
barrier_func: Thread 4 started
barrier_func: Thread 5 started
barrier_func: Thread 6 started
barrier_func: Thread 7 started
barrier_func: Thread 0 calling pthread_barrier_wait()
barrier_func: Thread 1 calling pthread_barrier_wait()
barrier_func: Thread 2 calling pthread_barrier_wait()
barrier_func: Thread 3 calling pthread_barrier_wait()
barrier_func: Thread 4 calling pthread_barrier_wait()
barrier_func: Thread 5 calling pthread_barrier_wait()
barrier_func: Thread 6 calling pthread_barrier_wait()
barrier_func: Thread 7 calling pthread_barrier_wait()
barrier_func: Thread 7, back with status=PTHREAD_BARRIER_SERIAL_THREAD (I AM SPECIAL)
barrier_func: Thread 0, back with status=0 (I am not special)
barrier_func: Thread 1, back with status=0 (I am not special)
barrier_func: Thread 2, back with status=0 (I am not special)
barrier_func: Thread 3, back with status=0 (I am not special)
barrier_func: Thread 4, back with status=0 (I am not special)
barrier_func: Thread 5, back with status=0 (I am not special)
barrier_func: Thread 6, back with status=0 (I am not special)
barrier_func: Thread 7 done
barrier_func: Thread 0 done
barrier_test: Thread 0 completed with result=0
barrier_func: Thread 1 done
barrier_func: Thread 2 done
barrier_func: Thread 3 done
barrier_test: Thread 1 completed with result=0
barrier_test: Thread 2 completed with result=0
barrier_test: Thread 3 completed with result=0
barrier_func: Thread 4 done
barrier_func: Thread 5 done
barrier_func: Thread 6 done
barrier_test: Thread 4 completed with result=0
barrier_test: Thread 5 completed with result=0
barrier_test: Thread 6 completed with result=0
barrier_test: Thread 7 completed with result=0

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fcfbe0  1fcfbe0
ordblks        11       11
mxordblk  1fb2468  1fb2468
uordblks     b818     b818
fordblks  1fc43c8  1fc43c8

user_main: scheduler lock test
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Starting lowpri_thread at 97
sched_lock: Set lowpri_thread priority to 97
sched_lock: Starting highpri_thread at 98
sched_lock: Set highpri_thread priority to 98
sched_lock: Waiting...
sched_lock: PASSED No pre-emption occurred while scheduler was locked.
sched_lock: Finished

End of test memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fcfbe0  1fcfbe0
ordblks        11       11
mxordblk  1fb2468  1fb2468
uordblks     b818     b818
fordblks  1fc43c8  1fc43c8

user_main: smp call test
smp_call_test: Test start
smp_call_test: Call cpu 0, nowait
smp_call_test: Call cpu 0, wait
smp_call_test: Call cpu 1, nowait
smp_call_test: Call cpu 1, wait
smp_call_test: Call cpu 2, nowait
smp_call_test: Call cpu 2, wait
smp_call_test: Call cpu 3, nowait
smp_call_test: Call cpu 3, wait
smp_call_test: Call cpu 4, nowait
smp_call_test: Call cpu 4, wait
smp_call_test: Call cpu 5, nowait
smp_call_test: Call cpu 5, wait
smp_call_test: Call cpu 6, nowait
smp_call_test: Call cpu 6, wait
smp_call_test: Call cpu 7, nowait
smp_call_test: Call cpu 7, wait
smp_call_test: Call multi cpu, nowait
smp_call_test: Call in interrupt, wait
smp_call_test: Call multi cpu, wait
smp_call_test: Test success

Final memory usage:
VARIABLE  BEFORE   AFTER
======== ======== ========
arena     1fcfbe0  1fcfbe0
ordblks         7       11
mxordblk  1fb2468  1fb2468
uordblks     daf0     b818
fordblks  1fc20f0  1fc43c8
user_main: Exiting
ostest_main: Exiting with status 0
nsh> 