### PR TITLE
drivers/sensor：Sensors add new types of electrical measurements.

### DIFF
--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -253,12 +253,14 @@ static const struct file_operations g_sensor_fops =
 static void sensor_lock(FAR void *priv)
 {
   FAR struct sensor_upperhalf_s *upper = priv;
+
   nxrmutex_lock(&upper->lock);
 }
 
 static void sensor_unlock(FAR void *priv)
 {
   FAR struct sensor_upperhalf_s *upper = priv;
+
   nxrmutex_unlock(&upper->lock);
 }
 
@@ -307,6 +309,7 @@ again:
           min_interval != upper->state.min_interval)
         {
           uint32_t expected_interval = min_interval;
+
           orig_min_interval = upper->state.min_interval;
           nxrmutex_unlock(&upper->lock);
           ret = lower->ops->set_interval(lower, filep, &min_interval);
@@ -500,6 +503,7 @@ static void sensor_generate_timing(FAR struct sensor_upperhalf_s *upper,
 {
   uint32_t interval = upper->state.min_interval != UINT32_MAX ?
                       upper->state.min_interval : 1;
+
   while (nums-- > 0)
     {
       upper->state.generation += interval;
@@ -1094,7 +1098,7 @@ static int sensor_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
-     case SNIOC_GET_EVENTS:
+      case SNIOC_GET_EVENTS:
         {
           nxrmutex_lock(&upper->lock);
           *(FAR unsigned int *)(uintptr_t)arg = user->event;
@@ -1104,7 +1108,7 @@ static int sensor_ioctl(FAR struct file *filep, int cmd, unsigned long arg)
         }
         break;
 
-     case SNIOC_FLUSH:
+      case SNIOC_FLUSH:
         {
           /* If the sensor is not activated, return -EINVAL. */
 
@@ -1235,7 +1239,7 @@ static int sensor_poll(FAR struct file *filep,
           eventset |= POLLPRI;
         }
 
-        poll_notify(&fds, 1, eventset);
+      poll_notify(&fds, 1, eventset);
     }
   else
     {

--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -227,6 +227,10 @@ static const struct sensor_meta_s g_sensor_meta[] =
   {sizeof(struct sensor_voltage),             "voltage"},
   {sizeof(struct sensor_current),             "current"},
   {sizeof(struct sensor_power),               "power"},
+  {sizeof(struct sensor_resistance),          "resistance"},
+  {sizeof(struct sensor_conductivity),        "conductivity"},
+  {sizeof(struct sensor_energy),              "energy"},
+  {sizeof(struct sensor_charge),              "charge"},
 };
 
 static const struct file_operations g_sensor_fops =

--- a/drivers/sensors/sensor.c
+++ b/drivers/sensors/sensor.c
@@ -224,6 +224,9 @@ static const struct sensor_meta_s g_sensor_meta[] =
   {sizeof(struct sensor_pm10),                "pm10"},
   {sizeof(struct sensor_uv),                  "uv"},
   {sizeof(struct sensor_eng),                 "eng"},
+  {sizeof(struct sensor_voltage),             "voltage"},
+  {sizeof(struct sensor_current),             "current"},
+  {sizeof(struct sensor_power),               "power"},
 };
 
 static const struct file_operations g_sensor_fops =

--- a/include/nuttx/uorb.h
+++ b/include/nuttx/uorb.h
@@ -590,11 +590,35 @@
 
 #define SENSOR_TYPE_ENG                             58
 
+/* Voltage
+ * A sensor of this type returns the measured voltage between two points.
+ * The value is in SI units volt(V).
+ */
+
+#define SENSOR_TYPE_VOLTAGE                         59
+
+/* Current
+ * A sensor of this type returns the measured current flowing through a
+ * path. The value is in SI units ampere(A) and is signed: a negative value
+ * indicates that the current flows in the opposite direction.
+ */
+
+#define SENSOR_TYPE_CURRENT                         60
+
+/* Power
+ * A sensor of this type returns the measured instantaneous active power.
+ * The value is in SI units watt(W). The accumulated energy and the AC
+ * power components (reactive, apparent and power factor) are not covered
+ * by this type.
+ */
+
+#define SENSOR_TYPE_POWER                           61
+
 /* The total number of sensor
  * please increase it if you added a new sensor type!
  */
 
-#define SENSOR_TYPE_COUNT                           59
+#define SENSOR_TYPE_COUNT                           62
 
 /* The additional sensor open flags */
 
@@ -1031,6 +1055,24 @@ struct sensor_eng           /* Type: ENG */
   uint64_t timestamp;       /* Unit is microseconds */
   float voltage[4];         /* Voltage unit in mV */
   uint32_t stat;            /* Status. bit3:0 - value 3:0 is valid or not */
+};
+
+struct sensor_voltage       /* Type: Voltage */
+{
+  uint64_t timestamp;       /* Unit is microseconds */
+  float voltage;            /* in SI units V */
+};
+
+struct sensor_current       /* Type: Current */
+{
+  uint64_t timestamp;       /* Unit is microseconds */
+  float current;            /* in SI units A, signed */
+};
+
+struct sensor_power         /* Type: Power */
+{
+  uint64_t timestamp;       /* Unit is microseconds */
+  float power;              /* Instantaneous active power in SI units W */
 };
 
 struct sensor_gnss          /* Type: GNSS */

--- a/include/nuttx/uorb.h
+++ b/include/nuttx/uorb.h
@@ -607,18 +607,52 @@
 
 /* Power
  * A sensor of this type returns the measured instantaneous active power.
- * The value is in SI units watt(W). The accumulated energy and the AC
- * power components (reactive, apparent and power factor) are not covered
- * by this type.
+ * The value is in SI units watt(W). The accumulated energy is reported by
+ * SENSOR_TYPE_ENERGY. The AC power components (reactive, apparent and
+ * power factor) are not covered by this type.
  */
 
 #define SENSOR_TYPE_POWER                           61
+
+/* Resistance
+ * A sensor of this type returns the measured DC resistance. The value is
+ * in SI units Ohm(Ω). Use SENSOR_TYPE_IMPEDANCE instead when the reactance
+ * is also needed.
+ */
+
+#define SENSOR_TYPE_RESISTANCE                      62
+
+/* Electrical conductivity
+ * A sensor of this type returns the measured electrical conductivity of a
+ * medium. The value is in SI units siemens per metre(S/m), where 1 S/m
+ * equals 1e4 uS/cm.
+ */
+
+#define SENSOR_TYPE_CONDUCTIVITY                    63
+
+/* Energy
+ * A sensor of this type returns the electrical energy accumulated since
+ * the accumulator was last reset. The value is in uJ, where 1 Wh equals
+ * 3.6e9 uJ. The value is signed: a negative value indicates that the
+ * energy flows in the direction opposite to the reference direction.
+ */
+
+#define SENSOR_TYPE_ENERGY                          64
+
+/* Charge
+ * A sensor of this type returns the electrical charge accumulated since
+ * the accumulator was last reset, that is the time integral of the
+ * current. The value is in uC, where 1 Ah equals 3.6e9 uC. The value is
+ * signed and uses the same direction convention as SENSOR_TYPE_CURRENT.
+ */
+
+#define SENSOR_TYPE_CHARGE                          65
 
 /* The total number of sensor
  * please increase it if you added a new sensor type!
  */
 
-#define SENSOR_TYPE_COUNT                           62
+#define SENSOR_TYPE_COUNT                           66
 
 /* The additional sensor open flags */
 
@@ -1073,6 +1107,30 @@ struct sensor_power         /* Type: Power */
 {
   uint64_t timestamp;       /* Unit is microseconds */
   float power;              /* Instantaneous active power in SI units W */
+};
+
+struct sensor_resistance    /* Type: Resistance */
+{
+  uint64_t timestamp;       /* Unit is microseconds */
+  float resistance;         /* in SI units Ohm(Ω) */
+};
+
+struct sensor_conductivity  /* Type: Electrical conductivity */
+{
+  uint64_t timestamp;       /* Unit is microseconds */
+  float conductivity;       /* in SI units S/m, 1 S/m = 1e4 uS/cm */
+};
+
+struct sensor_energy        /* Type: Energy */
+{
+  uint64_t timestamp;       /* Unit is microseconds */
+  int64_t energy;           /* Accumulated energy. Unit is uJ. */
+};
+
+struct sensor_charge        /* Type: Charge */
+{
+  uint64_t timestamp;       /* Unit is microseconds */
+  int64_t charge;           /* Accumulated charge. Unit is uC. */
 };
 
 struct sensor_gnss          /* Type: GNSS */


### PR DESCRIPTION
## Summary

uORB currently has no sensor type for electrical quantities. Drivers that measure voltage, current or power (power monitors, fuel gauges, PMICs) have to fall back on the legacy character drivers, which are deprecated and report their values in three mutually incompatible unit systems.
[[RFC] uORB: add power-monitor support (voltage/current/power)](https://github.com/apache/nuttx/issues/20094)
This series adds the missing electrical types to uORB, each with its own message struct in a single well-defined unit:
| Type | Value | Unit |
| --- | --- | --- |
| `SENSOR_TYPE_VOLTAGE` (59) | `struct sensor_voltage` | V |
| `SENSOR_TYPE_CURRENT` (60) | `struct sensor_current` | A, signed |
| `SENSOR_TYPE_POWER` (61) | `struct sensor_power` | W (instantaneous active) |
| `SENSOR_TYPE_RESISTANCE` (62) | `struct sensor_resistance` | Ohm |
| `SENSOR_TYPE_CONDUCTIVITY` (63) | `struct sensor_conductivity` | S/m |
| `SENSOR_TYPE_ENERGY` (64) | `struct sensor_energy` | uJ, signed |
| `SENSOR_TYPE_CHARGE` (65) | `struct sensor_charge` | uC, signed |

## Impact

- New feature only. No existing behaviour changes.

## Testing

Pass.