### PR TITLE
arch/arm/stm32h5: Add MPU support

### DIFF
--- a/arch/arm/src/stm32h5/CMakeLists.txt
+++ b/arch/arm/src/stm32h5/CMakeLists.txt
@@ -124,6 +124,10 @@ if(CONFIG_STM32_IWDG)
   list(APPEND SRCS stm32_iwdg.c)
 endif()
 
+if(CONFIG_ARM_MPU)
+  list(APPEND SRCS stm32_mpuinit.c)
+endif()
+
 # Required chip type specific files
 
 if(CONFIG_STM32_STM32H5XXXX)

--- a/arch/arm/src/stm32h5/Make.defs
+++ b/arch/arm/src/stm32h5/Make.defs
@@ -127,6 +127,10 @@ ifeq ($(CONFIG_STM32_IWDG),y)
 CHIP_CSRCS += stm32_iwdg.c
 endif
 
+ifeq ($(CONFIG_ARM_MPU),y)
+CHIP_CSRCS += stm32_mpuinit.c
+endif
+
 ifeq ($(CONFIG_STM32_WWDG),y)
 CHIP_CSRCS += stm32_wwdg.c
 endif

--- a/arch/arm/src/stm32h5/hardware/stm32h5xxx_memorymap.h
+++ b/arch/arm/src/stm32h5/hardware/stm32h5xxx_memorymap.h
@@ -60,6 +60,7 @@
 /* System Memory Addresses **************************************************/
 
 #define STM32_SYSMEM_MEM     0x0bf80000
+#define STM32_OTP_BASE       0x08FFF000     /* One-Time Programmable (OTP) memory base address */
 #define STM32_SYSMEM_UID     0x08FFF800     /* The 96-bit unique device identifier */
 #define STM32_SYSMEM_FSIZE   0x08FFF80C     /* Size of Flash memory in Kbytes. */
 #define STM32_SYSMEM_PACKAGE 0x08FFF80E     /* Indicates the device's package type. */

--- a/arch/arm/src/stm32h5/stm32_mpuinit.c
+++ b/arch/arm/src/stm32h5/stm32_mpuinit.c
@@ -1,0 +1,67 @@
+/****************************************************************************
+ * arch/arm/src/stm32h5/stm32_mpuinit.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <assert.h>
+#include <sys/param.h>
+
+#include "mpu.h"
+#include "stm32_mpuinit.h"
+
+#ifdef CONFIG_ARM_MPU
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: stm32_mpuinitialize
+ *
+ * Description:
+ *   Configure the MPU.
+ *
+ *   For FLAT build:
+ *     - just reset and enable the MPU with the default background region.
+ *
+ ****************************************************************************/
+
+void stm32_mpuinitialize(void)
+{
+  /* Show MPU information */
+
+  mpu_showtype();
+
+  /* Reset the MPU in case a bootloader left it configured */
+
+  mpu_reset();
+
+  /* Then enable the MPU */
+
+  mpu_control(true, false, true);
+}
+
+#endif /* CONFIG_ARM_MPU */

--- a/arch/arm/src/stm32h5/stm32_mpuinit.h
+++ b/arch/arm/src/stm32h5/stm32_mpuinit.h
@@ -1,0 +1,53 @@
+/****************************************************************************
+ * arch/arm/src/stm32h5/stm32_mpuinit.h
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.  The
+ * ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the
+ * License for the specific language governing permissions and limitations
+ * under the License.
+ *
+ ****************************************************************************/
+
+#ifndef __ARCH_ARM_SRC_STM32H5_STM32_MPUINIT_H
+#define __ARCH_ARM_SRC_STM32H5_STM32_MPUINIT_H
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+/****************************************************************************
+ * Public Function Prototypes
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: stm32_mpuinitialize
+ *
+ * Description:
+ *   Configure the MPU.
+ *
+ *   For FLAT build:
+ *     - just reset and enable the MPU with the default background region.
+ *
+ ****************************************************************************/
+
+#ifdef CONFIG_ARM_MPU
+void stm32_mpuinitialize(void);
+#else
+#  define stm32_mpuinitialize()
+#endif
+
+#endif /* __ARCH_ARM_SRC_STM32H5_STM32_MPUINIT_H */

--- a/arch/arm/src/stm32h5/stm32_start.c
+++ b/arch/arm/src/stm32h5/stm32_start.c
@@ -40,6 +40,10 @@
 #include "stm32_gpio.h"
 #include "stm32_start.h"
 
+#ifdef CONFIG_ARM_MPU
+#  include "stm32_mpuinit.h"
+#endif
+
 /****************************************************************************
  * Pre-processor Definitions
  ****************************************************************************/
@@ -219,6 +223,15 @@ void __start(void)
   arm_earlyserialinit();
 #endif
   showprogress('B');
+
+  /* Configure the MPU to permit user-space access to its FLASH and RAM (for
+   * CONFIG_BUILD_PROTECTED) or to manage cache properties of external
+   * memory regions (in a flat build).
+   */
+
+#ifdef CONFIG_ARM_MPU
+  stm32_mpuinitialize();
+#endif
 
   /* Initialize onboard resources */
 

--- a/boards/arm/stm32h5/nucleo-h563zi/src/CMakeLists.txt
+++ b/boards/arm/stm32h5/nucleo-h563zi/src/CMakeLists.txt
@@ -52,6 +52,10 @@ if(CONFIG_STM32_USBFS_HOST)
   list(APPEND SRCS stm32_usb.c)
 endif()
 
+if(CONFIG_ARM_MPU)
+  list(APPEND SRCS stm32_mpu.c)
+endif()
+
 target_sources(board PRIVATE ${SRCS})
 
 set_property(GLOBAL PROPERTY LD_SCRIPT "${NUTTX_BOARD_DIR}/scripts/flash.ld")

--- a/boards/arm/stm32h5/nucleo-h563zi/src/Make.defs
+++ b/boards/arm/stm32h5/nucleo-h563zi/src/Make.defs
@@ -58,6 +58,10 @@ ifeq ($(CONFIG_STM32_USBFS_HOST),y)
 CSRCS += stm32_usb.c
 endif
 
+ifeq ($(CONFIG_ARM_MPU),y)
+CSRCS += stm32_mpu.c
+endif
+
 DEPPATH += --dep-path board
 VPATH += :board
 CFLAGS += ${INCDIR_PREFIX}$(TOPDIR)$(DELIM)arch$(DELIM)$(CONFIG_ARCH)$(DELIM)src$(DELIM)board$(DELIM)board

--- a/boards/arm/stm32h5/nucleo-h563zi/src/nucleo-h563zi.h
+++ b/boards/arm/stm32h5/nucleo-h563zi/src/nucleo-h563zi.h
@@ -115,6 +115,18 @@
 
 int stm32_bringup(void);
 
+/****************************************************************************
+ * Name: stm32_mpu_configure_otp
+ *
+ * Description:
+ *   Initialize MPU and configure the OTP flash region.
+ *
+ ****************************************************************************/
+
+#if defined(CONFIG_ARM_MPU) && defined(CONFIG_STM32_ICACHE)
+void stm32_mpu_configure_otp(void);
+#endif
+
 #ifdef CONFIG_STM32_SPI
 /****************************************************************************
  * Name: stm32_spiregister

--- a/boards/arm/stm32h5/nucleo-h563zi/src/stm32_boot.c
+++ b/boards/arm/stm32h5/nucleo-h563zi/src/stm32_boot.c
@@ -53,6 +53,12 @@
 
 void stm32_board_initialize(void)
 {
+#if defined(CONFIG_ARM_MPU) && defined(CONFIG_STM32_ICACHE)
+  /* Configure OTP MPU region. */
+
+  stm32_mpu_configure_otp();
+#endif
+
 #ifdef CONFIG_ARCH_LEDS
   /* Configure on-board LEDs if LED support has been selected. */
 

--- a/boards/arm/stm32h5/nucleo-h563zi/src/stm32_mpu.c
+++ b/boards/arm/stm32h5/nucleo-h563zi/src/stm32_mpu.c
@@ -1,0 +1,41 @@
+/****************************************************************************
+ * boards/arm/stm32h5/nucleo-h563zi/src/stm32_mpu.c
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ ****************************************************************************/
+
+/****************************************************************************
+ * Included Files
+ ****************************************************************************/
+
+#include <nuttx/config.h>
+
+#include <debug.h>
+#include <errno.h>
+
+#include <nuttx/arch.h>
+
+#include "hardware/stm32_memorymap.h"
+#include "mpu.h"
+#include "stm32_mpuinit.h"
+
+/****************************************************************************
+ * Public Functions
+ ****************************************************************************/
+
+/****************************************************************************
+ * Name: stm32_mpu_configure_otp
+ *
+ * Description:
+ *   Configure the OTP flash region as non-cacheable, non-executable, non-
+ *   shareable, and read-only.
+ *
+ ****************************************************************************/
+
+void stm32_mpu_configure_otp(void)
+{
+  mpu_configure_region(STM32_OTP_BASE, 4096,
+      MPU_RBAR_XN | MPU_RBAR_SH_NO | MPU_RBAR_AP_RORO,
+      MPU_RLAR_NONCACHEABLE);
+}


### PR DESCRIPTION
## Summary

This adds basic MPU support for the STM32H5 based on the initialization in the STM32U5 (same core).

The STM32H5 has a couple issues ("features") related to the OTP flash region:

1. It cannot be accessed via cacheable reads. If ICACHE is enabled, reading OTP will cause a hard fault.
2. Reading unwritten OTP flash causes flash double ECC errors, which triggers NMIs by default. This crashes NuttX currently. (This is out of scope for this PR.)

**NOTE: This does not enable protected mode builds (`CONFIG_BUILD_PROTECTED`) at this time.** I don't currently understand that portion of the codebase enough (yet) to attempt that.

## Impact

No impact, since MPU support is currently not implemented.

## Testing

I added code to the NUCLEO-H563ZI board to configure an MPU region over the OTP flash in the case that `CONFIG_ARM_MPU` and `CONFIG_STM32_ICACHE` are enabled. I have not added these to any `defconfig`, though.


Before, with `CONFIG_STM32_ICACHE` disabled:

```
nsh> mh 0x08FFF800 0xC
  0x8fff800 = 0x003e
  0x8fff802 = 0x0063
  0x8fff804 = 0x5111
  0x8fff806 = 0x3332
  0x8fff808 = 0x3236
  0x8fff80a = 0x3836
```

Before, with `CONFIG_STM32_ICACHE` enabled:

```
nsh> mh 0x08FFF800 0xC
dump_assert_info: Current Version: NuttX  13.0.1-RC1 3a8b290f71-dirty Sep 11 2026 16:26:21 arm
dump_assert_info: Assertion failed panic: at file: armv8-m/arm_hardfault.c:147 task: <noname> process: <noname> 0x8012db5
up_dump_register: R0: 00000000 R1: 080150bb R2: 00000000  R3: 08fff800
up_dump_register: R4: 08014ce5 R5: 08014a19 R6: 0801a3e7  FP: 00000000
up_dump_register: R8: 00000000 SB: 00000000 SL: 20003f18 R11: 00000000
up_dump_register: IP: 00000000 SP: 20004448 LR: 0801508d  PC: 080150d2
up_dump_register: xPSR: 81000000 BASEPRI: 00000000 CONTROL: 00000000
up_dump_register: EXC_RETURN: ffffffac
...
```

After, with `CONFIG_ARM_MPU` and `CONFIG_STM32_ICACHE` enabled:

```
nsh> mh 0x08FFF800 0xC
  0x8fff800 = 0x003e
  0x8fff802 = 0x0063
  0x8fff804 = 0x5111
  0x8fff806 = 0x3332
  0x8fff808 = 0x3236
  0x8fff80a = 0x3836
```