### PR TITLE
sched/clock: Fix timekeeping adjtime handling

### DIFF
--- a/sched/clock/clock_adjtime.c
+++ b/sched/clock/clock_adjtime.c
@@ -50,6 +50,9 @@
  * Private Data
  ****************************************************************************/
 
+/* CLOCK_TIMEKEEPING provides its own software-based adjtime(). */
+
+#ifndef CONFIG_CLOCK_TIMEKEEPING
 static struct wdog_s g_adjtime_wdog;
 static long g_adjtime_ppb;
 static spinlock_t g_adjtime_lock = SP_UNLOCKED;
@@ -216,6 +219,7 @@ int adjtime(FAR const struct timeval *delta, FAR struct timeval *olddelta)
       return OK;
     }
 }
+#endif /* !CONFIG_CLOCK_TIMEKEEPING */
 
 /****************************************************************************
  * Name: nxclock_adjtime

--- a/sched/clock/clock_timekeeping.c
+++ b/sched/clock/clock_timekeeping.c
@@ -247,13 +247,22 @@ void clock_update_wall_time(void)
 
   if (g_clock_adjust != 0 && sec > 0)
     {
-      long adjust = NTP_MAX_ADJUST * (long)sec;
-      if (g_clock_adjust < adjust && g_clock_adjust > -adjust)
+      long limit = NTP_MAX_ADJUST * (long)sec;
+      long adjust = g_clock_adjust;
+
+      /* Limit the adjustment while preserving its direction. */
+
+      if (adjust > limit)
         {
-          adjust = g_clock_adjust;
+          adjust = limit;
+        }
+      else if (adjust < -limit)
+        {
+          adjust = -limit;
         }
 
       nsec += adjust * NSEC_PER_USEC;
+      g_clock_adjust -= adjust;
 
       while (nsec < 0)
         {


### PR DESCRIPTION
## Summary

- Fix a duplicate `adjtime()` definition when both `CONFIG_CLOCK_TIMEKEEPING` and `CONFIG_CLOCK_ADJTIME` are enabled.
- Keep the software-based `adjtime()` implementation provided by `clock_timekeeping.c` when timekeeping is enabled, while retaining `clock_adjtime()` support, including the PTP clock path, from `clock_adjtime.c`.
- Clamp wall-clock slew adjustments in both positive and negative directions.
- Subtract each applied adjustment from the remaining adjustment so that `adjtime()` converges to zero instead of changing the clock indefinitely.

The timekeeping implementation previously calculated and applied a bounded adjustment on every wall-clock update, but never removed that amount from `g_clock_adjust`. In addition, adjustments larger than the per-update limit were always clamped to a positive value, causing large negative adjustments to move the clock in the wrong direction.

When `CONFIG_CLOCK_TIMEKEEPING=y` and `CONFIG_CLOCK_ADJTIME=y`, both `clock_timekeeping.c` and `clock_adjtime.c` also defined `adjtime()`, resulting in a duplicate symbol. The timekeeping implementation now owns `adjtime()` in this configuration, while `clock_adjtime.c` continues to provide `nxclock_adjtime()` and `clock_adjtime()`.

## Impact

Bug fix only; no new features.

## Testing

Host: macOS 26.6.2 ARM64, Apple Clang 21.0.0.

Target: sim:ostest.

Build: make completes successfully with LD: nuttx.

Runtime: ran ./nuttx; all enabled OSTest subtests completed without assertions or unexpected errors.

Static checks: nxstyle, checkpatch, and commit-message checks pass.